### PR TITLE
feat: circuit breaker + X-Request-ID propagation

### DIFF
--- a/pkg/proxy/circuit_breaker.go
+++ b/pkg/proxy/circuit_breaker.go
@@ -1,0 +1,141 @@
+package proxy
+
+import (
+	"sync"
+	"time"
+)
+
+// CircuitState represents the state of a circuit breaker.
+type CircuitState int
+
+const (
+	CircuitClosed   CircuitState = iota // Normal operation
+	CircuitOpen                         // Failing — skip observability, forward directly
+	CircuitHalfOpen                     // Testing recovery
+)
+
+// CircuitBreaker implements a per-provider circuit breaker.
+// When tripped, the proxy continues forwarding requests to upstream (fail-open)
+// but skips span creation to avoid blocking on a failing storage pipeline.
+//
+// This is NOT about blocking upstream calls — LLM requests always go through.
+// It's about protecting the observability pipeline from cascading failures.
+type CircuitBreaker struct {
+	mu              sync.Mutex
+	state           CircuitState
+	failures        int
+	successes       int
+	lastFailureTime time.Time
+
+	// Config
+	threshold    int           // consecutive failures to trip
+	resetTimeout time.Duration // how long to wait before half-open
+	halfOpenMax  int           // successes needed to close
+}
+
+// CircuitBreakerConfig holds circuit breaker settings.
+type CircuitBreakerConfig struct {
+	Threshold    int           // default: 5
+	ResetTimeout time.Duration // default: 30s
+	HalfOpenMax  int           // default: 2
+}
+
+// DefaultCircuitBreakerConfig returns sensible defaults.
+func DefaultCircuitBreakerConfig() CircuitBreakerConfig {
+	return CircuitBreakerConfig{
+		Threshold:    5,
+		ResetTimeout: 30 * time.Second,
+		HalfOpenMax:  2,
+	}
+}
+
+// NewCircuitBreaker creates a circuit breaker with the given config.
+func NewCircuitBreaker(cfg CircuitBreakerConfig) *CircuitBreaker {
+	if cfg.Threshold == 0 {
+		cfg.Threshold = 5
+	}
+	if cfg.ResetTimeout == 0 {
+		cfg.ResetTimeout = 30 * time.Second
+	}
+	if cfg.HalfOpenMax == 0 {
+		cfg.HalfOpenMax = 2
+	}
+
+	return &CircuitBreaker{
+		state:        CircuitClosed,
+		threshold:    cfg.Threshold,
+		resetTimeout: cfg.ResetTimeout,
+		halfOpenMax:  cfg.HalfOpenMax,
+	}
+}
+
+// AllowRequest returns true if the request should include observability.
+// When the circuit is open, requests are still forwarded but observability is skipped.
+func (cb *CircuitBreaker) AllowRequest() bool {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.state {
+	case CircuitClosed:
+		return true
+	case CircuitOpen:
+		// Check if reset timeout has elapsed.
+		if time.Since(cb.lastFailureTime) > cb.resetTimeout {
+			cb.state = CircuitHalfOpen
+			cb.successes = 0
+			return true
+		}
+		return false
+	case CircuitHalfOpen:
+		return true
+	}
+	return true
+}
+
+// RecordSuccess records a successful upstream call.
+func (cb *CircuitBreaker) RecordSuccess() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	cb.failures = 0
+
+	if cb.state == CircuitHalfOpen {
+		cb.successes++
+		if cb.successes >= cb.halfOpenMax {
+			cb.state = CircuitClosed
+		}
+	}
+}
+
+// RecordFailure records a failed upstream call (5xx).
+func (cb *CircuitBreaker) RecordFailure() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	cb.failures++
+	cb.lastFailureTime = time.Now()
+
+	if cb.failures >= cb.threshold {
+		cb.state = CircuitOpen
+	}
+}
+
+// State returns the current circuit state.
+func (cb *CircuitBreaker) State() CircuitState {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	return cb.state
+}
+
+// String returns a human-readable state name.
+func (s CircuitState) String() string {
+	switch s {
+	case CircuitClosed:
+		return "closed"
+	case CircuitOpen:
+		return "open"
+	case CircuitHalfOpen:
+		return "half-open"
+	}
+	return "unknown"
+}

--- a/pkg/proxy/circuit_breaker_test.go
+++ b/pkg/proxy/circuit_breaker_test.go
@@ -1,0 +1,139 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCircuitBreaker_StartsClosedAllowsRequests(t *testing.T) {
+	cb := NewCircuitBreaker(DefaultCircuitBreakerConfig())
+
+	if cb.State() != CircuitClosed {
+		t.Errorf("expected closed, got %s", cb.State())
+	}
+	if !cb.AllowRequest() {
+		t.Error("expected allow on closed circuit")
+	}
+}
+
+func TestCircuitBreaker_TripsAfterThreshold(t *testing.T) {
+	cb := NewCircuitBreaker(CircuitBreakerConfig{
+		Threshold:    3,
+		ResetTimeout: 1 * time.Hour,
+		HalfOpenMax:  1,
+	})
+
+	// Record failures up to threshold.
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if cb.State() != CircuitClosed {
+		t.Errorf("expected closed after 2 failures, got %s", cb.State())
+	}
+
+	cb.RecordFailure() // 3rd failure = trip
+	if cb.State() != CircuitOpen {
+		t.Errorf("expected open after 3 failures, got %s", cb.State())
+	}
+	if cb.AllowRequest() {
+		t.Error("expected deny on open circuit")
+	}
+}
+
+func TestCircuitBreaker_SuccessResetsFailureCount(t *testing.T) {
+	cb := NewCircuitBreaker(CircuitBreakerConfig{
+		Threshold:    3,
+		ResetTimeout: 1 * time.Hour,
+		HalfOpenMax:  1,
+	})
+
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordSuccess() // Reset
+
+	// Should need 3 more failures to trip.
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if cb.State() != CircuitClosed {
+		t.Errorf("expected closed, got %s", cb.State())
+	}
+}
+
+func TestCircuitBreaker_HalfOpenAfterResetTimeout(t *testing.T) {
+	cb := NewCircuitBreaker(CircuitBreakerConfig{
+		Threshold:    1,
+		ResetTimeout: 10 * time.Millisecond,
+		HalfOpenMax:  1,
+	})
+
+	cb.RecordFailure() // Trip immediately.
+	if cb.State() != CircuitOpen {
+		t.Fatalf("expected open, got %s", cb.State())
+	}
+
+	// Wait for reset timeout.
+	time.Sleep(20 * time.Millisecond)
+
+	// Should transition to half-open on AllowRequest.
+	if !cb.AllowRequest() {
+		t.Error("expected allow after reset timeout (half-open)")
+	}
+	if cb.State() != CircuitHalfOpen {
+		t.Errorf("expected half-open, got %s", cb.State())
+	}
+}
+
+func TestCircuitBreaker_HalfOpenClosesAfterSuccesses(t *testing.T) {
+	cb := NewCircuitBreaker(CircuitBreakerConfig{
+		Threshold:    1,
+		ResetTimeout: 10 * time.Millisecond,
+		HalfOpenMax:  2,
+	})
+
+	cb.RecordFailure() // Trip.
+	time.Sleep(20 * time.Millisecond)
+	cb.AllowRequest() // → half-open
+
+	cb.RecordSuccess()
+	if cb.State() != CircuitHalfOpen {
+		t.Errorf("expected still half-open after 1 success, got %s", cb.State())
+	}
+
+	cb.RecordSuccess() // 2nd success → close.
+	if cb.State() != CircuitClosed {
+		t.Errorf("expected closed, got %s", cb.State())
+	}
+}
+
+func TestCircuitBreaker_HalfOpenReOpensOnFailure(t *testing.T) {
+	cb := NewCircuitBreaker(CircuitBreakerConfig{
+		Threshold:    1,
+		ResetTimeout: 10 * time.Millisecond,
+		HalfOpenMax:  2,
+	})
+
+	cb.RecordFailure() // Trip.
+	time.Sleep(20 * time.Millisecond)
+	cb.AllowRequest() // → half-open
+
+	cb.RecordFailure() // Fail during half-open → re-open.
+	if cb.State() != CircuitOpen {
+		t.Errorf("expected re-open, got %s", cb.State())
+	}
+}
+
+func TestCircuitState_String(t *testing.T) {
+	tests := []struct {
+		state CircuitState
+		want  string
+	}{
+		{CircuitClosed, "closed"},
+		{CircuitOpen, "open"},
+		{CircuitHalfOpen, "half-open"},
+		{CircuitState(99), "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.state.String(); got != tt.want {
+			t.Errorf("CircuitState(%d).String() = %q, want %q", tt.state, got, tt.want)
+		}
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -43,6 +43,7 @@ type Proxy struct {
 	calc      *costcalc.Calculator
 	client    *http.Client
 	projectID string
+	breakers  map[string]*CircuitBreaker
 }
 
 // Config holds proxy configuration.
@@ -66,8 +67,11 @@ func DefaultProviders() []Provider {
 // New creates a new LLM proxy.
 func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) *Proxy {
 	providers := make(map[string]Provider)
+	breakers := make(map[string]*CircuitBreaker)
+	cbCfg := DefaultCircuitBreakerConfig()
 	for _, p := range cfg.Providers {
 		providers[p.Name] = p
+		breakers[p.Name] = NewCircuitBreaker(cbCfg)
 	}
 
 	return &Proxy{
@@ -75,6 +79,7 @@ func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) *Proxy 
 		submitter: submitter,
 		calc:      calc,
 		projectID: cfg.ProjectID,
+		breakers:  breakers,
 		client: &http.Client{
 			Timeout: 5 * time.Minute, // LLM calls can be slow
 		},
@@ -93,6 +98,12 @@ func (p *Proxy) RegisterRoutes(mux *http.ServeMux) {
 
 func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
+
+	// Generate or accept request ID.
+	requestID := r.Header.Get("X-Request-ID")
+	if requestID == "" {
+		requestID = generateSpanID() + generateSpanID() // 32-char hex
+	}
 
 	// Extract provider from path: /proxy/{provider}/v1/...
 	parts := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/proxy/"), "/", 2)
@@ -135,19 +146,50 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// Forward headers (auth, content-type, etc).
 	forwardHeaders(r, upstreamReq, providerName)
 
+	// Propagate request ID to upstream.
+	upstreamReq.Header.Set("X-Request-ID", requestID)
+
 	// Execute the upstream request.
 	resp, err := p.client.Do(upstreamReq)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("upstream error: %v", err), http.StatusBadGateway)
+		p.recordCircuitBreaker(providerName, true)
 		return
 	}
 	ttfb := time.Since(startTime)
 	defer resp.Body.Close()
 
+	// Record circuit breaker state based on upstream response.
+	p.recordCircuitBreaker(providerName, resp.StatusCode >= 500)
+
+	// Return request ID to the client.
+	w.Header().Set("X-Request-ID", requestID)
+
+	// Check circuit breaker — if open, skip observability but still forward.
+	cbAllow := p.breakers[providerName].AllowRequest()
+
 	if isStreaming && resp.StatusCode == http.StatusOK {
-		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb)
+		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, cbAllow)
 	} else {
-		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb)
+		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, cbAllow)
+	}
+}
+
+// recordCircuitBreaker records success/failure for the provider's circuit breaker.
+func (p *Proxy) recordCircuitBreaker(providerName string, failed bool) {
+	cb, ok := p.breakers[providerName]
+	if !ok {
+		return
+	}
+	if failed {
+		cb.RecordFailure()
+		if cb.State() == CircuitOpen {
+			slog.Warn("circuit breaker tripped",
+				"provider", providerName,
+				"state", cb.State().String())
+		}
+	} else {
+		cb.RecordSuccess()
 	}
 }
 
@@ -156,6 +198,8 @@ func (p *Proxy) handleStandardResponse(
 	resp *http.Response, provider Provider,
 	reqBody []byte, startTime time.Time,
 	ttfb time.Duration,
+	requestID string,
+	cbAllow bool,
 ) {
 	// Read the full response.
 	respBody, err := io.ReadAll(resp.Body)
@@ -176,7 +220,11 @@ func (p *Proxy) handleStandardResponse(
 	w.Write(respBody)
 
 	// Create observability span (async — don't block the response).
-	go p.createSpan(r.Context(), provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb)
+	if cbAllow {
+		go p.createSpan(r.Context(), provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID)
+	} else {
+		slog.Debug("skipping span creation (circuit open)", "provider", provider.Name, "request_id", requestID)
+	}
 }
 
 func (p *Proxy) handleStreamingResponse(
@@ -184,6 +232,8 @@ func (p *Proxy) handleStreamingResponse(
 	resp *http.Response, provider Provider,
 	reqBody []byte, startTime time.Time,
 	ttfb time.Duration,
+	requestID string,
+	cbAllow bool,
 ) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -216,8 +266,10 @@ func (p *Proxy) handleStreamingResponse(
 			w.Write(buf[:n])
 			flusher.Flush()
 
-			// Buffer for span creation.
-			streamBuffer.Write(buf[:n])
+			// Buffer for span creation (only if circuit allows).
+			if cbAllow {
+				streamBuffer.Write(buf[:n])
+			}
 		}
 		if err != nil {
 			break
@@ -227,7 +279,11 @@ func (p *Proxy) handleStreamingResponse(
 	endTime := time.Now()
 
 	// Parse the accumulated stream to extract usage data.
-	go p.createStreamingSpan(r.Context(), provider, reqBody, streamBuffer.Bytes(), startTime, endTime, ttfb, ttft)
+	if cbAllow {
+		go p.createStreamingSpan(r.Context(), provider, reqBody, streamBuffer.Bytes(), startTime, endTime, ttfb, ttft, requestID)
+	} else {
+		slog.Debug("skipping streaming span (circuit open)", "provider", provider.Name, "request_id", requestID)
+	}
 }
 
 func (p *Proxy) createSpan(
@@ -236,6 +292,7 @@ func (p *Proxy) createSpan(
 	startTime, endTime time.Time,
 	statusCode int,
 	ttfb time.Duration,
+	requestID string,
 ) {
 	model, inputContent := extractRequestInfo(provider.Name, reqBody)
 	outputContent, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
@@ -269,9 +326,10 @@ func (p *Proxy) createSpan(
 			OutputContent: truncate(outputContent, 10000),
 		},
 		Attributes: map[string]string{
-			"proxy.upstream": provider.UpstreamURL,
-			"http.status":    fmt.Sprintf("%d", statusCode),
-			"http.ttfb_ms":   fmt.Sprintf("%d", ttfb.Milliseconds()),
+			"proxy.upstream":   provider.UpstreamURL,
+			"http.status":      fmt.Sprintf("%d", statusCode),
+			"http.ttfb_ms":     fmt.Sprintf("%d", ttfb.Milliseconds()),
+			"http.request_id":  requestID,
 		},
 	}
 
@@ -282,6 +340,7 @@ func (p *Proxy) createSpan(
 		"tokens", totalTokens,
 		"cost_usd", cost,
 		"latency", endTime.Sub(startTime),
+		"request_id", requestID,
 	)
 }
 
@@ -291,6 +350,7 @@ func (p *Proxy) createStreamingSpan(
 	startTime, endTime time.Time,
 	ttfb time.Duration,
 	ttft time.Duration,
+	requestID string,
 ) {
 	model, inputContent := extractRequestInfo(provider.Name, reqBody)
 	outputContent, inputTokens, outputTokens := extractStreamingUsage(provider.Name, streamData)
@@ -319,10 +379,11 @@ func (p *Proxy) createStreamingSpan(
 			OutputContent: truncate(outputContent, 10000),
 		},
 		Attributes: map[string]string{
-			"proxy.upstream":  provider.UpstreamURL,
-			"proxy.streaming": "true",
-			"http.ttfb_ms":    fmt.Sprintf("%d", ttfb.Milliseconds()),
-			"llm.ttft_ms":     fmt.Sprintf("%d", ttft.Milliseconds()),
+			"proxy.upstream":   provider.UpstreamURL,
+			"proxy.streaming":  "true",
+			"http.ttfb_ms":     fmt.Sprintf("%d", ttfb.Milliseconds()),
+			"llm.ttft_ms":      fmt.Sprintf("%d", ttft.Milliseconds()),
+			"http.request_id":  requestID,
 		},
 	}
 
@@ -333,6 +394,7 @@ func (p *Proxy) createStreamingSpan(
 		"tokens", totalTokens,
 		"cost_usd", cost,
 		"latency", endTime.Sub(startTime),
+		"request_id", requestID,
 	)
 }
 


### PR DESCRIPTION
### Circuit Breaker (2.14)
Per-provider circuit breaker with fail-open design. LLM requests always forward; when the circuit trips (5 consecutive 5xx), span creation is skipped to protect the observability pipeline. Auto-recovers after 30s cooldown via half-open state.

### X-Request-ID (2.15)
Accepts or generates X-Request-ID, propagates to upstream, returns in response, stores as span attribute for full request correlation.

7 new unit tests for circuit breaker state machine.