### PR TITLE
feat: Project CRUD + API key management (#2.11, #2.12, #2.13)

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/candelahq/candela/pkg/storage"
 	bqstore "github.com/candelahq/candela/pkg/storage/bigquery"
 	duckdbstore "github.com/candelahq/candela/pkg/storage/duckdb"
+	"github.com/candelahq/candela/pkg/storage/projectdb"
 	sqlitestore "github.com/candelahq/candela/pkg/storage/sqlite"
 )
 
@@ -119,10 +120,23 @@ func main() {
 		connecthandlers.NewDashboardHandler(reader))
 	mux.Handle(dashboardPath, dashboardH)
 
+	// Initialize project store (separate SQLite DB for relational metadata).
+	projectStore, err := projectdb.New("candela-projects.db")
+	if err != nil {
+		slog.Error("failed to initialize project store", "error", err)
+		os.Exit(1)
+	}
+	defer projectStore.Close()
+
+	projectPath, projectH := candelav1connect.NewProjectServiceHandler(
+		connecthandlers.NewProjectHandler(projectStore))
+	mux.Handle(projectPath, projectH)
+
 	slog.Info("ConnectRPC services registered",
 		"trace", tracePath,
 		"ingestion", ingestionPath,
-		"dashboard", dashboardPath)
+		"dashboard", dashboardPath,
+		"project", projectPath)
 
 	// Register LLM proxy routes (selective activation).
 	if cfg.Proxy.Enabled {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.54.0
 	go.opentelemetry.io/collector/processor v1.54.0
 	go.uber.org/zap v1.27.1
+	golang.org/x/crypto v0.49.0
 	golang.org/x/net v0.52.0
 	google.golang.org/api v0.273.0
 	google.golang.org/protobuf v1.36.11
@@ -65,7 +66,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.42.0 // indirect
 	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/pkg/connecthandlers/project_handler.go
+++ b/pkg/connecthandlers/project_handler.go
@@ -1,0 +1,171 @@
+package connecthandlers
+
+import (
+	"context"
+
+	connect "connectrpc.com/connect"
+	typespb "github.com/candelahq/candela/gen/go/candela/types"
+	v1 "github.com/candelahq/candela/gen/go/candela/v1"
+	"github.com/candelahq/candela/pkg/storage"
+	"github.com/candelahq/candela/pkg/storage/projectdb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ProjectHandler implements the ProjectService ConnectRPC handler.
+type ProjectHandler struct {
+	store storage.ProjectStore
+}
+
+// NewProjectHandler creates a new ProjectHandler.
+func NewProjectHandler(store storage.ProjectStore) *ProjectHandler {
+	return &ProjectHandler{store: store}
+}
+
+func (h *ProjectHandler) CreateProject(
+	ctx context.Context,
+	req *connect.Request[v1.CreateProjectRequest],
+) (*connect.Response[v1.CreateProjectResponse], error) {
+	p, err := h.store.CreateProject(ctx, storage.Project{
+		Name:        req.Msg.Name,
+		Description: req.Msg.Description,
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	return connect.NewResponse(&v1.CreateProjectResponse{
+		Project: projectToProto(p),
+	}), nil
+}
+
+func (h *ProjectHandler) GetProject(
+	ctx context.Context,
+	req *connect.Request[v1.GetProjectRequest],
+) (*connect.Response[v1.GetProjectResponse], error) {
+	p, err := h.store.GetProject(ctx, req.Msg.Id)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+
+	return connect.NewResponse(&v1.GetProjectResponse{
+		Project: projectToProto(p),
+	}), nil
+}
+
+func (h *ProjectHandler) ListProjects(
+	ctx context.Context,
+	req *connect.Request[v1.ListProjectsRequest],
+) (*connect.Response[v1.ListProjectsResponse], error) {
+	limit := 50
+	offset := 0
+	if req.Msg.Pagination != nil {
+		if req.Msg.Pagination.PageSize > 0 {
+			limit = int(req.Msg.Pagination.PageSize)
+		}
+	}
+
+	projects, total, err := h.store.ListProjects(ctx, limit, offset)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	pbProjects := make([]*typespb.Project, len(projects))
+	for i, p := range projects {
+		pp := p // avoid capture
+		pbProjects[i] = projectToProto(&pp)
+	}
+
+	return connect.NewResponse(&v1.ListProjectsResponse{
+		Projects: pbProjects,
+		Pagination: &typespb.PaginationResponse{
+			TotalCount: int32(total),
+		},
+	}), nil
+}
+
+func (h *ProjectHandler) DeleteProject(
+	ctx context.Context,
+	req *connect.Request[v1.DeleteProjectRequest],
+) (*connect.Response[v1.DeleteProjectResponse], error) {
+	if err := h.store.DeleteProject(ctx, req.Msg.Id); err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	return connect.NewResponse(&v1.DeleteProjectResponse{}), nil
+}
+
+func (h *ProjectHandler) CreateAPIKey(
+	ctx context.Context,
+	req *connect.Request[v1.CreateAPIKeyRequest],
+) (*connect.Response[v1.CreateAPIKeyResponse], error) {
+	fullKey := projectdb.GenerateAPIKey()
+
+	key, err := h.store.CreateAPIKey(ctx, storage.APIKey{
+		ProjectID: req.Msg.ProjectId,
+		Name:      req.Msg.Name,
+	}, fullKey)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	return connect.NewResponse(&v1.CreateAPIKeyResponse{
+		ApiKey:  apiKeyToProto(key),
+		FullKey: fullKey,
+	}), nil
+}
+
+func (h *ProjectHandler) ListAPIKeys(
+	ctx context.Context,
+	req *connect.Request[v1.ListAPIKeysRequest],
+) (*connect.Response[v1.ListAPIKeysResponse], error) {
+	keys, err := h.store.ListAPIKeys(ctx, req.Msg.ProjectId)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	pbKeys := make([]*typespb.APIKey, len(keys))
+	for i, k := range keys {
+		kk := k
+		pbKeys[i] = apiKeyToProto(&kk)
+	}
+
+	return connect.NewResponse(&v1.ListAPIKeysResponse{
+		ApiKeys: pbKeys,
+	}), nil
+}
+
+func (h *ProjectHandler) RevokeAPIKey(
+	ctx context.Context,
+	req *connect.Request[v1.RevokeAPIKeyRequest],
+) (*connect.Response[v1.RevokeAPIKeyResponse], error) {
+	if err := h.store.RevokeAPIKey(ctx, req.Msg.Id); err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	return connect.NewResponse(&v1.RevokeAPIKeyResponse{}), nil
+}
+
+// --- Proto converters ---
+
+func projectToProto(p *storage.Project) *typespb.Project {
+	return &typespb.Project{
+		Id:          p.ID,
+		Name:        p.Name,
+		Description: p.Description,
+		CreatedAt:   timestamppb.New(p.CreatedAt),
+		UpdatedAt:   timestamppb.New(p.UpdatedAt),
+	}
+}
+
+func apiKeyToProto(k *storage.APIKey) *typespb.APIKey {
+	key := &typespb.APIKey{
+		Id:        k.ID,
+		ProjectId: k.ProjectID,
+		Name:      k.Name,
+		KeyPrefix: k.KeyPrefix,
+		Active:    k.Active,
+		CreatedAt: timestamppb.New(k.CreatedAt),
+	}
+	if !k.ExpiresAt.IsZero() {
+		key.ExpiresAt = timestamppb.New(k.ExpiresAt)
+	}
+	return key
+}

--- a/pkg/storage/projectdb/projectdb.go
+++ b/pkg/storage/projectdb/projectdb.go
@@ -1,0 +1,315 @@
+// Package projectdb implements storage.ProjectStore using SQLite.
+// This is intentionally a separate database file from the span store
+// because project/key metadata is relational (ACID, foreign keys)
+// while span data is OLAP-optimized.
+package projectdb
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+	_ "modernc.org/sqlite"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// Store implements storage.ProjectStore backed by SQLite.
+type Store struct {
+	db *sql.DB
+}
+
+var _ storage.ProjectStore = (*Store)(nil)
+
+// New creates a new ProjectStore and ensures the schema exists.
+func New(path string) (*Store, error) {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("projectdb: open %s: %w", path, err)
+	}
+
+	// Enable WAL mode for concurrent reads.
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("projectdb: WAL mode: %w", err)
+	}
+
+	// Enable foreign key enforcement (required for CASCADE).
+	if _, err := db.Exec("PRAGMA foreign_keys = ON"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("projectdb: foreign keys: %w", err)
+	}
+
+	if err := migrate(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("projectdb: migrate: %w", err)
+	}
+
+	return &Store{db: db}, nil
+}
+
+func migrate(db *sql.DB) error {
+	schema := `
+	CREATE TABLE IF NOT EXISTS projects (
+		id          TEXT PRIMARY KEY,
+		name        TEXT NOT NULL,
+		description TEXT NOT NULL DEFAULT '',
+		environment TEXT NOT NULL DEFAULT '',
+		created_at  TEXT NOT NULL,
+		updated_at  TEXT NOT NULL
+	);
+
+	CREATE TABLE IF NOT EXISTS api_keys (
+		id         TEXT PRIMARY KEY,
+		project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+		name       TEXT NOT NULL,
+		key_hash   TEXT NOT NULL,
+		key_prefix TEXT NOT NULL,
+		active     INTEGER NOT NULL DEFAULT 1,
+		created_at TEXT NOT NULL,
+		expires_at TEXT NOT NULL DEFAULT ''
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_api_keys_project ON api_keys(project_id);
+	CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys(key_prefix);
+	`
+	_, err := db.Exec(schema)
+	return err
+}
+
+// --- Project CRUD ---
+
+func (s *Store) CreateProject(ctx context.Context, p storage.Project) (*storage.Project, error) {
+	if p.ID == "" {
+		p.ID = generateID()
+	}
+	now := time.Now().UTC()
+	p.CreatedAt = now
+	p.UpdatedAt = now
+
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO projects (id, name, description, environment, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		p.ID, p.Name, p.Description, p.Environment,
+		p.CreatedAt.Format(time.RFC3339), p.UpdatedAt.Format(time.RFC3339))
+	if err != nil {
+		return nil, fmt.Errorf("projectdb: create project: %w", err)
+	}
+	return &p, nil
+}
+
+func (s *Store) GetProject(ctx context.Context, id string) (*storage.Project, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT id, name, description, environment, created_at, updated_at
+		 FROM projects WHERE id = ?`, id)
+
+	var p storage.Project
+	var createdAt, updatedAt string
+	if err := row.Scan(&p.ID, &p.Name, &p.Description, &p.Environment, &createdAt, &updatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("projectdb: project %q not found", id)
+		}
+		return nil, fmt.Errorf("projectdb: get project: %w", err)
+	}
+	p.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+	p.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
+	return &p, nil
+}
+
+func (s *Store) ListProjects(ctx context.Context, limit, offset int) ([]storage.Project, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+
+	var total int
+	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM projects").Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("projectdb: count projects: %w", err)
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, name, description, environment, created_at, updated_at
+		 FROM projects ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+		limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("projectdb: list projects: %w", err)
+	}
+	defer rows.Close()
+
+	var projects []storage.Project
+	for rows.Next() {
+		var p storage.Project
+		var createdAt, updatedAt string
+		if err := rows.Scan(&p.ID, &p.Name, &p.Description, &p.Environment, &createdAt, &updatedAt); err != nil {
+			return nil, 0, fmt.Errorf("projectdb: scan project: %w", err)
+		}
+		p.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+		p.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
+		projects = append(projects, p)
+	}
+	return projects, total, rows.Err()
+}
+
+func (s *Store) UpdateProject(ctx context.Context, p storage.Project) (*storage.Project, error) {
+	p.UpdatedAt = time.Now().UTC()
+
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE projects SET name = ?, description = ?, environment = ?, updated_at = ?
+		 WHERE id = ?`,
+		p.Name, p.Description, p.Environment, p.UpdatedAt.Format(time.RFC3339), p.ID)
+	if err != nil {
+		return nil, fmt.Errorf("projectdb: update project: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return nil, fmt.Errorf("projectdb: project %q not found", p.ID)
+	}
+	return s.GetProject(ctx, p.ID)
+}
+
+func (s *Store) DeleteProject(ctx context.Context, id string) error {
+	result, err := s.db.ExecContext(ctx, "DELETE FROM projects WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("projectdb: delete project: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("projectdb: project %q not found", id)
+	}
+	return nil
+}
+
+// --- API Key Management ---
+
+func (s *Store) CreateAPIKey(ctx context.Context, key storage.APIKey, fullKey string) (*storage.APIKey, error) {
+	if key.ID == "" {
+		key.ID = generateID()
+	}
+	now := time.Now().UTC()
+	key.CreatedAt = now
+	key.Active = true
+
+	// Hash the full key.
+	hash, err := bcrypt.GenerateFromPassword([]byte(fullKey), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, fmt.Errorf("projectdb: hash key: %w", err)
+	}
+	key.KeyHash = string(hash)
+	key.KeyPrefix = fullKey[:8]
+
+	expiresAt := ""
+	if !key.ExpiresAt.IsZero() {
+		expiresAt = key.ExpiresAt.Format(time.RFC3339)
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO api_keys (id, project_id, name, key_hash, key_prefix, active, created_at, expires_at)
+		 VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+		key.ID, key.ProjectID, key.Name, key.KeyHash, key.KeyPrefix,
+		key.CreatedAt.Format(time.RFC3339), expiresAt)
+	if err != nil {
+		return nil, fmt.Errorf("projectdb: create api key: %w", err)
+	}
+	return &key, nil
+}
+
+func (s *Store) ListAPIKeys(ctx context.Context, projectID string) ([]storage.APIKey, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, project_id, name, key_prefix, active, created_at, expires_at
+		 FROM api_keys WHERE project_id = ? ORDER BY created_at DESC`, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("projectdb: list api keys: %w", err)
+	}
+	defer rows.Close()
+
+	var keys []storage.APIKey
+	for rows.Next() {
+		var k storage.APIKey
+		var createdAt, expiresAt string
+		var active int
+		if err := rows.Scan(&k.ID, &k.ProjectID, &k.Name, &k.KeyPrefix, &active, &createdAt, &expiresAt); err != nil {
+			return nil, fmt.Errorf("projectdb: scan api key: %w", err)
+		}
+		k.Active = active == 1
+		k.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+		if expiresAt != "" {
+			k.ExpiresAt, _ = time.Parse(time.RFC3339, expiresAt)
+		}
+		keys = append(keys, k)
+	}
+	return keys, rows.Err()
+}
+
+func (s *Store) RevokeAPIKey(ctx context.Context, id string) error {
+	result, err := s.db.ExecContext(ctx, "UPDATE api_keys SET active = 0 WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("projectdb: revoke api key: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("projectdb: api key %q not found", id)
+	}
+	return nil
+}
+
+func (s *Store) ValidateAPIKey(ctx context.Context, rawKey string) (*storage.APIKey, error) {
+	if len(rawKey) < 8 {
+		return nil, fmt.Errorf("projectdb: invalid key format")
+	}
+	prefix := rawKey[:8]
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, project_id, name, key_hash, key_prefix, active, created_at, expires_at
+		 FROM api_keys WHERE key_prefix = ? AND active = 1`, prefix)
+	if err != nil {
+		return nil, fmt.Errorf("projectdb: validate key: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var k storage.APIKey
+		var createdAt, expiresAt string
+		var active int
+		if err := rows.Scan(&k.ID, &k.ProjectID, &k.Name, &k.KeyHash, &k.KeyPrefix, &active, &createdAt, &expiresAt); err != nil {
+			continue
+		}
+		k.Active = active == 1
+		k.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+		if expiresAt != "" {
+			k.ExpiresAt, _ = time.Parse(time.RFC3339, expiresAt)
+			if time.Now().After(k.ExpiresAt) {
+				continue // expired
+			}
+		}
+
+		// Check bcrypt hash.
+		if err := bcrypt.CompareHashAndPassword([]byte(k.KeyHash), []byte(rawKey)); err == nil {
+			return &k, nil
+		}
+	}
+	return nil, fmt.Errorf("projectdb: invalid api key")
+}
+
+// Close closes the database.
+func (s *Store) Close() error {
+	return s.db.Close()
+}
+
+// --- Helpers ---
+
+// GenerateAPIKey creates a cryptographically secure API key.
+// Format: cdla_<32 hex chars> (40 chars total).
+func GenerateAPIKey() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return "cdla_" + hex.EncodeToString(b)
+}
+
+func generateID() string {
+	b := make([]byte, 12)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/pkg/storage/projectdb/projectdb_test.go
+++ b/pkg/storage/projectdb/projectdb_test.go
@@ -1,0 +1,188 @@
+package projectdb
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+func setupTestStore(t *testing.T) *Store {
+	t.Helper()
+	path := t.TempDir() + "/test.db"
+	store, err := New(path)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	t.Cleanup(func() {
+		store.Close()
+		os.Remove(path)
+	})
+	return store
+}
+
+func TestProjectCRUD(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	// Create
+	p, err := store.CreateProject(ctx, storage.Project{
+		Name:        "Test Project",
+		Description: "A test project",
+		Environment: "dev",
+	})
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	if p.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if p.Name != "Test Project" {
+		t.Errorf("expected name 'Test Project', got %q", p.Name)
+	}
+	if p.Environment != "dev" {
+		t.Errorf("expected environment 'dev', got %q", p.Environment)
+	}
+
+	// Get
+	got, err := store.GetProject(ctx, p.ID)
+	if err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+	if got.Name != "Test Project" {
+		t.Errorf("expected name 'Test Project', got %q", got.Name)
+	}
+
+	// List
+	projects, total, err := store.ListProjects(ctx, 10, 0)
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("expected 1 total, got %d", total)
+	}
+	if len(projects) != 1 {
+		t.Errorf("expected 1 project, got %d", len(projects))
+	}
+
+	// Update
+	p.Name = "Updated Project"
+	p.Environment = "staging"
+	updated, err := store.UpdateProject(ctx, *p)
+	if err != nil {
+		t.Fatalf("UpdateProject: %v", err)
+	}
+	if updated.Name != "Updated Project" {
+		t.Errorf("expected updated name, got %q", updated.Name)
+	}
+	if updated.Environment != "staging" {
+		t.Errorf("expected environment 'staging', got %q", updated.Environment)
+	}
+
+	// Delete
+	if err := store.DeleteProject(ctx, p.ID); err != nil {
+		t.Fatalf("DeleteProject: %v", err)
+	}
+
+	_, err = store.GetProject(ctx, p.ID)
+	if err == nil {
+		t.Error("expected error after delete")
+	}
+}
+
+func TestAPIKeyCRUD(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	// Create project first.
+	p, err := store.CreateProject(ctx, storage.Project{
+		Name: "Key Test Project",
+	})
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	// Create API key.
+	fullKey := GenerateAPIKey()
+	key, err := store.CreateAPIKey(ctx, storage.APIKey{
+		ProjectID: p.ID,
+		Name:      "dev-key",
+	}, fullKey)
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	if key.KeyPrefix != fullKey[:8] {
+		t.Errorf("expected prefix %q, got %q", fullKey[:8], key.KeyPrefix)
+	}
+	if !key.Active {
+		t.Error("expected active key")
+	}
+
+	// List keys.
+	keys, err := store.ListAPIKeys(ctx, p.ID)
+	if err != nil {
+		t.Fatalf("ListAPIKeys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Errorf("expected 1 key, got %d", len(keys))
+	}
+
+	// Validate key.
+	validated, err := store.ValidateAPIKey(ctx, fullKey)
+	if err != nil {
+		t.Fatalf("ValidateAPIKey: %v", err)
+	}
+	if validated.ID != key.ID {
+		t.Errorf("expected key ID %q, got %q", key.ID, validated.ID)
+	}
+
+	// Wrong key should fail.
+	_, err = store.ValidateAPIKey(ctx, "cdla_0000000000000000000000000000")
+	if err == nil {
+		t.Error("expected error for wrong key")
+	}
+
+	// Revoke.
+	if err := store.RevokeAPIKey(ctx, key.ID); err != nil {
+		t.Fatalf("RevokeAPIKey: %v", err)
+	}
+
+	// Validation should fail after revoke.
+	_, err = store.ValidateAPIKey(ctx, fullKey)
+	if err == nil {
+		t.Error("expected error for revoked key")
+	}
+}
+
+func TestCascadeDelete(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	p, _ := store.CreateProject(ctx, storage.Project{Name: "Cascade Test"})
+	fullKey := GenerateAPIKey()
+	store.CreateAPIKey(ctx, storage.APIKey{ProjectID: p.ID, Name: "k1"}, fullKey)
+
+	// Delete project — should cascade to keys.
+	if err := store.DeleteProject(ctx, p.ID); err != nil {
+		t.Fatalf("DeleteProject: %v", err)
+	}
+
+	keys, err := store.ListAPIKeys(ctx, p.ID)
+	if err != nil {
+		t.Fatalf("ListAPIKeys after delete: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Errorf("expected 0 keys after cascade delete, got %d", len(keys))
+	}
+}
+
+func TestGenerateAPIKey(t *testing.T) {
+	key := GenerateAPIKey()
+	if len(key) != 37 { // "cdla_" (5) + 32 hex chars
+		t.Errorf("expected 37 char key, got %d: %q", len(key), key)
+	}
+	if key[:5] != "cdla_" {
+		t.Errorf("expected cdla_ prefix, got %q", key[:5])
+	}
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -225,3 +225,58 @@ type TraceStore interface {
 	SpanWriter
 	SpanReader
 }
+
+// --- Project & API Key Management ---
+
+// Project is a top-level organizational unit in Candela.
+type Project struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	Environment string    `json:"environment,omitempty"` // default env for all spans in the project
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// APIKey authenticates ingestion and queries for a project.
+type APIKey struct {
+	ID        string    `json:"id"`
+	ProjectID string    `json:"project_id"`
+	Name      string    `json:"name"`
+	KeyHash   string    `json:"-"`         // bcrypt hash (never exposed)
+	KeyPrefix string    `json:"key_prefix"` // first 8 chars for identification
+	Active    bool      `json:"active"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at,omitempty"`
+}
+
+// ProjectStore manages projects and API keys.
+type ProjectStore interface {
+	// CreateProject creates a new project.
+	CreateProject(ctx context.Context, p Project) (*Project, error)
+
+	// GetProject retrieves a project by ID.
+	GetProject(ctx context.Context, id string) (*Project, error)
+
+	// ListProjects returns all projects.
+	ListProjects(ctx context.Context, limit, offset int) ([]Project, int, error)
+
+	// UpdateProject updates a project's mutable fields (name, description, environment).
+	UpdateProject(ctx context.Context, p Project) (*Project, error)
+
+	// DeleteProject removes a project and its API keys.
+	DeleteProject(ctx context.Context, id string) error
+
+	// CreateAPIKey creates a new API key for a project.
+	// Returns the full key only at creation time.
+	CreateAPIKey(ctx context.Context, key APIKey, fullKey string) (*APIKey, error)
+
+	// ListAPIKeys returns all keys for a project.
+	ListAPIKeys(ctx context.Context, projectID string) ([]APIKey, error)
+
+	// RevokeAPIKey deactivates an API key.
+	RevokeAPIKey(ctx context.Context, id string) error
+
+	// ValidateAPIKey checks a raw key against stored hashes. Returns the key record if valid.
+	ValidateAPIKey(ctx context.Context, rawKey string) (*APIKey, error)
+}


### PR DESCRIPTION
### Project Management (2.11)
- `ProjectStore` interface + SQLite implementation (`candela-projects.db`)
- Full CRUD: Create, Get, List, Update, Delete with cascade
- ConnectRPC `ProjectHandler` wired to existing `ProjectService` proto

### API Key Management (2.12)
- Secure key generation (`cdla_<32 hex>`)
- bcrypt-hashed storage, prefix-based lookup
- Create, List, Revoke, Validate operations

### Environment Tagging (2.13)
- `Environment` field on Project struct

### Tests
4 tests: Project CRUD, API key lifecycle, cascade delete, key format