### PR TITLE
feat(ui): trace waterfall viewer with span detail panel

### DIFF
--- a/ui/e2e/app.spec.ts
+++ b/ui/e2e/app.spec.ts
@@ -121,6 +121,158 @@ test.describe("Traces", () => {
 });
 
 // ──────────────────────────────────────────
+// Trace Detail (Waterfall)
+// ──────────────────────────────────────────
+
+test.describe("Trace Waterfall", () => {
+  const mockTrace = {
+    trace: {
+      traceId: "abc123def456",
+      startTime: "2024-03-31T00:00:00Z",
+      endTime: "2024-03-31T00:00:01.500Z",
+      duration: "1.5s",
+      projectId: "proj-1",
+      environment: "production",
+      spanCount: 3,
+      totalTokens: "2500",
+      totalCostUsd: 0.0125,
+      rootSpanName: "chat_completion",
+      spans: [
+        {
+          spanId: "span-root",
+          traceId: "abc123def456",
+          parentSpanId: "",
+          name: "chat_completion",
+          kind: "SPAN_KIND_AGENT",
+          status: "SPAN_STATUS_OK",
+          statusMessage: "",
+          startTime: "2024-03-31T00:00:00Z",
+          endTime: "2024-03-31T00:00:01.500Z",
+          duration: "1.5s",
+          attributes: [],
+          events: [],
+          projectId: "proj-1",
+          environment: "production",
+          serviceName: "my-app",
+        },
+        {
+          spanId: "span-llm",
+          traceId: "abc123def456",
+          parentSpanId: "span-root",
+          name: "gpt-4o-mini",
+          kind: "SPAN_KIND_LLM",
+          status: "SPAN_STATUS_OK",
+          statusMessage: "",
+          startTime: "2024-03-31T00:00:00.100Z",
+          endTime: "2024-03-31T00:00:01.200Z",
+          duration: "1.1s",
+          genAi: {
+            model: "gpt-4o-mini",
+            provider: "openai",
+            inputTokens: "1500",
+            outputTokens: "1000",
+            totalTokens: "2500",
+            costUsd: 0.0125,
+            temperature: 0.7,
+            inputContent: "Hello, how are you?",
+            outputContent: "I'm doing great, thanks for asking!",
+          },
+          attributes: [
+            { key: "gen_ai.system", stringValue: "openai" },
+          ],
+          events: [],
+          projectId: "proj-1",
+          environment: "production",
+          serviceName: "my-app",
+        },
+        {
+          spanId: "span-tool",
+          traceId: "abc123def456",
+          parentSpanId: "span-root",
+          name: "search_web",
+          kind: "SPAN_KIND_TOOL",
+          status: "SPAN_STATUS_OK",
+          statusMessage: "",
+          startTime: "2024-03-31T00:00:00.050Z",
+          endTime: "2024-03-31T00:00:00.090Z",
+          duration: "0.040s",
+          tool: {
+            toolName: "search_web",
+            toolInput: '{"query": "weather today"}',
+            toolOutput: '{"result": "sunny, 72°F"}',
+          },
+          attributes: [],
+          events: [],
+          projectId: "proj-1",
+          environment: "production",
+          serviceName: "my-app",
+        },
+      ],
+    },
+  };
+
+  test("renders waterfall with span tree", async ({ page }) => {
+    await mockConnectRPC(page, "/candela.v1.TraceService/GetTrace", mockTrace);
+    await page.goto("/traces/abc123def456");
+
+    // Summary bar
+    await expect(page.locator(".trace-summary-value").first()).toBeVisible();
+    await expect(page.locator(".trace-summary-item").filter({ hasText: "Duration" }).locator(".trace-summary-value")).toHaveText("1500ms");
+    await expect(page.locator("text=$0.0125")).toBeVisible();
+
+    // Waterfall rows
+    await expect(page.locator(".waterfall-row")).toHaveCount(3);
+
+    // Span kind badges
+    await expect(page.locator(".waterfall-kind").filter({ hasText: "AGENT" })).toBeVisible();
+    await expect(page.locator(".waterfall-kind").filter({ hasText: "LLM" })).toBeVisible();
+    await expect(page.locator(".waterfall-kind").filter({ hasText: "TOOL" })).toBeVisible();
+  });
+
+  test("shows span detail on click", async ({ page }) => {
+    await mockConnectRPC(page, "/candela.v1.TraceService/GetTrace", mockTrace);
+    await page.goto("/traces/abc123def456");
+
+    // Click the LLM span
+    await page.locator(".waterfall-row").nth(2).click();
+
+    // Detail panel should appear
+    await expect(page.locator(".span-detail")).toBeVisible();
+    await expect(page.locator(".span-detail h3")).toContainText("gpt-4o-mini");
+
+    // GenAI section
+    await expect(page.locator(".span-meta-value").filter({ hasText: "openai" })).toBeVisible();
+    await expect(page.locator("text=1,500")).toBeVisible(); // input tokens
+  });
+
+  test("shows prompt and completion content", async ({ page }) => {
+    await mockConnectRPC(page, "/candela.v1.TraceService/GetTrace", mockTrace);
+    await page.goto("/traces/abc123def456");
+
+    // Click the LLM span
+    await page.locator(".waterfall-row").nth(2).click();
+
+    // Prompt & completion
+    await expect(page.locator("text=Hello, how are you?")).toBeVisible();
+    await expect(page.locator("text=I'm doing great, thanks for asking!")).toBeVisible();
+  });
+
+  test("shows back button that navigates to traces list", async ({ page }) => {
+    await mockConnectRPC(page, "/candela.v1.TraceService/GetTrace", mockTrace);
+    await page.goto("/traces/abc123def456");
+
+    await expect(page.locator("text=← Back")).toBeVisible();
+  });
+
+  test("shows error when backend is down", async ({ page }) => {
+    await page.goto("/traces/nonexistent");
+    await expect(
+      page.locator(".card-title").filter({ hasText: /unavailable|error/i })
+    ).toBeVisible();
+  });
+});
+
+// ──────────────────────────────────────────
 // Projects — with mocked ConnectRPC
 // ──────────────────────────────────────────
 

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -435,3 +435,311 @@ tr:hover td {
   font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
   font-size: 12px;
 }
+
+/* ──────────────────────────────────────────
+   Trace Waterfall
+   ────────────────────────────────────────── */
+
+/* Summary bar */
+.trace-summary-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  padding: 16px 20px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  margin-bottom: 16px;
+}
+
+.trace-summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.trace-summary-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+.trace-summary-value {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+/* Split layout */
+.waterfall-split {
+  display: flex;
+  gap: 16px;
+  min-height: 400px;
+}
+
+.waterfall-panel {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.detail-panel {
+  width: 420px;
+  flex-shrink: 0;
+  overflow-y: auto;
+  max-height: calc(100vh - 200px);
+}
+
+/* Waterfall header */
+.waterfall-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+/* Time ruler */
+.waterfall-ruler {
+  position: relative;
+  height: 24px;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-left: 260px;
+  margin-right: 16px;
+  background: repeating-linear-gradient(
+    90deg,
+    var(--border-subtle) 0px,
+    var(--border-subtle) 1px,
+    transparent 1px,
+    transparent 25%
+  );
+}
+
+.waterfall-ruler-label {
+  position: absolute;
+  top: 4px;
+  font-size: 10px;
+  color: var(--text-muted);
+  font-family: 'SF Mono', monospace;
+}
+
+/* Waterfall body */
+.waterfall-body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+/* Span row */
+.waterfall-row {
+  display: flex;
+  height: 36px;
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+
+.waterfall-row:hover {
+  background: var(--bg-hover);
+}
+
+.waterfall-row-selected {
+  background: var(--accent-dim) !important;
+  border-left: 2px solid var(--accent);
+}
+
+.waterfall-row:last-child {
+  border-bottom: none;
+}
+
+/* Span label (left side) */
+.waterfall-label {
+  width: 260px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  border-right: 1px solid var(--border-subtle);
+}
+
+.waterfall-connector {
+  width: 8px;
+  height: 1px;
+  background: var(--border);
+  flex-shrink: 0;
+}
+
+.waterfall-kind {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 5px;
+  border: 1px solid;
+  border-radius: 3px;
+  flex-shrink: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.waterfall-name {
+  font-size: 12px;
+  font-weight: 450;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-primary);
+}
+
+/* Waterfall bar (right side) */
+.waterfall-bar-container {
+  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  padding: 0 16px;
+}
+
+.waterfall-bar {
+  position: absolute;
+  height: 14px;
+  border-radius: 3px;
+  opacity: 0.7;
+  min-width: 2px;
+  transition: opacity 0.15s ease;
+}
+
+.waterfall-row:hover .waterfall-bar {
+  opacity: 1;
+}
+
+.waterfall-duration {
+  position: absolute;
+  font-size: 10px;
+  color: var(--text-muted);
+  font-family: 'SF Mono', monospace;
+  white-space: nowrap;
+}
+
+/* ──────────────────────────────────────────
+   Span Detail Panel
+   ────────────────────────────────────────── */
+
+.span-detail {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+}
+
+.span-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.span-detail-header h3 {
+  font-size: 15px;
+  font-weight: 600;
+  word-break: break-all;
+}
+
+.span-meta-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.span-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.span-meta-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+.span-meta-value {
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.span-section {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.span-section h4 {
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+/* Content blocks (prompt/completion) */
+.span-content-block {
+  margin-top: 12px;
+}
+
+.span-content-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.span-content-pre {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 12px;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 300px;
+  overflow-y: auto;
+  color: var(--text-secondary);
+}
+
+/* Attribute table */
+.span-attr-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.span-attr-table td {
+  padding: 6px 8px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.span-attr-key {
+  color: var(--accent);
+  width: 40%;
+  word-break: break-all;
+}
+
+.span-attr-val {
+  color: var(--text-secondary);
+  word-break: break-all;
+}
+

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { createClient } from "@connectrpc/connect";
 import { transport } from "@/lib/connect";
 import { DashboardService } from "@/gen/v1/dashboard_service_pb";
@@ -92,9 +93,9 @@ export default function DashboardPage() {
         <div className="table-container animate-in" style={{ animationDelay: "0.1s" }}>
           <div className="table-header">
             <span className="table-title">Recent Traces</span>
-            <a href="/traces" className="btn">
+            <Link href="/traces" className="btn">
               View all →
-            </a>
+            </Link>
           </div>
           <div className="empty-state">
             <div className="empty-state-icon">🕯️</div>

--- a/ui/src/app/traces/[id]/page.tsx
+++ b/ui/src/app/traces/[id]/page.tsx
@@ -1,0 +1,540 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { createClient } from "@connectrpc/connect";
+import { transport } from "@/lib/connect";
+import { TraceService } from "@/gen/v1/trace_service_pb";
+import type { Span } from "@/gen/types/trace_pb";
+import { SpanKind, SpanStatus } from "@/gen/types/trace_pb";
+
+// ──────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────
+
+interface SpanNode {
+  span: Span;
+  children: SpanNode[];
+  depth: number;
+  /** Offset from trace start in ms */
+  offsetMs: number;
+  /** Duration in ms */
+  durationMs: number;
+}
+
+interface TraceData {
+  traceId: string;
+  rootSpanName: string;
+  totalDurationMs: number;
+  totalTokens: number;
+  totalCostUsd: number;
+  spanCount: number;
+  environment: string;
+  startTime: string;
+  tree: SpanNode[];
+  flatSpans: SpanNode[];
+}
+
+// ──────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────
+
+function tsToMs(ts?: { seconds: bigint; nanos: number }): number {
+  if (!ts) return 0;
+  return Number(ts.seconds) * 1000 + (ts.nanos ?? 0) / 1e6;
+}
+
+function durationToMs(d?: { seconds: bigint; nanos: number }): number {
+  if (!d) return 0;
+  return Number(d.seconds) * 1000 + (d.nanos ?? 0) / 1e6;
+}
+
+function kindLabel(kind: SpanKind): string {
+  const map: Record<SpanKind, string> = {
+    [SpanKind.UNSPECIFIED]: "span",
+    [SpanKind.LLM]: "LLM",
+    [SpanKind.AGENT]: "Agent",
+    [SpanKind.TOOL]: "Tool",
+    [SpanKind.RETRIEVAL]: "RAG",
+    [SpanKind.EMBEDDING]: "Embed",
+    [SpanKind.CHAIN]: "Chain",
+    [SpanKind.GENERAL]: "General",
+  };
+  return map[kind] ?? "span";
+}
+
+function kindColor(kind: SpanKind): string {
+  const map: Record<SpanKind, string> = {
+    [SpanKind.UNSPECIFIED]: "var(--text-secondary)",
+    [SpanKind.LLM]: "#a78bfa",
+    [SpanKind.AGENT]: "#f59e0b",
+    [SpanKind.TOOL]: "#34d399",
+    [SpanKind.RETRIEVAL]: "#60a5fa",
+    [SpanKind.EMBEDDING]: "#f472b6",
+    [SpanKind.CHAIN]: "#fb923c",
+    [SpanKind.GENERAL]: "var(--text-secondary)",
+  };
+  return map[kind] ?? "var(--text-secondary)";
+}
+
+function buildTree(spans: Span[], traceStartMs: number): SpanNode[] {
+  const nodeMap = new Map<string, SpanNode>();
+
+  // Create nodes
+  for (const span of spans) {
+    nodeMap.set(span.spanId, {
+      span,
+      children: [],
+      depth: 0,
+      offsetMs: tsToMs(span.startTime) - traceStartMs,
+      durationMs: durationToMs(span.duration),
+    });
+  }
+
+  // Build tree
+  const roots: SpanNode[] = [];
+  for (const node of nodeMap.values()) {
+    if (node.span.parentSpanId && nodeMap.has(node.span.parentSpanId)) {
+      const parent = nodeMap.get(node.span.parentSpanId)!;
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  // Set depths and sort children by start time
+  function setDepth(node: SpanNode, depth: number) {
+    node.depth = depth;
+    node.children.sort((a, b) => a.offsetMs - b.offsetMs);
+    for (const child of node.children) {
+      setDepth(child, depth + 1);
+    }
+  }
+  roots.sort((a, b) => a.offsetMs - b.offsetMs);
+  for (const root of roots) setDepth(root, 0);
+
+  return roots;
+}
+
+function flattenTree(nodes: SpanNode[]): SpanNode[] {
+  const result: SpanNode[] = [];
+  function walk(node: SpanNode) {
+    result.push(node);
+    for (const child of node.children) walk(child);
+  }
+  for (const n of nodes) walk(n);
+  return result;
+}
+
+// ──────────────────────────────────────────
+// Components
+// ──────────────────────────────────────────
+
+function SpanRow({
+  node,
+  totalDurationMs,
+  selected,
+  onClick,
+}: {
+  node: SpanNode;
+  totalDurationMs: number;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  const leftPct = totalDurationMs > 0 ? (node.offsetMs / totalDurationMs) * 100 : 0;
+  const widthPct = totalDurationMs > 0 ? Math.max((node.durationMs / totalDurationMs) * 100, 0.5) : 100;
+  const color = kindColor(node.span.kind);
+  const isError = node.span.status === SpanStatus.ERROR;
+
+  return (
+    <div
+      className={`waterfall-row ${selected ? "waterfall-row-selected" : ""}`}
+      onClick={onClick}
+      role="button"
+      tabIndex={0}
+    >
+      {/* Left: span label with tree indentation */}
+      <div className="waterfall-label" style={{ paddingLeft: node.depth * 20 + 8 }}>
+        <span className="waterfall-connector" />
+        <span
+          className="waterfall-kind"
+          style={{ color, borderColor: color }}
+        >
+          {kindLabel(node.span.kind)}
+        </span>
+        <span className="waterfall-name" title={node.span.name}>
+          {node.span.name}
+        </span>
+        {isError && <span className="badge badge-error" style={{ marginLeft: 6, fontSize: 10 }}>ERR</span>}
+      </div>
+
+      {/* Right: waterfall bar */}
+      <div className="waterfall-bar-container">
+        <div
+          className="waterfall-bar"
+          style={{
+            left: `${leftPct}%`,
+            width: `${widthPct}%`,
+            backgroundColor: isError ? "var(--error)" : color,
+          }}
+        />
+        <span
+          className="waterfall-duration"
+          style={{ left: `${Math.min(leftPct + widthPct + 1, 95)}%` }}
+        >
+          {node.durationMs.toFixed(0)}ms
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function SpanDetail({ node }: { node: SpanNode }) {
+  const { span } = node;
+  const genAi = span.genAi;
+  const tool = span.tool;
+
+  return (
+    <div className="span-detail animate-in">
+      <div className="span-detail-header">
+        <h3>{span.name}</h3>
+        <span
+          className="waterfall-kind"
+          style={{
+            color: kindColor(span.kind),
+            borderColor: kindColor(span.kind),
+          }}
+        >
+          {kindLabel(span.kind)}
+        </span>
+      </div>
+
+      {/* Metadata grid */}
+      <div className="span-meta-grid">
+        <div className="span-meta-item">
+          <span className="span-meta-label">Span ID</span>
+          <span className="span-meta-value mono">{span.spanId}</span>
+        </div>
+        <div className="span-meta-item">
+          <span className="span-meta-label">Duration</span>
+          <span className="span-meta-value">{node.durationMs.toFixed(1)}ms</span>
+        </div>
+        <div className="span-meta-item">
+          <span className="span-meta-label">Status</span>
+          <span className="span-meta-value">
+            <span className={`badge ${span.status === SpanStatus.ERROR ? "badge-error" : "badge-success"}`}>
+              {span.status === SpanStatus.ERROR ? "Error" : "OK"}
+            </span>
+          </span>
+        </div>
+        {span.statusMessage && (
+          <div className="span-meta-item" style={{ gridColumn: "1 / -1" }}>
+            <span className="span-meta-label">Error Message</span>
+            <span className="span-meta-value" style={{ color: "var(--error)" }}>{span.statusMessage}</span>
+          </div>
+        )}
+        {span.serviceName && (
+          <div className="span-meta-item">
+            <span className="span-meta-label">Service</span>
+            <span className="span-meta-value">{span.serviceName}</span>
+          </div>
+        )}
+      </div>
+
+      {/* GenAI attributes */}
+      {genAi && (genAi.model || Number(genAi.totalTokens) > 0) && (
+        <div className="span-section">
+          <h4>🤖 GenAI</h4>
+          <div className="span-meta-grid">
+            {genAi.model && (
+              <div className="span-meta-item">
+                <span className="span-meta-label">Model</span>
+                <span className="span-meta-value mono">{genAi.model}</span>
+              </div>
+            )}
+            {genAi.provider && (
+              <div className="span-meta-item">
+                <span className="span-meta-label">Provider</span>
+                <span className="span-meta-value">{genAi.provider}</span>
+              </div>
+            )}
+            {Number(genAi.inputTokens) > 0 && (
+              <div className="span-meta-item">
+                <span className="span-meta-label">Input Tokens</span>
+                <span className="span-meta-value">{Number(genAi.inputTokens).toLocaleString()}</span>
+              </div>
+            )}
+            {Number(genAi.outputTokens) > 0 && (
+              <div className="span-meta-item">
+                <span className="span-meta-label">Output Tokens</span>
+                <span className="span-meta-value">{Number(genAi.outputTokens).toLocaleString()}</span>
+              </div>
+            )}
+            {genAi.costUsd > 0 && (
+              <div className="span-meta-item">
+                <span className="span-meta-label">Cost</span>
+                <span className="span-meta-value">${genAi.costUsd.toFixed(6)}</span>
+              </div>
+            )}
+            {genAi.temperature > 0 && (
+              <div className="span-meta-item">
+                <span className="span-meta-label">Temperature</span>
+                <span className="span-meta-value">{genAi.temperature}</span>
+              </div>
+            )}
+          </div>
+
+          {/* Prompt / Completion */}
+          {genAi.inputContent && (
+            <div className="span-content-block">
+              <div className="span-content-label">📥 Prompt</div>
+              <pre className="span-content-pre">{genAi.inputContent}</pre>
+            </div>
+          )}
+          {genAi.outputContent && (
+            <div className="span-content-block">
+              <div className="span-content-label">📤 Completion</div>
+              <pre className="span-content-pre">{genAi.outputContent}</pre>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Tool attributes */}
+      {tool && tool.toolName && (
+        <div className="span-section">
+          <h4>🔧 Tool Call</h4>
+          <div className="span-meta-grid">
+            <div className="span-meta-item">
+              <span className="span-meta-label">Tool</span>
+              <span className="span-meta-value mono">{tool.toolName}</span>
+            </div>
+          </div>
+          {tool.toolInput && (
+            <div className="span-content-block">
+              <div className="span-content-label">Input</div>
+              <pre className="span-content-pre">{tool.toolInput}</pre>
+            </div>
+          )}
+          {tool.toolOutput && (
+            <div className="span-content-block">
+              <div className="span-content-label">Output</div>
+              <pre className="span-content-pre">{tool.toolOutput}</pre>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Custom attributes */}
+      {span.attributes.length > 0 && (
+        <div className="span-section">
+          <h4>📋 Attributes</h4>
+          <table className="span-attr-table">
+            <tbody>
+              {span.attributes.map((attr, i) => (
+                <tr key={i}>
+                  <td className="span-attr-key mono">{attr.key}</td>
+                  <td className="span-attr-val">
+                    {attr.value.case
+                      ? String(attr.value.value)
+                      : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────
+// Page
+// ──────────────────────────────────────────
+
+export default function TraceDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const traceId = params.id as string;
+
+  const [trace, setTrace] = useState<TraceData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const client = createClient(TraceService, transport);
+    client
+      .getTrace({ traceId })
+      .then((res) => {
+        if (!res.trace) {
+          setError("Trace not found");
+          return;
+        }
+        const t = res.trace;
+        const traceStartMs = tsToMs(t.startTime);
+        const tree = buildTree(t.spans, traceStartMs);
+        const flatSpans = flattenTree(tree);
+
+        setTrace({
+          traceId: t.traceId,
+          rootSpanName: t.rootSpanName || "unknown",
+          totalDurationMs: durationToMs(t.duration),
+          totalTokens: Number(t.totalTokens) || 0,
+          totalCostUsd: t.totalCostUsd || 0,
+          spanCount: t.spanCount || t.spans.length,
+          environment: t.environment || "—",
+          startTime: t.startTime
+            ? new Date(traceStartMs).toLocaleString()
+            : "—",
+          tree,
+          flatSpans,
+        });
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [traceId]);
+
+  const selectedNode = trace?.flatSpans.find(
+    (n) => n.span.spanId === selectedSpanId
+  );
+
+  return (
+    <>
+      <header className="main-header">
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <button
+            className="btn"
+            onClick={() => router.push("/traces")}
+            style={{ padding: "6px 12px" }}
+          >
+            ← Back
+          </button>
+          <h1 style={{ margin: 0 }}>
+            {loading ? "Loading..." : trace?.rootSpanName ?? "Trace"}
+          </h1>
+        </div>
+        {trace && (
+          <div className="mono" style={{ fontSize: 12, color: "var(--text-muted)" }}>
+            {trace.traceId}
+          </div>
+        )}
+      </header>
+
+      <div className="main-body">
+        {error && (
+          <div
+            className="card animate-in"
+            style={{
+              borderColor: "var(--error)",
+              marginBottom: 24,
+              background: "rgba(248,113,113,0.05)",
+            }}
+          >
+            <div className="card-title" style={{ color: "var(--error)" }}>
+              {error.includes("fetch") ? "Backend Unavailable" : "Error"}
+            </div>
+            <div style={{ fontSize: 13, color: "var(--text-secondary)" }}>
+              {error}
+            </div>
+          </div>
+        )}
+
+        {trace && (
+          <>
+            {/* Summary cards */}
+            <div className="trace-summary-bar animate-in">
+              <div className="trace-summary-item">
+                <span className="trace-summary-label">Duration</span>
+                <span className="trace-summary-value">
+                  {trace.totalDurationMs.toFixed(0)}ms
+                </span>
+              </div>
+              <div className="trace-summary-item">
+                <span className="trace-summary-label">Spans</span>
+                <span className="trace-summary-value">{trace.spanCount}</span>
+              </div>
+              <div className="trace-summary-item">
+                <span className="trace-summary-label">Tokens</span>
+                <span className="trace-summary-value">
+                  {trace.totalTokens.toLocaleString()}
+                </span>
+              </div>
+              <div className="trace-summary-item">
+                <span className="trace-summary-label">Cost</span>
+                <span className="trace-summary-value">
+                  ${trace.totalCostUsd.toFixed(4)}
+                </span>
+              </div>
+              <div className="trace-summary-item">
+                <span className="trace-summary-label">Environment</span>
+                <span className="badge badge-info">{trace.environment}</span>
+              </div>
+              <div className="trace-summary-item">
+                <span className="trace-summary-label">Started</span>
+                <span className="trace-summary-value" style={{ fontSize: 12 }}>
+                  {trace.startTime}
+                </span>
+              </div>
+            </div>
+
+            {/* Waterfall + Detail split */}
+            <div className="waterfall-split">
+              {/* Waterfall panel */}
+              <div className="waterfall-panel animate-in">
+                <div className="waterfall-header">
+                  <span className="table-title">Span Waterfall</span>
+                  <span style={{ fontSize: 12, color: "var(--text-muted)" }}>
+                    {trace.totalDurationMs.toFixed(0)}ms total
+                  </span>
+                </div>
+                {/* Time ruler */}
+                <div className="waterfall-ruler">
+                  <div className="waterfall-ruler-label" style={{ left: 0 }}>0ms</div>
+                  <div className="waterfall-ruler-label" style={{ left: "25%" }}>
+                    {(trace.totalDurationMs * 0.25).toFixed(0)}ms
+                  </div>
+                  <div className="waterfall-ruler-label" style={{ left: "50%" }}>
+                    {(trace.totalDurationMs * 0.5).toFixed(0)}ms
+                  </div>
+                  <div className="waterfall-ruler-label" style={{ left: "75%" }}>
+                    {(trace.totalDurationMs * 0.75).toFixed(0)}ms
+                  </div>
+                  <div className="waterfall-ruler-label" style={{ right: 0 }}>
+                    {trace.totalDurationMs.toFixed(0)}ms
+                  </div>
+                </div>
+                {/* Span rows */}
+                <div className="waterfall-body">
+                  {trace.flatSpans.map((node) => (
+                    <SpanRow
+                      key={node.span.spanId}
+                      node={node}
+                      totalDurationMs={trace.totalDurationMs}
+                      selected={node.span.spanId === selectedSpanId}
+                      onClick={() =>
+                        setSelectedSpanId(
+                          node.span.spanId === selectedSpanId
+                            ? null
+                            : node.span.spanId
+                        )
+                      }
+                    />
+                  ))}
+                </div>
+              </div>
+
+              {/* Detail panel */}
+              {selectedNode && (
+                <div className="detail-panel">
+                  <SpanDetail node={selectedNode} />
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/ui/src/app/traces/page.tsx
+++ b/ui/src/app/traces/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { createClient } from "@connectrpc/connect";
 import { transport } from "@/lib/connect";
 import { TraceService } from "@/gen/v1/trace_service_pb";
@@ -22,6 +23,7 @@ export default function TracesPage() {
   const [traces, setTraces] = useState<TraceSummaryRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     const client = createClient(TraceService, transport);
@@ -127,7 +129,7 @@ export default function TracesPage() {
                 {traces.map((t) => {
                   const st = statusLabel(t.status);
                   return (
-                    <tr key={t.traceId} style={{ cursor: "pointer" }}>
+                    <tr key={t.traceId} style={{ cursor: "pointer" }} onClick={() => router.push(`/traces/${t.traceId}`)}>
                       <td>
                         <span className="mono">{t.traceId.slice(0, 12)}…</span>
                       </td>


### PR DESCRIPTION
## Trace Waterfall Viewer (Feature 2.2)

The core trace visualization feature — click any trace in the list to see its full span hierarchy as an interactive waterfall.

### What's New

**`/traces/[id]` page:**
- **Summary bar** — duration, span count, total tokens, cost, environment, timestamp
- **Waterfall timeline** — tree-structured spans with horizontal timing bars
- **Time ruler** — gridlines at 0%, 25%, 50%, 75%, 100% of trace duration
- **Color-coded span kinds** — LLM (purple), Agent (amber), Tool (green), RAG (blue), Embedding (pink), Chain (orange)
- **Span detail panel** — click any span to see:
  - GenAI attributes (model, provider, tokens, cost, temperature)
  - Prompt/completion content in scrollable code blocks
  - Tool call input/output (JSON)
  - Custom OTel attributes table
- **Error highlighting** — red bars + ERR badge for failed spans

**Traces list:**  
- Rows now click through to `/traces/{traceId}`

### Testing
- 5 new Playwright E2E tests (17 total, all passing)
- Covers: waterfall rendering, span click → detail, prompt/completion display, back navigation, error state
- Uses correct protobuf JSON mock format (RFC 3339 timestamps, duration strings)