### PR TITLE
feat(ui): trace search, filters, and sorting

### DIFF
--- a/ui/e2e/app.spec.ts
+++ b/ui/e2e/app.spec.ts
@@ -118,6 +118,79 @@ test.describe("Traces", () => {
       page.locator(".card-title").filter({ hasText: "Could not load traces" })
     ).toBeVisible();
   });
+
+  test("renders search bar and filter controls", async ({ page }) => {
+    await mockConnectRPC(page, "/candela.v1.TraceService/ListTraces", {
+      traces: [],
+    });
+
+    await page.goto("/traces");
+    await expect(page.locator(".filter-search-input")).toBeVisible();
+    await expect(page.locator(".filter-search-input")).toHaveAttribute(
+      "placeholder",
+      "Search traces by name..."
+    );
+    // Sort dropdown
+    await expect(page.locator(".filter-select")).toBeVisible();
+    // Sort direction button
+    await expect(page.locator(".filter-dir-btn")).toBeVisible();
+  });
+
+  test("opens filter panel on click", async ({ page }) => {
+    await mockConnectRPC(page, "/candela.v1.TraceService/ListTraces", {
+      traces: [],
+    });
+
+    await page.goto("/traces");
+    // Panel should be hidden initially
+    await expect(page.locator(".filter-panel")).not.toBeVisible();
+
+    // Click filters button
+    await page.locator(".btn").filter({ hasText: "Filters" }).click();
+    await expect(page.locator(".filter-panel")).toBeVisible();
+
+    // Should show Model, Provider, Status filters
+    await expect(page.locator(".filter-label").filter({ hasText: "Model" })).toBeVisible();
+    await expect(page.locator(".filter-label").filter({ hasText: "Provider" })).toBeVisible();
+    await expect(page.locator(".filter-label").filter({ hasText: "Status" })).toBeVisible();
+  });
+
+  test("shows filtered empty state", async ({ page }) => {
+    await mockConnectRPC(page, "/candela.v1.TraceService/ListTraces", {
+      traces: [],
+    });
+
+    await page.goto("/traces");
+    // Type in search
+    await page.locator(".filter-search-input").fill("nonexistent-trace");
+    await page.waitForTimeout(400); // wait for debounce
+
+    await expect(page.locator(".empty-state-title")).toHaveText("No traces match filters");
+  });
+
+  test("shows trace count in table header", async ({ page }) => {
+    await mockConnectRPC(page, "/candela.v1.TraceService/ListTraces", {
+      traces: [
+        {
+          traceId: "trace-1",
+          rootSpanName: "chat",
+          primaryModel: "gpt-4o",
+          primaryProvider: "openai",
+          environment: "prod",
+          duration: "0.5s",
+          totalTokens: "100",
+          totalCostUsd: 0.001,
+          status: 1,
+          startTime: "2024-03-31T00:00:00Z",
+          spanCount: 2,
+          llmCallCount: 1,
+        },
+      ],
+    });
+
+    await page.goto("/traces");
+    await expect(page.locator(".table-title")).toHaveText("1 trace");
+  });
 });
 
 // ──────────────────────────────────────────

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -743,3 +743,175 @@ tr:hover td {
   word-break: break-all;
 }
 
+/* ──────────────────────────────────────────
+   Filter Bar & Search
+   ────────────────────────────────────────── */
+
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.filter-search {
+  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.filter-search-icon {
+  position: absolute;
+  left: 12px;
+  font-size: 14px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.filter-search-input {
+  width: 100%;
+  padding: 10px 36px 10px 36px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.filter-search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.filter-search-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-dim);
+}
+
+.filter-clear-btn {
+  position: absolute;
+  right: 8px;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.filter-clear-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.btn-active {
+  background: var(--accent-dim) !important;
+  border-color: var(--accent) !important;
+  color: var(--accent) !important;
+}
+
+.filter-sort {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.filter-select {
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.15s ease;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%236b7280' viewBox='0 0 16 16'%3E%3Cpath d='M4 6l4 4 4-4'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  padding-right: 28px;
+}
+
+.filter-select:focus {
+  border-color: var(--accent);
+}
+
+.filter-dir-btn {
+  padding: 8px 10px !important;
+  font-size: 14px !important;
+  min-width: 36px;
+  text-align: center;
+}
+
+/* Expanded filter panel */
+.filter-panel {
+  display: flex;
+  align-items: flex-end;
+  gap: 16px;
+  padding: 16px 20px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 160px;
+}
+
+.filter-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+.filter-input {
+  padding: 8px 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.filter-input::placeholder {
+  color: var(--text-muted);
+}
+
+.filter-input:focus {
+  border-color: var(--accent);
+}
+
+.filter-reset-btn {
+  color: var(--error) !important;
+  border-color: transparent !important;
+  background: rgba(248, 113, 113, 0.08) !important;
+  font-size: 12px !important;
+  align-self: flex-end;
+}
+
+.filter-reset-btn:hover {
+  background: rgba(248, 113, 113, 0.15) !important;
+}
+
+.badge-info {
+  background: var(--accent-dim);
+  color: var(--accent);
+}

--- a/ui/src/app/traces/page.tsx
+++ b/ui/src/app/traces/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@connectrpc/connect";
 import { transport } from "@/lib/connect";
@@ -10,6 +10,7 @@ interface TraceSummaryRow {
   traceId: string;
   rootSpanName: string;
   primaryModel: string;
+  primaryProvider: string;
   environment: string;
   durationMs: number;
   totalTokens: number;
@@ -17,65 +18,241 @@ interface TraceSummaryRow {
   status: number;
   startTime: string;
   spanCount: number;
+  llmCallCount: number;
 }
+
+interface Filters {
+  search: string;
+  model: string;
+  provider: string;
+  status: "" | "ok" | "error";
+  orderBy: string;
+  descending: boolean;
+}
+
+const DEFAULT_FILTERS: Filters = {
+  search: "",
+  model: "",
+  provider: "",
+  status: "",
+  orderBy: "start_time",
+  descending: true,
+};
 
 export default function TracesPage() {
   const [traces, setTraces] = useState<TraceSummaryRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
+  const [filtersOpen, setFiltersOpen] = useState(false);
   const router = useRouter();
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const fetchTraces = useCallback(
+    (f: Filters) => {
+      setLoading(true);
+      setError(null);
+      const client = createClient(TraceService, transport);
+      client
+        .listTraces({
+          pagination: { pageSize: 100 },
+          search: f.search,
+          model: f.model,
+          provider: f.provider,
+          status: f.status === "ok" ? 1 : f.status === "error" ? 2 : 0,
+          orderBy: f.orderBy,
+          descending: f.descending,
+        })
+        .then((res) => {
+          const mapped = (res.traces || []).map((t) => {
+            const durSeconds = Number(t.duration?.seconds ?? 0);
+            const durNanos = Number(t.duration?.nanos ?? 0);
+            const durationMs = durSeconds * 1000 + durNanos / 1e6;
+
+            return {
+              traceId: t.traceId,
+              rootSpanName: t.rootSpanName || "unknown",
+              primaryModel: t.primaryModel || "—",
+              primaryProvider: t.primaryProvider || "—",
+              environment: t.environment || "—",
+              durationMs,
+              totalTokens: Number(t.totalTokens) || 0,
+              totalCostUsd: t.totalCostUsd || 0,
+              status: t.status,
+              spanCount: t.spanCount || 0,
+              llmCallCount: t.llmCallCount || 0,
+              startTime: t.startTime
+                ? new Date(
+                    Number(t.startTime.seconds) * 1000 +
+                      Math.floor(Number(t.startTime.nanos) / 1e6)
+                  ).toLocaleString()
+                : "—",
+            };
+          });
+          setTraces(mapped);
+        })
+        .catch((err) => setError(err.message))
+        .finally(() => setLoading(false));
+    },
+    []
+  );
+
+  // Initial fetch
   useEffect(() => {
-    const client = createClient(TraceService, transport);
-    client
-      .listTraces({ pagination: { pageSize: 50 } })
-      .then((res) => {
-        const mapped = (res.traces || []).map((t) => {
-          const durSeconds = Number(t.duration?.seconds ?? 0);
-          const durNanos = Number(t.duration?.nanos ?? 0);
-          const durationMs = durSeconds * 1000 + durNanos / 1e6;
-
-          return {
-            traceId: t.traceId,
-            rootSpanName: t.rootSpanName || "unknown",
-            primaryModel: t.primaryModel || "—",
-            environment: t.environment || "—",
-            durationMs,
-            totalTokens: Number(t.totalTokens) || 0,
-            totalCostUsd: t.totalCostUsd || 0,
-            status: t.status,
-            spanCount: t.spanCount || 0,
-            startTime: t.startTime
-              ? new Date(
-                  Number(t.startTime.seconds) * 1000 +
-                    Math.floor(Number(t.startTime.nanos) / 1e6)
-                ).toLocaleString()
-              : "—",
-          };
-        });
-        setTraces(mapped);
-      })
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
+    fetchTraces(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Debounced filter changes
+  const updateFilters = useCallback(
+    (patch: Partial<Filters>) => {
+      const next = { ...filters, ...patch };
+      setFilters(next);
+
+      // Debounce search input, immediate for dropdowns
+      const isSearch = "search" in patch;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+
+      if (isSearch) {
+        debounceRef.current = setTimeout(() => fetchTraces(next), 300);
+      } else {
+        fetchTraces(next);
+      }
+    },
+    [filters, fetchTraces]
+  );
+
+  const clearFilters = () => {
+    setFilters(DEFAULT_FILTERS);
+    fetchTraces(DEFAULT_FILTERS);
+  };
+
+  const hasActiveFilters =
+    filters.search || filters.model || filters.provider || filters.status;
 
   const statusLabel = (s: number) => {
     if (s === 2) return { text: "error", cls: "badge-error" };
     return { text: "ok", cls: "badge-success" };
   };
 
+  const sortOptions = [
+    { value: "start_time", label: "Time" },
+    { value: "duration", label: "Latency" },
+    { value: "total_cost", label: "Cost" },
+    { value: "total_tokens", label: "Tokens" },
+  ];
+
   return (
     <>
       <header className="main-header">
         <h1>Traces</h1>
         <div style={{ display: "flex", gap: 8 }}>
-          <button className="btn" onClick={() => window.location.reload()}>
+          <button className="btn" onClick={() => fetchTraces(filters)}>
             🔄 Refresh
           </button>
         </div>
       </header>
 
       <div className="main-body">
+        {/* Search + Filter bar */}
+        <div className="filter-bar animate-in">
+          <div className="filter-search">
+            <span className="filter-search-icon">🔍</span>
+            <input
+              type="text"
+              placeholder="Search traces by name..."
+              value={filters.search}
+              onChange={(e) => updateFilters({ search: e.target.value })}
+              className="filter-search-input"
+            />
+            {filters.search && (
+              <button
+                className="filter-clear-btn"
+                onClick={() => updateFilters({ search: "" })}
+              >
+                ✕
+              </button>
+            )}
+          </div>
+
+          <button
+            className={`btn ${filtersOpen ? "btn-active" : ""}`}
+            onClick={() => setFiltersOpen(!filtersOpen)}
+          >
+            ⚙ Filters{hasActiveFilters ? " •" : ""}
+          </button>
+
+          {/* Sort */}
+          <div className="filter-sort">
+            <select
+              value={filters.orderBy}
+              onChange={(e) => updateFilters({ orderBy: e.target.value })}
+              className="filter-select"
+            >
+              {sortOptions.map((o) => (
+                <option key={o.value} value={o.value}>
+                  Sort: {o.label}
+                </option>
+              ))}
+            </select>
+            <button
+              className="btn filter-dir-btn"
+              onClick={() => updateFilters({ descending: !filters.descending })}
+              title={filters.descending ? "Descending" : "Ascending"}
+            >
+              {filters.descending ? "↓" : "↑"}
+            </button>
+          </div>
+        </div>
+
+        {/* Expanded filters */}
+        {filtersOpen && (
+          <div className="filter-panel animate-in">
+            <div className="filter-group">
+              <label className="filter-label">Model</label>
+              <input
+                type="text"
+                placeholder="e.g. gpt-4o, gemini-2.5-pro"
+                value={filters.model}
+                onChange={(e) => updateFilters({ model: e.target.value })}
+                className="filter-input"
+              />
+            </div>
+            <div className="filter-group">
+              <label className="filter-label">Provider</label>
+              <input
+                type="text"
+                placeholder="e.g. openai, google, anthropic"
+                value={filters.provider}
+                onChange={(e) => updateFilters({ provider: e.target.value })}
+                className="filter-input"
+              />
+            </div>
+            <div className="filter-group">
+              <label className="filter-label">Status</label>
+              <select
+                value={filters.status}
+                onChange={(e) =>
+                  updateFilters({
+                    status: e.target.value as Filters["status"],
+                  })
+                }
+                className="filter-select"
+              >
+                <option value="">All</option>
+                <option value="ok">OK</option>
+                <option value="error">Error</option>
+              </select>
+            </div>
+            {hasActiveFilters && (
+              <button className="btn filter-reset-btn" onClick={clearFilters}>
+                ✕ Clear all
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Error banner */}
         {error && (
           <div
             className="card animate-in"
@@ -94,19 +271,58 @@ export default function TracesPage() {
           </div>
         )}
 
+        {/* Results */}
         <div className="table-container animate-in">
           <div className="table-header">
             <span className="table-title">
-              {loading ? "Loading..." : `${traces.length} traces`}
+              {loading
+                ? "Loading..."
+                : `${traces.length} trace${traces.length !== 1 ? "s" : ""}`}
             </span>
+            {hasActiveFilters && (
+              <span
+                className="badge badge-info"
+                style={{ fontSize: 11, cursor: "pointer" }}
+                onClick={clearFilters}
+              >
+                Filtered — clear
+              </span>
+            )}
           </div>
 
           {traces.length === 0 && !loading ? (
             <div className="empty-state">
-              <div className="empty-state-icon">🔍</div>
-              <div className="empty-state-title">No traces found</div>
+              <div className="empty-state-icon">
+                {hasActiveFilters ? "🔍" : "🔍"}
+              </div>
+              <div className="empty-state-title">
+                {hasActiveFilters
+                  ? "No traces match filters"
+                  : "No traces found"}
+              </div>
               <div className="empty-state-desc">
-                Traces will appear here once LLM requests flow through the proxy.
+                {hasActiveFilters ? (
+                  <>
+                    Try adjusting your filters or{" "}
+                    <button
+                      onClick={clearFilters}
+                      style={{
+                        background: "none",
+                        border: "none",
+                        color: "var(--accent)",
+                        cursor: "pointer",
+                        textDecoration: "underline",
+                        padding: 0,
+                        font: "inherit",
+                      }}
+                    >
+                      clear all filters
+                    </button>
+                    .
+                  </>
+                ) : (
+                  "Traces will appear here once LLM requests flow through the proxy."
+                )}
               </div>
             </div>
           ) : (
@@ -116,7 +332,6 @@ export default function TracesPage() {
                   <th>Trace ID</th>
                   <th>Operation</th>
                   <th>Model</th>
-                  <th>Env</th>
                   <th>Spans</th>
                   <th>Tokens</th>
                   <th>Cost</th>
@@ -129,7 +344,11 @@ export default function TracesPage() {
                 {traces.map((t) => {
                   const st = statusLabel(t.status);
                   return (
-                    <tr key={t.traceId} style={{ cursor: "pointer" }} onClick={() => router.push(`/traces/${t.traceId}`)}>
+                    <tr
+                      key={t.traceId}
+                      style={{ cursor: "pointer" }}
+                      onClick={() => router.push(`/traces/${t.traceId}`)}
+                    >
                       <td>
                         <span className="mono">{t.traceId.slice(0, 12)}…</span>
                       </td>
@@ -139,9 +358,6 @@ export default function TracesPage() {
                           {t.primaryModel}
                         </span>
                       </td>
-                      <td>
-                        <span className="badge badge-info">{t.environment}</span>
-                      </td>
                       <td>{t.spanCount}</td>
                       <td>{t.totalTokens.toLocaleString()}</td>
                       <td>${t.totalCostUsd.toFixed(4)}</td>
@@ -149,7 +365,9 @@ export default function TracesPage() {
                       <td>
                         <span className={`badge ${st.cls}`}>{st.text}</span>
                       </td>
-                      <td style={{ color: "var(--text-muted)", fontSize: 12 }}>
+                      <td
+                        style={{ color: "var(--text-muted)", fontSize: 12 }}
+                      >
                         {t.startTime}
                       </td>
                     </tr>


### PR DESCRIPTION
## Trace Search + Filters (Feature 2.5)

Adds full search and filtering capabilities to the traces list page.

### What's New

**Search bar:**
- Full-text search by trace name
- 300ms debounce to avoid excessive API calls
- Clear button (✕) when search is active

**Filter panel** (expandable via ⚙ button):
- **Model** — filter by LLM model (e.g. `gpt-4o`, `gemini-2.5-pro`)
- **Provider** — filter by provider (e.g. `openai`, `google`)
- **Status** — OK / Error dropdown
- ✕ Clear all filters action
- Dot indicator on filter button when active

**Sort controls:**
- Sort by: Time, Latency, Cost, Tokens
- Toggle ascending/descending (↑/↓)

**UX improvements:**
- Result count in table header (e.g. `42 traces`)
- Filtered empty state with clear-filters action
- Refresh button

All filters are wired to the `ListTraces` RPC request params.

### Testing
- 4 new Playwright E2E tests (21 total, all passing)
- Covers: search bar rendering, filter panel toggle, filtered empty state, result count