### PR TITLE
refactor: extract React hooks for data fetching

### DIFF
--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -1,41 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Link from "next/link";
-import { createClient } from "@connectrpc/connect";
-import { transport } from "@/lib/connect";
-import { DashboardService } from "@/gen/v1/dashboard_service_pb";
-
-interface Stats {
-  totalTraces: string;
-  totalTokens: string;
-  totalCost: string;
-  avgLatency: string;
-  errorRate: string;
-}
+import { useDashboard } from "@/hooks/useDashboard";
 
 export default function DashboardPage() {
-  const [stats, setStats] = useState<Stats | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const { summary, error } = useDashboard();
 
-  useEffect(() => {
-    const client = createClient(DashboardService, transport);
-    client
-      .getUsageSummary({})
-      .then((res) => {
-        const totalTokens = Number(res.totalInputTokens) + Number(res.totalOutputTokens);
-        setStats({
-          totalTraces: Number(res.totalTraces).toLocaleString(),
-          totalTokens: totalTokens.toLocaleString(),
-          totalCost: `$${(res.totalCostUsd || 0).toFixed(2)}`,
-          avgLatency: `${(res.avgLatencyMs || 0).toFixed(0)}ms`,
-          errorRate: `${((res.errorRate || 0) * 100).toFixed(1)}%`,
-        });
-      })
-      .catch((err) => {
-        setError(err.message);
-      });
-  }, []);
+  const totalTokens = summary
+    ? (summary.totalInputTokens + summary.totalOutputTokens).toLocaleString()
+    : "—";
 
   return (
     <>
@@ -70,22 +43,28 @@ export default function DashboardPage() {
         <div className="stats-grid animate-in">
           <div className="card">
             <div className="card-title">Total Traces</div>
-            <div className="card-value">{stats?.totalTraces ?? "—"}</div>
+            <div className="card-value">
+              {summary ? Number(summary.totalTraces).toLocaleString() : "—"}
+            </div>
             <div className="card-subtitle">All time</div>
           </div>
           <div className="card">
             <div className="card-title">Total Tokens</div>
-            <div className="card-value">{stats?.totalTokens ?? "—"}</div>
+            <div className="card-value">{totalTokens}</div>
             <div className="card-subtitle">Input + Output</div>
           </div>
           <div className="card">
             <div className="card-title">Total Cost</div>
-            <div className="card-value">{stats?.totalCost ?? "—"}</div>
+            <div className="card-value">
+              {summary ? `$${(summary.totalCostUsd || 0).toFixed(2)}` : "—"}
+            </div>
             <div className="card-subtitle">Estimated USD</div>
           </div>
           <div className="card">
             <div className="card-title">Avg Latency</div>
-            <div className="card-value">{stats?.avgLatency ?? "—"}</div>
+            <div className="card-value">
+              {summary ? `${(summary.avgLatencyMs || 0).toFixed(0)}ms` : "—"}
+            </div>
             <div className="card-subtitle">Across all models</div>
           </div>
         </div>

--- a/ui/src/app/traces/[id]/page.tsx
+++ b/ui/src/app/traces/[id]/page.tsx
@@ -1,130 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { createClient } from "@connectrpc/connect";
-import { transport } from "@/lib/connect";
-import { TraceService } from "@/gen/v1/trace_service_pb";
-import type { Span } from "@/gen/types/trace_pb";
-import { SpanKind, SpanStatus } from "@/gen/types/trace_pb";
-
-// ──────────────────────────────────────────
-// Types
-// ──────────────────────────────────────────
-
-interface SpanNode {
-  span: Span;
-  children: SpanNode[];
-  depth: number;
-  /** Offset from trace start in ms */
-  offsetMs: number;
-  /** Duration in ms */
-  durationMs: number;
-}
-
-interface TraceData {
-  traceId: string;
-  rootSpanName: string;
-  totalDurationMs: number;
-  totalTokens: number;
-  totalCostUsd: number;
-  spanCount: number;
-  environment: string;
-  startTime: string;
-  tree: SpanNode[];
-  flatSpans: SpanNode[];
-}
-
-// ──────────────────────────────────────────
-// Helpers
-// ──────────────────────────────────────────
-
-function tsToMs(ts?: { seconds: bigint; nanos: number }): number {
-  if (!ts) return 0;
-  return Number(ts.seconds) * 1000 + (ts.nanos ?? 0) / 1e6;
-}
-
-function durationToMs(d?: { seconds: bigint; nanos: number }): number {
-  if (!d) return 0;
-  return Number(d.seconds) * 1000 + (d.nanos ?? 0) / 1e6;
-}
-
-function kindLabel(kind: SpanKind): string {
-  const map: Record<SpanKind, string> = {
-    [SpanKind.UNSPECIFIED]: "span",
-    [SpanKind.LLM]: "LLM",
-    [SpanKind.AGENT]: "Agent",
-    [SpanKind.TOOL]: "Tool",
-    [SpanKind.RETRIEVAL]: "RAG",
-    [SpanKind.EMBEDDING]: "Embed",
-    [SpanKind.CHAIN]: "Chain",
-    [SpanKind.GENERAL]: "General",
-  };
-  return map[kind] ?? "span";
-}
-
-function kindColor(kind: SpanKind): string {
-  const map: Record<SpanKind, string> = {
-    [SpanKind.UNSPECIFIED]: "var(--text-secondary)",
-    [SpanKind.LLM]: "#a78bfa",
-    [SpanKind.AGENT]: "#f59e0b",
-    [SpanKind.TOOL]: "#34d399",
-    [SpanKind.RETRIEVAL]: "#60a5fa",
-    [SpanKind.EMBEDDING]: "#f472b6",
-    [SpanKind.CHAIN]: "#fb923c",
-    [SpanKind.GENERAL]: "var(--text-secondary)",
-  };
-  return map[kind] ?? "var(--text-secondary)";
-}
-
-function buildTree(spans: Span[], traceStartMs: number): SpanNode[] {
-  const nodeMap = new Map<string, SpanNode>();
-
-  // Create nodes
-  for (const span of spans) {
-    nodeMap.set(span.spanId, {
-      span,
-      children: [],
-      depth: 0,
-      offsetMs: tsToMs(span.startTime) - traceStartMs,
-      durationMs: durationToMs(span.duration),
-    });
-  }
-
-  // Build tree
-  const roots: SpanNode[] = [];
-  for (const node of nodeMap.values()) {
-    if (node.span.parentSpanId && nodeMap.has(node.span.parentSpanId)) {
-      const parent = nodeMap.get(node.span.parentSpanId)!;
-      parent.children.push(node);
-    } else {
-      roots.push(node);
-    }
-  }
-
-  // Set depths and sort children by start time
-  function setDepth(node: SpanNode, depth: number) {
-    node.depth = depth;
-    node.children.sort((a, b) => a.offsetMs - b.offsetMs);
-    for (const child of node.children) {
-      setDepth(child, depth + 1);
-    }
-  }
-  roots.sort((a, b) => a.offsetMs - b.offsetMs);
-  for (const root of roots) setDepth(root, 0);
-
-  return roots;
-}
-
-function flattenTree(nodes: SpanNode[]): SpanNode[] {
-  const result: SpanNode[] = [];
-  function walk(node: SpanNode) {
-    result.push(node);
-    for (const child of node.children) walk(child);
-  }
-  for (const n of nodes) walk(n);
-  return result;
-}
+import { useTrace, kindLabel, kindColor } from "@/hooks/useTrace";
+import type { SpanNode } from "@/hooks/useTrace";
+import { SpanStatus } from "@/gen/types/trace_pb";
 
 // ──────────────────────────────────────────
 // Components
@@ -153,13 +32,9 @@ function SpanRow({
       role="button"
       tabIndex={0}
     >
-      {/* Left: span label with tree indentation */}
       <div className="waterfall-label" style={{ paddingLeft: node.depth * 20 + 8 }}>
         <span className="waterfall-connector" />
-        <span
-          className="waterfall-kind"
-          style={{ color, borderColor: color }}
-        >
+        <span className="waterfall-kind" style={{ color, borderColor: color }}>
           {kindLabel(node.span.kind)}
         </span>
         <span className="waterfall-name" title={node.span.name}>
@@ -168,7 +43,6 @@ function SpanRow({
         {isError && <span className="badge badge-error" style={{ marginLeft: 6, fontSize: 10 }}>ERR</span>}
       </div>
 
-      {/* Right: waterfall bar */}
       <div className="waterfall-bar-container">
         <div
           className="waterfall-bar"
@@ -284,7 +158,6 @@ function SpanDetail({ node }: { node: SpanNode }) {
             )}
           </div>
 
-          {/* Prompt / Completion */}
           {genAi.inputContent && (
             <div className="span-content-block">
               <div className="span-content-label">📥 Prompt</div>
@@ -358,47 +231,8 @@ export default function TraceDetailPage() {
   const router = useRouter();
   const traceId = params.id as string;
 
-  const [trace, setTrace] = useState<TraceData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
-
-  useEffect(() => {
-    const client = createClient(TraceService, transport);
-    client
-      .getTrace({ traceId })
-      .then((res) => {
-        if (!res.trace) {
-          setError("Trace not found");
-          return;
-        }
-        const t = res.trace;
-        const traceStartMs = tsToMs(t.startTime);
-        const tree = buildTree(t.spans, traceStartMs);
-        const flatSpans = flattenTree(tree);
-
-        setTrace({
-          traceId: t.traceId,
-          rootSpanName: t.rootSpanName || "unknown",
-          totalDurationMs: durationToMs(t.duration),
-          totalTokens: Number(t.totalTokens) || 0,
-          totalCostUsd: t.totalCostUsd || 0,
-          spanCount: t.spanCount || t.spans.length,
-          environment: t.environment || "—",
-          startTime: t.startTime
-            ? new Date(traceStartMs).toLocaleString()
-            : "—",
-          tree,
-          flatSpans,
-        });
-      })
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
-  }, [traceId]);
-
-  const selectedNode = trace?.flatSpans.find(
-    (n) => n.span.spanId === selectedSpanId
-  );
+  const { trace, loading, error, selectedSpanId, selectedNode, toggleSpan } =
+    useTrace(traceId);
 
   return (
     <>
@@ -481,7 +315,6 @@ export default function TraceDetailPage() {
 
             {/* Waterfall + Detail split */}
             <div className="waterfall-split">
-              {/* Waterfall panel */}
               <div className="waterfall-panel animate-in">
                 <div className="waterfall-header">
                   <span className="table-title">Span Waterfall</span>
@@ -513,13 +346,7 @@ export default function TraceDetailPage() {
                       node={node}
                       totalDurationMs={trace.totalDurationMs}
                       selected={node.span.spanId === selectedSpanId}
-                      onClick={() =>
-                        setSelectedSpanId(
-                          node.span.spanId === selectedSpanId
-                            ? null
-                            : node.span.spanId
-                        )
-                      }
+                      onClick={() => toggleSpan(node.span.spanId)}
                     />
                   ))}
                 </div>

--- a/ui/src/app/traces/page.tsx
+++ b/ui/src/app/traces/page.tsx
@@ -1,153 +1,47 @@
 "use client";
 
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClient } from "@connectrpc/connect";
-import { transport } from "@/lib/connect";
-import { TraceService } from "@/gen/v1/trace_service_pb";
+import { useTraces } from "@/hooks/useTraces";
+import type { TraceFilters } from "@/types/traces";
 
-interface TraceSummaryRow {
-  traceId: string;
-  rootSpanName: string;
-  primaryModel: string;
-  primaryProvider: string;
-  environment: string;
-  durationMs: number;
-  totalTokens: number;
-  totalCostUsd: number;
-  status: number;
-  startTime: string;
-  spanCount: number;
-  llmCallCount: number;
-}
+const sortOptions = [
+  { value: "start_time", label: "Time" },
+  { value: "duration", label: "Latency" },
+  { value: "total_cost", label: "Cost" },
+  { value: "total_tokens", label: "Tokens" },
+];
 
-interface Filters {
-  search: string;
-  model: string;
-  provider: string;
-  status: "" | "ok" | "error";
-  orderBy: string;
-  descending: boolean;
-}
-
-const DEFAULT_FILTERS: Filters = {
-  search: "",
-  model: "",
-  provider: "",
-  status: "",
-  orderBy: "start_time",
-  descending: true,
+const statusLabel = (s: number) => {
+  if (s === 2) return { text: "error", cls: "badge-error" };
+  return { text: "ok", cls: "badge-success" };
 };
 
 export default function TracesPage() {
-  const [traces, setTraces] = useState<TraceSummaryRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
-  const [filtersOpen, setFiltersOpen] = useState(false);
   const router = useRouter();
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const {
+    traces,
+    loading,
+    error,
+    filters,
+    hasActiveFilters,
+    updateFilters,
+    clearFilters,
+    refresh,
+    fetchInitial,
+  } = useTraces();
 
-  const fetchTraces = useCallback(
-    (f: Filters) => {
-      setLoading(true);
-      setError(null);
-      const client = createClient(TraceService, transport);
-      client
-        .listTraces({
-          pagination: { pageSize: 100 },
-          search: f.search,
-          model: f.model,
-          provider: f.provider,
-          status: f.status === "ok" ? 1 : f.status === "error" ? 2 : 0,
-          orderBy: f.orderBy,
-          descending: f.descending,
-        })
-        .then((res) => {
-          const mapped = (res.traces || []).map((t) => {
-            const durSeconds = Number(t.duration?.seconds ?? 0);
-            const durNanos = Number(t.duration?.nanos ?? 0);
-            const durationMs = durSeconds * 1000 + durNanos / 1e6;
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
-            return {
-              traceId: t.traceId,
-              rootSpanName: t.rootSpanName || "unknown",
-              primaryModel: t.primaryModel || "—",
-              primaryProvider: t.primaryProvider || "—",
-              environment: t.environment || "—",
-              durationMs,
-              totalTokens: Number(t.totalTokens) || 0,
-              totalCostUsd: t.totalCostUsd || 0,
-              status: t.status,
-              spanCount: t.spanCount || 0,
-              llmCallCount: t.llmCallCount || 0,
-              startTime: t.startTime
-                ? new Date(
-                    Number(t.startTime.seconds) * 1000 +
-                      Math.floor(Number(t.startTime.nanos) / 1e6)
-                  ).toLocaleString()
-                : "—",
-            };
-          });
-          setTraces(mapped);
-        })
-        .catch((err) => setError(err.message))
-        .finally(() => setLoading(false));
-    },
-    []
-  );
-
-  // Initial fetch
-  useEffect(() => {
-    fetchTraces(filters);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Debounced filter changes
-  const updateFilters = useCallback(
-    (patch: Partial<Filters>) => {
-      const next = { ...filters, ...patch };
-      setFilters(next);
-
-      // Debounce search input, immediate for dropdowns
-      const isSearch = "search" in patch;
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-
-      if (isSearch) {
-        debounceRef.current = setTimeout(() => fetchTraces(next), 300);
-      } else {
-        fetchTraces(next);
-      }
-    },
-    [filters, fetchTraces]
-  );
-
-  const clearFilters = () => {
-    setFilters(DEFAULT_FILTERS);
-    fetchTraces(DEFAULT_FILTERS);
-  };
-
-  const hasActiveFilters =
-    filters.search || filters.model || filters.provider || filters.status;
-
-  const statusLabel = (s: number) => {
-    if (s === 2) return { text: "error", cls: "badge-error" };
-    return { text: "ok", cls: "badge-success" };
-  };
-
-  const sortOptions = [
-    { value: "start_time", label: "Time" },
-    { value: "duration", label: "Latency" },
-    { value: "total_cost", label: "Cost" },
-    { value: "total_tokens", label: "Tokens" },
-  ];
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { fetchInitial(); }, []);
 
   return (
     <>
       <header className="main-header">
         <h1>Traces</h1>
         <div style={{ display: "flex", gap: 8 }}>
-          <button className="btn" onClick={() => fetchTraces(filters)}>
+          <button className="btn" onClick={refresh}>
             🔄 Refresh
           </button>
         </div>
@@ -234,7 +128,7 @@ export default function TracesPage() {
                 value={filters.status}
                 onChange={(e) =>
                   updateFilters({
-                    status: e.target.value as Filters["status"],
+                    status: e.target.value as TraceFilters["status"],
                   })
                 }
                 className="filter-select"
@@ -292,9 +186,7 @@ export default function TracesPage() {
 
           {traces.length === 0 && !loading ? (
             <div className="empty-state">
-              <div className="empty-state-icon">
-                {hasActiveFilters ? "🔍" : "🔍"}
-              </div>
+              <div className="empty-state-icon">🔍</div>
               <div className="empty-state-title">
                 {hasActiveFilters
                   ? "No traces match filters"
@@ -365,9 +257,7 @@ export default function TracesPage() {
                       <td>
                         <span className={`badge ${st.cls}`}>{st.text}</span>
                       </td>
-                      <td
-                        style={{ color: "var(--text-muted)", fontSize: 12 }}
-                      >
+                      <td style={{ color: "var(--text-muted)", fontSize: 12 }}>
                         {t.startTime}
                       </td>
                     </tr>

--- a/ui/src/hooks/useDashboard.ts
+++ b/ui/src/hooks/useDashboard.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useReducer } from "react";
 import { dashboardClient } from "@/lib/api";
 
 export interface DashboardSummary {
@@ -14,39 +14,73 @@ export interface DashboardSummary {
   errorRate: number;
 }
 
+type State = {
+  summary: DashboardSummary | null;
+  loading: boolean;
+  error: string | null;
+  fetchCount: number;
+};
+
+type Action =
+  | { type: "fetch" }
+  | { type: "success"; summary: DashboardSummary }
+  | { type: "error"; message: string }
+  | { type: "refresh" };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "fetch":
+      return { ...state, loading: true, error: null };
+    case "success":
+      return { ...state, loading: false, summary: action.summary };
+    case "error":
+      return { ...state, loading: false, error: action.message };
+    case "refresh":
+      return { ...state, fetchCount: state.fetchCount + 1 };
+  }
+}
+
 /**
  * Hook for fetching the dashboard usage summary.
  * Encapsulates the GetUsageSummary RPC.
  */
 export function useDashboard() {
-  const [summary, setSummary] = useState<DashboardSummary | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [state, dispatch] = useReducer(reducer, {
+    summary: null,
+    loading: true,
+    error: null,
+    fetchCount: 0,
+  });
 
-  const fetchSummary = useCallback(() => {
-    setLoading(true);
-    setError(null);
+  useEffect(() => {
+    let cancelled = false;
+
     dashboardClient
       .getUsageSummary({})
       .then((res) => {
-        setSummary({
-          totalTraces: Number(res.totalTraces),
-          totalSpans: Number(res.totalSpans),
-          totalLlmCalls: Number(res.totalLlmCalls),
-          totalInputTokens: Number(res.totalInputTokens),
-          totalOutputTokens: Number(res.totalOutputTokens),
-          totalCostUsd: res.totalCostUsd,
-          avgLatencyMs: res.avgLatencyMs,
-          errorRate: res.errorRate,
+        if (cancelled) return;
+        dispatch({
+          type: "success",
+          summary: {
+            totalTraces: Number(res.totalTraces),
+            totalSpans: Number(res.totalSpans),
+            totalLlmCalls: Number(res.totalLlmCalls),
+            totalInputTokens: Number(res.totalInputTokens),
+            totalOutputTokens: Number(res.totalOutputTokens),
+            totalCostUsd: res.totalCostUsd,
+            avgLatencyMs: res.avgLatencyMs,
+            errorRate: res.errorRate,
+          },
         });
       })
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
-  }, []);
+      .catch((err) => {
+        if (!cancelled) dispatch({ type: "error", message: err.message });
+      });
 
-  useEffect(() => {
-    fetchSummary();
-  }, [fetchSummary]);
+    return () => { cancelled = true; };
+  }, [state.fetchCount]);
 
-  return { summary, loading, error, refresh: fetchSummary };
+  const refresh = useCallback(() => dispatch({ type: "refresh" }), []);
+
+  return { summary: state.summary, loading: state.loading, error: state.error, refresh };
 }

--- a/ui/src/hooks/useDashboard.ts
+++ b/ui/src/hooks/useDashboard.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { dashboardClient } from "@/lib/api";
+
+export interface DashboardSummary {
+  totalTraces: number;
+  totalSpans: number;
+  totalLlmCalls: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+  avgLatencyMs: number;
+  errorRate: number;
+}
+
+/**
+ * Hook for fetching the dashboard usage summary.
+ * Encapsulates the GetUsageSummary RPC.
+ */
+export function useDashboard() {
+  const [summary, setSummary] = useState<DashboardSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSummary = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    dashboardClient
+      .getUsageSummary({})
+      .then((res) => {
+        setSummary({
+          totalTraces: Number(res.totalTraces),
+          totalSpans: Number(res.totalSpans),
+          totalLlmCalls: Number(res.totalLlmCalls),
+          totalInputTokens: Number(res.totalInputTokens),
+          totalOutputTokens: Number(res.totalOutputTokens),
+          totalCostUsd: res.totalCostUsd,
+          avgLatencyMs: res.avgLatencyMs,
+          errorRate: res.errorRate,
+        });
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetchSummary();
+  }, [fetchSummary]);
+
+  return { summary, loading, error, refresh: fetchSummary };
+}

--- a/ui/src/hooks/useTrace.ts
+++ b/ui/src/hooks/useTrace.ts
@@ -1,0 +1,185 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { traceClient } from "@/lib/api";
+import type { Span } from "@/gen/types/trace_pb";
+import { SpanKind } from "@/gen/types/trace_pb";
+
+// ──────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────
+
+export interface SpanNode {
+  span: Span;
+  children: SpanNode[];
+  depth: number;
+  /** Offset from trace start in ms */
+  offsetMs: number;
+  /** Duration in ms */
+  durationMs: number;
+}
+
+export interface TraceData {
+  traceId: string;
+  rootSpanName: string;
+  totalDurationMs: number;
+  totalTokens: number;
+  totalCostUsd: number;
+  spanCount: number;
+  environment: string;
+  startTime: string;
+  tree: SpanNode[];
+  flatSpans: SpanNode[];
+}
+
+// ──────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────
+
+export function tsToMs(ts?: { seconds: bigint; nanos: number }): number {
+  if (!ts) return 0;
+  return Number(ts.seconds) * 1000 + (ts.nanos ?? 0) / 1e6;
+}
+
+export function durationToMs(d?: { seconds: bigint; nanos: number }): number {
+  if (!d) return 0;
+  return Number(d.seconds) * 1000 + (d.nanos ?? 0) / 1e6;
+}
+
+export function kindLabel(kind: SpanKind): string {
+  const map: Record<SpanKind, string> = {
+    [SpanKind.UNSPECIFIED]: "span",
+    [SpanKind.LLM]: "LLM",
+    [SpanKind.AGENT]: "Agent",
+    [SpanKind.TOOL]: "Tool",
+    [SpanKind.RETRIEVAL]: "RAG",
+    [SpanKind.EMBEDDING]: "Embed",
+    [SpanKind.CHAIN]: "Chain",
+    [SpanKind.GENERAL]: "General",
+  };
+  return map[kind] ?? "span";
+}
+
+export function kindColor(kind: SpanKind): string {
+  const map: Record<SpanKind, string> = {
+    [SpanKind.UNSPECIFIED]: "var(--text-secondary)",
+    [SpanKind.LLM]: "#a78bfa",
+    [SpanKind.AGENT]: "#f59e0b",
+    [SpanKind.TOOL]: "#34d399",
+    [SpanKind.RETRIEVAL]: "#60a5fa",
+    [SpanKind.EMBEDDING]: "#f472b6",
+    [SpanKind.CHAIN]: "#fb923c",
+    [SpanKind.GENERAL]: "var(--text-secondary)",
+  };
+  return map[kind] ?? "var(--text-secondary)";
+}
+
+function buildTree(spans: Span[], traceStartMs: number): SpanNode[] {
+  const nodeMap = new Map<string, SpanNode>();
+
+  for (const span of spans) {
+    nodeMap.set(span.spanId, {
+      span,
+      children: [],
+      depth: 0,
+      offsetMs: tsToMs(span.startTime) - traceStartMs,
+      durationMs: durationToMs(span.duration),
+    });
+  }
+
+  const roots: SpanNode[] = [];
+  for (const node of nodeMap.values()) {
+    if (node.span.parentSpanId && nodeMap.has(node.span.parentSpanId)) {
+      const parent = nodeMap.get(node.span.parentSpanId)!;
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  function setDepth(node: SpanNode, depth: number) {
+    node.depth = depth;
+    node.children.sort((a, b) => a.offsetMs - b.offsetMs);
+    for (const child of node.children) setDepth(child, depth + 1);
+  }
+  roots.sort((a, b) => a.offsetMs - b.offsetMs);
+  for (const root of roots) setDepth(root, 0);
+
+  return roots;
+}
+
+function flattenTree(nodes: SpanNode[]): SpanNode[] {
+  const result: SpanNode[] = [];
+  function walk(node: SpanNode) {
+    result.push(node);
+    for (const child of node.children) walk(child);
+  }
+  for (const n of nodes) walk(n);
+  return result;
+}
+
+// ──────────────────────────────────────────
+// Hook
+// ──────────────────────────────────────────
+
+/**
+ * Hook for fetching a single trace with its span tree.
+ * Encapsulates the GetTrace RPC, tree building, and flattening.
+ */
+export function useTrace(traceId: string) {
+  const [trace, setTrace] = useState<TraceData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+
+    traceClient
+      .getTrace({ traceId })
+      .then((res) => {
+        if (!res.trace) {
+          setError("Trace not found");
+          return;
+        }
+        const t = res.trace;
+        const traceStartMs = tsToMs(t.startTime);
+        const tree = buildTree(t.spans, traceStartMs);
+        const flatSpans = flattenTree(tree);
+
+        setTrace({
+          traceId: t.traceId,
+          rootSpanName: t.rootSpanName || "unknown",
+          totalDurationMs: durationToMs(t.duration),
+          totalTokens: Number(t.totalTokens) || 0,
+          totalCostUsd: t.totalCostUsd || 0,
+          spanCount: t.spanCount || t.spans.length,
+          environment: t.environment || "—",
+          startTime: t.startTime
+            ? new Date(traceStartMs).toLocaleString()
+            : "—",
+          tree,
+          flatSpans,
+        });
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [traceId]);
+
+  const selectedNode = trace?.flatSpans.find(
+    (n) => n.span.spanId === selectedSpanId
+  );
+
+  const toggleSpan = (spanId: string) =>
+    setSelectedSpanId((prev) => (prev === spanId ? null : spanId));
+
+  return {
+    trace,
+    loading,
+    error,
+    selectedSpanId,
+    selectedNode,
+    toggleSpan,
+  };
+}

--- a/ui/src/hooks/useTrace.ts
+++ b/ui/src/hooks/useTrace.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useReducer, useState } from "react";
 import { traceClient } from "@/lib/api";
 import type { Span } from "@/gen/types/trace_pb";
 import { SpanKind } from "@/gen/types/trace_pb";
@@ -13,9 +13,7 @@ export interface SpanNode {
   span: Span;
   children: SpanNode[];
   depth: number;
-  /** Offset from trace start in ms */
   offsetMs: number;
-  /** Duration in ms */
   durationMs: number;
 }
 
@@ -90,8 +88,7 @@ function buildTree(spans: Span[], traceStartMs: number): SpanNode[] {
   const roots: SpanNode[] = [];
   for (const node of nodeMap.values()) {
     if (node.span.parentSpanId && nodeMap.has(node.span.parentSpanId)) {
-      const parent = nodeMap.get(node.span.parentSpanId)!;
-      parent.children.push(node);
+      nodeMap.get(node.span.parentSpanId)!.children.push(node);
     } else {
       roots.push(node);
     }
@@ -119,28 +116,56 @@ function flattenTree(nodes: SpanNode[]): SpanNode[] {
 }
 
 // ──────────────────────────────────────────
+// Reducer (avoids set-state-in-effect lint)
+// ──────────────────────────────────────────
+
+type TraceState = {
+  trace: TraceData | null;
+  loading: boolean;
+  error: string | null;
+};
+
+type TraceAction =
+  | { type: "success"; trace: TraceData }
+  | { type: "error"; message: string }
+  | { type: "not_found" };
+
+function traceReducer(_state: TraceState, action: TraceAction): TraceState {
+  switch (action.type) {
+    case "success":
+      return { trace: action.trace, loading: false, error: null };
+    case "error":
+      return { trace: null, loading: false, error: action.message };
+    case "not_found":
+      return { trace: null, loading: false, error: "Trace not found" };
+  }
+}
+
+// ──────────────────────────────────────────
 // Hook
 // ──────────────────────────────────────────
 
 /**
  * Hook for fetching a single trace with its span tree.
- * Encapsulates the GetTrace RPC, tree building, and flattening.
+ * Uses useReducer to dispatch state transitions from async callbacks.
  */
 export function useTrace(traceId: string) {
-  const [trace, setTrace] = useState<TraceData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [state, dispatch] = useReducer(traceReducer, {
+    trace: null,
+    loading: true,
+    error: null,
+  });
   const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
 
   useEffect(() => {
-    setLoading(true);
-    setError(null);
+    let cancelled = false;
 
     traceClient
       .getTrace({ traceId })
       .then((res) => {
+        if (cancelled) return;
         if (!res.trace) {
-          setError("Trace not found");
+          dispatch({ type: "not_found" });
           return;
         }
         const t = res.trace;
@@ -148,26 +173,32 @@ export function useTrace(traceId: string) {
         const tree = buildTree(t.spans, traceStartMs);
         const flatSpans = flattenTree(tree);
 
-        setTrace({
-          traceId: t.traceId,
-          rootSpanName: t.rootSpanName || "unknown",
-          totalDurationMs: durationToMs(t.duration),
-          totalTokens: Number(t.totalTokens) || 0,
-          totalCostUsd: t.totalCostUsd || 0,
-          spanCount: t.spanCount || t.spans.length,
-          environment: t.environment || "—",
-          startTime: t.startTime
-            ? new Date(traceStartMs).toLocaleString()
-            : "—",
-          tree,
-          flatSpans,
+        dispatch({
+          type: "success",
+          trace: {
+            traceId: t.traceId,
+            rootSpanName: t.rootSpanName || "unknown",
+            totalDurationMs: durationToMs(t.duration),
+            totalTokens: Number(t.totalTokens) || 0,
+            totalCostUsd: t.totalCostUsd || 0,
+            spanCount: t.spanCount || t.spans.length,
+            environment: t.environment || "—",
+            startTime: t.startTime
+              ? new Date(traceStartMs).toLocaleString()
+              : "—",
+            tree,
+            flatSpans,
+          },
         });
       })
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
+      .catch((err) => {
+        if (!cancelled) dispatch({ type: "error", message: err.message });
+      });
+
+    return () => { cancelled = true; };
   }, [traceId]);
 
-  const selectedNode = trace?.flatSpans.find(
+  const selectedNode = state.trace?.flatSpans.find(
     (n) => n.span.spanId === selectedSpanId
   );
 
@@ -175,9 +206,9 @@ export function useTrace(traceId: string) {
     setSelectedSpanId((prev) => (prev === spanId ? null : spanId));
 
   return {
-    trace,
-    loading,
-    error,
+    trace: state.trace,
+    loading: state.loading,
+    error: state.error,
     selectedSpanId,
     selectedNode,
     toggleSpan,

--- a/ui/src/hooks/useTraces.ts
+++ b/ui/src/hooks/useTraces.ts
@@ -1,24 +1,91 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useReducer, useRef } from "react";
 import { traceClient } from "@/lib/api";
 import type { TraceSummaryRow, TraceFilters } from "@/types/traces";
 import { DEFAULT_FILTERS } from "@/types/traces";
+
+type State = {
+  traces: TraceSummaryRow[];
+  loading: boolean;
+  error: string | null;
+  filters: TraceFilters;
+};
+
+type Action =
+  | { type: "fetch"; filters: TraceFilters }
+  | { type: "success"; traces: TraceSummaryRow[] }
+  | { type: "error"; message: string }
+  | { type: "set_filters"; filters: TraceFilters }
+  | { type: "clear_filters" };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "fetch":
+      return { ...state, loading: true, error: null, filters: action.filters };
+    case "success":
+      return { ...state, loading: false, traces: action.traces };
+    case "error":
+      return { ...state, loading: false, error: action.message };
+    case "set_filters":
+      return { ...state, filters: action.filters };
+    case "clear_filters":
+      return { ...state, loading: true, error: null, filters: DEFAULT_FILTERS };
+  }
+}
+
+function mapTrace(t: {
+  traceId: string;
+  rootSpanName: string;
+  primaryModel: string;
+  primaryProvider: string;
+  environment: string;
+  duration?: { seconds: bigint; nanos: number };
+  totalTokens: bigint;
+  totalCostUsd: number;
+  status: number;
+  spanCount: number;
+  llmCallCount: number;
+  startTime?: { seconds: bigint; nanos: number };
+}): TraceSummaryRow {
+  const durSeconds = Number(t.duration?.seconds ?? 0);
+  const durNanos = Number(t.duration?.nanos ?? 0);
+  return {
+    traceId: t.traceId,
+    rootSpanName: t.rootSpanName || "unknown",
+    primaryModel: t.primaryModel || "—",
+    primaryProvider: t.primaryProvider || "—",
+    environment: t.environment || "—",
+    durationMs: durSeconds * 1000 + durNanos / 1e6,
+    totalTokens: Number(t.totalTokens) || 0,
+    totalCostUsd: t.totalCostUsd || 0,
+    status: t.status,
+    spanCount: t.spanCount || 0,
+    llmCallCount: t.llmCallCount || 0,
+    startTime: t.startTime
+      ? new Date(
+          Number(t.startTime.seconds) * 1000 +
+            Math.floor(Number(t.startTime.nanos) / 1e6)
+        ).toLocaleString()
+      : "—",
+  };
+}
 
 /**
  * Hook for fetching and filtering traces.
  * Encapsulates the ListTraces RPC, debounced search, and filter state.
  */
 export function useTraces() {
-  const [traces, setTraces] = useState<TraceSummaryRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [filters, setFilters] = useState<TraceFilters>(DEFAULT_FILTERS);
+  const [state, dispatch] = useReducer(reducer, {
+    traces: [],
+    loading: true,
+    error: null,
+    filters: DEFAULT_FILTERS,
+  });
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchTraces = useCallback((f: TraceFilters) => {
-    setLoading(true);
-    setError(null);
+    dispatch({ type: "fetch", filters: f });
     traceClient
       .listTraces({
         pagination: { pageSize: 100 },
@@ -30,42 +97,18 @@ export function useTraces() {
         descending: f.descending,
       })
       .then((res) => {
-        const mapped = (res.traces || []).map((t) => {
-          const durSeconds = Number(t.duration?.seconds ?? 0);
-          const durNanos = Number(t.duration?.nanos ?? 0);
-          const durationMs = durSeconds * 1000 + durNanos / 1e6;
-
-          return {
-            traceId: t.traceId,
-            rootSpanName: t.rootSpanName || "unknown",
-            primaryModel: t.primaryModel || "—",
-            primaryProvider: t.primaryProvider || "—",
-            environment: t.environment || "—",
-            durationMs,
-            totalTokens: Number(t.totalTokens) || 0,
-            totalCostUsd: t.totalCostUsd || 0,
-            status: t.status,
-            spanCount: t.spanCount || 0,
-            llmCallCount: t.llmCallCount || 0,
-            startTime: t.startTime
-              ? new Date(
-                  Number(t.startTime.seconds) * 1000 +
-                    Math.floor(Number(t.startTime.nanos) / 1e6)
-                ).toLocaleString()
-              : "—",
-          };
+        dispatch({
+          type: "success",
+          traces: (res.traces || []).map(mapTrace),
         });
-        setTraces(mapped);
       })
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
+      .catch((err) => dispatch({ type: "error", message: err.message }));
   }, []);
 
-  /** Update filters with debounced search, immediate for other fields. */
   const updateFilters = useCallback(
     (patch: Partial<TraceFilters>) => {
-      const next = { ...filters, ...patch };
-      setFilters(next);
+      const next = { ...state.filters, ...patch };
+      dispatch({ type: "set_filters", filters: next });
 
       const isSearch = "search" in patch;
       if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -76,33 +119,35 @@ export function useTraces() {
         fetchTraces(next);
       }
     },
-    [filters, fetchTraces]
+    [state.filters, fetchTraces]
   );
 
   const clearFilters = useCallback(() => {
-    setFilters(DEFAULT_FILTERS);
+    dispatch({ type: "clear_filters" });
     fetchTraces(DEFAULT_FILTERS);
   }, [fetchTraces]);
 
   const hasActiveFilters = !!(
-    filters.search ||
-    filters.model ||
-    filters.provider ||
-    filters.status
+    state.filters.search ||
+    state.filters.model ||
+    state.filters.provider ||
+    state.filters.status
   );
 
-  const refresh = useCallback(() => fetchTraces(filters), [filters, fetchTraces]);
+  const refresh = useCallback(
+    () => fetchTraces(state.filters),
+    [state.filters, fetchTraces]
+  );
 
   return {
-    traces,
-    loading,
-    error,
-    filters,
+    traces: state.traces,
+    loading: state.loading,
+    error: state.error,
+    filters: state.filters,
     hasActiveFilters,
     updateFilters,
     clearFilters,
     refresh,
-    /** Call on mount to trigger initial fetch. */
-    fetchInitial: () => fetchTraces(filters),
+    fetchInitial: () => fetchTraces(state.filters),
   };
 }

--- a/ui/src/hooks/useTraces.ts
+++ b/ui/src/hooks/useTraces.ts
@@ -1,0 +1,108 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { traceClient } from "@/lib/api";
+import type { TraceSummaryRow, TraceFilters } from "@/types/traces";
+import { DEFAULT_FILTERS } from "@/types/traces";
+
+/**
+ * Hook for fetching and filtering traces.
+ * Encapsulates the ListTraces RPC, debounced search, and filter state.
+ */
+export function useTraces() {
+  const [traces, setTraces] = useState<TraceSummaryRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<TraceFilters>(DEFAULT_FILTERS);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchTraces = useCallback((f: TraceFilters) => {
+    setLoading(true);
+    setError(null);
+    traceClient
+      .listTraces({
+        pagination: { pageSize: 100 },
+        search: f.search,
+        model: f.model,
+        provider: f.provider,
+        status: f.status === "ok" ? 1 : f.status === "error" ? 2 : 0,
+        orderBy: f.orderBy,
+        descending: f.descending,
+      })
+      .then((res) => {
+        const mapped = (res.traces || []).map((t) => {
+          const durSeconds = Number(t.duration?.seconds ?? 0);
+          const durNanos = Number(t.duration?.nanos ?? 0);
+          const durationMs = durSeconds * 1000 + durNanos / 1e6;
+
+          return {
+            traceId: t.traceId,
+            rootSpanName: t.rootSpanName || "unknown",
+            primaryModel: t.primaryModel || "—",
+            primaryProvider: t.primaryProvider || "—",
+            environment: t.environment || "—",
+            durationMs,
+            totalTokens: Number(t.totalTokens) || 0,
+            totalCostUsd: t.totalCostUsd || 0,
+            status: t.status,
+            spanCount: t.spanCount || 0,
+            llmCallCount: t.llmCallCount || 0,
+            startTime: t.startTime
+              ? new Date(
+                  Number(t.startTime.seconds) * 1000 +
+                    Math.floor(Number(t.startTime.nanos) / 1e6)
+                ).toLocaleString()
+              : "—",
+          };
+        });
+        setTraces(mapped);
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  /** Update filters with debounced search, immediate for other fields. */
+  const updateFilters = useCallback(
+    (patch: Partial<TraceFilters>) => {
+      const next = { ...filters, ...patch };
+      setFilters(next);
+
+      const isSearch = "search" in patch;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+
+      if (isSearch) {
+        debounceRef.current = setTimeout(() => fetchTraces(next), 300);
+      } else {
+        fetchTraces(next);
+      }
+    },
+    [filters, fetchTraces]
+  );
+
+  const clearFilters = useCallback(() => {
+    setFilters(DEFAULT_FILTERS);
+    fetchTraces(DEFAULT_FILTERS);
+  }, [fetchTraces]);
+
+  const hasActiveFilters = !!(
+    filters.search ||
+    filters.model ||
+    filters.provider ||
+    filters.status
+  );
+
+  const refresh = useCallback(() => fetchTraces(filters), [filters, fetchTraces]);
+
+  return {
+    traces,
+    loading,
+    error,
+    filters,
+    hasActiveFilters,
+    updateFilters,
+    clearFilters,
+    refresh,
+    /** Call on mount to trigger initial fetch. */
+    fetchInitial: () => fetchTraces(filters),
+  };
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,0 +1,10 @@
+import { createClient } from "@connectrpc/connect";
+import { transport } from "@/lib/connect";
+import { TraceService } from "@/gen/v1/trace_service_pb";
+import { DashboardService } from "@/gen/v1/dashboard_service_pb";
+import { ProjectService } from "@/gen/v1/project_service_pb";
+
+// Singleton clients — reuse across hooks.
+export const traceClient = createClient(TraceService, transport);
+export const dashboardClient = createClient(DashboardService, transport);
+export const projectClient = createClient(ProjectService, transport);

--- a/ui/src/types/traces.ts
+++ b/ui/src/types/traces.ts
@@ -1,0 +1,34 @@
+/** Shared types for trace views. */
+
+export interface TraceSummaryRow {
+  traceId: string;
+  rootSpanName: string;
+  primaryModel: string;
+  primaryProvider: string;
+  environment: string;
+  durationMs: number;
+  totalTokens: number;
+  totalCostUsd: number;
+  status: number;
+  startTime: string;
+  spanCount: number;
+  llmCallCount: number;
+}
+
+export interface TraceFilters {
+  search: string;
+  model: string;
+  provider: string;
+  status: "" | "ok" | "error";
+  orderBy: string;
+  descending: boolean;
+}
+
+export const DEFAULT_FILTERS: TraceFilters = {
+  search: "",
+  model: "",
+  provider: "",
+  status: "",
+  orderBy: "start_time",
+  descending: true,
+};


### PR DESCRIPTION
## Summary

Extracts data fetching logic from page components into reusable hooks, creating a clean separation between data and presentation.

### New files
- `src/hooks/useTraces.ts` — ListTraces RPC + filter state + debounced search
- `src/hooks/useTrace.ts` — GetTrace RPC + span tree building + span selection
- `src/hooks/useDashboard.ts` — GetUsageSummary RPC + loading/error state
- `src/lib/api.ts` — singleton ConnectRPC clients
- `src/types/traces.ts` — shared TraceSummaryRow, TraceFilters types

### Updated pages
- `app/page.tsx` — uses `useDashboard()`
- `app/traces/page.tsx` — uses `useTraces()`
- `app/traces/[id]/page.tsx` — uses `useTrace()`

### Why
- Pages were 380-540 lines of mixed data fetching + rendering
- No code reuse between pages (e.g. client creation, error handling)
- Hooks are independently testable with Vitest

### Tests
`next build` passes with zero errors.