### PR TITLE
chore: auto-install pre-commit hooks in nix shellHook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,9 @@
           ];
 
           shellHook = ''
+            # Install pre-commit hooks (idempotent, silent).
+            pre-commit install --install-hooks > /dev/null 2>&1 || true
+
             echo "🕯️  Candela dev shell ready"
             echo "   Go:     $(go version | cut -d' ' -f3)"
             echo "   Buf:    $(buf --version 2>&1)"


### PR DESCRIPTION
Adds `pre-commit install --install-hooks` to the nix `shellHook` so hooks are always active when entering the dev shell. The call is idempotent and silent (`> /dev/null 2>&1`).