### PR TITLE
feat: Zed integration with Candela proxy + cloudflared in dev shell

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -16,7 +16,7 @@ This will automatically install:
 - **Buf** (Protobuf management)
 - **Node.js 22** & **pnpm**
 - **Python 3.12** & **uv**
-- **gh** (GitHub CLI)
+- **cloudflared** (Cloudflare tunnel for Cursor 3 integration)
 - **docker-compose**
 
 ---
@@ -31,18 +31,27 @@ Candela is proto-first. All service boundaries are defined in `proto/`.
 cd proto && buf generate
 ```
 
-This will populate `gen/go/` and `gen/ts/` (for the upcoming UI).
+This will populate `gen/go/` and `gen/ts/` (for the UI).
 
 ### 2. Running the Backend (Local Dev)
-The server defaults to **SQLite** and **Port 8080**.
+The server defaults to **DuckDB** and uses the port from `config.yaml` (default **8080**).
 
 ```bash
 go run ./cmd/candela-server
 ```
 
-You can point your browser at `http://localhost:8080/healthz` to verify it's running.
+You can point your browser at `http://localhost:8181/healthz` to verify it's running.
 
-### 3. Testing
+### 3. Running the UI
+The web interface is a Next.js 16 app in `ui/`.
+
+```bash
+cd ui && npm install && npm run dev
+```
+
+The UI will be available at `http://localhost:3000`.
+
+### 4. Testing
 We use standard Go testing. Candela includes integration tests for the Proxy and Storage backends.
 
 ```bash
@@ -55,25 +64,49 @@ go test ./pkg/proxy -v
 
 ---
 
-## 🗄️ Storage Backends
+## 🖱️ Cursor 3 Quick Start
 
-### SQLite (Default)
-No setup required. The database will be created as `candela.db` in your current directory.
-
-### ClickHouse
-For production-like testing, use the included Docker Compose file.
+Cursor 3 cannot connect to `localhost` (SSRF protection). Use a Cloudflare tunnel:
 
 ```bash
-docker compose -f deploy/docker-compose.yml up clickhouse
+# Terminal 1: Start Candela
+nix develop -c go run ./cmd/candela-server
+
+# Terminal 2: Start the tunnel
+nix develop -c cloudflared tunnel --url http://localhost:8181
 ```
 
-Then update `config.yaml`:
+Copy the tunnel URL and paste it into **Cursor Settings → Models → Override OpenAI Base URL**.
+
+See [docs/proxy.md](proxy.md) for full Cursor 3 setup instructions.
+
+---
+
+## 🗄️ Storage Backends
+
+### DuckDB (Default)
+No setup required. The database will be created as `candela.duckdb` in your current directory. DuckDB is OLAP-optimized for high-throughput analytics queries.
+
+### SQLite
+Lightweight alternative for minimal setups. Set in `config.yaml`:
+
 ```yaml
 storage:
-  backend: "clickhouse"
-  clickhouse:
-    addr: "localhost:9000"
-    database: "candela"
+  backend: "sqlite"
+  sqlite:
+    path: "candela.db"  # or ":memory:" for ephemeral
+```
+
+### BigQuery
+For production-scale analytics. Requires a GCP project with BigQuery enabled:
+
+```yaml
+storage:
+  backend: "bigquery"
+  bigquery:
+    project_id: "my-gcp-project"
+    dataset: "candela"
+    location: "US"
 ```
 
 ---
@@ -87,10 +120,10 @@ Since we use **ConnectRPC**, you can interact with the API using `curl` (Connect
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{}' \
-  http://localhost:8080/candela.v1.TraceService/ListTraces
+  http://localhost:8181/candela.v1.TraceService/ListTraces
 ```
 
 **List Traces via `grpcurl`:**
 ```bash
-grpcurl -plaintext localhost:8080 candela.v1.TraceService/ListTraces
+grpcurl -plaintext localhost:8181 candela.v1.TraceService/ListTraces
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,21 +64,19 @@ go test ./pkg/proxy -v
 
 ---
 
-## 🖱️ Cursor 3 Quick Start
+## 🖥️ Zed Quick Start
 
-Cursor 3 cannot connect to `localhost` (SSRF protection). Use a Cloudflare tunnel:
+To use Candela as the LLM proxy for Zed's AI features:
 
 ```bash
 # Terminal 1: Start Candela
 nix develop -c go run ./cmd/candela-server
 
-# Terminal 2: Start the tunnel
-nix develop -c cloudflared tunnel --url http://localhost:8181
+# Then launch Zed with the API key set
+OPENAI_API_KEY=candela open -a Zed
 ```
 
-Copy the tunnel URL and paste it into **Cursor Settings → Models → Override OpenAI Base URL**.
-
-See [docs/proxy.md](proxy.md) for full Cursor 3 setup instructions.
+Configure your Zed settings to point at Candela's proxy routes. See [docs/proxy.md](proxy.md) for full setup instructions.
 
 ---
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -17,7 +17,7 @@ To use the proxy, update your LLM client's `base_url` (or `api_base`).
 - **Auth**: API Key (usually in query param `?key=...`).
 
 ### 3. Gemini via OpenAI-Compatible API
-For clients that only speak OpenAI format (like **Cursor**).
+For clients that speak OpenAI format (like **Zed**).
 - **Endpoint**: `http://localhost:8181/proxy/gemini-oai/v1`
 - **Upstream**: `https://generativelanguage.googleapis.com/v1beta/openai`
 - **Auth**: API Key via `Authorization: Bearer YOUR_GEMINI_KEY` header.
@@ -34,99 +34,105 @@ Candela routes Anthropic through **Google Cloud Vertex AI** with automatic forma
 
 ---
 
-## 🖱️ Cursor 3 Integration
+## 🖥️ Zed Integration
 
-Cursor 3 routes API requests through their cloud infrastructure, which means it
-**cannot connect to `localhost` directly** (SSRF protection). You must expose
-Candela via a public tunnel.
+Zed connects directly to `localhost` — no tunnel needed.
 
 ### Prerequisites
 
 1. **Candela running locally**: `nix develop -c go run ./cmd/candela-server`
-2. **Cloudflare tunnel** (included in the nix dev shell):
+2. **GCP ADC** (for Anthropic/Claude): `gcloud auth application-default login`
+
+### Setup
+
+Add the following to your Zed settings (`~/.config/zed/settings.json`):
+
+#### Anthropic (Claude via Vertex AI)
+
+```json
+{
+  "language_models": {
+    "openai": {
+      "api_url": "http://localhost:8181/proxy/anthropic/v1",
+      "available_models": [
+        {
+          "name": "claude-sonnet-4-20250514",
+          "display_name": "Claude Sonnet 4 (via Candela)",
+          "max_tokens": 64000
+        },
+        {
+          "name": "claude-opus-4-20250514",
+          "display_name": "Claude Opus 4 (via Candela)",
+          "max_tokens": 32000
+        }
+      ]
+    }
+  },
+  "agent": {
+    "default_model": {
+      "provider": "openai",
+      "model": "claude-sonnet-4-20250514"
+    }
+  }
+}
+```
+
+#### Gemini
+
+```json
+{
+  "language_models": {
+    "openai": {
+      "api_url": "http://localhost:8181/proxy/gemini-oai/v1",
+      "available_models": [
+        {
+          "name": "gemini-2.5-pro",
+          "display_name": "Gemini 2.5 Pro (via Candela)",
+          "max_tokens": 65536
+        },
+        {
+          "name": "gemini-2.5-flash",
+          "display_name": "Gemini 2.5 Flash (via Candela)",
+          "max_tokens": 65536
+        }
+      ]
+    }
+  },
+  "agent": {
+    "default_model": {
+      "provider": "openai",
+      "model": "gemini-2.5-pro"
+    }
+  }
+}
+```
+
+### Setting the API Key
+
+Launch Zed with the API key environment variable:
 
 ```bash
-# Open a second terminal — this creates a temporary public URL
-nix develop -c cloudflared tunnel --url http://localhost:8181
+# For Anthropic (via Candela — key is a placeholder, ADC handles real auth):
+OPENAI_API_KEY=candela open -a Zed
+
+# For Gemini:
+OPENAI_API_KEY=your-gemini-api-key open -a Zed
+
+# For OpenAI:
+OPENAI_API_KEY=sk-... open -a Zed
 ```
 
-Cloudflared will print a URL like:
-```
-https://random-words-here.trycloudflare.com
-```
+### Anthropic Prerequisites
 
-Copy that URL — you'll use it as the base for Cursor's model settings below.
-
-> **⚠️ Security**: This exposes your Candela proxy to the public internet.
-> Since API keys are forwarded from the client (not stored), your keys aren't
-> at risk. But anyone who discovers the URL could route traffic through your
-> proxy. For daily-driver use, consider a [named Cloudflare tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
-> with access policies, or deploy Candela to **Cloud Run** for a stable endpoint.
-
-### Cursor Settings
-
-Open **Cursor Settings → Models** and configure your providers:
-
-#### OpenAI Models
-| Setting | Value |
-|---------|-------|
-| Override OpenAI Base URL | `https://<tunnel-url>/proxy/openai/v1` |
-| API Key | Your OpenAI `sk-...` key |
-| Models | `gpt-4o`, `gpt-4.1`, `o3-mini`, etc. |
-
-#### Gemini Models
-| Setting | Value |
-|---------|-------|
-| Override OpenAI Base URL | `https://<tunnel-url>/proxy/gemini-oai/v1` |
-| API Key | Your Gemini API key (from AI Studio) |
-| Models | `gemini-2.5-pro`, `gemini-2.5-flash`, etc. |
-
-#### Anthropic (Claude) Models
-| Setting | Value |
-|---------|-------|
-| Override OpenAI Base URL | `https://<tunnel-url>/proxy/anthropic/v1` |
-| API Key | `candela` (placeholder — ADC is auto-injected by Candela) |
-| Models | `claude-sonnet-4-20250514`, `claude-opus-4-20250514`, etc. |
-
-**Anthropic prerequisites**:
 1. Run `gcloud auth application-default login`
 2. Set `vertex_ai.project_id` in `config.yaml` to your GCP project
 3. Enable the Vertex AI API and request Claude model access in Model Garden
 
-### Network Settings
+### Verify
 
-In **Cursor Settings → Network**, set **HTTP Compatibility Mode** to **HTTP/1.1**
-for reliable streaming through the tunnel.
-
-### Known Limitations
-
-- **Agent Mode**: Cursor 3's Agent Mode sends requests in OpenAI's **Responses
-  API** format (`input` field instead of `messages`), which differs from the
-  standard Chat Completions format. Candela does not yet translate this format.
-  Use **Ask** or **Plan** mode for full observability. Agent Mode support is on
-  the roadmap.
-- **Override is global**: Cursor's "Override OpenAI Base URL" applies globally —
-  you can only point one provider route at a time unless you use separate Cursor
-  profiles.
-- **Tunnel URL changes on restart**: The Cloudflare quick tunnel URL is
-  temporary. You'll need to update Cursor settings each time you restart the
-  tunnel. Use a named tunnel or Cloud Run deployment for a stable URL.
-
-### Alternative: Cloud Run Deployment
-
-For a stable, always-on proxy without tunnels, deploy Candela to Google Cloud Run:
-
-```bash
-# Build and deploy (uses deploy/Dockerfile.server)
-gcloud run deploy candela \
-  --source . \
-  --dockerfile deploy/Dockerfile.server \
-  --region us-central1 \
-  --allow-unauthenticated
-```
-
-This gives you a permanent `https://candela-<hash>.run.app` URL. Cloud Run's
-service account handles Vertex AI auth automatically — no ADC setup needed.
+Send a message in Zed's Agent Panel (`Cmd+Shift+A`). You should see:
+- The response from the model in Zed
+- A trace in the Candela dashboard at `http://localhost:3000`
 
 ---
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -7,25 +7,25 @@ The Candela LLM Proxy is a transparent reverse proxy that adds instant observabi
 To use the proxy, update your LLM client's `base_url` (or `api_base`).
 
 ### 1. OpenAI
-- **Endpoint**: `http://localhost:8080/proxy/openai/v1`
+- **Endpoint**: `http://localhost:8181/proxy/openai/v1`
 - **Upstream**: `https://api.openai.com`
 - **Auth**: Standard `Authorization: Bearer sk-...` header.
 
 ### 2. Google Gemini (Native API)
-- **Endpoint**: `http://localhost:8080/proxy/google/`
+- **Endpoint**: `http://localhost:8181/proxy/google/`
 - **Upstream**: `https://generativelanguage.googleapis.com`
 - **Auth**: API Key (usually in query param `?key=...`).
 
 ### 3. Gemini via OpenAI-Compatible API
 For clients that only speak OpenAI format (like **Cursor**).
-- **Endpoint**: `http://localhost:8080/proxy/gemini-oai/v1`
+- **Endpoint**: `http://localhost:8181/proxy/gemini-oai/v1`
 - **Upstream**: `https://generativelanguage.googleapis.com/v1beta/openai`
 - **Auth**: API Key via `Authorization: Bearer YOUR_GEMINI_KEY` header.
 - **Models**: `gemini-2.5-pro`, `gemini-2.5-flash`, etc.
 
 ### 4. Anthropic (via Vertex AI)
 Candela routes Anthropic through **Google Cloud Vertex AI** with automatic format translation and auth.
-- **Endpoint**: `http://localhost:8080/proxy/anthropic/v1`
+- **Endpoint**: `http://localhost:8181/proxy/anthropic/v1`
 - **Upstream**: `https://{REGION}-aiplatform.googleapis.com` (configurable)
 - **Auth**: **Automatic** — Candela injects GCP credentials from Application Default Credentials (ADC).
 - **Format**: Candela translates OpenAI Chat Completions ↔ Anthropic Messages format automatically.
@@ -34,41 +34,99 @@ Candela routes Anthropic through **Google Cloud Vertex AI** with automatic forma
 
 ---
 
-## 🖱️ Cursor Integration
+## 🖱️ Cursor 3 Integration
 
-Cursor's BYOK mode speaks OpenAI Chat Completions format, so use these routes:
+Cursor 3 routes API requests through their cloud infrastructure, which means it
+**cannot connect to `localhost` directly** (SSRF protection). You must expose
+Candela via a public tunnel.
 
-### Setup
+### Prerequisites
 
-1. **Start Candela**: `nix develop -c go run ./cmd/candela-server`
-2. **Open Cursor Settings → Models**
+1. **Candela running locally**: `nix develop -c go run ./cmd/candela-server`
+2. **Cloudflare tunnel** (included in the nix dev shell):
 
-### OpenAI Models
+```bash
+# Open a second terminal — this creates a temporary public URL
+nix develop -c cloudflared tunnel --url http://localhost:8181
+```
+
+Cloudflared will print a URL like:
+```
+https://random-words-here.trycloudflare.com
+```
+
+Copy that URL — you'll use it as the base for Cursor's model settings below.
+
+> **⚠️ Security**: This exposes your Candela proxy to the public internet.
+> Since API keys are forwarded from the client (not stored), your keys aren't
+> at risk. But anyone who discovers the URL could route traffic through your
+> proxy. For daily-driver use, consider a [named Cloudflare tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
+> with access policies, or deploy Candela to **Cloud Run** for a stable endpoint.
+
+### Cursor Settings
+
+Open **Cursor Settings → Models** and configure your providers:
+
+#### OpenAI Models
 | Setting | Value |
 |---------|-------|
-| Base URL | `http://localhost:8080/proxy/openai/v1` |
+| Override OpenAI Base URL | `https://<tunnel-url>/proxy/openai/v1` |
 | API Key | Your OpenAI `sk-...` key |
+| Models | `gpt-4o`, `gpt-4.1`, `o3-mini`, etc. |
 
-### Gemini Models
+#### Gemini Models
 | Setting | Value |
 |---------|-------|
-| Base URL | `http://localhost:8080/proxy/gemini-oai/v1` |
+| Override OpenAI Base URL | `https://<tunnel-url>/proxy/gemini-oai/v1` |
 | API Key | Your Gemini API key (from AI Studio) |
-| Model | `gemini-2.5-pro`, `gemini-2.5-flash`, etc. |
+| Models | `gemini-2.5-pro`, `gemini-2.5-flash`, etc. |
 
-### Anthropic (Claude) Models
+#### Anthropic (Claude) Models
 | Setting | Value |
 |---------|-------|
-| Base URL | `http://localhost:8080/proxy/anthropic/v1` |
-| API Key | `candela` (placeholder — ADC is auto-injected) |
-| Model | `claude-sonnet-4-20250514`, `claude-opus-4-20250514`, etc. |
+| Override OpenAI Base URL | `https://<tunnel-url>/proxy/anthropic/v1` |
+| API Key | `candela` (placeholder — ADC is auto-injected by Candela) |
+| Models | `claude-sonnet-4-20250514`, `claude-opus-4-20250514`, etc. |
 
-**Prerequisites for Anthropic**:
+**Anthropic prerequisites**:
 1. Run `gcloud auth application-default login`
 2. Set `vertex_ai.project_id` in `config.yaml` to your GCP project
 3. Enable the Vertex AI API and request Claude model access in Model Garden
 
-> **⚠️ Important**: In Cursor, go to **Settings → Network → HTTP Compatibility Mode** and set it to **HTTP/1.1** for reliable localhost proxy connections.
+### Network Settings
+
+In **Cursor Settings → Network**, set **HTTP Compatibility Mode** to **HTTP/1.1**
+for reliable streaming through the tunnel.
+
+### Known Limitations
+
+- **Agent Mode**: Cursor 3's Agent Mode sends requests in OpenAI's **Responses
+  API** format (`input` field instead of `messages`), which differs from the
+  standard Chat Completions format. Candela does not yet translate this format.
+  Use **Ask** or **Plan** mode for full observability. Agent Mode support is on
+  the roadmap.
+- **Override is global**: Cursor's "Override OpenAI Base URL" applies globally —
+  you can only point one provider route at a time unless you use separate Cursor
+  profiles.
+- **Tunnel URL changes on restart**: The Cloudflare quick tunnel URL is
+  temporary. You'll need to update Cursor settings each time you restart the
+  tunnel. Use a named tunnel or Cloud Run deployment for a stable URL.
+
+### Alternative: Cloud Run Deployment
+
+For a stable, always-on proxy without tunnels, deploy Candela to Google Cloud Run:
+
+```bash
+# Build and deploy (uses deploy/Dockerfile.server)
+gcloud run deploy candela \
+  --source . \
+  --dockerfile deploy/Dockerfile.server \
+  --region us-central1 \
+  --allow-unauthenticated
+```
+
+This gives you a permanent `https://candela-<hash>.run.app` URL. Cloud Run's
+service account handles Vertex AI auth automatically — no ADC setup needed.
 
 ---
 

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,7 @@
 
             # Infrastructure tools
             docker-compose
+            cloudflared  # Cloudflare tunnel (expose Candela to Cursor 3)
             grpcurl
             jq
             yq-go


### PR DESCRIPTION
## Summary

Add Zed editor integration docs and cloudflared to the dev shell.

### Changes
- **flake.nix**: Add cloudflared to nix dev shell
- **docs/proxy.md**: Replace Cursor section with full Zed integration guide (settings.json examples for Anthropic + Gemini, API key launch pattern, verification steps)
- **docs/development.md**: Fix stale content (DuckDB not SQLite, remove ClickHouse), add Zed quick start

### Why Zed?
- Direct localhost — no tunnel needed (Cursor SSRF-blocks localhost)
- Free & open source — full model config without paid plans
- Standard Chat Completions API — works with Candela today

### Testing
- All Go tests passing
- Manual: Zed → Candela proxy → Vertex AI (Claude) → trace captured in DuckDB