### PR TITLE
docs: add OpenCode integration + fix stale Cursor references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ node_modules/
 .idea/
 .vscode/
 .opencode.json
+opencode.json
 *.swp
 *.swo
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,10 @@
 /vendor/
 node_modules/
 
-# IDE
+# IDE / AI tools
 .idea/
 .vscode/
+.opencode.json
 *.swp
 *.swo
 *~

--- a/config.yaml
+++ b/config.yaml
@@ -36,10 +36,10 @@ proxy:
   #   /proxy/gemini-oai/  → https://generativelanguage.googleapis.com/v1beta/openai (OpenAI-compat)
   #   /proxy/anthropic/   → Vertex AI (with format translation + ADC auth)
   #
-  # Cursor integration:
-  #   OpenAI:     Base URL = http://localhost:8080/proxy/openai/v1
-  #   Gemini:     Base URL = http://localhost:8080/proxy/gemini-oai/v1
-  #   Anthropic:  Base URL = http://localhost:8080/proxy/anthropic/v1
+  # Editor integration (Zed, OpenCode, etc.):
+  #   OpenAI:     Base URL = http://localhost:8181/proxy/openai/v1
+  #   Gemini:     Base URL = http://localhost:8181/proxy/gemini-oai/v1
+  #   Anthropic:  Base URL = http://localhost:8181/proxy/anthropic/v1
   providers:
     - openai
     - google

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,9 +64,9 @@ go test ./pkg/proxy -v
 
 ---
 
-## 🖥️ Zed Quick Start
+## 🖥️ Editor Quick Start
 
-To use Candela as the LLM proxy for Zed's AI features:
+### Zed
 
 ```bash
 # Terminal 1: Start Candela
@@ -76,7 +76,21 @@ nix develop -c go run ./cmd/candela-server
 OPENAI_API_KEY=candela open -a Zed
 ```
 
-Configure your Zed settings to point at Candela's proxy routes. See [docs/proxy.md](proxy.md) for full setup instructions.
+Configure Zed settings to point at Candela's proxy routes.
+
+### OpenCode
+
+```bash
+# Terminal 1: Start Candela
+nix develop -c go run ./cmd/candela-server
+
+# Terminal 2: Launch OpenCode (picks up opencode.json from project root)
+npx -y opencode-ai
+```
+
+Use `/connect` → Other → `candela-anthropic` → key `candela`, then `/models` to select a model.
+
+See [docs/proxy.md](proxy.md) for full setup instructions for both editors.
 
 ---
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -136,6 +136,112 @@ Send a message in Zed's Agent Panel (`Cmd+Shift+A`). You should see:
 
 ---
 
+## 💻 OpenCode Integration
+
+[OpenCode](https://opencode.ai/) is an open-source terminal AI coding agent. It connects directly
+to `localhost` — no tunnel needed.
+
+### Prerequisites
+
+1. **Candela running locally**: `nix develop -c go run ./cmd/candela-server`
+2. **OpenCode installed**: `npm install -g opencode-ai` (or use `npx -y opencode-ai`)
+3. **GCP ADC** (for Anthropic/Claude): `gcloud auth application-default login`
+
+### Step 1: Create `opencode.json`
+
+Create `opencode.json` in your project root (not `.opencode.json`):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "candela-anthropic": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Claude via Candela (Vertex AI)",
+      "options": {
+        "baseURL": "http://localhost:8181/proxy/anthropic/v1"
+      },
+      "models": {
+        "claude-sonnet-4-20250514": {
+          "name": "Claude Sonnet 4"
+        },
+        "claude-opus-4-20250514": {
+          "name": "Claude Opus 4"
+        }
+      }
+    },
+    "candela-gemini": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Gemini via Candela",
+      "options": {
+        "baseURL": "http://localhost:8181/proxy/gemini-oai/v1"
+      },
+      "models": {
+        "gemini-2.5-pro": {
+          "name": "Gemini 2.5 Pro"
+        },
+        "gemini-2.5-flash": {
+          "name": "Gemini 2.5 Flash"
+        }
+      }
+    },
+    "candela-openai": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "OpenAI via Candela",
+      "options": {
+        "baseURL": "http://localhost:8181/proxy/openai/v1"
+      },
+      "models": {
+        "gpt-4o": {
+          "name": "GPT-4o"
+        },
+        "o3-mini": {
+          "name": "o3-mini"
+        }
+      }
+    }
+  }
+}
+```
+
+### Step 2: Register credentials via `/connect`
+
+Launch OpenCode and register each provider:
+
+```bash
+npx -y opencode-ai
+```
+
+Inside the TUI:
+
+1. Type `/connect`
+2. Scroll to **"Other"** and select it
+3. Enter provider ID: `candela-anthropic`
+4. Enter API key: `candela` (placeholder — Candela injects ADC for Vertex AI)
+
+Repeat for other providers if needed:
+- Provider ID: `candela-gemini`, API key: your Gemini API key
+- Provider ID: `candela-openai`, API key: your OpenAI `sk-...` key
+
+### Step 3: Select a model
+
+Type `/models` in the TUI and select a model under **"Claude via Candela (Vertex AI)"**,
+**"Gemini via Candela"**, or **"OpenAI via Candela"**.
+
+### Verify
+
+Send a message in the OpenCode TUI. You should see:
+- The response from the model in OpenCode
+- A trace in the Candela dashboard at `http://localhost:3000`
+
+### Anthropic Prerequisites
+
+1. Run `gcloud auth application-default login`
+2. Set `vertex_ai.project_id` in `config.yaml` to your GCP project
+3. Enable the Vertex AI API and request Claude model access in Model Garden
+
+---
+
 ## 🛠️ Advanced Proxy Config
 
 Configuration is done via `config.yaml`:


### PR DESCRIPTION
## Summary

Add OpenCode integration docs and fix remaining Cursor references across the repo.

### Changes

#### `docs/proxy.md`
- Add full **OpenCode Integration** section with step-by-step setup
  - `opencode.json` config for all three Candela proxy providers
  - `/connect` → Other auth flow walkthrough
  - `/models` selection instructions
  - Verification steps

#### `docs/development.md`
- Rename "Zed Quick Start" → "Editor Quick Start" with both Zed and OpenCode

#### `config.yaml`
- Fix stale Cursor references → "Editor integration (Zed, OpenCode, etc.)"
- Fix incorrect port 8080 → 8181

#### `.gitignore`
- Add `opencode.json` and `.opencode.json` (per-user AI tool configs)