### PR TITLE
fix(ui): update e2e tests to use port 8181 and derive API_BASE from env var

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,10 @@ repos:
         language: system
         pass_filenames: false
         files: '\.go$'
+
+      - id: playwright-e2e
+        name: playwright e2e
+        entry: bash -c 'cd ui && npx playwright test'
+        language: system
+        pass_filenames: false
+        files: '^ui/'

--- a/ui/e2e/app.spec.ts
+++ b/ui/e2e/app.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-const API_BASE = "http://localhost:8080";
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8181";
 
 /**
  * Mock a ConnectRPC unary call by intercepting the POST to the service method URL.
@@ -55,7 +55,7 @@ test.describe("App Shell", () => {
   test("shows environment indicator in sidebar footer", async ({ page }) => {
     await page.goto("/");
     await expect(page.locator(".sidebar-env")).toContainText("Development");
-    await expect(page.locator(".sidebar-env")).toContainText("localhost:8080");
+    await expect(page.locator(".sidebar-env")).toContainText("localhost:8181");
   });
 });
 
@@ -373,7 +373,7 @@ test.describe("Settings", () => {
   test("shows backend connection info", async ({ page }) => {
     await page.goto("/settings");
     await expect(page.locator(".main-header h1")).toHaveText("Settings");
-    await expect(page.locator("text=http://localhost:8080")).toBeVisible();
+    await expect(page.locator("text=http://localhost:8181")).toBeVisible();
     await expect(page.locator("text=ConnectRPC")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Problem

All 7 failing E2E tests stem from a single root cause: the app's ConnectRPC transport was updated to use localhost:8181 but the tests still mocked on the old port 8080.

## Fix
- Derive API_BASE from NEXT_PUBLIC_API_URL (same env var the app uses) to prevent future drift
- Update 2 hardcoded :8080 assertions in sidebar footer and settings tests

**21/21 tests pass locally.**