### PR TITLE
feat: Nix-built CI container images + govulncheck enforcement

### DIFF
--- a/.github/workflows/build-ci-images.yml
+++ b/.github/workflows/build-ci-images.yml
@@ -1,0 +1,58 @@
+name: Build CI Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [ci-go, ci-ui]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build image
+        run: nix build .#${{ matrix.image }} -o result
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load and push image
+        run: |
+          # Load the Nix-built image tarball into Docker
+          docker load < result
+
+          # Get the image name:tag that was loaded
+          IMAGE_INFO=$(docker images --format '{{.Repository}}:{{.Tag}}' | head -1)
+          echo "Loaded image: $IMAGE_INFO"
+
+          # Push with the nixpkgs rev tag
+          docker push "$IMAGE_INFO"
+
+          # Also tag and push as :latest
+          IMAGE_NAME=$(echo "$IMAGE_INFO" | cut -d: -f1)
+          docker tag "$IMAGE_INFO" "$IMAGE_NAME:latest"
+          docker push "$IMAGE_NAME:latest"
+
+          echo "Pushed $IMAGE_INFO and $IMAGE_NAME:latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - uses: actions/setup-node@v4
         with:
@@ -54,6 +54,7 @@ jobs:
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
+        continue-on-error: true
 
   lint:
     runs-on: ubuntu-latest
@@ -62,7 +63,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
-        continue-on-error: true  # advisory — stdlib vulns shouldn't block CI
 
   lint:
     runs-on: ubuntu-latest
@@ -195,4 +194,3 @@ jobs:
           name: playwright-report
           path: ui/playwright-report/
           retention-days: 7
-

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774709303,
-        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,16 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        isLinux = pkgs.stdenv.isLinux;
+
+        # Short rev from flake lock for deterministic image tagging.
+        nixpkgsRev = builtins.substring 0 8 nixpkgs.rev;
+
+        # Shared base utilities for CI containers.
+        baseContents = with pkgs; [
+          coreutils bash gnugrep gawk findutils gnused
+          git cacert
+        ];
       in
       {
         devShells.default = pkgs.mkShell {
@@ -38,7 +48,7 @@
 
             # Infrastructure tools
             docker-compose
-            cloudflared  # Cloudflare tunnel (expose Candela to Cursor 3)
+            cloudflared
             grpcurl
             jq
             yq-go
@@ -58,6 +68,57 @@
             echo "   Node:   $(node --version)"
             echo "   Python: $(python3 --version | cut -d' ' -f2)"
           '';
+        };
+
+        # ── CI container images (Linux only) ───────────────────────────
+        # Built in CI via `nix build .#ci-go` / `nix build .#ci-ui`
+        # and pushed to GHCR. Tagged with the nixpkgs rev for lockstep.
+      } // pkgs.lib.optionalAttrs isLinux {
+        packages.ci-go = pkgs.dockerTools.buildLayeredImage {
+          name = "ghcr.io/candelahq/ci-go";
+          tag = nixpkgsRev;
+
+          contents = baseContents ++ (with pkgs; [
+            go_1_26
+            golangci-lint
+            buf
+            protobuf
+            protoc-gen-go
+            protoc-gen-go-grpc
+          ]);
+
+          config = {
+            Env = [
+              "PATH=/bin:/usr/bin:/sbin:/usr/sbin"
+              "GOPATH=/tmp/go"
+              "GOFLAGS=-buildvcs=false"
+              "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            ];
+            WorkingDir = "/workspace";
+          };
+        };
+
+        packages.ci-ui = pkgs.dockerTools.buildLayeredImage {
+          name = "ghcr.io/candelahq/ci-ui";
+          tag = nixpkgsRev;
+
+          contents = baseContents ++ (with pkgs; [
+            nodejs_22
+            buf
+            protobuf
+            chromium
+          ]);
+
+          config = {
+            Env = [
+              "PATH=/bin:/usr/bin:/sbin:/usr/sbin"
+              "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1"
+              "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=${pkgs.chromium}/bin/chromium"
+              "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+              "FONTCONFIG_FILE=${pkgs.fontconfig.out}/etc/fonts/fonts.conf"
+            ];
+            WorkingDir = "/workspace";
+          };
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
 
             # Node.js (for web UI)
             nodejs_22
-            nodePackages.pnpm
+            pnpm
 
             # Python (for eval engine)
             python312


### PR DESCRIPTION
## Summary

Add Nix-built OCI container images for CI, stored in GHCR. This is step 1 of 2 — the follow-up PR will switch `ci.yml` to consume these images.

### What's in this PR

**`flake.nix`** — Two new container image definitions (Linux only):
- **ci-go**: Go 1.26, Buf, protoc-gen-go, golangci-lint
- **ci-ui**: Node 22, Buf, Chromium (for Playwright E2E)
- Images tagged with nixpkgs rev from `flake.lock` for deterministic versioning
- Uses `dockerTools.buildLayeredImage` — no Dockerfile, fully reproducible

**`.github/workflows/build-ci-images.yml`** — New workflow:
- Triggers on `flake.nix`/`flake.lock` changes to main, or manual dispatch
- Uses DeterminateSystems Nix installer + magic-nix-cache
- Builds both images in parallel via matrix strategy
- Pushes to `ghcr.io/candelahq/ci-go` and `ghcr.io/candelahq/ci-ui`

**`.github/workflows/ci.yml`** — govulncheck fix:
- Removed `continue-on-error: true` so real dependency vulns fail CI

### Follow-up
Once this merges and images are built, a follow-up PR will update `ci.yml` to use `container:` directives, eliminating setup-go/setup-node/buf-setup/playwright-install steps.