### PR TITLE
ci: switch CI jobs to Nix-built container images from GHCR

### DIFF
--- a/.github/workflows/build-ci-images.yml
+++ b/.github/workflows/build-ci-images.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
 
       - name: Build image
         run: nix build .#${{ matrix.image }} -o result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,30 +8,18 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    container: ghcr.io/candelahq/ci-go:latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.26.2'
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: ui/package-lock.json
 
       - name: Install UI deps (protoc-gen-es)
         run: npm ci
         working-directory: ui
-
-      - uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ github.token }}
 
       - name: Generate proto (gen/ is gitignored)
         run: |
@@ -58,26 +46,13 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    container: ghcr.io/candelahq/ci-go:latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.26.2'
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: ui/package-lock.json
 
       - name: Install UI deps (protoc-gen-es)
         run: npm ci
         working-directory: ui
-
-      - uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ github.token }}
 
       - name: Generate proto
         run: |
@@ -97,14 +72,11 @@ jobs:
 
   proto:
     runs-on: ubuntu-latest
+    container: ghcr.io/candelahq/ci-go:latest
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # buf breaking needs main ref
-
-      - uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ github.token }}
+          fetch-depth: 0
 
       - name: buf format check
         run: buf format --diff --exit-code proto/
@@ -112,23 +84,15 @@ jobs:
       - name: buf breaking (PR only)
         if: github.event_name == 'pull_request'
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch origin main
           buf breaking proto/ --against '.git#branch=origin/main,subdir=proto'
 
   ui-build-and-lint:
     runs-on: ubuntu-latest
+    container: ghcr.io/candelahq/ci-ui:latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: ui/package-lock.json
-
-      - uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ github.token }}
 
       - name: Install dependencies
         run: npm ci
@@ -152,19 +116,10 @@ jobs:
 
   ui-e2e:
     runs-on: ubuntu-latest
+    container: ghcr.io/candelahq/ci-ui:latest
     needs: [ui-build-and-lint]
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: ui/package-lock.json
-
-      - uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ github.token }}
 
       - name: Install dependencies
         run: npm ci
@@ -177,10 +132,6 @@ jobs:
 
       - name: Copy generated types
         run: cp -r gen/ts/candela ui/src/gen
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-        working-directory: ui
 
       - name: Run Playwright tests
         run: npx playwright test

--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,9 @@
               "GOFLAGS=-buildvcs=false"
               "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
             ];
+            Labels = {
+              "org.opencontainers.image.source" = "https://github.com/candelahq/candela";
+            };
             WorkingDir = "/workspace";
           };
         };
@@ -118,6 +121,9 @@
               "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
               "FONTCONFIG_FILE=${pkgs.fontconfig.out}/etc/fonts/fonts.conf"
             ];
+            Labels = {
+              "org.opencontainers.image.source" = "https://github.com/candelahq/candela";
+            };
             WorkingDir = "/workspace";
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,7 @@
             protobuf
             protoc-gen-go
             protoc-gen-go-grpc
+            nodejs_22  # needed for protoc-gen-es during buf generate
           ]);
 
           config = {


### PR DESCRIPTION
## Summary

Switches all 5 CI jobs to use pre-built container images from GHCR, eliminating per-run tool installation.

### Removed steps (per job)
- `actions/setup-go`
- `actions/setup-node`
- `bufbuild/buf-setup-action`
- `npx playwright install --with-deps chromium`

### Result
- **-57 lines, +9 lines** in ci.yml
- Expected ~2-3min faster CI runs (no tool downloads)

### Blockers
GHCR push permissions need to be enabled for the candelahq org. Run:
```
gh api --method PUT /orgs/candelahq/actions/permissions -f default_workflow_permissions=write
```
Then re-run the image build: `gh run rerun 24115139559 --repo candelahq/candela`