### PR TITLE
feat: Phase 3 Visual Explorer — Dashboard Charts & Cost Analytics

### DIFF
--- a/ui/e2e/app.spec.ts
+++ b/ui/e2e/app.spec.ts
@@ -74,6 +74,13 @@ test.describe("Dashboard", () => {
       totalCostUsd: 3.47,
       avgLatencyMs: 234.5,
       errorRate: 0.02,
+      tracesOverTime: [],
+      costOverTime: [],
+      tokensOverTime: [],
+    });
+    await mockConnectRPC(page, "/candela.v1.TraceService/ListTraces", {
+      traces: [],
+      pagination: { totalCount: 0, nextPageToken: "" },
     });
 
     await page.goto("/");
@@ -383,10 +390,25 @@ test.describe("Settings", () => {
 // ──────────────────────────────────────────
 
 test.describe("Costs", () => {
-  test("renders cost page with placeholder stats", async ({ page }) => {
+  test("renders cost page with model breakdown", async ({ page }) => {
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetUsageSummary", {
+      totalTraces: "0",
+      totalSpans: "0",
+      totalLlmCalls: "0",
+      totalInputTokens: "0",
+      totalOutputTokens: "0",
+      totalCostUsd: 0,
+      avgLatencyMs: 0,
+      errorRate: 0,
+      costOverTime: [],
+    });
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetModelBreakdown", {
+      models: [],
+    });
+
     await page.goto("/costs");
     await expect(page.locator(".main-header h1")).toHaveText("Costs");
-    await expect(page.locator(".card").filter({ hasText: "Today" })).toBeVisible();
+    await expect(page.locator(".card").filter({ hasText: "Total Cost" })).toBeVisible();
     await expect(page.locator(".empty-state-title")).toHaveText("No cost data yet");
   });
 });

--- a/ui/src/app/costs/page.tsx
+++ b/ui/src/app/costs/page.tsx
@@ -1,51 +1,202 @@
 "use client";
 
+import { useCosts } from "@/hooks/useCosts";
+import { AreaChart } from "@/components/chart";
+import type { TimeRange } from "@/hooks/useDashboard";
+
+// ──────────────────────────────────────────
+// Time Range Selector
+// ──────────────────────────────────────────
+
+const ranges: { value: TimeRange; label: string }[] = [
+  { value: "24h", label: "24h" },
+  { value: "7d", label: "7d" },
+  { value: "30d", label: "30d" },
+];
+
+function TimeRangeSelector({
+  value,
+  onChange,
+}: {
+  value: TimeRange;
+  onChange: (r: TimeRange) => void;
+}) {
+  return (
+    <div className="time-range-selector">
+      {ranges.map((r) => (
+        <button
+          key={r.value}
+          className={`time-range-btn ${value === r.value ? "active" : ""}`}
+          onClick={() => onChange(r.value)}
+        >
+          {r.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────
+// Page
+// ──────────────────────────────────────────
+
 export default function CostsPage() {
+  const { summary, models, error, timeRange, setTimeRange, refresh } =
+    useCosts();
+
+  const maxCost = Math.max(...models.map((m) => m.costUsd), 0.001);
+
   return (
     <>
       <header className="main-header">
-        <h1>Costs</h1>
-        <span className="mono" style={{ color: "var(--text-muted)" }}>
-          Token usage &amp; spending
-        </span>
+        <div>
+          <h1>Costs</h1>
+          <span className="mono" style={{ color: "var(--text-muted)", fontSize: 12 }}>
+            Token usage &amp; spending
+          </span>
+        </div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          <button className="btn" onClick={refresh}>
+            🔄
+          </button>
+        </div>
       </header>
 
       <div className="main-body">
+        {error && (
+          <div
+            className="card animate-in"
+            style={{
+              borderColor: "var(--error)",
+              marginBottom: 24,
+              background: "rgba(248,113,113,0.05)",
+            }}
+          >
+            <div className="card-title" style={{ color: "var(--error)" }}>
+              Could not load cost data
+            </div>
+            <div style={{ fontSize: 13, color: "var(--text-secondary)" }}>
+              {error}
+            </div>
+          </div>
+        )}
+
+        {/* Summary cards */}
         <div className="stats-grid animate-in">
           <div className="card">
-            <div className="card-title">Today</div>
-            <div className="card-value">$0.00</div>
-            <div className="card-subtitle">0 requests</div>
+            <div className="card-title">Total Cost</div>
+            <div className="card-value">
+              {summary ? `$${summary.totalCostUsd.toFixed(4)}` : "—"}
+            </div>
+            <div className="card-subtitle">
+              {timeRange === "24h" ? "Last 24 hours" : timeRange === "7d" ? "Last 7 days" : "Last 30 days"}
+            </div>
           </div>
           <div className="card">
-            <div className="card-title">This Week</div>
-            <div className="card-value">$0.00</div>
-            <div className="card-subtitle">0 requests</div>
+            <div className="card-title">Total Requests</div>
+            <div className="card-value">
+              {summary ? Number(summary.totalTraces).toLocaleString() : "—"}
+            </div>
+            <div className="card-subtitle">LLM calls</div>
           </div>
           <div className="card">
-            <div className="card-title">This Month</div>
-            <div className="card-value">$0.00</div>
-            <div className="card-subtitle">0 requests</div>
+            <div className="card-title">Input Tokens</div>
+            <div className="card-value">
+              {summary ? summary.totalInputTokens.toLocaleString() : "—"}
+            </div>
+            <div className="card-subtitle">Prompt tokens</div>
           </div>
           <div className="card">
-            <div className="card-title">All Time</div>
-            <div className="card-value">$0.00</div>
-            <div className="card-subtitle">0 requests</div>
+            <div className="card-title">Output Tokens</div>
+            <div className="card-value">
+              {summary ? summary.totalOutputTokens.toLocaleString() : "—"}
+            </div>
+            <div className="card-subtitle">Completion tokens</div>
           </div>
         </div>
 
+        {/* Cost over time chart */}
+        <div className="chart-card animate-in" style={{ marginBottom: 24, animationDelay: "0.05s" }}>
+          <div className="chart-card-header">
+            <span className="chart-card-title">Cost Over Time</span>
+            {summary && (
+              <span className="mono" style={{ fontSize: 12, color: "var(--text-muted)" }}>
+                ${summary.totalCostUsd.toFixed(4)} total
+              </span>
+            )}
+          </div>
+          <AreaChart
+            data={summary?.costOverTime ?? []}
+            height={220}
+            color="var(--success)"
+            formatValue={(v) => `$${v.toFixed(4)}`}
+            emptyMessage="No cost data for this period"
+          />
+        </div>
+
+        {/* Model breakdown */}
         <div className="table-container animate-in" style={{ animationDelay: "0.1s" }}>
           <div className="table-header">
             <span className="table-title">Cost by Model</span>
+            <span className="mono" style={{ fontSize: 12, color: "var(--text-muted)" }}>
+              {models.length} model{models.length !== 1 ? "s" : ""}
+            </span>
           </div>
-          <div className="empty-state">
-            <div className="empty-state-icon">💰</div>
-            <div className="empty-state-title">No cost data yet</div>
-            <div className="empty-state-desc">
-              Cost breakdowns will appear here once traces start flowing
-              through the proxy.
+          {models.length === 0 ? (
+            <div className="empty-state">
+              <div className="empty-state-icon">💰</div>
+              <div className="empty-state-title">No cost data yet</div>
+              <div className="empty-state-desc">
+                Cost breakdowns will appear here once traces start flowing
+                through the proxy.
+              </div>
             </div>
-          </div>
+          ) : (
+            <table>
+              <thead>
+                <tr>
+                  <th>Model</th>
+                  <th>Provider</th>
+                  <th>Calls</th>
+                  <th>Input Tokens</th>
+                  <th>Output Tokens</th>
+                  <th>Cost</th>
+                  <th>Avg Latency</th>
+                  <th style={{ width: 120 }}>Share</th>
+                </tr>
+              </thead>
+              <tbody>
+                {models
+                  .sort((a, b) => b.costUsd - a.costUsd)
+                  .map((m) => (
+                    <tr key={`${m.model}-${m.provider}`}>
+                      <td>
+                        <span className="mono" style={{ fontSize: 12 }}>
+                          {m.model}
+                        </span>
+                      </td>
+                      <td>{m.provider}</td>
+                      <td>{m.callCount.toLocaleString()}</td>
+                      <td>{m.inputTokens.toLocaleString()}</td>
+                      <td>{m.outputTokens.toLocaleString()}</td>
+                      <td style={{ fontWeight: 600 }}>
+                        ${m.costUsd.toFixed(4)}
+                      </td>
+                      <td>{m.avgLatencyMs.toFixed(0)}ms</td>
+                      <td>
+                        <div
+                          className="model-bar"
+                          style={{
+                            width: `${(m.costUsd / maxCost) * 100}%`,
+                          }}
+                        />
+                      </td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          )}
         </div>
       </div>
     </>

--- a/ui/src/app/costs/page.tsx
+++ b/ui/src/app/costs/page.tsx
@@ -167,7 +167,7 @@ export default function CostsPage() {
                 </tr>
               </thead>
               <tbody>
-                {models
+                {[...models]
                   .sort((a, b) => b.costUsd - a.costUsd)
                   .map((m) => (
                     <tr key={`${m.model}-${m.provider}`}>

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -915,3 +915,161 @@ tr:hover td {
   background: var(--accent-dim);
   color: var(--accent);
 }
+
+/* ──────────────────────────────────────────
+   Charts
+   ────────────────────────────────────────── */
+
+.chart-container {
+  position: relative;
+  width: 100%;
+  user-select: none;
+}
+
+.chart-svg {
+  display: block;
+}
+
+.chart-grid-line {
+  stroke: var(--border-subtle);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+}
+
+.chart-axis-label {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 10px;
+  fill: var(--text-muted);
+}
+
+.chart-hover-line {
+  stroke: var(--text-muted);
+  stroke-width: 1;
+  stroke-dasharray: 4 4;
+  opacity: 0.5;
+}
+
+.chart-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  box-shadow: var(--shadow-md);
+  z-index: 10;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+
+.chart-tooltip-value {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.chart-tooltip-label {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.chart-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 13px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+/* Chart cards */
+.chart-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: border-color 0.15s ease;
+}
+
+.chart-card:hover {
+  border-color: var(--border);
+}
+
+.chart-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 8px;
+}
+
+.chart-card-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.chart-card-value {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  padding: 0 20px 8px;
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+/* ──────────────────────────────────────────
+   Time Range Selector
+   ────────────────────────────────────────── */
+
+.time-range-selector {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-md);
+  padding: 2px;
+}
+
+.time-range-btn {
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.time-range-btn:hover {
+  color: var(--text-primary);
+}
+
+.time-range-btn.active {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+/* ──────────────────────────────────────────
+   Model Breakdown Table
+   ────────────────────────────────────────── */
+
+.model-bar {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--accent);
+  opacity: 0.6;
+  transition: opacity 0.15s ease;
+}
+
+tr:hover .model-bar {
+  opacity: 1;
+}

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useDashboard } from "@/hooks/useDashboard";
 import { AreaChart } from "@/components/chart";
+import { SpanStatus } from "@/gen/types/trace_pb";
 import type { TimeRange } from "@/hooks/useDashboard";
 
 // ──────────────────────────────────────────
@@ -42,7 +43,7 @@ function TimeRangeSelector({
 // ──────────────────────────────────────────
 
 const statusLabel = (s: number) => {
-  if (s === 2) return { text: "error", cls: "badge-error" };
+  if (s === SpanStatus.ERROR) return { text: "error", cls: "badge-error" };
   return { text: "ok", cls: "badge-success" };
 };
 

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -2,9 +2,63 @@
 
 import Link from "next/link";
 import { useDashboard } from "@/hooks/useDashboard";
+import { AreaChart } from "@/components/chart";
+import type { TimeRange } from "@/hooks/useDashboard";
+
+// ──────────────────────────────────────────
+// Time Range Selector
+// ──────────────────────────────────────────
+
+const ranges: { value: TimeRange; label: string }[] = [
+  { value: "24h", label: "24h" },
+  { value: "7d", label: "7d" },
+  { value: "30d", label: "30d" },
+];
+
+function TimeRangeSelector({
+  value,
+  onChange,
+}: {
+  value: TimeRange;
+  onChange: (r: TimeRange) => void;
+}) {
+  return (
+    <div className="time-range-selector">
+      {ranges.map((r) => (
+        <button
+          key={r.value}
+          className={`time-range-btn ${value === r.value ? "active" : ""}`}
+          onClick={() => onChange(r.value)}
+        >
+          {r.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────
+// Status helpers
+// ──────────────────────────────────────────
+
+const statusLabel = (s: number) => {
+  if (s === 2) return { text: "error", cls: "badge-error" };
+  return { text: "ok", cls: "badge-success" };
+};
+
+// ──────────────────────────────────────────
+// Page
+// ──────────────────────────────────────────
 
 export default function DashboardPage() {
-  const { summary, error } = useDashboard();
+  const {
+    summary,
+    recentTraces,
+    error,
+    timeRange,
+    setTimeRange,
+    refresh,
+  } = useDashboard();
 
   const totalTokens = summary
     ? (summary.totalInputTokens + summary.totalOutputTokens).toLocaleString()
@@ -14,9 +68,12 @@ export default function DashboardPage() {
     <>
       <header className="main-header">
         <h1>Dashboard</h1>
-        <span className="mono" style={{ color: "var(--text-muted)" }}>
-          Overview
-        </span>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          <button className="btn" onClick={refresh}>
+            🔄
+          </button>
+        </div>
       </header>
 
       <div className="main-body">
@@ -40,13 +97,16 @@ export default function DashboardPage() {
           </div>
         )}
 
+        {/* Summary cards */}
         <div className="stats-grid animate-in">
           <div className="card">
             <div className="card-title">Total Traces</div>
             <div className="card-value">
               {summary ? Number(summary.totalTraces).toLocaleString() : "—"}
             </div>
-            <div className="card-subtitle">All time</div>
+            <div className="card-subtitle">
+              {timeRange === "24h" ? "Last 24 hours" : timeRange === "7d" ? "Last 7 days" : "Last 30 days"}
+            </div>
           </div>
           <div className="card">
             <div className="card-title">Total Tokens</div>
@@ -69,6 +129,46 @@ export default function DashboardPage() {
           </div>
         </div>
 
+        {/* Charts */}
+        <div className="chart-grid animate-in" style={{ animationDelay: "0.05s" }}>
+          <div className="chart-card">
+            <div className="chart-card-header">
+              <span className="chart-card-title">Traces</span>
+            </div>
+            <AreaChart
+              data={summary?.tracesOverTime ?? []}
+              color="var(--accent)"
+              formatValue={(v) => Math.round(v).toString()}
+              emptyMessage="No trace data for this period"
+            />
+          </div>
+
+          <div className="chart-card">
+            <div className="chart-card-header">
+              <span className="chart-card-title">Cost (USD)</span>
+            </div>
+            <AreaChart
+              data={summary?.costOverTime ?? []}
+              color="var(--success)"
+              formatValue={(v) => `$${v.toFixed(4)}`}
+              emptyMessage="No cost data for this period"
+            />
+          </div>
+
+          <div className="chart-card">
+            <div className="chart-card-header">
+              <span className="chart-card-title">Tokens</span>
+            </div>
+            <AreaChart
+              data={summary?.tokensOverTime ?? []}
+              color="var(--info)"
+              formatValue={(v) => v >= 1000 ? `${(v / 1000).toFixed(1)}k` : Math.round(v).toString()}
+              emptyMessage="No token data for this period"
+            />
+          </div>
+        </div>
+
+        {/* Recent Traces */}
         <div className="table-container animate-in" style={{ animationDelay: "0.1s" }}>
           <div className="table-header">
             <span className="table-title">Recent Traces</span>
@@ -76,15 +176,61 @@ export default function DashboardPage() {
               View all →
             </Link>
           </div>
-          <div className="empty-state">
-            <div className="empty-state-icon">🕯️</div>
-            <div className="empty-state-title">No traces yet</div>
-            <div className="empty-state-desc">
-              Send your first LLM request through the Candela proxy to see traces
-              appear here. Configure a provider in your candela.yaml and point your
-              SDK to <code className="mono">http://localhost:8181/proxy/</code>.
+          {recentTraces.length === 0 ? (
+            <div className="empty-state">
+              <div className="empty-state-icon">🕯️</div>
+              <div className="empty-state-title">No traces yet</div>
+              <div className="empty-state-desc">
+                Send your first LLM request through the Candela proxy to see traces
+                appear here. Configure a provider in your candela.yaml and point your
+                SDK to <code className="mono">http://localhost:8181/proxy/</code>.
+              </div>
             </div>
-          </div>
+          ) : (
+            <table>
+              <thead>
+                <tr>
+                  <th>Trace ID</th>
+                  <th>Operation</th>
+                  <th>Model</th>
+                  <th>Tokens</th>
+                  <th>Cost</th>
+                  <th>Latency</th>
+                  <th>Status</th>
+                  <th>Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recentTraces.map((t) => {
+                  const st = statusLabel(t.status);
+                  return (
+                    <tr key={t.traceId}>
+                      <td>
+                        <Link href={`/traces/${t.traceId}`} className="mono">
+                          {t.traceId.slice(0, 12)}…
+                        </Link>
+                      </td>
+                      <td>{t.rootSpanName}</td>
+                      <td>
+                        <span className="mono" style={{ fontSize: 12 }}>
+                          {t.primaryModel}
+                        </span>
+                      </td>
+                      <td>{t.totalTokens.toLocaleString()}</td>
+                      <td>${t.totalCostUsd.toFixed(4)}</td>
+                      <td>{t.durationMs.toFixed(0)}ms</td>
+                      <td>
+                        <span className={`badge ${st.cls}`}>{st.text}</span>
+                      </td>
+                      <td style={{ color: "var(--text-muted)", fontSize: 12 }}>
+                        {t.startTime}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
         </div>
       </div>
     </>

--- a/ui/src/components/chart.tsx
+++ b/ui/src/components/chart.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useRef, useState, useCallback, useMemo } from "react";
+
+// ──────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────
+
+export interface DataPoint {
+  label: string; // Display label (e.g. "Apr 8", "14:00")
+  value: number;
+}
+
+export interface AreaChartProps {
+  data: DataPoint[];
+  height?: number;
+  color?: string; // CSS color for the line/fill
+  formatValue?: (value: number) => string;
+  emptyMessage?: string;
+}
+
+// ──────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────
+
+function buildPath(
+  points: { x: number; y: number }[],
+  smoothing = 0.2
+): string {
+  if (points.length < 2) return "";
+
+  const line = (a: { x: number; y: number }, b: { x: number; y: number }) => ({
+    length: Math.sqrt((b.x - a.x) ** 2 + (b.y - a.y) ** 2),
+    angle: Math.atan2(b.y - a.y, b.x - a.x),
+  });
+
+  const controlPoint = (
+    current: { x: number; y: number },
+    previous: { x: number; y: number } | undefined,
+    next: { x: number; y: number } | undefined,
+    reverse = false
+  ) => {
+    const p = previous || current;
+    const n = next || current;
+    const l = line(p, n);
+    const angle = l.angle + (reverse ? Math.PI : 0);
+    const length = l.length * smoothing;
+    return {
+      x: current.x + Math.cos(angle) * length,
+      y: current.y + Math.sin(angle) * length,
+    };
+  };
+
+  let d = `M ${points[0].x},${points[0].y}`;
+
+  for (let i = 1; i < points.length; i++) {
+    const cp1 = controlPoint(points[i - 1], points[i - 2], points[i]);
+    const cp2 = controlPoint(points[i], points[i - 1], points[i + 1], true);
+    d += ` C ${cp1.x},${cp1.y} ${cp2.x},${cp2.y} ${points[i].x},${points[i].y}`;
+  }
+
+  return d;
+}
+
+// ──────────────────────────────────────────
+// Component
+// ──────────────────────────────────────────
+
+const PADDING = { top: 8, right: 12, bottom: 28, left: 48 };
+
+export function AreaChart({
+  data,
+  height = 180,
+  color = "var(--accent)",
+  formatValue = (v) => v.toLocaleString(),
+  emptyMessage = "No data",
+}: AreaChartProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [tooltip, setTooltip] = useState<{
+    x: number;
+    y: number;
+    point: DataPoint;
+  } | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  // Measure container width
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setContainerWidth(entry.contentRect.width);
+      }
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  // Compute chart geometry
+  const chartWidth = containerWidth - PADDING.left - PADDING.right;
+  const chartHeight = height - PADDING.top - PADDING.bottom;
+
+  const { points, yTicks, linePath, areaPath } = useMemo(() => {
+    if (data.length === 0 || chartWidth <= 0 || chartHeight <= 0) {
+      return { points: [], yTicks: [], linePath: "", areaPath: "" };
+    }
+
+    const maxVal = Math.max(...data.map((d) => d.value), 1);
+    const minVal = 0;
+    const range = maxVal - minVal;
+
+    const pts = data.map((d, i) => ({
+      x: PADDING.left + (i / Math.max(data.length - 1, 1)) * chartWidth,
+      y:
+        PADDING.top +
+        chartHeight -
+        ((d.value - minVal) / range) * chartHeight,
+      data: d,
+    }));
+
+    // Y-axis ticks (4 ticks)
+    const tickCount = 4;
+    const ticks = Array.from({ length: tickCount + 1 }, (_, i) => {
+      const val = minVal + (range / tickCount) * i;
+      const y =
+        PADDING.top + chartHeight - ((val - minVal) / range) * chartHeight;
+      return { value: val, y };
+    });
+
+    const lp = buildPath(pts);
+    // Area path = line path + close to bottom
+    const ap = lp
+      ? `${lp} L ${pts[pts.length - 1].x},${PADDING.top + chartHeight} L ${pts[0].x},${PADDING.top + chartHeight} Z`
+      : "";
+
+    return { points: pts, yTicks: ticks, linePath: lp, areaPath: ap };
+  }, [data, chartWidth, chartHeight]);
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      if (!svgRef.current || points.length === 0) return;
+      const rect = svgRef.current.getBoundingClientRect();
+      const mouseX = e.clientX - rect.left;
+
+      // Find nearest point
+      let nearest = points[0];
+      let minDist = Infinity;
+      for (const pt of points) {
+        const dist = Math.abs(pt.x - mouseX);
+        if (dist < minDist) {
+          minDist = dist;
+          nearest = pt;
+        }
+      }
+
+      setTooltip({ x: nearest.x, y: nearest.y, point: nearest.data });
+    },
+    [points]
+  );
+
+  if (data.length === 0) {
+    return (
+      <div className="chart-empty" style={{ height }}>
+        <span>{emptyMessage}</span>
+      </div>
+    );
+  }
+
+  // Determine which x-axis labels to show (avoid overlap)
+  const labelStep = Math.max(1, Math.floor(data.length / 6));
+
+  return (
+    <div ref={containerRef} className="chart-container">
+      <svg
+        ref={svgRef}
+        width="100%"
+        height={height}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={() => setTooltip(null)}
+        className="chart-svg"
+      >
+        <defs>
+          <linearGradient id={`grad-${color.replace(/[^a-z0-9]/gi, "")}`} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity={0.3} />
+            <stop offset="100%" stopColor={color} stopOpacity={0.02} />
+          </linearGradient>
+        </defs>
+
+        {/* Grid lines */}
+        {yTicks.map((tick, i) => (
+          <line
+            key={i}
+            x1={PADDING.left}
+            y1={tick.y}
+            x2={PADDING.left + chartWidth}
+            y2={tick.y}
+            className="chart-grid-line"
+          />
+        ))}
+
+        {/* Y-axis labels */}
+        {yTicks.map((tick, i) => (
+          <text
+            key={`y-${i}`}
+            x={PADDING.left - 8}
+            y={tick.y + 3}
+            className="chart-axis-label"
+            textAnchor="end"
+          >
+            {formatValue(tick.value)}
+          </text>
+        ))}
+
+        {/* X-axis labels */}
+        {points
+          .filter((_, i) => i % labelStep === 0 || i === points.length - 1)
+          .map((pt, i) => (
+            <text
+              key={`x-${i}`}
+              x={pt.x}
+              y={height - 4}
+              className="chart-axis-label"
+              textAnchor="middle"
+            >
+              {pt.data.label}
+            </text>
+          ))}
+
+        {/* Area fill */}
+        {areaPath && (
+          <path
+            d={areaPath}
+            fill={`url(#grad-${color.replace(/[^a-z0-9]/gi, "")})`}
+          />
+        )}
+
+        {/* Line */}
+        {linePath && (
+          <path
+            d={linePath}
+            fill="none"
+            stroke={color}
+            strokeWidth={2}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+          />
+        )}
+
+        {/* Hover indicator */}
+        {tooltip && (
+          <>
+            <line
+              x1={tooltip.x}
+              y1={PADDING.top}
+              x2={tooltip.x}
+              y2={PADDING.top + chartHeight}
+              className="chart-hover-line"
+            />
+            <circle
+              cx={tooltip.x}
+              cy={tooltip.y}
+              r={4}
+              fill={color}
+              stroke="var(--bg-primary)"
+              strokeWidth={2}
+            />
+          </>
+        )}
+      </svg>
+
+      {/* Tooltip */}
+      {tooltip && (
+        <div
+          className="chart-tooltip"
+          style={{
+            left: Math.min(tooltip.x, containerWidth - 120),
+            top: tooltip.y - 40,
+          }}
+        >
+          <div className="chart-tooltip-value">{formatValue(tooltip.point.value)}</div>
+          <div className="chart-tooltip-label">{tooltip.point.label}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/chart.tsx
+++ b/ui/src/components/chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useCallback, useMemo } from "react";
+import { useRef, useState, useCallback, useMemo, useEffect } from "react";
 
 // ──────────────────────────────────────────
 // Types
@@ -82,9 +82,11 @@ export function AreaChart({
     point: DataPoint;
   } | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  // Measure container width
-  const containerRef = useCallback((node: HTMLDivElement | null) => {
+  // Measure container width via ResizeObserver with proper cleanup
+  useEffect(() => {
+    const node = containerRef.current;
     if (!node) return;
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
@@ -272,7 +274,7 @@ export function AreaChart({
         <div
           className="chart-tooltip"
           style={{
-            left: Math.min(tooltip.x, containerWidth - 120),
+            left: Math.max(60, Math.min(tooltip.x, containerWidth - 60)),
             top: tooltip.y - 40,
           }}
         >

--- a/ui/src/hooks/useCosts.ts
+++ b/ui/src/hooks/useCosts.ts
@@ -1,0 +1,150 @@
+"use client";
+
+import { useCallback, useEffect, useReducer } from "react";
+import { dashboardClient } from "@/lib/api";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+import type { DataPoint } from "@/components/chart";
+import type { TimeRange } from "@/hooks/useDashboard";
+
+export interface CostSummary {
+  totalCostUsd: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalTraces: number;
+  costOverTime: DataPoint[];
+}
+
+export interface ModelBreakdown {
+  model: string;
+  provider: string;
+  callCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  avgLatencyMs: number;
+}
+
+type State = {
+  summary: CostSummary | null;
+  models: ModelBreakdown[];
+  loading: boolean;
+  error: string | null;
+  timeRange: TimeRange;
+  fetchCount: number;
+};
+
+type Action =
+  | { type: "fetch" }
+  | { type: "success"; summary: CostSummary; models: ModelBreakdown[] }
+  | { type: "error"; message: string }
+  | { type: "refresh" }
+  | { type: "setTimeRange"; range: TimeRange };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "fetch":
+      return { ...state, loading: true, error: null };
+    case "success":
+      return { ...state, loading: false, summary: action.summary, models: action.models };
+    case "error":
+      return { ...state, loading: false, error: action.message };
+    case "refresh":
+      return { ...state, fetchCount: state.fetchCount + 1 };
+    case "setTimeRange":
+      return { ...state, timeRange: action.range, fetchCount: state.fetchCount + 1 };
+  }
+}
+
+function timeRangeToMs(range: TimeRange): number {
+  switch (range) {
+    case "24h": return 24 * 60 * 60 * 1000;
+    case "7d": return 7 * 24 * 60 * 60 * 1000;
+    case "30d": return 30 * 24 * 60 * 60 * 1000;
+  }
+}
+
+function formatTimeLabel(ts: string, range: TimeRange): string {
+  const d = new Date(ts);
+  if (range === "24h") {
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+  return d.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+/**
+ * Hook for fetching cost data — summary, time series, and model breakdown.
+ */
+export function useCosts() {
+  const [state, dispatch] = useReducer(reducer, {
+    summary: null,
+    models: [],
+    loading: true,
+    error: null,
+    timeRange: "7d",
+    fetchCount: 0,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    dispatch({ type: "fetch" });
+
+    const now = new Date();
+    const start = new Date(now.getTime() - timeRangeToMs(state.timeRange));
+
+    const timeRange = {
+      start: timestampFromDate(start),
+      end: timestampFromDate(now),
+    };
+
+    const summaryPromise = dashboardClient.getUsageSummary({ timeRange });
+    const modelsPromise = dashboardClient.getModelBreakdown({ timeRange });
+
+    Promise.all([summaryPromise, modelsPromise])
+      .then(([summaryRes, modelsRes]) => {
+        if (cancelled) return;
+        dispatch({
+          type: "success",
+          summary: {
+            totalCostUsd: summaryRes.totalCostUsd,
+            totalInputTokens: Number(summaryRes.totalInputTokens),
+            totalOutputTokens: Number(summaryRes.totalOutputTokens),
+            totalTraces: Number(summaryRes.totalTraces),
+            costOverTime: (summaryRes.costOverTime || []).map((p) => ({
+              label: formatTimeLabel(p.timestamp, state.timeRange),
+              value: p.value,
+            })),
+          },
+          models: (modelsRes.models || []).map((m) => ({
+            model: m.model,
+            provider: m.provider,
+            callCount: Number(m.callCount),
+            inputTokens: Number(m.inputTokens),
+            outputTokens: Number(m.outputTokens),
+            costUsd: m.costUsd,
+            avgLatencyMs: m.avgLatencyMs,
+          })),
+        });
+      })
+      .catch((err) => {
+        if (!cancelled) dispatch({ type: "error", message: err.message });
+      });
+
+    return () => { cancelled = true; };
+  }, [state.fetchCount, state.timeRange]);
+
+  const refresh = useCallback(() => dispatch({ type: "refresh" }), []);
+  const setTimeRange = useCallback(
+    (range: TimeRange) => dispatch({ type: "setTimeRange", range }),
+    []
+  );
+
+  return {
+    summary: state.summary,
+    models: state.models,
+    loading: state.loading,
+    error: state.error,
+    timeRange: state.timeRange,
+    setTimeRange,
+    refresh,
+  };
+}

--- a/ui/src/hooks/useDashboard.ts
+++ b/ui/src/hooks/useDashboard.ts
@@ -81,8 +81,8 @@ function formatTimeLabel(ts: string, range: TimeRange): string {
   return d.toLocaleDateString([], { month: "short", day: "numeric" });
 }
 
-function toDataPoints(pts: Array<{ timestamp: string; value: number }>, range: TimeRange): DataPoint[] {
-  return pts.map((p) => ({
+function toDataPoints(pts: Array<{ timestamp: string; value: number }> | undefined, range: TimeRange): DataPoint[] {
+  return (pts || []).map((p) => ({
     label: formatTimeLabel(p.timestamp, range),
     value: p.value,
   }));

--- a/ui/src/hooks/useDashboard.ts
+++ b/ui/src/hooks/useDashboard.ts
@@ -1,7 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useReducer } from "react";
-import { dashboardClient } from "@/lib/api";
+import { dashboardClient, traceClient } from "@/lib/api";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+import type { DataPoint } from "@/components/chart";
 
 export interface DashboardSummary {
   totalTraces: number;
@@ -12,52 +14,116 @@ export interface DashboardSummary {
   totalCostUsd: number;
   avgLatencyMs: number;
   errorRate: number;
+  // Time series
+  tracesOverTime: DataPoint[];
+  costOverTime: DataPoint[];
+  tokensOverTime: DataPoint[];
 }
+
+export interface RecentTrace {
+  traceId: string;
+  rootSpanName: string;
+  primaryModel: string;
+  spanCount: number;
+  totalTokens: number;
+  totalCostUsd: number;
+  durationMs: number;
+  status: number;
+  startTime: string;
+}
+
+export type TimeRange = "24h" | "7d" | "30d";
 
 type State = {
   summary: DashboardSummary | null;
+  recentTraces: RecentTrace[];
   loading: boolean;
   error: string | null;
+  timeRange: TimeRange;
   fetchCount: number;
 };
 
 type Action =
   | { type: "fetch" }
-  | { type: "success"; summary: DashboardSummary }
+  | { type: "success"; summary: DashboardSummary; recentTraces: RecentTrace[] }
   | { type: "error"; message: string }
-  | { type: "refresh" };
+  | { type: "refresh" }
+  | { type: "setTimeRange"; range: TimeRange };
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case "fetch":
       return { ...state, loading: true, error: null };
     case "success":
-      return { ...state, loading: false, summary: action.summary };
+      return { ...state, loading: false, summary: action.summary, recentTraces: action.recentTraces };
     case "error":
       return { ...state, loading: false, error: action.message };
     case "refresh":
       return { ...state, fetchCount: state.fetchCount + 1 };
+    case "setTimeRange":
+      return { ...state, timeRange: action.range, fetchCount: state.fetchCount + 1 };
   }
 }
 
+function timeRangeToMs(range: TimeRange): number {
+  switch (range) {
+    case "24h": return 24 * 60 * 60 * 1000;
+    case "7d": return 7 * 24 * 60 * 60 * 1000;
+    case "30d": return 30 * 24 * 60 * 60 * 1000;
+  }
+}
+
+function formatTimeLabel(ts: string, range: TimeRange): string {
+  const d = new Date(ts);
+  if (range === "24h") {
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+  return d.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+function toDataPoints(pts: Array<{ timestamp: string; value: number }>, range: TimeRange): DataPoint[] {
+  return pts.map((p) => ({
+    label: formatTimeLabel(p.timestamp, range),
+    value: p.value,
+  }));
+}
+
 /**
- * Hook for fetching the dashboard usage summary.
- * Encapsulates the GetUsageSummary RPC.
+ * Hook for fetching the dashboard usage summary with time-series data
+ * and recent traces. Supports time range filtering.
  */
 export function useDashboard() {
   const [state, dispatch] = useReducer(reducer, {
     summary: null,
+    recentTraces: [],
     loading: true,
     error: null,
+    timeRange: "24h",
     fetchCount: 0,
   });
 
   useEffect(() => {
     let cancelled = false;
+    dispatch({ type: "fetch" });
 
-    dashboardClient
-      .getUsageSummary({})
-      .then((res) => {
+    const now = new Date();
+    const start = new Date(now.getTime() - timeRangeToMs(state.timeRange));
+
+    const summaryPromise = dashboardClient.getUsageSummary({
+      timeRange: {
+        start: timestampFromDate(start),
+        end: timestampFromDate(now),
+      },
+    });
+
+    const tracesPromise = traceClient.listTraces({
+      orderBy: "start_time",
+      descending: true,
+      pagination: { pageSize: 5 },
+    });
+
+    Promise.all([summaryPromise, tracesPromise])
+      .then(([res, tracesRes]) => {
         if (cancelled) return;
         dispatch({
           type: "success",
@@ -70,7 +136,30 @@ export function useDashboard() {
             totalCostUsd: res.totalCostUsd,
             avgLatencyMs: res.avgLatencyMs,
             errorRate: res.errorRate,
+            tracesOverTime: toDataPoints(res.tracesOverTime, state.timeRange),
+            costOverTime: toDataPoints(res.costOverTime, state.timeRange),
+            tokensOverTime: toDataPoints(res.tokensOverTime, state.timeRange),
           },
+          recentTraces: (tracesRes.traces || []).map((t) => {
+            const durSeconds = Number(t.duration?.seconds ?? 0);
+            const durNanos = Number(t.duration?.nanos ?? 0);
+            return {
+              traceId: t.traceId,
+              rootSpanName: t.rootSpanName || "unknown",
+              primaryModel: t.primaryModel || "—",
+              spanCount: t.spanCount || 0,
+              totalTokens: Number(t.totalTokens) || 0,
+              totalCostUsd: t.totalCostUsd || 0,
+              durationMs: durSeconds * 1000 + durNanos / 1e6,
+              status: t.status,
+              startTime: t.startTime
+                ? new Date(
+                    Number(t.startTime.seconds) * 1000 +
+                      Math.floor(Number(t.startTime.nanos) / 1e6)
+                  ).toLocaleString()
+                : "—",
+            };
+          }),
         });
       })
       .catch((err) => {
@@ -78,9 +167,21 @@ export function useDashboard() {
       });
 
     return () => { cancelled = true; };
-  }, [state.fetchCount]);
+  }, [state.fetchCount, state.timeRange]);
 
   const refresh = useCallback(() => dispatch({ type: "refresh" }), []);
+  const setTimeRange = useCallback(
+    (range: TimeRange) => dispatch({ type: "setTimeRange", range }),
+    []
+  );
 
-  return { summary: state.summary, loading: state.loading, error: state.error, refresh };
+  return {
+    summary: state.summary,
+    recentTraces: state.recentTraces,
+    loading: state.loading,
+    error: state.error,
+    timeRange: state.timeRange,
+    setTimeRange,
+    refresh,
+  };
 }


### PR DESCRIPTION
## Summary

Upgrades the Candela UI from a functional MVP to a full observability tool by wiring existing (but previously unused) backend RPCs and adding interactive charts.

### Changes

**New: Reusable Chart Component** (`ui/src/components/chart.tsx`)
- Vanilla SVG area chart with smooth cubic bezier interpolation
- Gradient fills, hover tooltips, responsive sizing via ResizeObserver
- Zero external dependencies

**Dashboard Enhancement** (`/`)
- Time-series charts: traces over time, cost over time, tokens over time
- Time range selector (24h / 7d / 30d)
- Recent traces table (replaces empty state)

**Costs Page** (`/costs`)
- Wired to real data from `GetUsageSummary` and `GetModelBreakdown` RPCs
- Cost-over-time area chart
- Model breakdown table with proportional cost bars
- Time range selector

**Tests**
- All 21 E2E tests pass
- TypeScript compilation clean
- Updated test mocks for new dashboard and costs RPCs