### PR TITLE
feat: Phase 4 — Multi-User Platform (Terraform + Proto Scaffold)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,14 @@ The UI communicates with the backend via **ConnectRPC v2** on `localhost:8080`. 
 
 - **Phase 1: Foundation** ✅ (Ingestion, Proxy, Cost Calc, Docs)
 - **Phase 2: Storage & Architecture** ✅ (DuckDB, CQRS, BigQuery, Pub/Sub, CORS)
-- **Phase 3: Visual Explorer** 🟡 (Next.js UI, Dashboard, Traces, Projects — Waterfall & Cost Charts next)
-- **Phase 4: Platform & Evaluation** 📋 (Admin Panel, Token Metering, LLM-as-Judge)
-- **Phase 5: Ecosystem & Polish** 📋 (Agent DAGs, Multi-tenant, Alerting)
+- **Phase 3: Visual Explorer** ✅ (Next.js UI, Dashboard, Traces, Costs, Settings, E2E Tests)
+- **Phase 4: Multi-User Platform** 🟡 (IAP Auth, Token Budgets, Admin Panel, Per-User Views)
+  - Terraform infrastructure (Cloud Run, BigQuery, Firestore, IAP)
+  - Proto-first user/budget/grant schemas
+  - `candela-local` auth-injecting proxy for developer machines
+  - Budget enforcement with grant-first waterfall
+  - Admin panel for user/budget management
+- **Phase 5: Ecosystem & Polish** 📋 (Agent DAGs, Multi-region, Alerting, OpenCode Plugin)
 
 ---
 
@@ -243,6 +248,11 @@ candela/
 │   ├── costcalc/                # Token cost calculation engine
 │   ├── connecthandlers/         # ConnectRPC service handlers
 │   └── ingestion/               # OTel span ingestion
+├── terraform/                   # GCP infrastructure (OpenTofu/Terraform)
+│   ├── cloud_run.tf             # Cloud Run + IAP
+│   ├── bigquery.tf              # Spans storage
+│   ├── firestore.tf             # Users, budgets, grants
+│   └── iam.tf                   # Service accounts + roles
 ├── collector/                   # Custom OTel Collector distro
 ├── docs/                        # Deep-dive documentation
 ├── ui/                          # Next.js 16 web interface

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
             uv
 
             # Infrastructure tools
+            opentofu    # Open-source Terraform fork (BSL-free, same CLI as `tofu`)
             docker-compose
             cloudflared
             grpcurl

--- a/proto/candela/types/trace.proto
+++ b/proto/candela/types/trace.proto
@@ -88,6 +88,7 @@ message Span {
   string project_id = 40;
   string environment = 41;
   string service_name = 42;
+  string user_id = 43; // Developer who triggered this span
 
   // Events (OTel span events)
   repeated SpanEvent events = 50;
@@ -114,6 +115,7 @@ message Trace {
   int64 total_tokens = 8;
   double total_cost_usd = 9;
   string root_span_name = 10;
+  string user_id = 11; // Developer who owns this trace
 
   // All spans in the trace
   repeated Span spans = 20;
@@ -137,4 +139,5 @@ message TraceSummary {
   SpanStatus status = 14;
   string primary_model = 15; // Most-used model in the trace
   string primary_provider = 16;
+  string user_id = 17; // Developer who owns this trace
 }

--- a/proto/candela/types/user.proto
+++ b/proto/candela/types/user.proto
@@ -1,0 +1,94 @@
+syntax = "proto3";
+
+package candela.types;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/candelahq/candela/gen/go/candela/types";
+
+// UserRole defines the access level of a user.
+enum UserRole {
+  USER_ROLE_UNSPECIFIED = 0;
+  USER_ROLE_DEVELOPER = 1; // Can use proxy, view own data
+  USER_ROLE_ADMIN = 2; // Can manage users, budgets, view all data
+}
+
+// UserStatus tracks the lifecycle of a user account.
+enum UserStatus {
+  USER_STATUS_UNSPECIFIED = 0;
+  USER_STATUS_PROVISIONED = 1; // Pre-provisioned by admin, awaiting first login
+  USER_STATUS_ACTIVE = 2; // Has authenticated at least once
+  USER_STATUS_INACTIVE = 3; // Deactivated by admin
+}
+
+// BudgetPeriod defines the recurrence interval for a budget.
+enum BudgetPeriod {
+  BUDGET_PERIOD_UNSPECIFIED = 0;
+  BUDGET_PERIOD_MONTHLY = 1; // Resets 1st of each month
+  BUDGET_PERIOD_WEEKLY = 2; // Resets every Monday
+  BUDGET_PERIOD_QUARTERLY = 3; // Resets Jan/Apr/Jul/Oct
+  BUDGET_PERIOD_CUSTOM = 4; // Admin sets explicit start/end dates
+}
+
+// User represents a developer or admin in the Candela platform.
+// Firestore path: users/{id}
+message User {
+  string id = 1; // UUID
+  string email = 2; // From IAP JWT claims
+  string display_name = 3;
+  UserRole role = 4;
+  UserStatus status = 5;
+  google.protobuf.Timestamp created_at = 6;
+  google.protobuf.Timestamp last_seen_at = 7;
+  int32 rate_limit = 8; // Max requests/minute (0 = default)
+}
+
+// UserBudget tracks a user's recurring spend for a budget period.
+// Firestore path: users/{user_id}/budgets/{period_key}
+message UserBudget {
+  string user_id = 1;
+  double limit_usd = 2; // Budget cap; 0 = no budget (denied)
+  double spent_usd = 3; // Accumulated spend this period
+  int64 tokens_used = 4; // Accumulated tokens this period
+  BudgetPeriod period_type = 5;
+  string period_key = 6; // "2026-04", "2026-W15", "2026-Q2"
+  google.protobuf.Timestamp period_start = 7;
+  google.protobuf.Timestamp period_end = 8;
+}
+
+// BudgetGrant is a one-time bonus budget with an expiry window.
+// Consumed BEFORE the recurring budget (grants-first waterfall).
+// Firestore path: users/{user_id}/grants/{id}
+message BudgetGrant {
+  string id = 1; // UUID
+  string user_id = 2;
+  double amount_usd = 3; // Total grant amount
+  double spent_usd = 4; // How much has been used
+  string reason = 5; // e.g. "Hackathon weekend"
+  string granted_by = 6; // Admin email who issued it
+  google.protobuf.Timestamp starts_at = 7;
+  google.protobuf.Timestamp expires_at = 8;
+  google.protobuf.Timestamp created_at = 9;
+}
+
+// AuditEntry records an admin action for accountability.
+// Firestore path: users/{user_id}/audit/{id}
+message AuditEntry {
+  string id = 1; // UUID
+  string user_id = 2; // Target user
+  string actor_email = 3; // Admin who performed the action
+  string action = 4; // "set_budget", "create_grant", "deactivate"
+  string details = 5; // JSON with old/new values
+  google.protobuf.Timestamp timestamp = 6;
+}
+
+// RateWindow tracks per-minute request counts for rate limiting.
+// Firestore path: rate_limit/{user_id}:{window_key}
+// TTL: auto-expires after 2 minutes.
+message RateWindow {
+  string user_id = 1;
+  int32 request_count = 2;
+  int32 limit = 3; // Per-user, admin-configurable
+  string window_key = 4; // "2026-04-08T18:24"
+  google.protobuf.Timestamp expire_at = 5; // Firestore TTL field
+}

--- a/proto/candela/v1/user_service.proto
+++ b/proto/candela/v1/user_service.proto
@@ -1,0 +1,223 @@
+syntax = "proto3";
+
+package candela.v1;
+
+import "candela/types/common.proto";
+import "candela/types/user.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/candelahq/candela/gen/go/candela/v1";
+
+// UserService manages users, budgets, and grants.
+service UserService {
+  // ── Admin endpoints ──
+
+  // CreateUser pre-provisions a user by email (optionally with an initial budget).
+  rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+
+  // ListUsers returns all users with pagination.
+  rpc ListUsers(ListUsersRequest) returns (ListUsersResponse);
+
+  // GetUser returns a user with their budget and active grants.
+  rpc GetUser(GetUserRequest) returns (GetUserResponse);
+
+  // UpdateUser modifies a user's display name or role.
+  rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse);
+
+  // DeactivateUser disables a user's access (sets status to INACTIVE).
+  rpc DeactivateUser(DeactivateUserRequest) returns (DeactivateUserResponse);
+
+  // ReactivateUser re-enables a previously deactivated user.
+  rpc ReactivateUser(ReactivateUserRequest) returns (ReactivateUserResponse);
+
+  // ── Budget management (admin) ──
+
+  // SetBudget configures a user's recurring budget.
+  rpc SetBudget(SetBudgetRequest) returns (SetBudgetResponse);
+
+  // GetBudget returns a user's current budget for the active period.
+  rpc GetBudget(GetBudgetRequest) returns (GetBudgetResponse);
+
+  // ResetSpend zeroes a user's current-period spend (emergency override).
+  rpc ResetSpend(ResetSpendRequest) returns (ResetSpendResponse);
+
+  // ── Grants (admin) ──
+
+  // CreateGrant issues a one-time bonus budget with an expiry window.
+  rpc CreateGrant(CreateGrantRequest) returns (CreateGrantResponse);
+
+  // ListGrants returns all grants for a user (active and expired).
+  rpc ListGrants(ListGrantsRequest) returns (ListGrantsResponse);
+
+  // RevokeGrant cancels an active grant.
+  rpc RevokeGrant(RevokeGrantRequest) returns (RevokeGrantResponse);
+
+  // ── Audit (admin) ──
+
+  // ListAuditLog returns the audit trail for a user.
+  rpc ListAuditLog(ListAuditLogRequest) returns (ListAuditLogResponse);
+
+  // ── Self-service (current authenticated user) ──
+
+  // GetCurrentUser returns the authenticated user's profile, budget, and grants.
+  rpc GetCurrentUser(GetCurrentUserRequest) returns (GetCurrentUserResponse);
+
+  // GetMyBudget returns just the budget summary for the authenticated user.
+  rpc GetMyBudget(GetMyBudgetRequest) returns (GetMyBudgetResponse);
+}
+
+// ──────────────────────────────────────────────────
+// Admin — User CRUD
+// ──────────────────────────────────────────────────
+
+message CreateUserRequest {
+  string email = 1;
+  string display_name = 2;
+  candela.types.UserRole role = 3;
+  double monthly_budget_usd = 4; // Optional: set budget at creation
+}
+
+message CreateUserResponse {
+  candela.types.User user = 1;
+  candela.types.UserBudget budget = 2; // Present if monthly_budget_usd > 0
+}
+
+message ListUsersRequest {
+  candela.types.PaginationRequest pagination = 1;
+  candela.types.UserStatus status_filter = 2; // Optional: filter by status
+}
+
+message ListUsersResponse {
+  repeated candela.types.User users = 1;
+  candela.types.PaginationResponse pagination = 2;
+}
+
+message GetUserRequest {
+  string id = 1;
+}
+
+message GetUserResponse {
+  candela.types.User user = 1;
+  candela.types.UserBudget budget = 2;
+  repeated candela.types.BudgetGrant active_grants = 3;
+}
+
+message UpdateUserRequest {
+  string id = 1;
+  string display_name = 2;
+  candela.types.UserRole role = 3;
+}
+
+message UpdateUserResponse {
+  candela.types.User user = 1;
+}
+
+message DeactivateUserRequest {
+  string id = 1;
+}
+
+message DeactivateUserResponse {}
+
+message ReactivateUserRequest {
+  string id = 1;
+}
+
+message ReactivateUserResponse {
+  candela.types.User user = 1;
+}
+
+// ──────────────────────────────────────────────────
+// Admin — Budget management
+// ──────────────────────────────────────────────────
+
+message SetBudgetRequest {
+  string user_id = 1;
+  double limit_usd = 2;
+  candela.types.BudgetPeriod period_type = 3;
+}
+
+message SetBudgetResponse {
+  candela.types.UserBudget budget = 1;
+}
+
+message GetBudgetRequest {
+  string user_id = 1;
+}
+
+message GetBudgetResponse {
+  candela.types.UserBudget budget = 1;
+}
+
+message ResetSpendRequest {
+  string user_id = 1;
+}
+
+message ResetSpendResponse {
+  candela.types.UserBudget budget = 1;
+}
+
+// ──────────────────────────────────────────────────
+// Admin — Grants
+// ──────────────────────────────────────────────────
+
+message CreateGrantRequest {
+  string user_id = 1;
+  double amount_usd = 2;
+  string reason = 3;
+  google.protobuf.Timestamp starts_at = 4;
+  google.protobuf.Timestamp expires_at = 5;
+}
+
+message CreateGrantResponse {
+  candela.types.BudgetGrant grant = 1;
+}
+
+message ListGrantsRequest {
+  string user_id = 1;
+  bool active_only = 2; // If true, only return non-expired grants
+}
+
+message ListGrantsResponse {
+  repeated candela.types.BudgetGrant grants = 1;
+}
+
+message RevokeGrantRequest {
+  string user_id = 1;
+  string grant_id = 2;
+}
+
+message RevokeGrantResponse {}
+
+// ──────────────────────────────────────────────────
+// Admin — Audit
+// ──────────────────────────────────────────────────
+
+message ListAuditLogRequest {
+  string user_id = 1;
+  int32 limit = 2; // Max entries to return (default 50)
+}
+
+message ListAuditLogResponse {
+  repeated candela.types.AuditEntry entries = 1;
+}
+
+// ──────────────────────────────────────────────────
+// Self-service — Current user
+// ──────────────────────────────────────────────────
+
+message GetCurrentUserRequest {}
+
+message GetCurrentUserResponse {
+  candela.types.User user = 1;
+  candela.types.UserBudget budget = 2;
+  repeated candela.types.BudgetGrant active_grants = 3;
+  double total_remaining_usd = 4; // Combined: grants + budget remaining
+}
+
+message GetMyBudgetRequest {}
+
+message GetMyBudgetResponse {
+  candela.types.UserBudget budget = 1;
+  repeated candela.types.BudgetGrant active_grants = 2;
+  double total_remaining_usd = 3;
+}

--- a/proto/candela/v1/user_service.proto
+++ b/proto/candela/v1/user_service.proto
@@ -4,6 +4,7 @@ package candela.v1;
 
 import "candela/types/common.proto";
 import "candela/types/user.proto";
+import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/candelahq/candela/gen/go/candela/v1";
@@ -106,6 +107,7 @@ message UpdateUserRequest {
   string id = 1;
   string display_name = 2;
   candela.types.UserRole role = 3;
+  google.protobuf.FieldMask update_mask = 4;  // Which fields to update
 }
 
 message UpdateUserResponse {

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,5 @@
+# Terraform state and secrets
+.terraform/
+*.tfstate
+*.tfstate.backup
+terraform.tfvars

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}

--- a/terraform/artifact_registry.tf
+++ b/terraform/artifact_registry.tf
@@ -1,0 +1,20 @@
+# ──────────────────────────────────────────────────
+# Artifact Registry — Container image repository
+# ──────────────────────────────────────────────────
+
+resource "google_artifact_registry_repository" "candela" {
+  location      = var.region
+  repository_id = "candela"
+  description   = "Candela container images"
+  format        = "DOCKER"
+
+  cleanup_policies {
+    id     = "keep-recent"
+    action = "KEEP"
+    most_recent_versions {
+      keep_count = 10
+    }
+  }
+
+  depends_on = [google_project_service.apis]
+}

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -1,0 +1,68 @@
+# ──────────────────────────────────────────────────
+# BigQuery — Spans storage (OLAP)
+# Schema mirrors proto/candela/types/trace.proto
+# ──────────────────────────────────────────────────
+
+resource "google_bigquery_dataset" "candela" {
+  dataset_id    = var.bigquery_dataset
+  friendly_name = "Candela"
+  description   = "LLM observability spans and traces"
+  location      = var.bigquery_location
+
+  labels = {
+    app = "candela"
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_bigquery_table" "spans" {
+  dataset_id = google_bigquery_dataset.candela.dataset_id
+  table_id   = "spans"
+
+  # Time partitioning on start_time for efficient time-range queries.
+  time_partitioning {
+    type  = "DAY"
+    field = "start_time"
+  }
+
+  # Clustering for common access patterns.
+  clustering = ["user_id", "project_id", "trace_id"]
+
+  # Schema matches the Go storage.Span struct and proto definitions.
+  schema = jsonencode([
+    { name = "span_id", type = "STRING", mode = "REQUIRED" },
+    { name = "trace_id", type = "STRING", mode = "REQUIRED" },
+    { name = "parent_span_id", type = "STRING", mode = "NULLABLE" },
+    { name = "name", type = "STRING", mode = "REQUIRED" },
+    { name = "kind", type = "INTEGER", mode = "REQUIRED" },
+    { name = "status", type = "INTEGER", mode = "REQUIRED" },
+    { name = "status_message", type = "STRING", mode = "NULLABLE" },
+    { name = "start_time", type = "TIMESTAMP", mode = "REQUIRED" },
+    { name = "end_time", type = "TIMESTAMP", mode = "REQUIRED" },
+    { name = "duration_ns", type = "INT64", mode = "REQUIRED" },
+    { name = "project_id", type = "STRING", mode = "NULLABLE" },
+    { name = "environment", type = "STRING", mode = "NULLABLE" },
+    { name = "service_name", type = "STRING", mode = "NULLABLE" },
+    { name = "user_id", type = "STRING", mode = "NULLABLE" },
+    # GenAI attributes
+    { name = "gen_ai_model", type = "STRING", mode = "NULLABLE" },
+    { name = "gen_ai_provider", type = "STRING", mode = "NULLABLE" },
+    { name = "gen_ai_input_tokens", type = "INT64", mode = "NULLABLE" },
+    { name = "gen_ai_output_tokens", type = "INT64", mode = "NULLABLE" },
+    { name = "gen_ai_total_tokens", type = "INT64", mode = "NULLABLE" },
+    { name = "gen_ai_cost_usd", type = "FLOAT64", mode = "NULLABLE" },
+    # Structured attributes
+    {
+      name = "attributes",
+      type = "RECORD",
+      mode = "REPEATED",
+      fields = [
+        { name = "key", type = "STRING", mode = "REQUIRED" },
+        { name = "value", type = "STRING", mode = "REQUIRED" },
+      ]
+    },
+  ])
+
+  deletion_protection = true
+}

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -1,0 +1,115 @@
+# ──────────────────────────────────────────────────
+# Cloud Run — Candela server + IAP
+# Single service: Go backend + proxy + embedded UI.
+# ──────────────────────────────────────────────────
+
+locals {
+  image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.candela.repository_id}/candela-server:${var.image_tag}"
+}
+
+resource "google_cloud_run_v2_service" "candela" {
+  name     = var.service_name
+  location = var.region
+
+  # Delete protection for production.
+  deletion_protection = false
+
+  template {
+    service_account = google_service_account.candela.email
+
+    scaling {
+      min_instance_count = var.min_instances
+      max_instance_count = var.max_instances
+    }
+
+    containers {
+      image = local.image
+
+      ports {
+        container_port = 8181
+      }
+
+      resources {
+        limits = {
+          cpu    = var.cpu
+          memory = var.memory
+        }
+      }
+
+      # ── Environment variables ──
+      env {
+        name  = "CANDELA_STORAGE_BACKEND"
+        value = "bigquery"
+      }
+      env {
+        name  = "CANDELA_BQ_PROJECT"
+        value = var.project_id
+      }
+      env {
+        name  = "CANDELA_BQ_DATASET"
+        value = var.bigquery_dataset
+      }
+      env {
+        name  = "CANDELA_BQ_LOCATION"
+        value = var.bigquery_location
+      }
+      env {
+        name  = "CANDELA_FIRESTORE_DATABASE"
+        value = google_firestore_database.candela.name
+      }
+      env {
+        name  = "CANDELA_FIRESTORE_PROJECT"
+        value = var.project_id
+      }
+      env {
+        name  = "CANDELA_VERTEX_PROJECT"
+        value = var.project_id
+      }
+      env {
+        name  = "CANDELA_VERTEX_REGION"
+        value = var.vertex_ai_region
+      }
+      env {
+        name  = "CANDELA_PROXY_ENABLED"
+        value = "true"
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.apis,
+    google_artifact_registry_repository.candela,
+  ]
+}
+
+# ── IAP Configuration ──
+# Require authentication — IAP handles it.
+# No unauthenticated access to the Cloud Run service.
+
+resource "google_cloud_run_v2_service_iam_member" "iap_invoker" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.candela.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:service-${data.google_project.current.number}@gcp-sa-iap.iam.gserviceaccount.com"
+}
+
+# Grant the Google Group access through IAP.
+resource "google_iap_web_iam_member" "group_access" {
+  project = var.project_id
+  role    = "roles/iap.httpsResourceAccessUser"
+  member  = "group:${var.iap_google_group}"
+}
+
+# NOTE: The google_iap_brand Terraform resource is deprecated (July 2025+).
+# Create the OAuth consent screen and client manually in the Google Cloud Console:
+#   1. Go to APIs & Services → OAuth consent screen → configure
+#   2. Go to APIs & Services → Credentials → Create OAuth 2.0 Client ID
+#   3. Set the client ID in terraform.tfvars as iap_oauth_client_id
+# Variable defined in variables.tf
+
+# ── Data Sources ──
+
+data "google_project" "current" {
+  project_id = var.project_id
+}

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -11,8 +11,8 @@ resource "google_cloud_run_v2_service" "candela" {
   name     = var.service_name
   location = var.region
 
-  # Delete protection for production.
-  deletion_protection = false
+  # Prevent accidental deletion in production.
+  deletion_protection = true
 
   template {
     service_account = google_service_account.candela.email

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -101,12 +101,15 @@ resource "google_iap_web_iam_member" "group_access" {
   member  = "group:${var.iap_google_group}"
 }
 
-# NOTE: The google_iap_brand Terraform resource is deprecated (July 2025+).
-# Create the OAuth consent screen and client manually in the Google Cloud Console:
-#   1. Go to APIs & Services → OAuth consent screen → configure
-#   2. Go to APIs & Services → Credentials → Create OAuth 2.0 Client ID
-#   3. Set the client ID in terraform.tfvars as iap_oauth_client_id
-# Variable defined in variables.tf
+# ── IAP Enablement ──
+# IAP is enabled via gcloud (not Terraform — the Terraform resources are deprecated).
+# Run once after initial deploy:
+#
+#   gcloud run services update candela --region=REGION --iap
+#   gcloud run services describe candela --region=REGION \
+#     --format='value(metadata.annotations."run.googleapis.com/iap-client-id")'
+#
+# The client ID from above is the `audience` value for candela-local (~/.candela.yaml).
 
 # ── Data Sources ──
 

--- a/terraform/firestore.tf
+++ b/terraform/firestore.tf
@@ -8,10 +8,8 @@ resource "google_firestore_database" "candela" {
   location_id = var.firestore_location
   type        = "FIRESTORE_NATIVE"
 
-  # Prevent accidental deletion.
-  deletion_policy = "DELETE"
-  # Use "ABANDON" in production to prevent data loss:
-  # deletion_policy = "ABANDON"
+  # Prevent accidental data loss on terraform destroy.
+  deletion_policy = "ABANDON"
 
   depends_on = [google_project_service.apis]
 }

--- a/terraform/firestore.tf
+++ b/terraform/firestore.tf
@@ -1,0 +1,74 @@
+# ──────────────────────────────────────────────────
+# Firestore — Transactional data
+# Users, budgets, grants, projects, audit, rate limits.
+# ──────────────────────────────────────────────────
+
+resource "google_firestore_database" "candela" {
+  name        = "candela"
+  location_id = var.firestore_location
+  type        = "FIRESTORE_NATIVE"
+
+  # Prevent accidental deletion.
+  deletion_policy = "DELETE"
+  # Use "ABANDON" in production to prevent data loss:
+  # deletion_policy = "ABANDON"
+
+  depends_on = [google_project_service.apis]
+}
+
+# ── Composite indexes for common query patterns ──
+
+# Budget lookup: current period for a user
+resource "google_firestore_index" "user_budgets_by_period" {
+  database   = google_firestore_database.candela.name
+  collection = "budgets"
+
+  fields {
+    field_path = "userId"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "periodKey"
+    order      = "DESCENDING"
+  }
+}
+
+# Active grants: not expired, ordered by expiry
+resource "google_firestore_index" "user_grants_active" {
+  database   = google_firestore_database.candela.name
+  collection = "grants"
+
+  fields {
+    field_path = "userId"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "expiresAt"
+    order      = "ASCENDING"
+  }
+}
+
+# Audit log: most recent first
+resource "google_firestore_index" "user_audit_log" {
+  database   = google_firestore_database.candela.name
+  collection = "audit"
+
+  fields {
+    field_path = "userId"
+    order      = "ASCENDING"
+  }
+  fields {
+    field_path = "timestamp"
+    order      = "DESCENDING"
+  }
+}
+
+# ── TTL policy for rate limit documents (auto-cleanup) ──
+
+resource "google_firestore_field" "rate_limit_ttl" {
+  database   = google_firestore_database.candela.name
+  collection = "rate_limit"
+  field      = "expireAt"
+
+  ttl_config {}
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,40 @@
+# ──────────────────────────────────────────────────
+# IAM — Service account and role bindings
+# ──────────────────────────────────────────────────
+
+# Service account for the Candela Cloud Run service.
+resource "google_service_account" "candela" {
+  account_id   = "candela-server"
+  display_name = "Candela Server"
+  description  = "Service identity for the Candela Cloud Run service"
+}
+
+# ── Role bindings for the service account ──
+
+# BigQuery: read + write spans
+resource "google_project_iam_member" "candela_bigquery" {
+  project = var.project_id
+  role    = "roles/bigquery.dataEditor"
+  member  = "serviceAccount:${google_service_account.candela.email}"
+}
+
+# Firestore: read + write users, budgets, grants
+resource "google_project_iam_member" "candela_firestore" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.candela.email}"
+}
+
+# Vertex AI: proxy LLM requests to Claude
+resource "google_project_iam_member" "candela_vertex_ai" {
+  project = var.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.candela.email}"
+}
+
+# Service Account Token Creator: generate identity tokens for Vertex AI
+resource "google_project_iam_member" "candela_token_creator" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:${google_service_account.candela.email}"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -11,11 +11,12 @@ resource "google_service_account" "candela" {
 
 # ── Role bindings for the service account ──
 
-# BigQuery: read + write spans
-resource "google_project_iam_member" "candela_bigquery" {
-  project = var.project_id
-  role    = "roles/bigquery.dataEditor"
-  member  = "serviceAccount:${google_service_account.candela.email}"
+# BigQuery: read + write spans (scoped to candela dataset only)
+resource "google_bigquery_dataset_iam_member" "candela_bigquery" {
+  project    = var.project_id
+  dataset_id = google_bigquery_dataset.candela.dataset_id
+  role       = "roles/bigquery.dataEditor"
+  member     = "serviceAccount:${google_service_account.candela.email}"
 }
 
 # Firestore: read + write users, budgets, grants
@@ -32,9 +33,10 @@ resource "google_project_iam_member" "candela_vertex_ai" {
   member  = "serviceAccount:${google_service_account.candela.email}"
 }
 
-# Service Account Token Creator: generate identity tokens for Vertex AI
-resource "google_project_iam_member" "candela_token_creator" {
-  project = var.project_id
-  role    = "roles/iam.serviceAccountTokenCreator"
-  member  = "serviceAccount:${google_service_account.candela.email}"
+# Service Account Token Creator: scoped to self only (not project-wide)
+# Needed for generating identity tokens for Vertex AI calls.
+resource "google_service_account_iam_member" "candela_self_token_creator" {
+  service_account_id = google_service_account.candela.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.candela.email}"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,46 @@
+# ──────────────────────────────────────────────────
+# Candela — Terraform Main
+# Provider config, backend, and API enablement.
+# ──────────────────────────────────────────────────
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+
+  # Remote state in GCS — create this bucket manually first:
+  #   gsutil mb -p $PROJECT_ID -l $REGION gs://$PROJECT_ID-terraform-state
+  backend "gcs" {
+    # Configured via -backend-config or terraform.tfvars
+    # bucket = "<project-id>-terraform-state"
+    prefix = "candela"
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# ── Enable required GCP APIs ──
+
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "run.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "bigquery.googleapis.com",
+    "firestore.googleapis.com",
+    "iap.googleapis.com",
+    "iam.googleapis.com",
+    "aiplatform.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+  ])
+
+  service            = each.value
+  disable_on_destroy = false
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,13 +7,6 @@ output "cloud_run_url" {
   value       = google_cloud_run_v2_service.candela.uri
 }
 
-output "iap_client_id" {
-  description = "IAP OAuth Client ID — used as audience for candela-local identity tokens"
-  value       = var.iap_oauth_client_id
-}
-
-
-
 output "artifact_registry_repo" {
   description = "Docker image repository for pushing Candela images"
   value       = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.candela.repository_id}"
@@ -30,11 +23,12 @@ output "service_account_email" {
 }
 
 output "candela_local_config" {
-  description = "Paste into ~/.candela.yaml for local proxy setup"
+  description = "Template for ~/.candela.yaml — fill in audience after enabling IAP"
   value       = <<-EOT
     # ~/.candela.yaml
     remote: ${google_cloud_run_v2_service.candela.uri}
-    audience: ${var.iap_oauth_client_id}
+    audience: <run: gcloud run services describe ${var.service_name} --region=${var.region} --format='value(metadata.annotations."run.googleapis.com/iap-client-id")'>
     port: 8181
   EOT
 }
+

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,40 @@
+# ──────────────────────────────────────────────────
+# Outputs — Values needed for deployment and candela-local config
+# ──────────────────────────────────────────────────
+
+output "cloud_run_url" {
+  description = "Cloud Run service URL"
+  value       = google_cloud_run_v2_service.candela.uri
+}
+
+output "iap_client_id" {
+  description = "IAP OAuth Client ID — used as audience for candela-local identity tokens"
+  value       = var.iap_oauth_client_id
+}
+
+
+
+output "artifact_registry_repo" {
+  description = "Docker image repository for pushing Candela images"
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.candela.repository_id}"
+}
+
+output "bigquery_table" {
+  description = "BigQuery spans table fully-qualified name"
+  value       = "${var.project_id}.${google_bigquery_dataset.candela.dataset_id}.${google_bigquery_table.spans.table_id}"
+}
+
+output "service_account_email" {
+  description = "Candela service account email"
+  value       = google_service_account.candela.email
+}
+
+output "candela_local_config" {
+  description = "Paste into ~/.candela.yaml for local proxy setup"
+  value       = <<-EOT
+    # ~/.candela.yaml
+    remote: ${google_cloud_run_v2_service.candela.uri}
+    audience: ${var.iap_oauth_client_id}
+    port: 8181
+  EOT
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,20 @@
+# ──────────────────────────────────────────────────
+# Example tfvars — Copy to terraform.tfvars and fill in
+# ──────────────────────────────────────────────────
+
+project_id          = "your-gcp-project-id"
+region              = "us-central1"
+iap_google_group    = "devs@company.com"
+iap_oauth_client_id = ""  # Set after creating OAuth client in Cloud Console
+
+# Optional overrides:
+# service_name       = "candela"
+# image_tag          = "latest"
+# min_instances      = 0
+# max_instances      = 10
+# cpu                = "1"
+# memory             = "512Mi"
+# bigquery_dataset   = "candela"
+# bigquery_location  = "US"
+# firestore_location = "nam5"
+# vertex_ai_region   = "us-east5"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -2,10 +2,9 @@
 # Example tfvars — Copy to terraform.tfvars and fill in
 # ──────────────────────────────────────────────────
 
-project_id          = "your-gcp-project-id"
-region              = "us-central1"
-iap_google_group    = "devs@company.com"
-iap_oauth_client_id = ""  # Set after creating OAuth client in Cloud Console
+project_id       = "your-gcp-project-id"
+region           = "us-central1"
+iap_google_group = "devs@company.com"
 
 # Optional overrides:
 # service_name       = "candela"
@@ -18,3 +17,6 @@ iap_oauth_client_id = ""  # Set after creating OAuth client in Cloud Console
 # bigquery_location  = "US"
 # firestore_location = "nam5"
 # vertex_ai_region   = "us-east5"
+
+# NOTE: IAP is enabled post-deploy via:
+#   gcloud run services update candela --region=us-central1 --iap

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -64,11 +64,7 @@ variable "iap_google_group" {
   type        = string
 }
 
-variable "iap_oauth_client_id" {
-  description = "OAuth 2.0 Client ID for IAP (created manually in Cloud Console)"
-  type        = string
-  default     = ""
-}
+
 
 # ── BigQuery ──
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,101 @@
+# ──────────────────────────────────────────────────
+# Candela — Terraform Variables
+# ──────────────────────────────────────────────────
+
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for Cloud Run and Vertex AI"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "GCP zone (used for some zonal resources)"
+  type        = string
+  default     = "us-central1-a"
+}
+
+# ── Cloud Run ──
+
+variable "service_name" {
+  description = "Cloud Run service name"
+  type        = string
+  default     = "candela"
+}
+
+variable "image_tag" {
+  description = "Container image tag to deploy (e.g., 'latest', 'v1.0.0', commit SHA)"
+  type        = string
+  default     = "latest"
+}
+
+variable "min_instances" {
+  description = "Minimum Cloud Run instances (0 = scale to zero)"
+  type        = number
+  default     = 0
+}
+
+variable "max_instances" {
+  description = "Maximum Cloud Run instances"
+  type        = number
+  default     = 10
+}
+
+variable "cpu" {
+  description = "CPU allocation per instance"
+  type        = string
+  default     = "1"
+}
+
+variable "memory" {
+  description = "Memory allocation per instance"
+  type        = string
+  default     = "512Mi"
+}
+
+# ── IAP ──
+
+variable "iap_google_group" {
+  description = "Google Group email that gets IAP access (e.g., devs@company.com)"
+  type        = string
+}
+
+variable "iap_oauth_client_id" {
+  description = "OAuth 2.0 Client ID for IAP (created manually in Cloud Console)"
+  type        = string
+  default     = ""
+}
+
+# ── BigQuery ──
+
+variable "bigquery_dataset" {
+  description = "BigQuery dataset name for spans"
+  type        = string
+  default     = "candela"
+}
+
+variable "bigquery_location" {
+  description = "BigQuery dataset location"
+  type        = string
+  default     = "US"
+}
+
+# ── Firestore ──
+
+variable "firestore_location" {
+  description = "Firestore database location"
+  type        = string
+  default     = "nam5"  # US multi-region
+}
+
+# ── Vertex AI ──
+
+variable "vertex_ai_region" {
+  description = "Vertex AI region for Claude proxy"
+  type        = string
+  default     = "us-east5"
+}


### PR DESCRIPTION
## Phase 4: Productionization — Multi-User Token Budgets

### What's in this PR (Milestone 0 + 1 partial)

**Terraform Infrastructure** (Milestone 0 ✅)
- `terraform/` with 8 `.tf` files managing the full GCP production stack
- Cloud Run + IAP (Google Group access control)
- BigQuery spans table (time-partitioned, clustered by `user_id`)
- Firestore for users, budgets, grants (composite indexes, rate limit TTL)
- Artifact Registry, IAM service account + roles
- Validated with OpenTofu 1.11.5

**Proto Types** (Milestone 1 partial ✅)
- `user.proto`: User, UserBudget, BudgetGrant, AuditEntry, RateWindow
- `user_service.proto`: 14 RPCs (admin CRUD, budgets, grants, audit, self-service)
- `trace.proto`: `user_id` added to Span, Trace, TraceSummary
- `buf generate` — Go + TypeScript stubs generated, `go build` clean

**Other**
- OpenTofu added to `flake.nix` (BSL-free Terraform fork)
- README roadmap updated (Phase 3 ✅, Phase 4 🟡)

### Architecture Decisions
- **Auth**: IAP only (Google Group) — no Firebase, no API keys
- **Developer proxy**: `candela-local` binary + ADC (tool-agnostic, auto-refreshing)
- **Schemas**: Proto-first — all Firestore documents typed via protojson
- **Storage**: Firestore (transactional) + BigQuery (OLAP)
- **Budget**: Grants consumed first → monthly → deny
- **Deploy**: Single Cloud Run service with embedded UI (split later via LB)

### Remaining Work (follow-up PRs)
- [ ] Firestore store implementation (`pkg/storage/firestoredb/`)
- [ ] IAP auth interceptor (`pkg/auth/`)
- [ ] `candela-local` binary (`cmd/candela-local/`)
- [ ] Budget enforcement in proxy (`pkg/proxy/`)
- [ ] Admin UI + per-user dashboard views
- [ ] Notification system (Teams/email/webhook)