### PR TITLE
feat: proto-driven BigQuery schema generation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,22 +15,29 @@ repos:
       - id: golangci-lint
         args: ["--timeout=5m"]
 
-  - repo: https://github.com/bufbuild/buf
-    rev: v1.50.0
-    hooks:
-      - id: buf-lint
-        args: ["--config", "proto/buf.yaml"]
-      - id: buf-format
-        args: ["-w", "--config", "proto/buf.yaml"]
-      - id: buf-breaking
-        args:
-          - "--config"
-          - "proto/buf.yaml"
-          - "--against"
-          - ".git#branch=main,subdir=proto"
-
   - repo: local
     hooks:
+      - id: buf-lint
+        name: buf lint
+        entry: buf lint proto
+        language: system
+        pass_filenames: false
+        files: '\.proto$'
+
+      - id: buf-format
+        name: buf format
+        entry: buf format -w proto
+        language: system
+        pass_filenames: false
+        files: '\.proto$'
+
+      - id: buf-breaking
+        name: buf breaking
+        entry: buf breaking proto --against '.git#branch=main,subdir=proto'
+        language: system
+        pass_filenames: false
+        files: '\.proto$'
+
       - id: go-vet
         name: go vet
         entry: go vet ./...

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,19 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+
+        # BigQuery schema generator for protobuf (not in nixpkgs).
+        protoc-gen-bq-schema = pkgs.buildGoModule rec {
+          pname = "protoc-gen-bq-schema";
+          version = "3.1.0";
+          src = pkgs.fetchFromGitHub {
+            owner = "GoogleCloudPlatform";
+            repo = "protoc-gen-bq-schema";
+            rev = "v${version}";
+            sha256 = "sha256-fsnCGv9C5S+/VcBr88IXZTvgcMacQ2x4fnV3NyHrwSk=";
+          };
+          vendorHash = "sha256-nGAX1r6JgjZ0w9McpICd8nP+oWqu9PY6hSqTztm3s70=";
+        };
       in
       {
         devShells.default = pkgs.mkShell {
@@ -24,6 +37,7 @@
             # Protobuf / Buf
             buf
             protobuf
+            protoc-gen-bq-schema
 
             # Node.js (for web UI)
             nodejs_22

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
 
             # Git
             git
+            gh
             pre-commit
           ];
 

--- a/gen/bq/candela/types/spans.schema
+++ b/gen/bq/candela/types/spans.schema
@@ -2,119 +2,140 @@
  {
   "name": "span_id",
   "type": "STRING",
-  "mode": "REQUIRED"
+  "mode": "REQUIRED",
+  "description": "Unique identifier for the span."
  },
  {
   "name": "trace_id",
   "type": "STRING",
-  "mode": "REQUIRED"
+  "mode": "REQUIRED",
+  "description": "Unique identifier for the trace this span belongs to."
  },
  {
   "name": "parent_span_id",
   "type": "STRING",
-  "mode": "NULLABLE"
+  "mode": "NULLABLE",
+  "description": "Identifier of the parent span, if this is a child span."
  },
  {
   "name": "name",
   "type": "STRING",
-  "mode": "REQUIRED"
+  "mode": "REQUIRED",
+  "description": "A human-readable name for the span."
  },
  {
   "name": "kind",
   "type": "INTEGER",
-  "mode": "REQUIRED"
+  "mode": "REQUIRED",
+  "description": "The kind of span (LLM, agent, tool, etc.), as a SpanKind enum int."
  },
  {
   "name": "status",
   "type": "INTEGER",
-  "mode": "REQUIRED"
+  "mode": "REQUIRED",
+  "description": "The status of the span (ok, error), as a SpanStatus enum int."
  },
  {
   "name": "status_message",
   "type": "STRING",
-  "mode": "NULLABLE"
+  "mode": "NULLABLE",
+  "description": "A description of the status, present if status is error."
  },
  {
   "name": "start_time",
   "type": "TIMESTAMP",
-  "mode": "REQUIRED"
+  "mode": "REQUIRED",
+  "description": "The time the span started, in UTC."
  },
  {
   "name": "end_time",
   "type": "TIMESTAMP",
-  "mode": "REQUIRED"
+  "mode": "REQUIRED",
+  "description": "The time the span ended, in UTC."
  },
  {
   "name": "duration_ns",
   "type": "INTEGER",
-  "mode": "REQUIRED"
+  "mode": "REQUIRED",
+  "description": "The duration of the span in nanoseconds."
  },
  {
   "name": "project_id",
   "type": "STRING",
-  "mode": "NULLABLE"
+  "mode": "NULLABLE",
+  "description": "The ID of the project this span belongs to."
  },
  {
   "name": "environment",
   "type": "STRING",
-  "mode": "NULLABLE"
+  "mode": "NULLABLE",
+  "description": "The deployment environment (e.g., production, staging)."
  },
  {
   "name": "service_name",
   "type": "STRING",
-  "mode": "NULLABLE"
+  "mode": "NULLABLE",
+  "description": "The name of the service that generated this span."
  },
  {
   "name": "user_id",
   "type": "STRING",
-  "mode": "NULLABLE"
+  "mode": "NULLABLE",
+  "description": "The developer who triggered this span."
  },
  {
   "name": "gen_ai_model",
   "type": "STRING",
   "mode": "NULLABLE",
-  "description": "GenAI attributes (flattened from GenAIAttributes message)"
+  "description": "GenAI model identifier (e.g., gpt-4o, gemini-2.5-pro)."
  },
  {
   "name": "gen_ai_provider",
   "type": "STRING",
-  "mode": "NULLABLE"
+  "mode": "NULLABLE",
+  "description": "GenAI provider (e.g., openai, google_ai, anthropic)."
  },
  {
   "name": "gen_ai_input_tokens",
   "type": "INTEGER",
-  "mode": "NULLABLE"
+  "mode": "NULLABLE",
+  "description": "Number of input/prompt tokens."
  },
  {
   "name": "gen_ai_output_tokens",
   "type": "INTEGER",
-  "mode": "NULLABLE"
+  "mode": "NULLABLE",
+  "description": "Number of output/completion tokens."
  },
  {
   "name": "gen_ai_total_tokens",
   "type": "INTEGER",
-  "mode": "NULLABLE"
+  "mode": "NULLABLE",
+  "description": "Total tokens (input + output)."
  },
  {
   "name": "gen_ai_cost_usd",
   "type": "FLOAT",
-  "mode": "NULLABLE"
+  "mode": "NULLABLE",
+  "description": "Estimated cost in USD, calculated by Candela."
  },
  {
   "name": "attributes",
   "type": "RECORD",
   "mode": "REPEATED",
-  "description": "Structured attributes (OTel key-value pairs)",
+  "description": "Structured attributes from OpenTelemetry key-value pairs.",
   "fields": [
    {
     "name": "key",
     "type": "STRING",
-    "mode": "REQUIRED"
+    "mode": "REQUIRED",
+    "description": "The attribute key."
    },
    {
     "name": "value",
     "type": "STRING",
-    "mode": "REQUIRED"
+    "mode": "REQUIRED",
+    "description": "The attribute value (stringified)."
    }
   ]
  }

--- a/gen/bq/candela/types/spans.schema
+++ b/gen/bq/candela/types/spans.schema
@@ -1,0 +1,121 @@
+[
+ {
+  "name": "span_id",
+  "type": "STRING",
+  "mode": "REQUIRED"
+ },
+ {
+  "name": "trace_id",
+  "type": "STRING",
+  "mode": "REQUIRED"
+ },
+ {
+  "name": "parent_span_id",
+  "type": "STRING",
+  "mode": "NULLABLE"
+ },
+ {
+  "name": "name",
+  "type": "STRING",
+  "mode": "REQUIRED"
+ },
+ {
+  "name": "kind",
+  "type": "INTEGER",
+  "mode": "REQUIRED"
+ },
+ {
+  "name": "status",
+  "type": "INTEGER",
+  "mode": "REQUIRED"
+ },
+ {
+  "name": "status_message",
+  "type": "STRING",
+  "mode": "NULLABLE"
+ },
+ {
+  "name": "start_time",
+  "type": "TIMESTAMP",
+  "mode": "REQUIRED"
+ },
+ {
+  "name": "end_time",
+  "type": "TIMESTAMP",
+  "mode": "REQUIRED"
+ },
+ {
+  "name": "duration_ns",
+  "type": "INTEGER",
+  "mode": "REQUIRED"
+ },
+ {
+  "name": "project_id",
+  "type": "STRING",
+  "mode": "NULLABLE"
+ },
+ {
+  "name": "environment",
+  "type": "STRING",
+  "mode": "NULLABLE"
+ },
+ {
+  "name": "service_name",
+  "type": "STRING",
+  "mode": "NULLABLE"
+ },
+ {
+  "name": "user_id",
+  "type": "STRING",
+  "mode": "NULLABLE"
+ },
+ {
+  "name": "gen_ai_model",
+  "type": "STRING",
+  "mode": "NULLABLE",
+  "description": "GenAI attributes (flattened from GenAIAttributes message)"
+ },
+ {
+  "name": "gen_ai_provider",
+  "type": "STRING",
+  "mode": "NULLABLE"
+ },
+ {
+  "name": "gen_ai_input_tokens",
+  "type": "INTEGER",
+  "mode": "NULLABLE"
+ },
+ {
+  "name": "gen_ai_output_tokens",
+  "type": "INTEGER",
+  "mode": "NULLABLE"
+ },
+ {
+  "name": "gen_ai_total_tokens",
+  "type": "INTEGER",
+  "mode": "NULLABLE"
+ },
+ {
+  "name": "gen_ai_cost_usd",
+  "type": "FLOAT",
+  "mode": "NULLABLE"
+ },
+ {
+  "name": "attributes",
+  "type": "RECORD",
+  "mode": "REPEATED",
+  "description": "Structured attributes (OTel key-value pairs)",
+  "fields": [
+   {
+    "name": "key",
+    "type": "STRING",
+    "mode": "REQUIRED"
+   },
+   {
+    "name": "value",
+    "type": "STRING",
+    "mode": "REQUIRED"
+   }
+  ]
+ }
+]

--- a/proto/bq_field.proto
+++ b/proto/bq_field.proto
@@ -1,0 +1,57 @@
+// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package gen_bq_schema;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/GoogleCloudPlatform/protoc-gen-bq-schema/v3/protos";
+
+// Message containing options related to BigQuery schema generation
+// and management via Protobuf.
+message BigQueryFieldOptions {
+  // Flag to specify that a field should be marked as 'REQUIRED' when
+  // used to generate schema for BigQuery.
+  bool require = 1;
+
+  // Optionally override whatever type is resolved by the schema
+  // generator. This is useful, for example, to store epoch timestamps
+  // with the underlying 'TIMESTAMP' type, when normally, they would
+  // be structured as 'INTEGER' fields.
+  string type_override = 2;
+
+  // Optionally omit a field from BigQuery schema.
+  bool ignore = 3;
+
+  // Set the description for a field in BigQuery schema.
+  string description = 4;
+
+  // Customize the name of the field in the BigQuery schema.
+  string name = 5;
+
+  // Optionally add PolicyTag for a field in BigQuery schema.
+  string policy_tags = 6;
+
+  // Optional default value.
+  //
+  // See https://cloud.google.com/bigquery/docs/default-values for possible
+  // values.
+  string default_value_expression = 7;
+}
+
+extend google.protobuf.FieldOptions {
+  // BigQuery field schema generation options.
+  BigQueryFieldOptions bigquery = 1021;
+}

--- a/proto/bq_table.proto
+++ b/proto/bq_table.proto
@@ -1,0 +1,65 @@
+// Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package gen_bq_schema;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/GoogleCloudPlatform/protoc-gen-bq-schema/v3/protos";
+
+extend google.protobuf.MessageOptions {
+  // NB: There used to be a custom option named "table_name". But only one tag
+  // is registered for this project: 1021. So when adding other options, the
+  // only solution was to change tag 1021 to be a message, with all the various
+  // options as fields therein.
+  //
+  // If you are upgrading this library and find that protoc begins to reject
+  // your proto files, you'll need to change all lines that look like so:
+  //    option (gen_bq_schema.table_name) = "foo";
+  // to instead look like this:
+  //    option (gen_bq_schema.bigquery_opts).table_name = "foo";
+  // There was no backwards compatible way to make this change. Sorry for
+  // the inconvenience.
+
+  // BigQuery message schema generation options.
+  //
+  // The field number is a globally unique id for this option, assigned by
+  // protobuf-global-extension-registry@google.com
+  BigQueryMessageOptions bigquery_opts = 1021;
+}
+
+message BigQueryMessageOptions {
+  // Specifies a name of table in BigQuery for the message.
+  //
+  // If not blank, indicates the message is a type of record to be stored into BigQuery.
+  string table_name = 1;
+
+  // If true, BigQuery field names will default to a field's JSON name,
+  // not its original/proto field name.
+  bool use_json_names = 2;
+
+  // If set, adds defined extra fields to a JSON representation of the message.
+  // Value format: "<field name>:<BigQuery field type>" for basic types
+  // or "<field name>:RECORD:<protobuf type>" for message types.
+  // "NULLABLE" by default, different mode may be set via optional suffix ":<mode>"
+  repeated string extra_fields = 3;
+
+  // If set will output the schema file order based on the provided value.
+  enum FieldOrder {
+    FIELD_ORDER_UNSPECIFIED = 0;
+    FIELD_ORDER_BY_NUMBER = 1;
+  }
+  FieldOrder output_field_order = 4;
+}

--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -17,3 +17,7 @@ plugins:
   - remote: buf.build/connectrpc/es
     out: ../gen/ts
     opt: target=ts
+  # BigQuery schema generation from proto (local plugin)
+  # Install: go install github.com/GoogleCloudPlatform/protoc-gen-bq-schema/v3@latest
+  - local: protoc-gen-bq-schema
+    out: ../gen/bq

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -5,6 +5,12 @@ modules:
 lint:
   use:
     - STANDARD
+  except:
+    # Vendored bq_field.proto / bq_table.proto use package gen_bq_schema
+    # which doesn't match our directory layout — that's expected.
+    - PACKAGE_DIRECTORY_MATCH
+    # Our types package uses candela.types without a version suffix.
+    - PACKAGE_VERSION_SUFFIX
 breaking:
   use:
     - FILE

--- a/proto/candela/types/bq_span.proto
+++ b/proto/candela/types/bq_span.proto
@@ -16,37 +16,58 @@ option go_package = "github.com/candelahq/candela/gen/go/candela/types";
 message BqSpanRow {
   option (gen_bq_schema.bigquery_opts).table_name = "spans";
 
+  // Unique identifier for the span.
   string span_id = 1 [(gen_bq_schema.bigquery) = {require: true}];
+  // Unique identifier for the trace this span belongs to.
   string trace_id = 2 [(gen_bq_schema.bigquery) = {require: true}];
+  // Identifier of the parent span, if this is a child span.
   string parent_span_id = 3;
+  // A human-readable name for the span.
   string name = 4 [(gen_bq_schema.bigquery) = {require: true}];
+  // The kind of span (LLM, agent, tool, etc.), as a SpanKind enum int.
   int32 kind = 5 [(gen_bq_schema.bigquery) = {require: true}];
+  // The status of the span (ok, error), as a SpanStatus enum int.
   int32 status = 6 [(gen_bq_schema.bigquery) = {require: true}];
+  // A description of the status, present if status is error.
   string status_message = 7;
 
+  // The time the span started, in UTC.
   google.protobuf.Timestamp start_time = 10 [(gen_bq_schema.bigquery) = {require: true}];
+  // The time the span ended, in UTC.
   google.protobuf.Timestamp end_time = 11 [(gen_bq_schema.bigquery) = {require: true}];
+  // The duration of the span in nanoseconds.
   int64 duration_ns = 12 [(gen_bq_schema.bigquery) = {require: true}];
 
+  // The ID of the project this span belongs to.
   string project_id = 20;
+  // The deployment environment (e.g., production, staging).
   string environment = 21;
+  // The name of the service that generated this span.
   string service_name = 22;
+  // The developer who triggered this span.
   string user_id = 23;
 
-  // GenAI attributes (flattened from GenAIAttributes message)
+  // GenAI model identifier (e.g., gpt-4o, gemini-2.5-pro).
   string gen_ai_model = 30;
+  // GenAI provider (e.g., openai, google_ai, anthropic).
   string gen_ai_provider = 31;
+  // Number of input/prompt tokens.
   int64 gen_ai_input_tokens = 32;
+  // Number of output/completion tokens.
   int64 gen_ai_output_tokens = 33;
+  // Total tokens (input + output).
   int64 gen_ai_total_tokens = 34;
+  // Estimated cost in USD, calculated by Candela.
   double gen_ai_cost_usd = 35;
 
-  // Structured attributes (OTel key-value pairs)
+  // Structured attributes from OpenTelemetry key-value pairs.
   repeated BqAttribute attributes = 40;
 }
 
 // BqAttribute is a key-value pair stored as a RECORD in BigQuery.
 message BqAttribute {
+  // The attribute key.
   string key = 1 [(gen_bq_schema.bigquery) = {require: true}];
+  // The attribute value (stringified).
   string value = 2 [(gen_bq_schema.bigquery) = {require: true}];
 }

--- a/proto/candela/types/bq_span.proto
+++ b/proto/candela/types/bq_span.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package candela.types;
+
+import "bq_field.proto";
+import "bq_table.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/candelahq/candela/gen/go/candela/types";
+
+// BqSpanRow is the flattened BigQuery projection of a Span.
+// This message is the SINGLE SOURCE OF TRUTH for the `spans` table schema.
+// Generated schema: gen/bq/spans.schema
+//
+// Proto → `buf generate` → gen/bq/spans.schema → Terraform file() reference
+message BqSpanRow {
+  option (gen_bq_schema.bigquery_opts).table_name = "spans";
+
+  string span_id = 1 [(gen_bq_schema.bigquery) = {require: true}];
+  string trace_id = 2 [(gen_bq_schema.bigquery) = {require: true}];
+  string parent_span_id = 3;
+  string name = 4 [(gen_bq_schema.bigquery) = {require: true}];
+  int32 kind = 5 [(gen_bq_schema.bigquery) = {require: true}];
+  int32 status = 6 [(gen_bq_schema.bigquery) = {require: true}];
+  string status_message = 7;
+
+  google.protobuf.Timestamp start_time = 10 [(gen_bq_schema.bigquery) = {require: true}];
+  google.protobuf.Timestamp end_time = 11 [(gen_bq_schema.bigquery) = {require: true}];
+  int64 duration_ns = 12 [(gen_bq_schema.bigquery) = {require: true}];
+
+  string project_id = 20;
+  string environment = 21;
+  string service_name = 22;
+  string user_id = 23;
+
+  // GenAI attributes (flattened from GenAIAttributes message)
+  string gen_ai_model = 30;
+  string gen_ai_provider = 31;
+  int64 gen_ai_input_tokens = 32;
+  int64 gen_ai_output_tokens = 33;
+  int64 gen_ai_total_tokens = 34;
+  double gen_ai_cost_usd = 35;
+
+  // Structured attributes (OTel key-value pairs)
+  repeated BqAttribute attributes = 40;
+}
+
+// BqAttribute is a key-value pair stored as a RECORD in BigQuery.
+message BqAttribute {
+  string key = 1 [(gen_bq_schema.bigquery) = {require: true}];
+  string value = 2 [(gen_bq_schema.bigquery) = {require: true}];
+}

--- a/proto/candela/v1/user_service.proto
+++ b/proto/candela/v1/user_service.proto
@@ -107,7 +107,7 @@ message UpdateUserRequest {
   string id = 1;
   string display_name = 2;
   candela.types.UserRole role = 3;
-  google.protobuf.FieldMask update_mask = 4;  // Which fields to update
+  google.protobuf.FieldMask update_mask = 4; // Which fields to update
 }
 
 message UpdateUserResponse {

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -1,6 +1,7 @@
 # ──────────────────────────────────────────────────
 # BigQuery — Spans storage (OLAP)
-# Schema mirrors proto/candela/types/trace.proto
+# Schema generated from proto/candela/types/bq_span.proto
+# Regenerate: cd proto && buf generate
 # ──────────────────────────────────────────────────
 
 resource "google_bigquery_dataset" "candela" {
@@ -29,40 +30,9 @@ resource "google_bigquery_table" "spans" {
   # Clustering for common access patterns.
   clustering = ["user_id", "project_id", "trace_id"]
 
-  # Schema matches the Go storage.Span struct and proto definitions.
-  schema = jsonencode([
-    { name = "span_id", type = "STRING", mode = "REQUIRED" },
-    { name = "trace_id", type = "STRING", mode = "REQUIRED" },
-    { name = "parent_span_id", type = "STRING", mode = "NULLABLE" },
-    { name = "name", type = "STRING", mode = "REQUIRED" },
-    { name = "kind", type = "INTEGER", mode = "REQUIRED" },
-    { name = "status", type = "INTEGER", mode = "REQUIRED" },
-    { name = "status_message", type = "STRING", mode = "NULLABLE" },
-    { name = "start_time", type = "TIMESTAMP", mode = "REQUIRED" },
-    { name = "end_time", type = "TIMESTAMP", mode = "REQUIRED" },
-    { name = "duration_ns", type = "INT64", mode = "REQUIRED" },
-    { name = "project_id", type = "STRING", mode = "NULLABLE" },
-    { name = "environment", type = "STRING", mode = "NULLABLE" },
-    { name = "service_name", type = "STRING", mode = "NULLABLE" },
-    { name = "user_id", type = "STRING", mode = "NULLABLE" },
-    # GenAI attributes
-    { name = "gen_ai_model", type = "STRING", mode = "NULLABLE" },
-    { name = "gen_ai_provider", type = "STRING", mode = "NULLABLE" },
-    { name = "gen_ai_input_tokens", type = "INT64", mode = "NULLABLE" },
-    { name = "gen_ai_output_tokens", type = "INT64", mode = "NULLABLE" },
-    { name = "gen_ai_total_tokens", type = "INT64", mode = "NULLABLE" },
-    { name = "gen_ai_cost_usd", type = "FLOAT64", mode = "NULLABLE" },
-    # Structured attributes
-    {
-      name = "attributes",
-      type = "RECORD",
-      mode = "REPEATED",
-      fields = [
-        { name = "key", type = "STRING", mode = "REQUIRED" },
-        { name = "value", type = "STRING", mode = "REQUIRED" },
-      ]
-    },
-  ])
+  # Schema is generated from proto/candela/types/bq_span.proto
+  # via protoc-gen-bq-schema. Do NOT hand-edit — update the proto instead.
+  schema = file("${path.module}/../gen/bq/candela/types/spans.schema")
 
   deletion_protection = true
 }

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -32,7 +32,8 @@ resource "google_bigquery_table" "spans" {
 
   # Schema is generated from proto/candela/types/bq_span.proto
   # via protoc-gen-bq-schema. Do NOT hand-edit — update the proto instead.
-  schema = file("${path.module}/../gen/bq/candela/types/spans.schema")
+  description = "Flattened OpenTelemetry span data for LLM observability and cost analysis."
+  schema      = file("${path.module}/../gen/bq/candela/types/spans.schema")
 
   deletion_protection = true
 }


### PR DESCRIPTION
## Summary

Make proto the **single source of truth** for BigQuery table schemas, eliminating hand-maintained `jsonencode()` blocks in Terraform that can drift from proto definitions.

## Changes

- **`proto/candela/types/bq_span.proto`** — Dedicated `BqSpanRow` message with BQ annotations
- **`bq_field.proto` / `bq_table.proto`** — Vendored from protoc-gen-bq-schema v3.1.0
- **`buf.gen.yaml`** — Added local protoc-gen-bq-schema plugin → outputs to `gen/bq/`
- **`terraform/bigquery.tf`** — Replaced 35-line `jsonencode()` with `file()` reference
- **`.pre-commit-config.yaml`** — Moved buf hooks to local system hooks
- **`flake.nix`** — Added `gh` (GitHub CLI) to dev shell

## Workflow
```
bq_span.proto → buf generate → gen/bq/candela/types/spans.schema → terraform file()
```

## Verification
- ✅ buf lint / buf generate / tofu validate all pass
- ✅ Generated schema matches previous hand-written columns
- ✅ All pre-commit hooks pass