### PR TITLE
feat: LM Studio compatibility mode

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -64,6 +64,11 @@ type Config struct {
 			ProjectID string `yaml:"project_id"` // GCP project for Vertex AI
 			Region    string `yaml:"region"`     // e.g. "us-central1"
 		} `yaml:"vertex_ai"`
+		LMStudio struct {
+			Enabled bool                `yaml:"enabled"`
+			Port    int                 `yaml:"port"` // Default: 1234 (LM Studio default)
+			Models  []proxy.CompatModel `yaml:"models"`
+		} `yaml:"lmstudio"`
 	} `yaml:"proxy"`
 	CORS struct {
 		AllowedOrigins []string `yaml:"allowed_origins"` // e.g. ["http://localhost:3000"]
@@ -255,6 +260,20 @@ func main() {
 				names = append(names, "/proxy/"+p.Name+"/")
 			}
 			slog.Info("🔀 LLM proxy enabled", "routes", names)
+
+			// LM Studio compat mode: register /v1/ routes on main mux
+			// and start a secondary listener on the LM Studio port.
+			if cfg.Proxy.LMStudio.Enabled && len(cfg.Proxy.LMStudio.Models) > 0 {
+				llmProxy.RegisterCompatRoutes(mux, cfg.Proxy.LMStudio.Models)
+
+				var modelNames []string
+				for _, m := range cfg.Proxy.LMStudio.Models {
+					modelNames = append(modelNames, m.ID)
+				}
+				slog.Info("🖥️  LM Studio compat mode enabled",
+					"models", modelNames,
+					"main_routes", []string{"/v1/models", "/v1/chat/completions"})
+			}
 		} else {
 			slog.Warn("proxy enabled but no valid providers configured")
 		}
@@ -314,6 +333,68 @@ func main() {
 		}
 	}()
 
+	// Secondary LM Studio-compatible listener (port 1234 by default).
+	// This lets IntelliJ's "Enable LM Studio" checkbox work with zero URL changes.
+	var lmSrv *http.Server
+	if cfg.Proxy.LMStudio.Enabled && len(cfg.Proxy.LMStudio.Models) > 0 {
+		lmPort := cfg.Proxy.LMStudio.Port
+		if lmPort == 0 {
+			lmPort = 1234
+		}
+
+		// Build a minimal mux for the LM Studio port (compat routes only).
+		lmMux := http.NewServeMux()
+		// Re-create the proxy for the LM Studio mux routes.
+		if cfg.Proxy.Enabled {
+			allProviders := proxy.DefaultProviders()
+			if cfg.Proxy.VertexAI.ProjectID != "" {
+				region := cfg.Proxy.VertexAI.Region
+				if region == "" {
+					region = "us-central1"
+				}
+				tokenSource, _ := google.DefaultTokenSource(context.Background(),
+					"https://www.googleapis.com/auth/cloud-platform")
+				for i, p := range allProviders {
+					if p.Name == "anthropic" {
+						allProviders[i].UpstreamURL = fmt.Sprintf(
+							"https://%s-aiplatform.googleapis.com", region)
+						allProviders[i].FormatTranslator = &proxy.AnthropicFormatTranslator{}
+						allProviders[i].PathRewriter = &proxy.VertexAIPathRewriter{
+							ProjectID: cfg.Proxy.VertexAI.ProjectID,
+							Region:    region,
+						}
+						if tokenSource != nil {
+							allProviders[i].TokenSource = tokenSource
+						}
+						break
+					}
+				}
+			}
+			lmProxy := proxy.New(proxy.Config{
+				Providers: allProviders,
+				ProjectID: cfg.Proxy.ProjectID,
+			}, processor, calc)
+			lmProxy.RegisterRoutes(lmMux)
+			lmProxy.RegisterCompatRoutes(lmMux, cfg.Proxy.LMStudio.Models)
+		}
+
+		// Health check for LM Studio port.
+		lmMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = fmt.Fprintln(w, `{"status":"ok","mode":"lmstudio"}`)
+		})
+
+		lmAddr := fmt.Sprintf("%s:%d", cfg.Server.Host, lmPort)
+		lmSrv = &http.Server{Addr: lmAddr, Handler: lmMux}
+
+		go func() {
+			slog.Info("🖥️  LM Studio compat listener starting", "addr", lmAddr)
+			if err := lmSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				slog.Warn("LM Studio compat listener failed (port may be in use)",
+					"addr", lmAddr, "error", err)
+			}
+		}()
+	}
+
 	<-ctx.Done()
 	slog.Info("shutting down...")
 
@@ -321,6 +402,11 @@ func main() {
 	defer cancel()
 
 	processor.Stop()
+	if lmSrv != nil {
+		if err := lmSrv.Shutdown(shutdownCtx); err != nil {
+			slog.Error("LM Studio listener shutdown error", "error", err)
+		}
+	}
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		slog.Error("shutdown error", "error", err)
 	}

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -190,6 +190,7 @@ func main() {
 		"project", projectPath)
 
 	// Register LLM proxy routes (selective activation).
+	var llmProxy *proxy.Proxy
 	if cfg.Proxy.Enabled {
 		allProviders := proxy.DefaultProviders()
 
@@ -249,7 +250,7 @@ func main() {
 		}
 
 		if len(activeProviders) > 0 {
-			llmProxy := proxy.New(proxy.Config{
+			llmProxy = proxy.New(proxy.Config{
 				Providers: activeProviders,
 				ProjectID: cfg.Proxy.ProjectID,
 			}, processor, calc)
@@ -336,47 +337,18 @@ func main() {
 	// Secondary LM Studio-compatible listener (port 1234 by default).
 	// This lets IntelliJ's "Enable LM Studio" checkbox work with zero URL changes.
 	var lmSrv *http.Server
-	if cfg.Proxy.LMStudio.Enabled && len(cfg.Proxy.LMStudio.Models) > 0 {
+	if cfg.Proxy.LMStudio.Enabled && len(cfg.Proxy.LMStudio.Models) > 0 && llmProxy != nil {
 		lmPort := cfg.Proxy.LMStudio.Port
 		if lmPort == 0 {
 			lmPort = 1234
 		}
 
-		// Build a minimal mux for the LM Studio port (compat routes only).
+		// Build a minimal mux for the LM Studio port.
+		// Reuse the same proxy instance — shares circuit breakers,
+		// connection pool, and respects provider filtering.
 		lmMux := http.NewServeMux()
-		// Re-create the proxy for the LM Studio mux routes.
-		if cfg.Proxy.Enabled {
-			allProviders := proxy.DefaultProviders()
-			if cfg.Proxy.VertexAI.ProjectID != "" {
-				region := cfg.Proxy.VertexAI.Region
-				if region == "" {
-					region = "us-central1"
-				}
-				tokenSource, _ := google.DefaultTokenSource(context.Background(),
-					"https://www.googleapis.com/auth/cloud-platform")
-				for i, p := range allProviders {
-					if p.Name == "anthropic" {
-						allProviders[i].UpstreamURL = fmt.Sprintf(
-							"https://%s-aiplatform.googleapis.com", region)
-						allProviders[i].FormatTranslator = &proxy.AnthropicFormatTranslator{}
-						allProviders[i].PathRewriter = &proxy.VertexAIPathRewriter{
-							ProjectID: cfg.Proxy.VertexAI.ProjectID,
-							Region:    region,
-						}
-						if tokenSource != nil {
-							allProviders[i].TokenSource = tokenSource
-						}
-						break
-					}
-				}
-			}
-			lmProxy := proxy.New(proxy.Config{
-				Providers: allProviders,
-				ProjectID: cfg.Proxy.ProjectID,
-			}, processor, calc)
-			lmProxy.RegisterRoutes(lmMux)
-			lmProxy.RegisterCompatRoutes(lmMux, cfg.Proxy.LMStudio.Models)
-		}
+		llmProxy.RegisterRoutes(lmMux)
+		llmProxy.RegisterCompatRoutes(lmMux, cfg.Proxy.LMStudio.Models)
 
 		// Health check for LM Studio port.
 		lmMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -46,6 +46,30 @@ proxy:
     - anthropic
     - gemini-oai
 
+  # LM Studio compatibility mode.
+  # Serves /v1/chat/completions and /v1/models at the root path (no /proxy/ prefix).
+  # Model names in requests are routed to the matching upstream provider.
+  # Also starts a secondary listener on the LM Studio default port (1234)
+  # so IntelliJ/tools can simply "Enable LM Studio" with no URL changes.
+  lmstudio:
+    enabled: true
+    port: 1234              # Secondary listener port (default: 1234, LM Studio's default)
+    models:
+      - id: gpt-4o
+        provider: openai
+      - id: gpt-4o-mini
+        provider: openai
+      - id: o3-mini
+        provider: openai
+      - id: claude-sonnet-4-20250514
+        provider: anthropic
+      - id: claude-opus-4-20250514
+        provider: anthropic
+      - id: gemini-2.5-pro
+        provider: gemini-oai
+      - id: gemini-2.5-flash
+        provider: gemini-oai
+
 cors:
   # Origins allowed to make cross-origin requests.
   allowed_origins:

--- a/pkg/proxy/compat_test.go
+++ b/pkg/proxy/compat_test.go
@@ -1,0 +1,320 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/costcalc"
+)
+
+func TestBuildModelsResponse(t *testing.T) {
+	models := []CompatModel{
+		{ID: "gpt-4o", Provider: "openai"},
+		{ID: "claude-sonnet-4-20250514", Provider: "anthropic"},
+		{ID: "gemini-2.5-pro", Provider: "gemini-oai"},
+	}
+
+	data := buildModelsResponse(models)
+
+	var resp struct {
+		Object string `json:"object"`
+		Data   []struct {
+			ID      string `json:"id"`
+			Object  string `json:"object"`
+			Created int64  `json:"created"`
+			OwnedBy string `json:"owned_by"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if resp.Object != "list" {
+		t.Errorf("object = %q, want 'list'", resp.Object)
+	}
+	if len(resp.Data) != 3 {
+		t.Fatalf("len(data) = %d, want 3", len(resp.Data))
+	}
+
+	// Verify each model entry.
+	expected := []struct {
+		id, ownedBy string
+	}{
+		{"gpt-4o", "openai"},
+		{"claude-sonnet-4-20250514", "anthropic"},
+		{"gemini-2.5-pro", "gemini-oai"},
+	}
+	for i, want := range expected {
+		got := resp.Data[i]
+		if got.ID != want.id {
+			t.Errorf("data[%d].id = %q, want %q", i, got.ID, want.id)
+		}
+		if got.OwnedBy != want.ownedBy {
+			t.Errorf("data[%d].owned_by = %q, want %q", i, got.OwnedBy, want.ownedBy)
+		}
+		if got.Object != "model" {
+			t.Errorf("data[%d].object = %q, want 'model'", i, got.Object)
+		}
+	}
+}
+
+func TestBuildModelsResponse_Empty(t *testing.T) {
+	data := buildModelsResponse(nil)
+
+	var resp struct {
+		Object string        `json:"object"`
+		Data   []interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if resp.Object != "list" {
+		t.Errorf("object = %q, want 'list'", resp.Object)
+	}
+	// Data should be null or empty — either is valid for the OpenAI API.
+}
+
+func TestCompatRoutes_GetModels(t *testing.T) {
+	submitter := &mockSubmitter{}
+	calc := costcalc.New()
+
+	p := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: "http://unused"}},
+		ProjectID: "test",
+	}, submitter, calc)
+
+	models := []CompatModel{
+		{ID: "gpt-4o", Provider: "openai"},
+		{ID: "gpt-4o-mini", Provider: "openai"},
+	}
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	p.RegisterCompatRoutes(mux, models)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatalf("GET /v1/models failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q, want application/json", ct)
+	}
+
+	var result struct {
+		Object string `json:"object"`
+		Data   []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if len(result.Data) != 2 {
+		t.Fatalf("len(data) = %d, want 2", len(result.Data))
+	}
+	if result.Data[0].ID != "gpt-4o" {
+		t.Errorf("data[0].id = %q, want gpt-4o", result.Data[0].ID)
+	}
+}
+
+func TestCompatRoutes_ChatCompletions_RoutesToProvider(t *testing.T) {
+	// Fake upstream that returns an OpenAI-format response.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{
+			"id": "chatcmpl-test",
+			"object": "chat.completion",
+			"choices": [{"message": {"role": "assistant", "content": "Hello from proxy!"}}],
+			"usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12}
+		}`)
+	}))
+	defer upstream.Close()
+
+	submitter := &mockSubmitter{}
+	calc := costcalc.New()
+
+	p := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, submitter, calc)
+
+	models := []CompatModel{
+		{ID: "gpt-4o", Provider: "openai"},
+	}
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	p.RegisterCompatRoutes(mux, models)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// POST to /v1/chat/completions (LM Studio path).
+	body := `{"model": "gpt-4o", "messages": [{"role": "user", "content": "hello"}]}`
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, respBody)
+	}
+
+	var result map[string]interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+
+	if result["id"] != "chatcmpl-test" {
+		t.Errorf("response id = %v, want chatcmpl-test", result["id"])
+	}
+
+	// Wait for async span creation.
+	for i := 0; i < 50; i++ {
+		if len(submitter.getSpans()) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	spans := submitter.getSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected span to be submitted via compat route")
+	}
+
+	span := spans[0]
+	if span.GenAI == nil {
+		t.Fatal("expected GenAI attributes")
+	}
+	if span.GenAI.Model != "gpt-4o" {
+		t.Errorf("span model = %q, want gpt-4o", span.GenAI.Model)
+	}
+	if span.GenAI.Provider != "openai" {
+		t.Errorf("span provider = %q, want openai", span.GenAI.Provider)
+	}
+}
+
+func TestCompatRoutes_ChatCompletions_UnknownModel(t *testing.T) {
+	submitter := &mockSubmitter{}
+	calc := costcalc.New()
+
+	p := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: "http://unused"}},
+		ProjectID: "test",
+	}, submitter, calc)
+
+	models := []CompatModel{
+		{ID: "gpt-4o", Provider: "openai"},
+	}
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	p.RegisterCompatRoutes(mux, models)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Request with a model not in the configured list.
+	body := `{"model": "unknown-model-xyz", "messages": [{"role": "user", "content": "hi"}]}`
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(respBody), "unknown-model-xyz") {
+		t.Errorf("error body should mention the unknown model, got: %s", respBody)
+	}
+}
+
+func TestCompatRoutes_ChatCompletions_MissingModel(t *testing.T) {
+	submitter := &mockSubmitter{}
+	calc := costcalc.New()
+
+	p := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: "http://unused"}},
+		ProjectID: "test",
+	}, submitter, calc)
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	p.RegisterCompatRoutes(mux, []CompatModel{{ID: "gpt-4o", Provider: "openai"}})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Request with no model field.
+	body := `{"messages": [{"role": "user", "content": "hi"}]}`
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(respBody), "missing or invalid model") {
+		t.Errorf("error body = %s", respBody)
+	}
+}
+
+func TestCompatRoutes_ChatCompletions_InvalidJSON(t *testing.T) {
+	submitter := &mockSubmitter{}
+	calc := costcalc.New()
+
+	p := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: "http://unused"}},
+		ProjectID: "test",
+	}, submitter, calc)
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	p.RegisterCompatRoutes(mux, []CompatModel{{ID: "gpt-4o", Provider: "openai"}})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Send garbage body.
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/chat/completions", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -134,6 +134,95 @@ func (p *Proxy) RegisterRoutes(mux *http.ServeMux) {
 	}
 }
 
+// CompatModel maps a model ID to a provider name for LM Studio compat mode.
+type CompatModel struct {
+	ID       string `yaml:"id" json:"id"`
+	Provider string `yaml:"provider" json:"provider"`
+}
+
+// RegisterCompatRoutes registers OpenAI-compatible routes at /v1/ (no /proxy/ prefix).
+// This enables LM Studio, IntelliJ's LM Studio integration, and similar tools
+// that expect an OpenAI-compatible API at the root path.
+//
+// GET /v1/models returns the configured model list.
+// POST /v1/chat/completions routes to the correct provider based on the model name.
+func (p *Proxy) RegisterCompatRoutes(mux *http.ServeMux, models []CompatModel) {
+	// Build the /v1/models response once at startup.
+	modelList := buildModelsResponse(models)
+
+	// GET /v1/models — return the configured model list.
+	mux.HandleFunc("GET /v1/models", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(modelList)
+	})
+
+	// Build model→provider lookup.
+	modelToProvider := make(map[string]string, len(models))
+	for _, m := range models {
+		modelToProvider[m.ID] = m.Provider
+	}
+
+	// POST /v1/chat/completions — route to provider based on model name in body.
+	mux.HandleFunc("POST /v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "failed to read request body", http.StatusBadRequest)
+			return
+		}
+		_ = r.Body.Close()
+
+		var req struct {
+			Model string `json:"model"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil || req.Model == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"missing or invalid model field","type":"invalid_request_error"}}`))
+			return
+		}
+
+		providerName, ok := modelToProvider[req.Model]
+		if !ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprintf(w, `{"error":{"message":"unknown model: %s. Configure it in proxy.lmstudio.models","type":"invalid_request_error"}}`, req.Model)
+			return
+		}
+
+		// Rewrite to internal proxy path and delegate to existing handler.
+		r.URL.Path = "/proxy/" + providerName + "/v1/chat/completions"
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		r.ContentLength = int64(len(body))
+		p.handleProxy(w, r)
+	})
+}
+
+func buildModelsResponse(models []CompatModel) []byte {
+	type modelEntry struct {
+		ID      string `json:"id"`
+		Object  string `json:"object"`
+		Created int64  `json:"created"`
+		OwnedBy string `json:"owned_by"`
+	}
+	type modelsResponse struct {
+		Object string       `json:"object"`
+		Data   []modelEntry `json:"data"`
+	}
+
+	resp := modelsResponse{Object: "list"}
+	for _, m := range models {
+		resp.Data = append(resp.Data, modelEntry{
+			ID:      m.ID,
+			Object:  "model",
+			Created: 1700000000,
+			OwnedBy: m.Provider,
+		})
+	}
+
+	b, _ := json.Marshal(resp)
+	return b
+}
+
 func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -219,7 +219,12 @@ func buildModelsResponse(models []CompatModel) []byte {
 		})
 	}
 
-	b, _ := json.Marshal(resp)
+	b, err := json.Marshal(resp)
+	if err != nil {
+		// Should never happen with simple string/int fields, but be safe.
+		slog.Error("failed to marshal models response", "error", err)
+		return []byte(`{"object":"list","data":[]}`)
+	}
 	return b
 }
 


### PR DESCRIPTION
## Summary

Add config-driven LM Studio compat mode that serves OpenAI-compatible API endpoints at `/v1/` (no `/proxy/` prefix). This enables IntelliJ's built-in **"Enable LM Studio"** checkbox to work with **zero URL changes**.

## What it does

- `GET /v1/models` — returns configurable model list
- `POST /v1/chat/completions` — routes to upstream provider by model name
- Starts a secondary HTTP listener on port **1234** (LM Studio default)
- Soft-fails if port is occupied (logs warning, continues)

## Config

```yaml
proxy:
  lmstudio:
    enabled: true
    port: 1234
    models:
      - id: gpt-4o
        provider: openai
      - id: claude-sonnet-4-20250514
        provider: anthropic
      - id: gemini-2.5-pro
        provider: gemini-oai
```

## Design

The compat handler rewrites URLs to `/proxy/{provider}/v1/chat/completions` and delegates to the existing `handleProxy` — **zero duplicated proxy logic**. All observability, cost tracking, streaming, and circuit breaker behavior is reused.

## Testing

- 7 new unit tests in `compat_test.go`
- Full test suite passes (`go test ./...`)
- All pre-commit hooks pass

## Files changed

| File | Change |
|---|---|
| `pkg/proxy/proxy.go` | `CompatModel`, `RegisterCompatRoutes`, `buildModelsResponse` |
| `cmd/candela-server/main.go` | Config field, route registration, secondary listener |
| `config.example.yaml` | `proxy.lmstudio` section |
| `pkg/proxy/compat_test.go` | **[NEW]** 7 unit tests |