### PR TITLE
feat: add local provider for Ollama/vLLM/LM Studio

### DIFF
--- a/cmd/candela-local/main.go
+++ b/cmd/candela-local/main.go
@@ -37,10 +37,11 @@ import (
 
 // Config holds the candela-local configuration.
 type Config struct {
-	Remote       string `yaml:"remote"`        // Remote Candela server URL
-	Audience     string `yaml:"audience"`      // IAP OAuth Client ID (OIDC audience)
-	Port         int    `yaml:"port"`          // Local port to listen on
-	LMStudioPort int    `yaml:"lmstudio_port"` // LM Studio compat listener port (default: 1234)
+	Remote        string `yaml:"remote"`         // Remote Candela server URL
+	Audience      string `yaml:"audience"`       // IAP OAuth Client ID (OIDC audience)
+	Port          int    `yaml:"port"`           // Local port to listen on
+	LMStudioPort  int    `yaml:"lmstudio_port"`  // LM Studio compat listener port (default: 1234)
+	LocalUpstream string `yaml:"local_upstream"` // Local runtime URL (e.g. http://127.0.0.1:11434)
 }
 
 func main() {
@@ -153,10 +154,48 @@ func main() {
 		},
 	}
 
+	// ── Local runtime proxy ──
+	// If a local upstream is configured, route /proxy/local/ directly to the
+	// local runtime (Ollama, vLLM, LM Studio) without a cloud round-trip.
+	mux := http.NewServeMux()
+
+	if cfg.LocalUpstream != "" {
+		localURL, err := url.Parse(cfg.LocalUpstream)
+		if err != nil {
+			slog.Error("invalid local_upstream URL", "url", cfg.LocalUpstream, "error", err)
+			os.Exit(1)
+		}
+
+		localProxy := &httputil.ReverseProxy{
+			Director: func(req *http.Request) {
+				// Strip the /proxy/local prefix before forwarding.
+				req.URL.Scheme = localURL.Scheme
+				req.URL.Host = localURL.Host
+				req.Host = localURL.Host
+				req.URL.Path = strings.TrimPrefix(req.URL.Path, "/proxy/local")
+				if req.URL.Path == "" {
+					req.URL.Path = "/"
+				}
+				if _, ok := req.Header["User-Agent"]; !ok {
+					req.Header.Set("User-Agent", "candela-local/1.0")
+				}
+			},
+			ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+				slog.Error("local proxy error", "path", r.URL.Path, "error", err)
+				http.Error(w, fmt.Sprintf(`{"error": "local runtime unavailable: %s"}`, err), http.StatusBadGateway)
+			},
+		}
+		mux.Handle("/proxy/local/", localProxy)
+		slog.Info("🏠 local runtime proxy enabled", "upstream", cfg.LocalUpstream)
+	}
+
+	// Everything else → remote Candela server.
+	mux.Handle("/", proxy)
+
 	addr := fmt.Sprintf("127.0.0.1:%d", cfg.Port)
 	srv := &http.Server{
 		Addr:    addr,
-		Handler: proxy,
+		Handler: mux,
 	}
 
 	// ── LM Studio compat listener ──
@@ -178,10 +217,15 @@ func main() {
 			"local", fmt.Sprintf("http://%s", addr),
 			"remote", cfg.Remote,
 			"audience", cfg.Audience[:min(20, len(cfg.Audience))]+"...")
-		slog.Info("Point your tools at:",
+		logFields := []any{
 			"openai", fmt.Sprintf("http://%s/proxy/openai/v1", addr),
 			"anthropic", fmt.Sprintf("http://%s/proxy/anthropic/", addr),
-			"google", fmt.Sprintf("http://%s/proxy/google/", addr))
+			"google", fmt.Sprintf("http://%s/proxy/google/", addr),
+		}
+		if cfg.LocalUpstream != "" {
+			logFields = append(logFields, "local", fmt.Sprintf("http://%s/proxy/local/v1", addr))
+		}
+		slog.Info("Point your tools at:", logFields...)
 
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("server error", "error", err)

--- a/cmd/candela-local/main.go
+++ b/cmd/candela-local/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -150,7 +151,9 @@ func main() {
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			slog.Error("proxy error", "path", r.URL.Path, "error", err)
-			http.Error(w, fmt.Sprintf(`{"error": "proxy error: %s"}`, err), http.StatusBadGateway)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadGateway)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("proxy error: %v", err)})
 		},
 	}
 
@@ -168,21 +171,24 @@ func main() {
 
 		localProxy := &httputil.ReverseProxy{
 			Director: func(req *http.Request) {
-				// Strip the /proxy/local prefix before forwarding.
+				// Strip the /proxy/local prefix and prepend the upstream path.
 				req.URL.Scheme = localURL.Scheme
 				req.URL.Host = localURL.Host
 				req.Host = localURL.Host
-				req.URL.Path = strings.TrimPrefix(req.URL.Path, "/proxy/local")
-				if req.URL.Path == "" {
-					req.URL.Path = "/"
+				stripped := strings.TrimPrefix(req.URL.Path, "/proxy/local")
+				if stripped == "" {
+					stripped = "/"
 				}
+				req.URL.Path = singleJoiningSlash(localURL.Path, stripped)
 				if _, ok := req.Header["User-Agent"]; !ok {
 					req.Header.Set("User-Agent", "candela-local/1.0")
 				}
 			},
 			ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 				slog.Error("local proxy error", "path", r.URL.Path, "error", err)
-				http.Error(w, fmt.Sprintf(`{"error": "local runtime unavailable: %s"}`, err), http.StatusBadGateway)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadGateway)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("local runtime unavailable: %v", err)})
 			},
 		}
 		mux.Handle("/proxy/local/", localProxy)
@@ -316,4 +322,18 @@ func loadConfig(configPath string) *Config {
 
 	slog.Info("loaded config", "path", configPath)
 	return cfg
+}
+
+// singleJoiningSlash joins two URL path segments with exactly one slash.
+// This is the same logic used by net/http/httputil.NewSingleHostReverseProxy.
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -40,6 +40,9 @@ proxy:
   #   OpenAI:     Base URL = http://localhost:8181/proxy/openai/v1
   #   Gemini:     Base URL = http://localhost:8181/proxy/gemini-oai/v1
   #   Anthropic:  Base URL = http://localhost:8181/proxy/anthropic/v1
+  #
+  # Local models (Ollama/vLLM/LM Studio) are handled by candela-local.
+  # See ~/.candela.yaml for local runtime configuration.
   providers:
     - openai
     - google
@@ -69,6 +72,11 @@ proxy:
         provider: gemini-oai
       - id: gemini-2.5-flash
         provider: gemini-oai
+      # Local models (requires a running Ollama/vLLM/LM Studio)
+      # - id: llama3.2:8b
+      #   provider: local
+      # - id: codellama:13b
+      #   provider: local
 
 cors:
   # Origins allowed to make cross-origin requests.

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -33,6 +33,11 @@ func New() *Calculator {
 
 // Calculate returns the estimated cost in USD for the given model and token counts.
 func (c *Calculator) Calculate(provider, model string, inputTokens, outputTokens int64) float64 {
+	// Local models run on your hardware — no API cost.
+	if strings.ToLower(provider) == "local" {
+		return 0
+	}
+
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 


### PR DESCRIPTION
## Summary

Add local model proxy support to `candela-local`. When `local_upstream` is configured in `~/.candela.yaml`, requests to `/proxy/local/*` are forwarded directly to the local runtime (Ollama, vLLM, LM Studio) **without a cloud round-trip**. All other requests continue to the remote Candela server as before.

## How it works

```
Tool (Zed/IntelliJ) → candela-local → /proxy/local/ → Ollama (:11434)
                                     → /proxy/openai/ → remote candela-server → OpenAI
```

Local model requests stay on the machine. Cloud model requests go through the authenticated remote proxy.

## Changes

### `cmd/candela-local/main.go`
- Add `LocalUpstream` config field (`local_upstream` in YAML)
- Build a second `httputil.ReverseProxy` for the local runtime
- Switch from raw `ReverseProxy` handler to `ServeMux` for routing: `/proxy/local/` → local runtime, everything else → remote server
- Strip `/proxy/local` prefix before forwarding (so `/proxy/local/v1/chat/completions` → `/v1/chat/completions`)
- Show local endpoint in startup log when configured

### `pkg/costcalc/calculator.go`
- Short-circuit `Calculate()` to return `$0.00` when `provider == "local"` — local models run on your hardware

### `config.example.yaml`
- Note that local models are handled by `candela-local`, not the server
- Add commented-out local model entries to LM Studio compat section

## Usage

```yaml
# ~/.candela.yaml
remote: "https://candela-xxx.a.run.app"
audience: "12345..."
port: 8181
local_upstream: "http://127.0.0.1:11434"  # Ollama (or :8000 for vLLM, :1234 for LM Studio)
```

```bash
curl http://localhost:8181/proxy/local/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model": "llama3.2:8b", "messages": [{"role": "user", "content": "hello"}]}'
```

## Testing
- `go build ./...` ✅
- `go test ./pkg/proxy/... ./pkg/costcalc/... ./cmd/candela-local/...` ✅
- All pre-commit hooks pass ✅

## Context
Step 1 of the local model serving roadmap. Future PRs:
- **Step 2**: `pkg/runtime/` — managed lifecycle (start/stop/pull)
- **Step 3**: `/_local/*` REST API in candela-local
- **Step 4**: Embedded management UI