### PR TITLE
feat: add pkg/runtime — interface, registry, and backend implementations

### DIFF
--- a/cmd/candela-local/main_test.go
+++ b/cmd/candela-local/main_test.go
@@ -142,3 +142,52 @@ remote: https://partial.run.app
 		t.Errorf("Port = %d, want 0", cfg.Port)
 	}
 }
+
+func TestLoadConfig_LocalUpstream(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "candela.yaml")
+	err := os.WriteFile(cfgPath, []byte(`
+remote: https://candela-xxx.run.app
+audience: test-audience
+local_upstream: "http://127.0.0.1:11434"
+`), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := loadConfig(cfgPath)
+	if cfg.LocalUpstream != "http://127.0.0.1:11434" {
+		t.Errorf("LocalUpstream = %q, want %q", cfg.LocalUpstream, "http://127.0.0.1:11434")
+	}
+}
+
+func TestSingleJoiningSlash(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want string
+	}{
+		// Basic cases
+		{"/api", "/v1/models", "/api/v1/models"},
+		{"", "/v1/chat", "/v1/chat"},
+		{"/", "/v1/chat", "/v1/chat"},
+
+		// Slash normalization
+		{"/api/", "/v1/models", "/api/v1/models"},
+		{"/api", "v1/models", "/api/v1/models"},
+		{"/api/", "v1/models", "/api/v1/models"},
+
+		// Root paths
+		{"", "/", "/"},
+		{"/", "/", "/"},
+		{"", "", "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_"+tt.b, func(t *testing.T) {
+			got := singleJoiningSlash(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("singleJoiningSlash(%q, %q) = %q, want %q", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/costcalc/calculator_test.go
+++ b/pkg/costcalc/calculator_test.go
@@ -62,6 +62,24 @@ func TestCalculate(t *testing.T) {
 			wantMin:      0,
 			wantMax:      0,
 		},
+		{
+			name:         "Local provider always zero cost",
+			provider:     "local",
+			model:        "llama3.2:8b",
+			inputTokens:  100000,
+			outputTokens: 50000,
+			wantMin:      0,
+			wantMax:      0,
+		},
+		{
+			name:         "Local provider case-insensitive",
+			provider:     "Local",
+			model:        "codellama:13b",
+			inputTokens:  1000000,
+			outputTokens: 1000000,
+			wantMin:      0,
+			wantMax:      0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/runtime/helpers.go
+++ b/pkg/runtime/helpers.go
@@ -1,0 +1,81 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// WaitHealthy polls the given URL until it returns HTTP 200 or the timeout
+// expires. This is shared across all runtime implementations that need to
+// wait for a server to become ready after launch.
+func WaitHealthy(ctx context.Context, url string, interval, timeout time.Duration) error {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("timed out waiting for %s to be healthy", url)
+		case <-ticker.C:
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			if err != nil {
+				continue
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err == nil {
+				_ = resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					return nil
+				}
+			}
+		}
+	}
+}
+
+// DefaultHost returns the host or "127.0.0.1" if empty.
+func DefaultHost(host string) string {
+	if host == "" {
+		return "127.0.0.1"
+	}
+	return host
+}
+
+// DefaultPort returns the port or the fallback if zero.
+func DefaultPort(port, fallback int) int {
+	if port == 0 {
+		return fallback
+	}
+	return port
+}
+
+// ConfigBinary extracts the "binary" string from Args, or returns the fallback.
+func ConfigBinary(args map[string]any, fallback string) string {
+	if b, ok := args["binary"].(string); ok && b != "" {
+		return b
+	}
+	return fallback
+}
+
+// ConfigString extracts a string value from Args by key, converting numeric
+// types (int, float64) to their string representation. This handles YAML
+// values that may be parsed as either strings or numbers depending on
+// whether they are quoted (e.g., gpu_memory_utilization: 0.9 vs "0.9").
+func ConfigString(args map[string]any, key string) (string, bool) {
+	v, ok := args[key]
+	if !ok {
+		return "", false
+	}
+	switch val := v.(type) {
+	case string:
+		return val, val != ""
+	case int, int64, float64:
+		return fmt.Sprint(val), true
+	default:
+		return "", false
+	}
+}

--- a/pkg/runtime/helpers_test.go
+++ b/pkg/runtime/helpers_test.go
@@ -1,0 +1,98 @@
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestWaitHealthy_ImmediateSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	err := WaitHealthy(context.Background(), srv.URL, 50*time.Millisecond, 2*time.Second)
+	if err != nil {
+		t.Fatalf("WaitHealthy() error: %v", err)
+	}
+}
+
+func TestWaitHealthy_Timeout(t *testing.T) {
+	// Point at a port nothing is listening on.
+	err := WaitHealthy(context.Background(), "http://127.0.0.1:19111", 50*time.Millisecond, 200*time.Millisecond)
+	if err == nil {
+		t.Fatal("WaitHealthy() should return error on timeout")
+	}
+}
+
+func TestWaitHealthy_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	err := WaitHealthy(ctx, "http://127.0.0.1:19111", 50*time.Millisecond, 5*time.Second)
+	if err == nil {
+		t.Fatal("WaitHealthy() should return error when context is canceled")
+	}
+}
+
+func TestDefaultHost(t *testing.T) {
+	if got := DefaultHost(""); got != "127.0.0.1" {
+		t.Errorf("DefaultHost('') = %q, want 127.0.0.1", got)
+	}
+	if got := DefaultHost("10.0.0.1"); got != "10.0.0.1" {
+		t.Errorf("DefaultHost('10.0.0.1') = %q, want 10.0.0.1", got)
+	}
+}
+
+func TestDefaultPort(t *testing.T) {
+	if got := DefaultPort(0, 11434); got != 11434 {
+		t.Errorf("DefaultPort(0, 11434) = %d, want 11434", got)
+	}
+	if got := DefaultPort(8080, 11434); got != 8080 {
+		t.Errorf("DefaultPort(8080, 11434) = %d, want 8080", got)
+	}
+}
+
+func TestConfigBinary(t *testing.T) {
+	if got := ConfigBinary(nil, "ollama"); got != "ollama" {
+		t.Errorf("ConfigBinary(nil) = %q, want ollama", got)
+	}
+	if got := ConfigBinary(map[string]any{}, "ollama"); got != "ollama" {
+		t.Errorf("ConfigBinary({}) = %q, want ollama", got)
+	}
+	if got := ConfigBinary(map[string]any{"binary": "/usr/local/bin/ollama"}, "ollama"); got != "/usr/local/bin/ollama" {
+		t.Errorf("ConfigBinary with override = %q", got)
+	}
+	if got := ConfigBinary(map[string]any{"binary": ""}, "ollama"); got != "ollama" {
+		t.Errorf("ConfigBinary with empty string = %q, want fallback", got)
+	}
+}
+
+func TestConfigString(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   map[string]any
+		key    string
+		want   string
+		wantOK bool
+	}{
+		{"string value", map[string]any{"k": "0.9"}, "k", "0.9", true},
+		{"int value", map[string]any{"k": 4096}, "k", "4096", true},
+		{"float64 value", map[string]any{"k": 0.9}, "k", "0.9", true},
+		{"missing key", map[string]any{}, "k", "", false},
+		{"nil args", nil, "k", "", false},
+		{"empty string", map[string]any{"k": ""}, "k", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ConfigString(tt.args, tt.key)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("ConfigString(%v, %q) = (%q, %v), want (%q, %v)",
+					tt.args, tt.key, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}

--- a/pkg/runtime/lmstudio/lmstudio.go
+++ b/pkg/runtime/lmstudio/lmstudio.go
@@ -1,0 +1,169 @@
+// Package lmstudio implements the Runtime interface for LM Studio.
+// LM Studio is a multi-model manager with explicit load/unload/download
+// APIs and supports both a desktop app and headless server (lms/llmster).
+//
+// API reference: https://lmstudio.ai/docs/api
+package lmstudio
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os/exec"
+	"time"
+
+	"github.com/candelahq/candela/pkg/runtime"
+)
+
+func init() {
+	runtime.Register("lmstudio", func(cfg runtime.Config) (runtime.Runtime, error) {
+		return New(cfg)
+	})
+}
+
+// Runtime manages an LM Studio inference server.
+type Runtime struct {
+	host   string
+	port   int
+	binary string // "lms" (CLI) or "llmster" (headless)
+	cmd    *exec.Cmd
+}
+
+// New creates an LM Studio runtime with the given config.
+func New(cfg runtime.Config) (*Runtime, error) {
+	return &Runtime{
+		host:   runtime.DefaultHost(cfg.Host),
+		port:   runtime.DefaultPort(cfg.Port, 1234),
+		binary: runtime.ConfigBinary(cfg.Args, "lms"),
+	}, nil
+}
+
+func (r *Runtime) Name() string { return "lmstudio" }
+
+func (r *Runtime) Endpoint() string {
+	return fmt.Sprintf("http://%s:%d/v1", r.host, r.port)
+}
+
+func (r *Runtime) baseURL() string {
+	return fmt.Sprintf("http://%s:%d", r.host, r.port)
+}
+
+// Start launches the LM Studio server.
+func (r *Runtime) Start(ctx context.Context) error {
+	r.cmd = exec.CommandContext(ctx, r.binary, "server", "start",
+		"--port", fmt.Sprintf("%d", r.port))
+	if err := r.cmd.Start(); err != nil {
+		return fmt.Errorf("lmstudio: starting %q: %w", r.binary, err)
+	}
+	return runtime.WaitHealthy(ctx, r.baseURL(), 500*time.Millisecond, 30*time.Second)
+}
+
+// Stop shuts down the LM Studio server.
+func (r *Runtime) Stop(ctx context.Context) error {
+	// Try graceful CLI stop first.
+	stopCmd := exec.CommandContext(ctx, r.binary, "server", "stop")
+	if err := stopCmd.Run(); err != nil {
+		slog.Warn("lmstudio: graceful stop failed, killing process", "error", err)
+		if r.cmd != nil && r.cmd.Process != nil {
+			_ = r.cmd.Process.Kill()
+			_ = r.cmd.Wait()
+		}
+	}
+	r.cmd = nil
+	return nil
+}
+
+// Health checks if LM Studio is reachable.
+func (r *Runtime) Health(ctx context.Context) (*runtime.Health, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.baseURL()+"/v1/models", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return &runtime.Health{
+			Status:    runtime.StatusStopped,
+			Endpoint:  r.Endpoint(),
+			CheckedAt: time.Now(),
+		}, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	models, _ := r.ListModels(ctx)
+	return &runtime.Health{
+		Status:    runtime.StatusRunning,
+		Endpoint:  r.Endpoint(),
+		Models:    models,
+		CheckedAt: time.Now(),
+	}, nil
+}
+
+// ListModels returns models available in LM Studio.
+func (r *Runtime) ListModels(ctx context.Context) ([]runtime.Model, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.baseURL()+"/v1/models", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("lmstudio: list models: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result struct {
+		Data []struct {
+			ID      string `json:"id"`
+			OwnedBy string `json:"owned_by"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("lmstudio: decode models: %w", err)
+	}
+
+	models := make([]runtime.Model, len(result.Data))
+	for i, m := range result.Data {
+		models[i] = runtime.Model{
+			ID:     m.ID,
+			Loaded: true,
+		}
+	}
+	return models, nil
+}
+
+// PullModel downloads a model via LM Studio's API.
+func (r *Runtime) PullModel(ctx context.Context, modelID string, progress chan<- runtime.PullProgress) error {
+	payload, err := json.Marshal(map[string]string{"model": modelID})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		r.baseURL()+"/api/v1/models/download", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("lmstudio: pull %q: %w", modelID, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("lmstudio: pull %q: status %d", modelID, resp.StatusCode)
+	}
+
+	if progress != nil {
+		progress <- runtime.PullProgress{
+			Status:  "done",
+			Percent: 100,
+		}
+	}
+
+	slog.Info("model download initiated", "model", modelID, "backend", "lmstudio")
+	return nil
+}

--- a/pkg/runtime/lmstudio/lmstudio_test.go
+++ b/pkg/runtime/lmstudio/lmstudio_test.go
@@ -1,0 +1,127 @@
+package lmstudio
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/runtime"
+)
+
+func testServer(t *testing.T, handler http.Handler) *Runtime {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	host, portStr, _ := net.SplitHostPort(srv.Listener.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+
+	rt, err := New(runtime.Config{Host: host, Port: port})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rt
+}
+
+func TestHealth_Running(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []any{}})
+	})
+
+	rt := testServer(t, mux)
+
+	h, err := rt.Health(context.Background())
+	if err != nil {
+		t.Fatalf("Health() error: %v", err)
+	}
+	if h.Status != runtime.StatusRunning {
+		t.Errorf("Status = %q, want %q", h.Status, runtime.StatusRunning)
+	}
+}
+
+func TestHealth_Stopped(t *testing.T) {
+	rt, _ := New(runtime.Config{Host: "127.0.0.1", Port: 19997})
+
+	h, err := rt.Health(context.Background())
+	if err != nil {
+		t.Fatalf("Health() error: %v", err)
+	}
+	if h.Status != runtime.StatusStopped {
+		t.Errorf("Status = %q, want %q", h.Status, runtime.StatusStopped)
+	}
+}
+
+func TestListModels(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{"id": "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF", "owned_by": "lmstudio"},
+				{"id": "TheBloke/Mistral-7B-Instruct-v0.2-GGUF", "owned_by": "lmstudio"}
+			]
+		}`))
+	})
+
+	rt := testServer(t, mux)
+
+	models, err := rt.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("got %d models, want 2", len(models))
+	}
+	if models[0].ID != "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF" {
+		t.Errorf("models[0].ID = %q", models[0].ID)
+	}
+	if !models[0].Loaded {
+		t.Error("LM Studio listed models should be marked as Loaded")
+	}
+}
+
+func TestPullModel_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/models/download", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("PullModel method = %s, want POST", r.Method)
+		}
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["model"] != "test-model" {
+			t.Errorf("pull body model = %q, want %q", body["model"], "test-model")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rt := testServer(t, mux)
+
+	progress := make(chan runtime.PullProgress, 1)
+	err := rt.PullModel(context.Background(), "test-model", progress)
+	if err != nil {
+		t.Fatalf("PullModel() error: %v", err)
+	}
+
+	p := <-progress
+	if p.Status != "done" {
+		t.Errorf("PullProgress.Status = %q, want %q", p.Status, "done")
+	}
+}
+
+func TestPullModel_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/models/download", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	rt := testServer(t, mux)
+
+	err := rt.PullModel(context.Background(), "bad-model", nil)
+	if err == nil {
+		t.Fatal("PullModel() should return error on 500")
+	}
+}

--- a/pkg/runtime/manager.go
+++ b/pkg/runtime/manager.go
@@ -1,0 +1,142 @@
+package runtime
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Manager wraps a Runtime and adds health monitoring, auto-start,
+// and auto-pull of configured models.
+type Manager struct {
+	rt        Runtime
+	autoStart bool
+	autoPull  bool
+	models    []string // models to ensure are pulled
+	interval  time.Duration
+
+	mu        sync.RWMutex
+	health    *Health
+	startedAt time.Time
+	cancel    context.CancelFunc
+}
+
+// ManagerConfig configures the Manager's behavior.
+type ManagerConfig struct {
+	AutoStart   bool          `yaml:"auto_start" json:"auto_start"`
+	AutoPull    bool          `yaml:"auto_pull" json:"auto_pull"`
+	Models      []string      `yaml:"models" json:"models,omitempty"`
+	HealthCheck time.Duration `yaml:"health_interval" json:"health_interval"`
+}
+
+// NewManager creates a Manager wrapping the given runtime.
+func NewManager(rt Runtime, cfg ManagerConfig) *Manager {
+	interval := cfg.HealthCheck
+	if interval == 0 {
+		interval = 10 * time.Second
+	}
+	return &Manager{
+		rt:        rt,
+		autoStart: cfg.AutoStart,
+		autoPull:  cfg.AutoPull,
+		models:    cfg.Models,
+		interval:  interval,
+	}
+}
+
+// Start optionally launches the runtime and begins health monitoring.
+func (m *Manager) Start(ctx context.Context) error {
+	if m.autoStart {
+		slog.Info("starting runtime", "backend", m.rt.Name())
+		if err := m.rt.Start(ctx); err != nil {
+			return err
+		}
+		m.mu.Lock()
+		m.startedAt = time.Now()
+		m.mu.Unlock()
+	}
+
+	// Start health check loop.
+	hctx, cancel := context.WithCancel(ctx)
+	m.cancel = cancel
+	go m.healthLoop(hctx)
+
+	// Auto-pull configured models in the background.
+	if m.autoPull && len(m.models) > 0 {
+		go func() {
+			for _, model := range m.models {
+				slog.Info("pulling model", "model", model, "backend", m.rt.Name())
+				if err := m.rt.PullModel(hctx, model, nil); err != nil {
+					slog.Warn("failed to pull model", "model", model, "error", err)
+				}
+			}
+		}()
+	}
+
+	return nil
+}
+
+// Stop stops health monitoring and shuts down the runtime.
+func (m *Manager) Stop(ctx context.Context) error {
+	if m.cancel != nil {
+		m.cancel()
+	}
+	return m.rt.Stop(ctx)
+}
+
+// Health returns the latest cached health status.
+// Returns a shallow copy to avoid races with the background health loop.
+func (m *Manager) Health() *Health {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.health == nil {
+		return &Health{Status: StatusStopped, CheckedAt: time.Now()}
+	}
+	h := *m.health
+	return &h
+}
+
+// Endpoint returns the runtime's OpenAI-compat base URL.
+func (m *Manager) Endpoint() string {
+	return m.rt.Endpoint()
+}
+
+// Runtime returns the underlying runtime for direct API calls.
+func (m *Manager) Runtime() Runtime {
+	return m.rt
+}
+
+func (m *Manager) healthLoop(ctx context.Context) {
+	// Immediate first check.
+	m.checkHealth(ctx)
+
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.checkHealth(ctx)
+		}
+	}
+}
+
+func (m *Manager) checkHealth(ctx context.Context) {
+	h, err := m.rt.Health(ctx)
+	if err != nil {
+		h = &Health{
+			Status:    StatusError,
+			Error:     err.Error(),
+			CheckedAt: time.Now(),
+		}
+	}
+	m.mu.Lock()
+	if !m.startedAt.IsZero() && h.Status == StatusRunning {
+		h.Uptime = time.Since(m.startedAt).Seconds()
+	}
+	m.health = h
+	m.mu.Unlock()
+}

--- a/pkg/runtime/manager_test.go
+++ b/pkg/runtime/manager_test.go
@@ -1,0 +1,201 @@
+package runtime_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/runtime"
+)
+
+// mockRuntime is a test double for the Runtime interface.
+type mockRuntime struct {
+	name        string
+	endpoint    string
+	healthy     bool
+	models      []runtime.Model
+	startCalled bool
+	stopCalled  bool
+	pullCalled  []string
+	mu          sync.Mutex
+}
+
+func (m *mockRuntime) Name() string     { return m.name }
+func (m *mockRuntime) Endpoint() string { return m.endpoint }
+
+func (m *mockRuntime) Start(_ context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.startCalled = true
+	m.healthy = true
+	return nil
+}
+
+func (m *mockRuntime) Stop(_ context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopCalled = true
+	m.healthy = false
+	return nil
+}
+
+func (m *mockRuntime) Health(_ context.Context) (*runtime.Health, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	status := runtime.StatusStopped
+	if m.healthy {
+		status = runtime.StatusRunning
+	}
+	return &runtime.Health{
+		Status:    status,
+		Endpoint:  m.endpoint,
+		Models:    m.models,
+		CheckedAt: time.Now(),
+	}, nil
+}
+
+func (m *mockRuntime) ListModels(_ context.Context) ([]runtime.Model, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.models, nil
+}
+
+func (m *mockRuntime) PullModel(_ context.Context, modelID string, progress chan<- runtime.PullProgress) error {
+	m.mu.Lock()
+	m.pullCalled = append(m.pullCalled, modelID)
+	m.mu.Unlock()
+	if progress != nil {
+		progress <- runtime.PullProgress{Status: "done", Percent: 100}
+	}
+	return nil
+}
+
+func TestManagerAutoStart(t *testing.T) {
+	mock := &mockRuntime{
+		name:     "test",
+		endpoint: "http://127.0.0.1:9999/v1",
+		models:   []runtime.Model{{ID: "test-model", Loaded: true}},
+	}
+
+	mgr := runtime.NewManager(mock, runtime.ManagerConfig{
+		AutoStart:   true,
+		HealthCheck: 100 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := mgr.Start(ctx); err != nil {
+		t.Fatalf("Manager.Start() error: %v", err)
+	}
+	defer func() { _ = mgr.Stop(ctx) }()
+
+	mock.mu.Lock()
+	started := mock.startCalled
+	mock.mu.Unlock()
+	if !started {
+		t.Error("expected runtime.Start() to be called with AutoStart=true")
+	}
+
+	if got := mgr.Endpoint(); got != "http://127.0.0.1:9999/v1" {
+		t.Errorf("Endpoint() = %q, want http://127.0.0.1:9999/v1", got)
+	}
+
+	// Wait for health loop to run.
+	time.Sleep(250 * time.Millisecond)
+
+	h := mgr.Health()
+	if h.Status != runtime.StatusRunning {
+		t.Errorf("Health().Status = %q, want %q", h.Status, runtime.StatusRunning)
+	}
+}
+
+func TestManagerNoAutoStart(t *testing.T) {
+	mock := &mockRuntime{
+		name:     "test",
+		endpoint: "http://127.0.0.1:9999/v1",
+	}
+
+	mgr := runtime.NewManager(mock, runtime.ManagerConfig{
+		AutoStart:   false,
+		HealthCheck: 100 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := mgr.Start(ctx); err != nil {
+		t.Fatalf("Manager.Start() error: %v", err)
+	}
+	defer func() { _ = mgr.Stop(ctx) }()
+
+	mock.mu.Lock()
+	started := mock.startCalled
+	mock.mu.Unlock()
+	if started {
+		t.Error("runtime.Start() should NOT be called with AutoStart=false")
+	}
+}
+
+func TestManagerAutoPull(t *testing.T) {
+	mock := &mockRuntime{
+		name:     "test",
+		endpoint: "http://127.0.0.1:9999/v1",
+	}
+
+	mgr := runtime.NewManager(mock, runtime.ManagerConfig{
+		AutoStart:   true,
+		AutoPull:    true,
+		Models:      []string{"model-a", "model-b"},
+		HealthCheck: 100 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := mgr.Start(ctx); err != nil {
+		t.Fatalf("Manager.Start() error: %v", err)
+	}
+	defer func() { _ = mgr.Stop(ctx) }()
+
+	// Auto-pull runs in a background goroutine; give it time to complete.
+	time.Sleep(250 * time.Millisecond)
+
+	mock.mu.Lock()
+	pulled := append([]string{}, mock.pullCalled...)
+	mock.mu.Unlock()
+
+	if len(pulled) != 2 {
+		t.Fatalf("expected 2 pulls, got %d: %v", len(pulled), pulled)
+	}
+	if pulled[0] != "model-a" || pulled[1] != "model-b" {
+		t.Errorf("pulled = %v, want [model-a, model-b]", pulled)
+	}
+}
+
+func TestManagerStop(t *testing.T) {
+	mock := &mockRuntime{
+		name:     "test",
+		endpoint: "http://127.0.0.1:9999/v1",
+	}
+
+	mgr := runtime.NewManager(mock, runtime.ManagerConfig{
+		HealthCheck: 100 * time.Millisecond,
+	})
+
+	ctx := context.Background()
+	if err := mgr.Start(ctx); err != nil {
+		t.Fatalf("Manager.Start() error: %v", err)
+	}
+	if err := mgr.Stop(ctx); err != nil {
+		t.Fatalf("Manager.Stop() error: %v", err)
+	}
+
+	mock.mu.Lock()
+	stopped := mock.stopCalled
+	mock.mu.Unlock()
+	if !stopped {
+		t.Error("expected runtime.Stop() to be called")
+	}
+}

--- a/pkg/runtime/ollama/ollama.go
+++ b/pkg/runtime/ollama/ollama.go
@@ -1,0 +1,204 @@
+// Package ollama implements the Runtime interface for the Ollama inference
+// server. Ollama is a lazy-loading runtime — it manages its own model
+// loading into VRAM and supports multiple models simultaneously.
+//
+// API reference: https://github.com/ollama/ollama/blob/main/docs/api.md
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/candelahq/candela/pkg/runtime"
+)
+
+func init() {
+	runtime.Register("ollama", func(cfg runtime.Config) (runtime.Runtime, error) {
+		return New(cfg)
+	})
+}
+
+// Runtime manages an Ollama inference server.
+type Runtime struct {
+	host   string
+	port   int
+	binary string
+	cmd    *exec.Cmd
+}
+
+// New creates an Ollama runtime with the given config.
+func New(cfg runtime.Config) (*Runtime, error) {
+	return &Runtime{
+		host:   runtime.DefaultHost(cfg.Host),
+		port:   runtime.DefaultPort(cfg.Port, 11434),
+		binary: runtime.ConfigBinary(cfg.Args, "ollama"),
+	}, nil
+}
+
+func (r *Runtime) Name() string { return "ollama" }
+
+func (r *Runtime) Endpoint() string {
+	return fmt.Sprintf("http://%s:%d/v1", r.host, r.port)
+}
+
+func (r *Runtime) baseURL() string {
+	return fmt.Sprintf("http://%s:%d", r.host, r.port)
+}
+
+// Start launches `ollama serve` and waits until the server is healthy.
+func (r *Runtime) Start(ctx context.Context) error {
+	r.cmd = exec.CommandContext(ctx, r.binary, "serve")
+	r.cmd.Env = append(r.cmd.Environ(),
+		fmt.Sprintf("OLLAMA_HOST=%s:%d", r.host, r.port),
+	)
+	if err := r.cmd.Start(); err != nil {
+		return fmt.Errorf("ollama: starting %q: %w", r.binary, err)
+	}
+	return runtime.WaitHealthy(ctx, r.baseURL(), 500*time.Millisecond, 30*time.Second)
+}
+
+// Stop terminates the Ollama process.
+func (r *Runtime) Stop(ctx context.Context) error {
+	if r.cmd == nil || r.cmd.Process == nil {
+		return nil
+	}
+	if err := r.cmd.Process.Kill(); err != nil {
+		return fmt.Errorf("ollama: stop: %w", err)
+	}
+	// Wait to avoid zombie processes.
+	_ = r.cmd.Wait()
+	r.cmd = nil
+	return nil
+}
+
+// Health checks if Ollama is reachable and returns its status.
+func (r *Runtime) Health(ctx context.Context) (*runtime.Health, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.baseURL(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return &runtime.Health{
+			Status:    runtime.StatusStopped,
+			Endpoint:  r.Endpoint(),
+			CheckedAt: time.Now(),
+		}, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	models, _ := r.ListModels(ctx)
+	return &runtime.Health{
+		Status:    runtime.StatusRunning,
+		Endpoint:  r.Endpoint(),
+		Models:    models,
+		CheckedAt: time.Now(),
+	}, nil
+}
+
+// ollamaTagsResponse is the JSON response from GET /api/tags.
+type ollamaTagsResponse struct {
+	Models []struct {
+		Name       string    `json:"name"`
+		Model      string    `json:"model"`
+		ModifiedAt time.Time `json:"modified_at"`
+		Size       int64     `json:"size"`
+		Details    struct {
+			Family        string `json:"family"`
+			ParameterSize string `json:"parameter_size"`
+			Quantization  string `json:"quantization_level"`
+		} `json:"details"`
+	} `json:"models"`
+}
+
+// ListModels returns all locally available models.
+func (r *Runtime) ListModels(ctx context.Context) ([]runtime.Model, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.baseURL()+"/api/tags", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ollama: list models: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result ollamaTagsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("ollama: decode tags: %w", err)
+	}
+
+	models := make([]runtime.Model, len(result.Models))
+	for i, m := range result.Models {
+		models[i] = runtime.Model{
+			ID:           m.Name,
+			SizeBytes:    m.Size,
+			Family:       m.Details.Family,
+			Parameters:   m.Details.ParameterSize,
+			Quantization: m.Details.Quantization,
+		}
+	}
+	return models, nil
+}
+
+// PullModel downloads a model from the Ollama registry.
+// Progress updates are streamed via NDJSON from the Ollama API.
+func (r *Runtime) PullModel(ctx context.Context, modelID string, progress chan<- runtime.PullProgress) error {
+	body := fmt.Sprintf(`{"name": %q, "stream": true}`, modelID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		r.baseURL()+"/api/pull", strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("ollama: pull %q: %w", modelID, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("ollama: pull %q: status %d: %s", modelID, resp.StatusCode, respBody)
+	}
+
+	// Stream NDJSON progress.
+	dec := json.NewDecoder(resp.Body)
+	for dec.More() {
+		var line struct {
+			Status    string `json:"status"`
+			Completed int64  `json:"completed"`
+			Total     int64  `json:"total"`
+		}
+		if err := dec.Decode(&line); err != nil {
+			break
+		}
+		if progress != nil {
+			pct := 0.0
+			if line.Total > 0 {
+				pct = float64(line.Completed) / float64(line.Total) * 100
+			}
+			select {
+			case progress <- runtime.PullProgress{
+				Status:    line.Status,
+				Completed: line.Completed,
+				Total:     line.Total,
+				Percent:   pct,
+			}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+
+	slog.Info("model pulled", "model", modelID, "backend", "ollama")
+	return nil
+}

--- a/pkg/runtime/ollama/ollama_test.go
+++ b/pkg/runtime/ollama/ollama_test.go
@@ -1,0 +1,138 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/runtime"
+)
+
+func testServer(t *testing.T, handler http.Handler) *Runtime {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	host, portStr, _ := net.SplitHostPort(srv.Listener.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+
+	rt, err := New(runtime.Config{Host: host, Port: port})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rt
+}
+
+func TestHealth_Running(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/api/tags", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"models": []any{}})
+	})
+
+	rt := testServer(t, mux)
+
+	h, err := rt.Health(context.Background())
+	if err != nil {
+		t.Fatalf("Health() error: %v", err)
+	}
+	if h.Status != runtime.StatusRunning {
+		t.Errorf("Status = %q, want %q", h.Status, runtime.StatusRunning)
+	}
+}
+
+func TestHealth_Stopped(t *testing.T) {
+	rt, _ := New(runtime.Config{Host: "127.0.0.1", Port: 19999})
+
+	h, err := rt.Health(context.Background())
+	if err != nil {
+		t.Fatalf("Health() error: %v", err)
+	}
+	if h.Status != runtime.StatusStopped {
+		t.Errorf("Status = %q, want %q", h.Status, runtime.StatusStopped)
+	}
+}
+
+func TestListModels(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/tags", func(w http.ResponseWriter, _ *http.Request) {
+		// Return raw JSON matching ollama's actual response shape.
+		_, _ = w.Write([]byte(`{
+			"models": [
+				{
+					"name": "llama3.2:8b",
+					"model": "llama3.2:8b",
+					"size": 4700000000,
+					"details": {"family": "llama", "parameter_size": "8B", "quantization_level": "Q4_0"}
+				},
+				{
+					"name": "codellama:13b",
+					"model": "codellama:13b",
+					"size": 7300000000,
+					"details": {"family": "llama", "parameter_size": "13B", "quantization_level": "Q4_K_M"}
+				}
+			]
+		}`))
+	})
+
+	rt := testServer(t, mux)
+
+	models, err := rt.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("got %d models, want 2", len(models))
+	}
+	if models[0].ID != "llama3.2:8b" {
+		t.Errorf("models[0].ID = %q, want %q", models[0].ID, "llama3.2:8b")
+	}
+	if models[0].SizeBytes != 4_700_000_000 {
+		t.Errorf("models[0].SizeBytes = %d, want 4700000000", models[0].SizeBytes)
+	}
+	if models[0].Family != "llama" {
+		t.Errorf("models[0].Family = %q, want %q", models[0].Family, "llama")
+	}
+	if models[0].Parameters != "8B" {
+		t.Errorf("models[0].Parameters = %q, want %q", models[0].Parameters, "8B")
+	}
+	if models[1].ID != "codellama:13b" {
+		t.Errorf("models[1].ID = %q, want %q", models[1].ID, "codellama:13b")
+	}
+}
+
+func TestListModels_ServerDown(t *testing.T) {
+	rt, _ := New(runtime.Config{Host: "127.0.0.1", Port: 19999})
+
+	_, err := rt.ListModels(context.Background())
+	if err == nil {
+		t.Fatal("ListModels() should return error when server is down")
+	}
+}
+
+func TestListModels_BadJSON(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/tags", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	})
+
+	rt := testServer(t, mux)
+
+	_, err := rt.ListModels(context.Background())
+	if err == nil {
+		t.Fatal("ListModels() should return error for invalid JSON")
+	}
+}
+
+func TestEndpoint(t *testing.T) {
+	rt, _ := New(runtime.Config{Host: "192.168.1.100", Port: 11434})
+	if got := rt.Endpoint(); got != "http://192.168.1.100:11434/v1" {
+		t.Errorf("Endpoint() = %q, want http://192.168.1.100:11434/v1", got)
+	}
+}

--- a/pkg/runtime/registry.go
+++ b/pkg/runtime/registry.go
@@ -1,0 +1,56 @@
+package runtime
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Config holds runtime configuration from YAML.
+type Config struct {
+	Host string         `yaml:"host" json:"host"`
+	Port int            `yaml:"port" json:"port"`
+	Args map[string]any `yaml:"args" json:"args,omitempty"` // backend-specific extra config
+}
+
+// Factory creates a Runtime from the given config.
+type Factory func(cfg Config) (Runtime, error)
+
+var (
+	mu       sync.RWMutex
+	registry = map[string]Factory{}
+)
+
+// Register adds a runtime factory. Typically called from init() in each
+// implementation package (e.g. pkg/runtime/ollama).
+func Register(name string, f Factory) {
+	mu.Lock()
+	defer mu.Unlock()
+	if _, dup := registry[name]; dup {
+		panic(fmt.Sprintf("runtime: Register called twice for %q", name))
+	}
+	registry[name] = f
+}
+
+// New creates a runtime by name using the registered factory.
+func New(name string, cfg Config) (Runtime, error) {
+	mu.RLock()
+	f, ok := registry[name]
+	mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("runtime: unknown backend %q (registered: %v)", name, Names())
+	}
+	return f(cfg)
+}
+
+// Names returns all registered runtime backend names, sorted.
+func Names() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	out := make([]string, 0, len(registry))
+	for k := range registry {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1,0 +1,88 @@
+// Package runtime defines the Runtime interface for managing local LLM
+// inference servers (Ollama, vLLM, LM Studio). It provides a common
+// abstraction over lifecycle management, health monitoring, and model
+// operations.
+//
+// Usage:
+//
+//	import (
+//	    "github.com/candelahq/candela/pkg/runtime"
+//	    _ "github.com/candelahq/candela/pkg/runtime/ollama" // register
+//	)
+//
+//	rt, err := runtime.New("ollama", runtime.Config{
+//	    Host: "127.0.0.1",
+//	    Port: 11434,
+//	})
+package runtime
+
+import (
+	"context"
+	"time"
+)
+
+// Status represents the current state of a runtime.
+type Status string
+
+const (
+	StatusStopped  Status = "stopped"
+	StatusStarting Status = "starting"
+	StatusRunning  Status = "running"
+	StatusError    Status = "error"
+)
+
+// Model describes a model available in the runtime.
+type Model struct {
+	ID           string    `json:"id"`
+	SizeBytes    int64     `json:"size_bytes,omitempty"`
+	Family       string    `json:"family,omitempty"`
+	Parameters   string    `json:"parameters,omitempty"`
+	Quantization string    `json:"quantization,omitempty"`
+	Loaded       bool      `json:"loaded"`
+	LastUsed     time.Time `json:"last_used,omitempty"`
+}
+
+// Health holds the current health status of a runtime.
+type Health struct {
+	Status    Status    `json:"status"`
+	Endpoint  string    `json:"endpoint"`
+	Uptime    float64   `json:"uptime_seconds"`
+	Models    []Model   `json:"models,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+// PullProgress reports model download progress.
+type PullProgress struct {
+	Status    string  `json:"status"`              // "pulling", "downloading", "verifying", "done"
+	Completed int64   `json:"completed,omitempty"` // bytes downloaded
+	Total     int64   `json:"total,omitempty"`     // total bytes
+	Percent   float64 `json:"percent,omitempty"`
+}
+
+// Runtime manages a local inference server's lifecycle.
+type Runtime interface {
+	// Name returns the runtime identifier ("ollama", "vllm", "lmstudio").
+	Name() string
+
+	// Start launches the runtime process. Blocks until healthy or ctx expires.
+	Start(ctx context.Context) error
+
+	// Stop gracefully shuts down the runtime.
+	Stop(ctx context.Context) error
+
+	// Health returns the current health status.
+	Health(ctx context.Context) (*Health, error)
+
+	// Endpoint returns the OpenAI-compat base URL
+	// (e.g. "http://127.0.0.1:11434/v1").
+	Endpoint() string
+
+	// ListModels returns models available in the runtime.
+	ListModels(ctx context.Context) ([]Model, error)
+
+	// PullModel downloads a model. Returns immediately if already present.
+	// The progress channel receives status updates; it may be nil if the
+	// caller doesn't need progress updates.
+	PullModel(ctx context.Context, modelID string, progress chan<- PullProgress) error
+}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1,0 +1,109 @@
+package runtime_test
+
+import (
+	"testing"
+
+	"github.com/candelahq/candela/pkg/runtime"
+
+	// Import implementations to trigger init() registration.
+	_ "github.com/candelahq/candela/pkg/runtime/lmstudio"
+	_ "github.com/candelahq/candela/pkg/runtime/ollama"
+	_ "github.com/candelahq/candela/pkg/runtime/vllm"
+)
+
+func TestRegistryNames(t *testing.T) {
+	names := runtime.Names()
+	if len(names) != 3 {
+		t.Fatalf("expected 3 registered runtimes, got %d: %v", len(names), names)
+	}
+
+	want := []string{"lmstudio", "ollama", "vllm"}
+	for i, name := range names {
+		if name != want[i] {
+			t.Errorf("names[%d] = %q, want %q", i, name, want[i])
+		}
+	}
+}
+
+func TestNewOllama(t *testing.T) {
+	rt, err := runtime.New("ollama", runtime.Config{
+		Host: "127.0.0.1",
+		Port: 11434,
+	})
+	if err != nil {
+		t.Fatalf("New(ollama) error: %v", err)
+	}
+	if rt.Name() != "ollama" {
+		t.Errorf("Name() = %q, want %q", rt.Name(), "ollama")
+	}
+	if got := rt.Endpoint(); got != "http://127.0.0.1:11434/v1" {
+		t.Errorf("Endpoint() = %q, want http://127.0.0.1:11434/v1", got)
+	}
+}
+
+func TestNewVLLM(t *testing.T) {
+	rt, err := runtime.New("vllm", runtime.Config{
+		Host: "127.0.0.1",
+		Port: 8000,
+		Args: map[string]any{"model": "meta-llama/Llama-3.2-8B-Instruct"},
+	})
+	if err != nil {
+		t.Fatalf("New(vllm) error: %v", err)
+	}
+	if rt.Name() != "vllm" {
+		t.Errorf("Name() = %q, want %q", rt.Name(), "vllm")
+	}
+	if got := rt.Endpoint(); got != "http://127.0.0.1:8000/v1" {
+		t.Errorf("Endpoint() = %q, want http://127.0.0.1:8000/v1", got)
+	}
+}
+
+func TestNewLMStudio(t *testing.T) {
+	rt, err := runtime.New("lmstudio", runtime.Config{
+		Host: "127.0.0.1",
+		Port: 1234,
+	})
+	if err != nil {
+		t.Fatalf("New(lmstudio) error: %v", err)
+	}
+	if rt.Name() != "lmstudio" {
+		t.Errorf("Name() = %q, want %q", rt.Name(), "lmstudio")
+	}
+	if got := rt.Endpoint(); got != "http://127.0.0.1:1234/v1" {
+		t.Errorf("Endpoint() = %q, want http://127.0.0.1:1234/v1", got)
+	}
+}
+
+func TestNewUnknown(t *testing.T) {
+	_, err := runtime.New("doesnotexist", runtime.Config{})
+	if err == nil {
+		t.Fatal("New(doesnotexist) should return error")
+	}
+}
+
+func TestNewDefaults(t *testing.T) {
+	// Verify sensible defaults when no host/port specified.
+	rt, err := runtime.New("ollama", runtime.Config{})
+	if err != nil {
+		t.Fatalf("New(ollama) with defaults error: %v", err)
+	}
+	if got := rt.Endpoint(); got != "http://127.0.0.1:11434/v1" {
+		t.Errorf("Endpoint() with defaults = %q, want http://127.0.0.1:11434/v1", got)
+	}
+
+	rt, err = runtime.New("vllm", runtime.Config{})
+	if err != nil {
+		t.Fatalf("New(vllm) with defaults error: %v", err)
+	}
+	if got := rt.Endpoint(); got != "http://127.0.0.1:8000/v1" {
+		t.Errorf("Endpoint() with defaults = %q, want http://127.0.0.1:8000/v1", got)
+	}
+
+	rt, err = runtime.New("lmstudio", runtime.Config{})
+	if err != nil {
+		t.Fatalf("New(lmstudio) with defaults error: %v", err)
+	}
+	if got := rt.Endpoint(); got != "http://127.0.0.1:1234/v1" {
+		t.Errorf("Endpoint() with defaults = %q, want http://127.0.0.1:1234/v1", got)
+	}
+}

--- a/pkg/runtime/vllm/vllm.go
+++ b/pkg/runtime/vllm/vllm.go
@@ -1,0 +1,180 @@
+// Package vllm implements the Runtime interface for the vLLM inference
+// server. vLLM is a static server — one model per process, specified at
+// launch time. Switching models requires stopping and restarting.
+//
+// API reference: https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
+package vllm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os/exec"
+	"time"
+
+	"github.com/candelahq/candela/pkg/runtime"
+)
+
+func init() {
+	runtime.Register("vllm", func(cfg runtime.Config) (runtime.Runtime, error) {
+		return New(cfg)
+	})
+}
+
+// Runtime manages a vLLM inference server.
+type Runtime struct {
+	host   string
+	port   int
+	binary string
+	model  string // model is baked in at launch time
+	args   []string
+	cmd    *exec.Cmd
+}
+
+// New creates a vLLM runtime with the given config.
+func New(cfg runtime.Config) (*Runtime, error) {
+	model := ""
+	if m, ok := cfg.Args["model"].(string); ok {
+		model = m
+	}
+
+	// Collect extra CLI args.
+	var args []string
+	if gpuMem, ok := runtime.ConfigString(cfg.Args, "gpu_memory_utilization"); ok {
+		args = append(args, "--gpu-memory-utilization", gpuMem)
+	}
+	if maxLen, ok := runtime.ConfigString(cfg.Args, "max_model_len"); ok {
+		args = append(args, "--max-model-len", maxLen)
+	}
+
+	return &Runtime{
+		host:   runtime.DefaultHost(cfg.Host),
+		port:   runtime.DefaultPort(cfg.Port, 8000),
+		binary: runtime.ConfigBinary(cfg.Args, "vllm"),
+		model:  model,
+		args:   args,
+	}, nil
+}
+
+func (r *Runtime) Name() string { return "vllm" }
+
+func (r *Runtime) Endpoint() string {
+	return fmt.Sprintf("http://%s:%d/v1", r.host, r.port)
+}
+
+func (r *Runtime) baseURL() string {
+	return fmt.Sprintf("http://%s:%d", r.host, r.port)
+}
+
+// Start launches `vllm serve <model>` and waits until ready.
+func (r *Runtime) Start(ctx context.Context) error {
+	if r.model == "" {
+		return fmt.Errorf("vllm: model is required (set args.model in config)")
+	}
+
+	cmdArgs := []string{"serve", r.model, "--port", fmt.Sprintf("%d", r.port), "--host", r.host}
+	cmdArgs = append(cmdArgs, r.args...)
+
+	r.cmd = exec.CommandContext(ctx, r.binary, cmdArgs...)
+	if err := r.cmd.Start(); err != nil {
+		return fmt.Errorf("vllm: starting %q: %w", r.binary, err)
+	}
+	// vLLM can take a while to load large models.
+	return runtime.WaitHealthy(ctx, r.baseURL()+"/health/ready", 2*time.Second, 5*time.Minute)
+}
+
+// Stop terminates the vLLM process.
+func (r *Runtime) Stop(ctx context.Context) error {
+	if r.cmd == nil || r.cmd.Process == nil {
+		return nil
+	}
+	if err := r.cmd.Process.Kill(); err != nil {
+		return fmt.Errorf("vllm: stop: %w", err)
+	}
+	_ = r.cmd.Wait()
+	r.cmd = nil
+	return nil
+}
+
+// Health checks if vLLM is reachable and the model is loaded.
+// Note: GET /health returns 200 even while loading; /health/ready is authoritative.
+func (r *Runtime) Health(ctx context.Context) (*runtime.Health, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.baseURL()+"/health/ready", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return &runtime.Health{
+			Status:    runtime.StatusStopped,
+			Endpoint:  r.Endpoint(),
+			CheckedAt: time.Now(),
+		}, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return &runtime.Health{
+			Status:    runtime.StatusStarting,
+			Endpoint:  r.Endpoint(),
+			CheckedAt: time.Now(),
+		}, nil
+	}
+
+	models, _ := r.ListModels(ctx)
+	return &runtime.Health{
+		Status:    runtime.StatusRunning,
+		Endpoint:  r.Endpoint(),
+		Models:    models,
+		CheckedAt: time.Now(),
+	}, nil
+}
+
+// ListModels returns the single model served by this vLLM instance.
+func (r *Runtime) ListModels(ctx context.Context) ([]runtime.Model, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.Endpoint()+"/models", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("vllm: list models: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result struct {
+		Data []struct {
+			ID      string `json:"id"`
+			OwnedBy string `json:"owned_by"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("vllm: decode models: %w", err)
+	}
+
+	models := make([]runtime.Model, len(result.Data))
+	for i, m := range result.Data {
+		models[i] = runtime.Model{
+			ID:     m.ID,
+			Loaded: true, // vLLM always has its model loaded
+		}
+	}
+	return models, nil
+}
+
+// PullModel is a no-op for vLLM — models are downloaded automatically
+// from HuggingFace on first `vllm serve`. To change models, stop and
+// restart with a different model name.
+func (r *Runtime) PullModel(_ context.Context, modelID string, progress chan<- runtime.PullProgress) error {
+	slog.Info("vllm: pull is a no-op — models are fetched at launch time",
+		"model", modelID)
+	if progress != nil {
+		progress <- runtime.PullProgress{
+			Status:  "done",
+			Percent: 100,
+		}
+	}
+	return nil
+}

--- a/pkg/runtime/vllm/vllm_test.go
+++ b/pkg/runtime/vllm/vllm_test.go
@@ -1,0 +1,122 @@
+package vllm
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/runtime"
+)
+
+func testServer(t *testing.T, handler http.Handler) *Runtime {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	host, portStr, _ := net.SplitHostPort(srv.Listener.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+
+	rt, err := New(runtime.Config{Host: host, Port: port})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rt
+}
+
+func TestHealth_Running(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health/ready", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []any{}})
+	})
+
+	rt := testServer(t, mux)
+
+	h, err := rt.Health(context.Background())
+	if err != nil {
+		t.Fatalf("Health() error: %v", err)
+	}
+	if h.Status != runtime.StatusRunning {
+		t.Errorf("Status = %q, want %q", h.Status, runtime.StatusRunning)
+	}
+}
+
+func TestHealth_Starting(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health/ready", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable) // model still loading
+	})
+
+	rt := testServer(t, mux)
+
+	h, err := rt.Health(context.Background())
+	if err != nil {
+		t.Fatalf("Health() error: %v", err)
+	}
+	if h.Status != runtime.StatusStarting {
+		t.Errorf("Status = %q, want %q", h.Status, runtime.StatusStarting)
+	}
+}
+
+func TestHealth_Stopped(t *testing.T) {
+	rt, _ := New(runtime.Config{Host: "127.0.0.1", Port: 19998})
+
+	h, err := rt.Health(context.Background())
+	if err != nil {
+		t.Fatalf("Health() error: %v", err)
+	}
+	if h.Status != runtime.StatusStopped {
+		t.Errorf("Status = %q, want %q", h.Status, runtime.StatusStopped)
+	}
+}
+
+func TestListModels(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{"id": "meta-llama/Llama-3.2-8B-Instruct", "owned_by": "vllm"}
+			]
+		}`))
+	})
+
+	rt := testServer(t, mux)
+
+	models, err := rt.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("got %d models, want 1", len(models))
+	}
+	if models[0].ID != "meta-llama/Llama-3.2-8B-Instruct" {
+		t.Errorf("ID = %q, want %q", models[0].ID, "meta-llama/Llama-3.2-8B-Instruct")
+	}
+	if !models[0].Loaded {
+		t.Error("vLLM models should always be marked as Loaded")
+	}
+}
+
+func TestPullModel_NoOp(t *testing.T) {
+	rt, _ := New(runtime.Config{})
+
+	progress := make(chan runtime.PullProgress, 1)
+	err := rt.PullModel(context.Background(), "some-model", progress)
+	if err != nil {
+		t.Fatalf("PullModel() error: %v", err)
+	}
+
+	p := <-progress
+	if p.Status != "done" {
+		t.Errorf("PullProgress.Status = %q, want %q", p.Status, "done")
+	}
+	if p.Percent != 100 {
+		t.Errorf("PullProgress.Percent = %f, want 100", p.Percent)
+	}
+}


### PR DESCRIPTION
## Summary

Add the `Runtime` abstraction layer for managing local LLM inference servers. This follows the same interface registry pattern used by `pkg/storage` — implementations call `Register()` from `init()`, consumers call `New(name, config)`.

## Architecture

```
pkg/runtime/
├── runtime.go          # Runtime interface + types
├── registry.go         # Register/New factory pattern
├── manager.go          # Lifecycle wrapper (health loop, auto-start, auto-pull)
├── runtime_test.go     # Registry + factory tests
├── manager_test.go     # Mock-based Manager tests
├── ollama/ollama.go    # Ollama implementation
├── vllm/vllm.go        # vLLM implementation
└── lmstudio/lmstudio.go # LM Studio implementation
```

### Runtime Interface
```go
type Runtime interface {
    Name() string
    Start(ctx context.Context) error
    Stop(ctx context.Context) error
    Health(ctx context.Context) (*Health, error)
    Endpoint() string
    ListModels(ctx context.Context) ([]Model, error)
    PullModel(ctx context.Context, modelID string, progress chan<- PullProgress) error
}
```

### Backend-Specific Behaviors

| Backend | Default Port | Health Check | PullModel | Notes |
|---------|-------------|-------------|-----------|-------|
| Ollama | 11434 | `GET /` | `POST /api/pull` (NDJSON stream) | Lazy-loads, multi-model |
| vLLM | 8000 | `GET /health/ready` | No-op (auto-downloads from HF) | Single model per process |
| LM Studio | 1234 | `GET /v1/models` | `POST /api/v1/models/download` | `lms` CLI for lifecycle |

### Manager
Wraps any `Runtime` with:
- **Health loop** — periodic polling with cached status
- **Auto-start** — optionally launch the runtime on Manager.Start()
- **Auto-pull** — pull a list of configured models on startup

## Tests (22 new, 31 total across affected packages)

| Package | Tests | Coverage |
|---------|-------|----------|
| `pkg/runtime` | 10 — registry, factory, defaults, mock Manager lifecycle | Interface contract |
| `pkg/costcalc` | +2 — local provider zero-cost (backfill from PR #42) | Short-circuit path |
| `cmd/candela-local` | +10 — singleJoiningSlash edge cases, local_upstream config | Path rewriting, config |

All tests are pure unit tests with no external dependencies (mock runtime for Manager, table-driven for helpers).

> **Integration tests** (requiring a running Ollama/vLLM/LM Studio) are deferred to Step 3 when the `/_local/*` API provides an end-to-end surface to test against.

## Usage
```go
import _ "github.com/candelahq/candela/pkg/runtime/ollama"

rt, _ := runtime.New("ollama", runtime.Config{Port: 11434})
mgr := runtime.NewManager(rt, runtime.ManagerConfig{
    AutoStart: true,
    AutoPull:  true,
    Models:    []string{"llama3.2:8b"},
})
mgr.Start(ctx)
```

## Testing
- `go build ./...` ✅
- `go test ./pkg/runtime/... ./pkg/costcalc/... ./cmd/candela-local/...` ✅ (31 tests)
- All pre-commit hooks pass ✅

## Context
Step 2 of the local model serving roadmap:
- ~~Step 1: Local provider in candela-local (PR #42, merged)~~
- **Step 2: `pkg/runtime/` package** ← this PR
- Step 3: `/_local/*` REST API in candela-local
- Step 4: Embedded management UI