### PR TITLE
feat: add /_local/* management API for runtime control

### DIFF
--- a/cmd/candela-local/local_api.go
+++ b/cmd/candela-local/local_api.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/candelahq/candela/pkg/runtime"
+)
+
+// localAPI provides the /_local/* management endpoints for controlling
+// the local LLM runtime from the embedded UI or curl.
+//
+// Endpoints:
+//
+//	GET  /_local/health        — runtime health + loaded models
+//	GET  /_local/models        — list available models
+//	POST /_local/models/pull   — pull/download a model
+//	GET  /_local/backends      — list registered runtime backends
+type localAPI struct {
+	mgr *runtime.Manager
+}
+
+// registerLocalAPI mounts the /_local/* routes on the mux.
+func registerLocalAPI(mux *http.ServeMux, mgr *runtime.Manager) {
+	api := &localAPI{mgr: mgr}
+
+	mux.HandleFunc("GET /_local/health", api.handleHealth)
+	mux.HandleFunc("GET /_local/models", api.handleListModels)
+	mux.HandleFunc("POST /_local/models/pull", api.handlePullModel)
+	mux.HandleFunc("GET /_local/backends", api.handleBackends)
+}
+
+// GET /_local/health
+func (a *localAPI) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	h := a.mgr.Health()
+	writeJSON(w, http.StatusOK, h)
+}
+
+// GET /_local/models
+func (a *localAPI) handleListModels(w http.ResponseWriter, r *http.Request) {
+	models, err := a.mgr.Runtime().ListModels(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error": err.Error(),
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"models": models,
+	})
+}
+
+// POST /_local/models/pull
+// Body: {"model": "llama3.2:8b"}
+func (a *localAPI) handlePullModel(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1024*1024) // Limit body to 1MB
+	var req struct {
+		Model string `json:"model"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "invalid JSON: " + err.Error(),
+		})
+		return
+	}
+	if req.Model == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "model is required",
+		})
+		return
+	}
+
+	slog.Info("pulling model via API", "model", req.Model)
+
+	// Pull in a goroutine and return immediately with 202 Accepted.
+	// The UI can poll /_local/health to see when the model appears.
+	go func() {
+		// Use context.Background() because r.Context() is cancelled when the handler returns.
+		ctx := context.Background()
+		progress := make(chan runtime.PullProgress, 16)
+		defer close(progress)
+		go func() {
+			for p := range progress {
+				slog.Info("pull progress",
+					"model", req.Model,
+					"status", p.Status,
+					"percent", p.Percent,
+				)
+			}
+		}()
+		if err := a.mgr.Runtime().PullModel(ctx, req.Model, progress); err != nil {
+			slog.Error("model pull failed", "model", req.Model, "error", err)
+		}
+	}()
+
+	writeJSON(w, http.StatusAccepted, map[string]string{
+		"status": "pulling",
+		"model":  req.Model,
+	})
+}
+
+// GET /_local/backends
+func (a *localAPI) handleBackends(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"backends": runtime.Names(),
+	})
+}
+
+// writeJSON is a helper for consistent JSON responses.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("failed to encode JSON response", "error", err)
+	}
+}

--- a/cmd/candela-local/local_api_test.go
+++ b/cmd/candela-local/local_api_test.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/runtime"
+)
+
+// apiMockRuntime is a test double for the Runtime interface.
+type apiMockRuntime struct {
+	healthy    bool
+	models     []runtime.Model
+	listErr    error // if set, ListModels returns this error
+	pullCalled []string
+	mu         sync.Mutex
+}
+
+func (m *apiMockRuntime) Name() string     { return "test" }
+func (m *apiMockRuntime) Endpoint() string { return "http://127.0.0.1:9999/v1" }
+func (m *apiMockRuntime) Start(_ context.Context) error {
+	return nil
+}
+func (m *apiMockRuntime) Stop(_ context.Context) error { return nil }
+func (m *apiMockRuntime) Health(_ context.Context) (*runtime.Health, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	status := runtime.StatusStopped
+	if m.healthy {
+		status = runtime.StatusRunning
+	}
+	return &runtime.Health{
+		Status:    status,
+		Endpoint:  m.Endpoint(),
+		Models:    m.models,
+		CheckedAt: time.Now(),
+	}, nil
+}
+func (m *apiMockRuntime) ListModels(_ context.Context) ([]runtime.Model, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.models, nil
+}
+func (m *apiMockRuntime) PullModel(_ context.Context, modelID string, progress chan<- runtime.PullProgress) error {
+	m.mu.Lock()
+	m.pullCalled = append(m.pullCalled, modelID)
+	m.mu.Unlock()
+	if progress != nil {
+		progress <- runtime.PullProgress{Status: "done", Percent: 100}
+	}
+	return nil
+}
+
+func setupAPI(t *testing.T) (*http.ServeMux, *apiMockRuntime) {
+	t.Helper()
+	mock := &apiMockRuntime{
+		healthy: true,
+		models: []runtime.Model{
+			{ID: "llama3.2:8b", SizeBytes: 4_700_000_000, Loaded: true},
+			{ID: "codellama:13b", SizeBytes: 7_300_000_000, Loaded: true},
+		},
+	}
+	mgr := runtime.NewManager(mock, runtime.ManagerConfig{
+		HealthCheck: 10 * time.Second,
+	})
+	ctx := context.Background()
+	if err := mgr.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = mgr.Stop(ctx) })
+
+	mux := http.NewServeMux()
+	registerLocalAPI(mux, mgr)
+
+	// Poll for the health loop's initial check to complete.
+	for i := 0; i < 10; i++ {
+		if mgr.Health().Status == runtime.StatusRunning {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	return mux, mock
+}
+
+func TestAPIHealth(t *testing.T) {
+	mux, _ := setupAPI(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/_local/health", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var resp runtime.Health
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp.Status != runtime.StatusRunning {
+		t.Errorf("status = %q, want %q", resp.Status, runtime.StatusRunning)
+	}
+}
+
+func TestAPIListModels(t *testing.T) {
+	mux, _ := setupAPI(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/_local/models", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp struct {
+		Models []runtime.Model `json:"models"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(resp.Models) != 2 {
+		t.Fatalf("got %d models, want 2", len(resp.Models))
+	}
+	if resp.Models[0].ID != "llama3.2:8b" {
+		t.Errorf("models[0].ID = %q, want %q", resp.Models[0].ID, "llama3.2:8b")
+	}
+}
+
+func TestAPIPullModel(t *testing.T) {
+	mux, mock := setupAPI(t)
+
+	body := `{"model": "mistral:7b"}`
+	req := httptest.NewRequest(http.MethodPost, "/_local/models/pull", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp["status"] != "pulling" {
+		t.Errorf("status = %q, want %q", resp["status"], "pulling")
+	}
+	if resp["model"] != "mistral:7b" {
+		t.Errorf("model = %q, want %q", resp["model"], "mistral:7b")
+	}
+
+	// Poll for background pull goroutine to complete.
+	for i := 0; i < 10; i++ {
+		mock.mu.Lock()
+		n := len(mock.pullCalled)
+		mock.mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mock.mu.Lock()
+	pulled := append([]string{}, mock.pullCalled...)
+	mock.mu.Unlock()
+	if len(pulled) != 1 || pulled[0] != "mistral:7b" {
+		t.Errorf("pullCalled = %v, want [mistral:7b]", pulled)
+	}
+}
+
+func TestAPIPullModel_EmptyModel(t *testing.T) {
+	mux, _ := setupAPI(t)
+
+	body := `{"model": ""}`
+	req := httptest.NewRequest(http.MethodPost, "/_local/models/pull", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestAPIPullModel_BadJSON(t *testing.T) {
+	mux, _ := setupAPI(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/_local/models/pull", strings.NewReader("not json"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestAPIBackends(t *testing.T) {
+	mux, _ := setupAPI(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/_local/backends", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp struct {
+		Backends []string `json:"backends"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(resp.Backends) < 3 {
+		t.Errorf("expected at least 3 backends, got %d: %v", len(resp.Backends), resp.Backends)
+	}
+}
+
+func TestAPIHealth_WrongMethod(t *testing.T) {
+	mux, _ := setupAPI(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/_local/health", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST /_local/health status = %d, want 405", w.Code)
+	}
+}
+
+func TestAPIPullModel_WrongMethod(t *testing.T) {
+	mux, _ := setupAPI(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/_local/models/pull", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET /_local/models/pull status = %d, want 405", w.Code)
+	}
+}
+
+func TestAPIListModels_RuntimeDown(t *testing.T) {
+	mux, mock := setupAPI(t)
+
+	// Simulate runtime being unreachable.
+	mock.mu.Lock()
+	mock.listErr = fmt.Errorf("connection refused")
+	mock.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/_local/models", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp["error"] == "" {
+		t.Error("expected error message in response")
+	}
+}

--- a/cmd/candela-local/main.go
+++ b/cmd/candela-local/main.go
@@ -30,6 +30,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/candelahq/candela/pkg/runtime"
+
+	// Register runtime backends.
+	_ "github.com/candelahq/candela/pkg/runtime/lmstudio"
+	_ "github.com/candelahq/candela/pkg/runtime/ollama"
+	_ "github.com/candelahq/candela/pkg/runtime/vllm"
+
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/idtoken"
@@ -43,6 +50,11 @@ type Config struct {
 	Port          int    `yaml:"port"`           // Local port to listen on
 	LMStudioPort  int    `yaml:"lmstudio_port"`  // LM Studio compat listener port (default: 1234)
 	LocalUpstream string `yaml:"local_upstream"` // Local runtime URL (e.g. http://127.0.0.1:11434)
+
+	// Runtime management configuration.
+	RuntimeBackend string                `yaml:"runtime_backend"` // "ollama", "vllm", "lmstudio"
+	RuntimeConfig  runtime.Config        `yaml:"runtime_config"`  // Host, port, args for the backend
+	RuntimeManage  runtime.ManagerConfig `yaml:"runtime_manage"`  // Auto-start, auto-pull, models
 }
 
 func main() {
@@ -195,6 +207,26 @@ func main() {
 		slog.Info("🏠 local runtime proxy enabled", "upstream", cfg.LocalUpstream)
 	}
 
+	// ── Local runtime management API ──
+	// If a runtime backend is configured, create a Manager and expose
+	// the /_local/* management endpoints for the embedded UI.
+	var mgr *runtime.Manager
+	if cfg.RuntimeBackend != "" {
+		rt, err := runtime.New(cfg.RuntimeBackend, cfg.RuntimeConfig)
+		if err != nil {
+			slog.Error("failed to create runtime", "backend", cfg.RuntimeBackend, "error", err)
+			os.Exit(1)
+		}
+		mgr = runtime.NewManager(rt, cfg.RuntimeManage)
+		if err := mgr.Start(ctx); err != nil {
+			slog.Error("failed to start runtime manager", "error", err)
+			os.Exit(1)
+		}
+		registerLocalAPI(mux, mgr)
+		slog.Info("🔧 local management API enabled", "backend", cfg.RuntimeBackend,
+			"endpoints", "/_local/{health,models,models/pull,backends}")
+	}
+
 	// Everything else → remote Candela server.
 	mux.Handle("/", proxy)
 
@@ -260,6 +292,11 @@ func main() {
 	if lmSrv != nil {
 		if err := lmSrv.Shutdown(shutdownCtx); err != nil {
 			slog.Error("LM Studio shutdown error", "error", err)
+		}
+	}
+	if mgr != nil {
+		if err := mgr.Stop(shutdownCtx); err != nil {
+			slog.Error("runtime manager shutdown error", "error", err)
 		}
 	}
 	if err := srv.Shutdown(shutdownCtx); err != nil {

--- a/cmd/candela-local/main_test.go
+++ b/cmd/candela-local/main_test.go
@@ -191,3 +191,51 @@ func TestSingleJoiningSlash(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadConfig_RuntimeManagement(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "candela.yaml")
+	err := os.WriteFile(cfgPath, []byte(`
+remote: https://candela-xxx.run.app
+audience: test-audience
+port: 8181
+runtime_backend: ollama
+runtime_config:
+  host: 127.0.0.1
+  port: 11434
+runtime_manage:
+  auto_start: true
+  auto_pull: true
+  health_interval: 15s
+  models:
+    - llama3.2:8b
+    - codellama:13b
+`), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := loadConfig(cfgPath)
+
+	if cfg.RuntimeBackend != "ollama" {
+		t.Errorf("RuntimeBackend = %q, want %q", cfg.RuntimeBackend, "ollama")
+	}
+	if cfg.RuntimeConfig.Host != "127.0.0.1" {
+		t.Errorf("RuntimeConfig.Host = %q, want %q", cfg.RuntimeConfig.Host, "127.0.0.1")
+	}
+	if cfg.RuntimeConfig.Port != 11434 {
+		t.Errorf("RuntimeConfig.Port = %d, want 11434", cfg.RuntimeConfig.Port)
+	}
+	if !cfg.RuntimeManage.AutoStart {
+		t.Error("RuntimeManage.AutoStart should be true")
+	}
+	if !cfg.RuntimeManage.AutoPull {
+		t.Error("RuntimeManage.AutoPull should be true")
+	}
+	if len(cfg.RuntimeManage.Models) != 2 {
+		t.Fatalf("RuntimeManage.Models = %v, want 2 entries", cfg.RuntimeManage.Models)
+	}
+	if cfg.RuntimeManage.Models[0] != "llama3.2:8b" {
+		t.Errorf("Models[0] = %q, want %q", cfg.RuntimeManage.Models[0], "llama3.2:8b")
+	}
+}


### PR DESCRIPTION
## Summary

Add REST API endpoints in `candela-local` for managing local LLM runtimes. These endpoints power the upcoming embedded management UI and can also be used with `curl` for debugging.

## Endpoints

| Method | Path | Description | Status |
|--------|------|-------------|--------|
| `GET` | `/_local/health` | Cached runtime health + loaded models | 200 |
| `GET` | `/_local/models` | List available models from the runtime | 200 / 502 |
| `POST` | `/_local/models/pull` | Async model pull | 202 / 400 |
| `GET` | `/_local/backends` | List registered backends | 200 |

### Example: Pull a model
```bash
curl -X POST http://localhost:8181/_local/models/pull \
  -H 'Content-Type: application/json' \
  -d '{"model": "llama3.2:8b"}'
# {"status": "pulling", "model": "llama3.2:8b"}
```

### Example: Check health
```bash
curl http://localhost:8181/_local/health
# {"status": "running", "endpoint": "http://127.0.0.1:11434/v1", "models": [...]}
```

## Config (`~/.candela.yaml`)

```yaml
# Existing settings...
remote: https://candela-xxx.run.app
audience: xxx.apps.googleusercontent.com
port: 8181

# NEW: Runtime management
runtime_backend: ollama          # or vllm, lmstudio
runtime_config:
  host: 127.0.0.1
  port: 11434
runtime_manage:
  auto_start: true               # Launch ollama serve on startup
  auto_pull: true                 # Pull configured models in background
  health_interval: 10s
  models:
    - llama3.2:8b
    - codellama:13b
```

## Architecture

```
~/.candela.yaml
    ↓
candela-local main.go
    ├── runtime.New(backend, config)  → creates Runtime
    ├── runtime.NewManager(rt, cfg)   → wraps with health loop + auto-pull
    ├── registerLocalAPI(mux, mgr)    → mounts /_local/* handlers
    └── mgr.Stop() on shutdown        → graceful cleanup
```

## Tests (6 new)

| Test | What |
|------|------|
| `TestAPIHealth` | Returns running status with JSON |
| `TestAPIListModels` | Returns 2 mock models |
| `TestAPIPullModel` | Returns 202, background pull executes |
| `TestAPIPullModel_EmptyModel` | Returns 400 for empty model |
| `TestAPIPullModel_BadJSON` | Returns 400 for invalid body |
| `TestAPIBackends` | Returns ≥3 registered backends |

All tests use `httptest` with a mock runtime — no external dependencies.

## Context
Step 3 of the local model serving roadmap:
- ~~Step 1: Local provider in candela-local (PR #42, merged)~~
- ~~Step 2: `pkg/runtime/` package (PR #43, merged)~~
- **Step 3: `/_local/*` REST API** ← this PR
- Step 4: Embedded management UI