### PR TITLE
feat: delete model, cancel pull, and state DB catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,21 @@ The UI communicates with the backend via **ConnectRPC v2** on `localhost:8080`. 
 
 ---
 
+## 🕹️ candela-local — Runtime Management
+
+`candela-local` includes an embedded management UI at `/_local/` for controlling local LLM runtimes:
+
+- **Runtime control** — Start/stop Ollama, vLLM, or LM Studio; health monitoring with auto-polling
+- **Model management** — List, load, unload, and **delete** models from disk
+- **Pull models** — Download models with real-time progress tracking and **cancel** support
+- **Model catalog** — Suggested models stored in SQLite (`local_model_catalog`), seeded with popular defaults
+- **Backend discovery** — Auto-detect installed runtimes and show install hints
+- **State persistence** — Settings, pull history, and runtime state persisted to `~/.candela/state.db`
+
+All features are accessible via **ConnectRPC** (`RuntimeService`) and the embedded vanilla JS dashboard.
+
+---
+
 ## 🗺️ Roadmap
 
 - **Phase 1: Foundation** ✅ (Ingestion, Proxy, Cost Calc, Docs)
@@ -230,6 +245,7 @@ The UI communicates with the backend via **ConnectRPC v2** on `localhost:8080`. 
   - Client-side form validation (`@bufbuild/protovalidate`)
   - Budget enforcement with grant-first waterfall
   - `candela-local` auth-injecting proxy for developer machines
+  - `candela-local` embedded runtime management UI (`/_local/`)
 - **Phase 5: Ecosystem & Polish** 📋 (Agent DAGs, Multi-region, Alerting, Google Workspace Sync)
 
 ---
@@ -250,6 +266,7 @@ candela/
 │   ├── proxy/                   # LLM API reverse proxy
 │   ├── costcalc/                # Token cost calculation engine
 │   ├── connecthandlers/         # ConnectRPC service handlers
+│   ├── runtime/                 # Local LLM runtime abstraction (Ollama, vLLM, LM Studio)
 │   └── ingestion/               # OTel span ingestion
 ├── terraform/                   # GCP infrastructure (OpenTofu/Terraform)
 │   ├── cloud_run.tf             # Cloud Run + IAP
@@ -266,6 +283,8 @@ candela/
 │   ├── e2e/                     # Playwright E2E tests (app + admin)
 │   └── playwright.config.ts     # Playwright config
 ├── .github/workflows/ci.yml    # CI pipeline (Go + UI + Playwright)
+├── cmd/candela-local/           # Local dev proxy + runtime manager
+│   └── ui/                      # Embedded management UI (vanilla JS)
 └── config.yaml                  # Server configuration
 ```
 ---

--- a/cmd/candela-local/local_api_test.go
+++ b/cmd/candela-local/local_api_test.go
@@ -63,6 +63,7 @@ func (m *apiMockRuntime) PullModel(_ context.Context, modelID string, progress c
 
 func (m *apiMockRuntime) LoadModel(_ context.Context, _ string) error   { return nil }
 func (m *apiMockRuntime) UnloadModel(_ context.Context, _ string) error { return nil }
+func (m *apiMockRuntime) DeleteModel(_ context.Context, _ string) error { return nil }
 
 func setupAPI(t *testing.T) (*http.ServeMux, *apiMockRuntime) {
 	t.Helper()

--- a/cmd/candela-local/runtime_handler.go
+++ b/cmd/candela-local/runtime_handler.go
@@ -313,6 +313,9 @@ func (h *runtimeHandler) DeleteModel(
 	if model == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errModelRequired)
 	}
+	if _, pulling := h.activePulls.Load(model); pulling {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("cannot delete model %q while it is being pulled", model))
+	}
 	if err := h.mgr.Runtime().DeleteModel(ctx, model); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}

--- a/cmd/candela-local/runtime_handler.go
+++ b/cmd/candela-local/runtime_handler.go
@@ -19,11 +19,12 @@ import (
 // pullStatus tracks an in-flight model pull.
 type pullStatus struct {
 	mu        sync.Mutex
-	Model     string  `json:"model"`
-	Status    string  `json:"status"` // "pulling", "complete", "failed"
-	Percent   float64 `json:"percent"`
-	Error     string  `json:"error,omitempty"`
-	StartedAt string  `json:"startedAt"`
+	cancel    context.CancelFunc // cancels the pull context
+	Model     string             `json:"model"`
+	Status    string             `json:"status"` // "pulling", "complete", "failed", "cancelled"
+	Percent   float64            `json:"percent"`
+	Error     string             `json:"error,omitempty"`
+	StartedAt string             `json:"startedAt"`
 }
 
 // snapshot returns a copy safe for reading without holding the lock.
@@ -180,7 +181,9 @@ func (h *runtimeHandler) PullModel(
 	}
 
 	// Register the active pull.
+	pullCtx, pullCancel := context.WithCancel(h.appCtx)
 	ps := &pullStatus{
+		cancel:    pullCancel,
 		Model:     model,
 		Status:    "pulling",
 		StartedAt: time.Now().UTC().Format(time.RFC3339),
@@ -200,16 +203,21 @@ func (h *runtimeHandler) PullModel(
 			}
 		}()
 
-		err := h.mgr.Runtime().PullModel(h.appCtx, model, progress)
+		err := h.mgr.Runtime().PullModel(pullCtx, model, progress)
 		close(progress)
 
 		if err != nil {
-			slog.Error("model pull failed", "model", model, "error", err)
 			ps.mu.Lock()
-			ps.Status = "failed"
-			ps.Error = err.Error()
+			if pullCtx.Err() != nil {
+				slog.Info("model pull cancelled", "model", model)
+				ps.Status = "cancelled"
+			} else {
+				slog.Error("model pull failed", "model", model, "error", err)
+				ps.Status = "failed"
+				ps.Error = err.Error()
+			}
 			ps.mu.Unlock()
-			// Keep failed status visible for 30s then remove — use
+			// Keep status visible for 30s then remove — use
 			// CompareAndDelete so a re-pull's entry isn't clobbered.
 			time.AfterFunc(30*time.Second, func() { h.activePulls.CompareAndDelete(model, ps) })
 			return
@@ -291,7 +299,66 @@ func (h *runtimeHandler) ResetState(
 	return connect.NewResponse(&v1.ResetStateResponse{}), nil
 }
 
-// ── Helpers ──
+func (h *runtimeHandler) DeleteModel(
+	ctx context.Context,
+	req *connect.Request[v1.DeleteModelRequest],
+) (*connect.Response[v1.DeleteModelResponse], error) {
+	if h.mgr == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errNoRuntime)
+	}
+	model := req.Msg.GetModel()
+	if model == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errModelRequired)
+	}
+	if err := h.mgr.Runtime().DeleteModel(ctx, model); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	slog.Info("model deleted via RPC", "model", model)
+	return connect.NewResponse(&v1.DeleteModelResponse{}), nil
+}
+
+func (h *runtimeHandler) CancelPull(
+	_ context.Context,
+	req *connect.Request[v1.CancelPullRequest],
+) (*connect.Response[v1.CancelPullResponse], error) {
+	model := req.Msg.GetModel()
+	if model == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errModelRequired)
+	}
+	val, ok := h.activePulls.Load(model)
+	if !ok {
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("no active pull for %q", model))
+	}
+	ps := val.(*pullStatus)
+	ps.mu.Lock()
+	if ps.cancel != nil {
+		ps.cancel()
+	}
+	ps.mu.Unlock()
+	slog.Info("pull cancelled via RPC", "model", model)
+	return connect.NewResponse(&v1.CancelPullResponse{}), nil
+}
+
+func (h *runtimeHandler) ListCatalog(
+	_ context.Context,
+	_ *connect.Request[v1.ListCatalogRequest],
+) (*connect.Response[v1.ListCatalogResponse], error) {
+	if h.state == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errNoStateDB)
+	}
+	entries := h.state.ListCatalog()
+	resp := &v1.ListCatalogResponse{}
+	for _, e := range entries {
+		resp.Models = append(resp.Models, &v1.CatalogModel{
+			Id:          e.ID,
+			Name:        e.Name,
+			Description: e.Description,
+			SizeHint:    e.SizeHint,
+			Pinned:      e.Pinned,
+		})
+	}
+	return connect.NewResponse(resp), nil
+}
 
 var (
 	errNoRuntime     = fmt.Errorf("no runtime backend configured")

--- a/cmd/candela-local/runtime_handler.go
+++ b/cmd/candela-local/runtime_handler.go
@@ -194,7 +194,9 @@ func (h *runtimeHandler) PullModel(
 	progress := make(chan runtime.PullProgress, 16)
 	go func() {
 		// Drain progress updates.
+		progressDone := make(chan struct{})
 		go func() {
+			defer close(progressDone)
 			for p := range progress {
 				ps.mu.Lock()
 				ps.Percent = p.Percent
@@ -205,6 +207,7 @@ func (h *runtimeHandler) PullModel(
 
 		err := h.mgr.Runtime().PullModel(pullCtx, model, progress)
 		close(progress)
+		<-progressDone // wait for drain goroutine to finish before setting final status
 
 		if err != nil {
 			ps.mu.Lock()

--- a/cmd/candela-local/runtime_handler_test.go
+++ b/cmd/candela-local/runtime_handler_test.go
@@ -29,6 +29,7 @@ type rpcMockRuntime struct {
 	loadCalled   []string
 	unloadCalled []string
 	pullCalled   []string
+	deleteCalled []string
 	healthErr    error
 	listErr      error
 	pullDelay    time.Duration // simulate slow pull for progress tracking tests
@@ -80,7 +81,7 @@ func (m *rpcMockRuntime) ListModels(_ context.Context) ([]runtime.Model, error) 
 	return m.models, nil
 }
 
-func (m *rpcMockRuntime) PullModel(_ context.Context, modelID string, progress chan<- runtime.PullProgress) error {
+func (m *rpcMockRuntime) PullModel(ctx context.Context, modelID string, progress chan<- runtime.PullProgress) error {
 	m.mu.Lock()
 	m.pullCalled = append(m.pullCalled, modelID)
 	delay := m.pullDelay
@@ -90,7 +91,11 @@ func (m *rpcMockRuntime) PullModel(_ context.Context, modelID string, progress c
 		if progress != nil {
 			progress <- runtime.PullProgress{Status: "pulling", Percent: 50}
 		}
-		time.Sleep(delay)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
 	}
 	if progress != nil {
 		progress <- runtime.PullProgress{Status: "done", Percent: 100}
@@ -108,6 +113,13 @@ func (m *rpcMockRuntime) LoadModel(_ context.Context, modelID string) error {
 func (m *rpcMockRuntime) UnloadModel(_ context.Context, modelID string) error {
 	m.mu.Lock()
 	m.unloadCalled = append(m.unloadCalled, modelID)
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *rpcMockRuntime) DeleteModel(_ context.Context, modelID string) error {
+	m.mu.Lock()
+	m.deleteCalled = append(m.deleteCalled, modelID)
 	m.mu.Unlock()
 	return nil
 }
@@ -622,5 +634,148 @@ func TestRPC_StartRuntime_AlwaysStartsRegardlessOfAutoStart(t *testing.T) {
 	mock.mu.Unlock()
 	if !healthy {
 		t.Error("mock should be healthy after StartRuntime RPC")
+	}
+}
+
+func TestRPC_DeleteModel(t *testing.T) {
+	client, mock := setupRPCHandler(t)
+
+	_, err := client.DeleteModel(context.Background(),
+		connect.NewRequest(&v1.DeleteModelRequest{Model: "llama3.2:8b"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mock.mu.Lock()
+	deleted := mock.deleteCalled
+	mock.mu.Unlock()
+	if len(deleted) != 1 || deleted[0] != "llama3.2:8b" {
+		t.Errorf("deleteCalled = %v, want [llama3.2:8b]", deleted)
+	}
+}
+
+func TestRPC_DeleteModel_EmptyModel(t *testing.T) {
+	client, _ := setupRPCHandler(t)
+
+	_, err := client.DeleteModel(context.Background(),
+		connect.NewRequest(&v1.DeleteModelRequest{}))
+	if err == nil {
+		t.Fatal("expected error for empty model")
+	}
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", connect.CodeOf(err))
+	}
+}
+
+func TestRPC_CancelPull(t *testing.T) {
+	mock := &rpcMockRuntime{
+		healthy:   true,
+		pullDelay: 2 * time.Second, // long enough to cancel
+	}
+	mgr := runtime.NewManager(mock, runtime.ManagerConfig{
+		HealthCheck: 10 * time.Second,
+	})
+	if err := mgr.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	h := newRuntimeHandler(mgr, nil, context.Background())
+
+	mux := http.NewServeMux()
+	path, handler := candelav1connect.NewRuntimeServiceHandler(h)
+	mux.Handle(path, handler)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := candelav1connect.NewRuntimeServiceClient(http.DefaultClient, srv.URL)
+
+	// Start a pull.
+	_, err := client.PullModel(context.Background(),
+		connect.NewRequest(&v1.PullModelRequest{Model: "big-model:70b"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for it to appear in active pulls.
+	time.Sleep(50 * time.Millisecond)
+	pulls := h.ActivePulls()
+	if len(pulls) != 1 || pulls[0].Status != "pulling" {
+		t.Fatalf("expected active pull, got %+v", pulls)
+	}
+
+	// Cancel it.
+	_, err = client.CancelPull(context.Background(),
+		connect.NewRequest(&v1.CancelPullRequest{Model: "big-model:70b"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for status to update.
+	var cancelled bool
+	for i := 0; i < 40; i++ {
+		time.Sleep(50 * time.Millisecond)
+		pulls = h.ActivePulls()
+		if len(pulls) == 1 && pulls[0].Status == "cancelled" {
+			cancelled = true
+			break
+		}
+	}
+	if !cancelled {
+		t.Fatalf("pull not cancelled; status = %+v", pulls)
+	}
+}
+
+func TestRPC_CancelPull_NotFound(t *testing.T) {
+	client, _ := setupRPCHandler(t)
+
+	_, err := client.CancelPull(context.Background(),
+		connect.NewRequest(&v1.CancelPullRequest{Model: "nonexistent:7b"}))
+	if err == nil {
+		t.Fatal("expected error for non-existent pull")
+	}
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", connect.CodeOf(err))
+	}
+}
+
+func TestRPC_ListCatalog(t *testing.T) {
+	client, _ := setupRPCHandlerWithState(t)
+
+	resp, err := client.ListCatalog(context.Background(),
+		connect.NewRequest(&v1.ListCatalogRequest{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	models := resp.Msg.GetModels()
+	if len(models) != 8 {
+		t.Fatalf("catalog = %d models, want 8", len(models))
+	}
+
+	// Verify a known entry.
+	found := false
+	for _, m := range models {
+		if m.Id == "llama3.2:3b" {
+			found = true
+			if m.Name != "Llama 3.2 3B" {
+				t.Errorf("name = %q, want Llama 3.2 3B", m.Name)
+			}
+		}
+	}
+	if !found {
+		t.Error("llama3.2:3b not found in catalog response")
+	}
+}
+
+func TestRPC_ListCatalog_NoStateDB(t *testing.T) {
+	client, _ := setupRPCHandler(t) // nil state DB
+
+	_, err := client.ListCatalog(context.Background(),
+		connect.NewRequest(&v1.ListCatalogRequest{}))
+	if err == nil {
+		t.Fatal("expected error when state DB is nil")
+	}
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", connect.CodeOf(err))
 	}
 }

--- a/cmd/candela-local/state.go
+++ b/cmd/candela-local/state.go
@@ -274,6 +274,7 @@ func (s *StateDB) ListCatalog() []CatalogEntry {
 	for rows.Next() {
 		var e CatalogEntry
 		if err := rows.Scan(&e.ID, &e.Name, &e.Description, &e.SizeHint, &e.Pinned); err != nil {
+			slog.Warn("state db: scan catalog row", "error", err)
 			continue
 		}
 		entries = append(entries, e)

--- a/cmd/candela-local/state.go
+++ b/cmd/candela-local/state.go
@@ -92,8 +92,7 @@ func (s *StateDB) migrate() error {
 
 	// Seed default catalog if empty.
 	var count int
-	_ = s.db.QueryRow("SELECT COUNT(*) FROM local_model_catalog").Scan(&count)
-	if count == 0 {
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM local_model_catalog").Scan(&count); err == nil && count == 0 {
 		s.seedCatalog()
 	}
 	return nil
@@ -253,9 +252,11 @@ func (s *StateDB) seedCatalog() {
 		{ID: "codellama:7b", Name: "Code Llama 7B", Description: "Optimized for code generation", SizeHint: "3.8 GB"},
 	}
 	for _, m := range models {
-		_, _ = s.db.Exec(
+		if _, err := s.db.Exec(
 			"INSERT OR IGNORE INTO local_model_catalog (id, name, description, size_hint) VALUES (?, ?, ?, ?)",
-			m.ID, m.Name, m.Description, m.SizeHint)
+			m.ID, m.Name, m.Description, m.SizeHint); err != nil {
+			slog.Warn("state db: seed catalog entry", "id", m.ID, "error", err)
+		}
 	}
 }
 
@@ -276,6 +277,9 @@ func (s *StateDB) ListCatalog() []CatalogEntry {
 			continue
 		}
 		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		slog.Warn("state db: list catalog rows", "error", err)
 	}
 	return entries
 }

--- a/cmd/candela-local/state.go
+++ b/cmd/candela-local/state.go
@@ -74,11 +74,27 @@ func (s *StateDB) migrate() error {
 			pulled_at  TEXT NOT NULL DEFAULT (datetime('now')),
 			size_bytes INTEGER DEFAULT 0
 		);
+		CREATE TABLE IF NOT EXISTS local_model_catalog (
+			id          TEXT PRIMARY KEY,
+			name        TEXT NOT NULL,
+			description TEXT DEFAULT '',
+			size_hint   TEXT DEFAULT '',
+			backend     TEXT DEFAULT 'ollama',
+			pinned      BOOLEAN DEFAULT 0,
+			added_at    TEXT DEFAULT (datetime('now'))
+		);
 		INSERT OR IGNORE INTO runtime_state (id) VALUES (1);
 	`
 	_, err := s.db.Exec(schema)
 	if err != nil {
 		return fmt.Errorf("state db: migrate: %w", err)
+	}
+
+	// Seed default catalog if empty.
+	var count int
+	_ = s.db.QueryRow("SELECT COUNT(*) FROM local_model_catalog").Scan(&count)
+	if count == 0 {
+		s.seedCatalog()
 	}
 	return nil
 }
@@ -211,4 +227,69 @@ func (s *StateDB) Reset() error {
 		return err
 	}
 	return tx.Commit()
+}
+
+// ── Model Catalog ──
+
+// CatalogEntry represents a model in the user's catalog.
+type CatalogEntry struct {
+	ID          string
+	Name        string
+	Description string
+	SizeHint    string
+	Pinned      bool
+}
+
+// seedCatalog inserts the default popular models.
+func (s *StateDB) seedCatalog() {
+	models := []CatalogEntry{
+		{ID: "llama3.2:3b", Name: "Llama 3.2 3B", Description: "Fast, versatile small model", SizeHint: "2.0 GB"},
+		{ID: "llama3.2:1b", Name: "Llama 3.2 1B", Description: "Ultra-light for quick tasks", SizeHint: "1.3 GB"},
+		{ID: "gemma3:4b", Name: "Gemma 3 4B", Description: "Google's efficient model", SizeHint: "3.3 GB"},
+		{ID: "qwen3:4b", Name: "Qwen 3 4B", Description: "Strong multilingual model", SizeHint: "2.6 GB"},
+		{ID: "phi4-mini:3.8b", Name: "Phi-4 Mini", Description: "Microsoft's compact reasoning model", SizeHint: "2.5 GB"},
+		{ID: "deepseek-r1:7b", Name: "DeepSeek R1 7B", Description: "Advanced reasoning model", SizeHint: "4.7 GB"},
+		{ID: "mistral:7b", Name: "Mistral 7B", Description: "High-quality general purpose", SizeHint: "4.1 GB"},
+		{ID: "codellama:7b", Name: "Code Llama 7B", Description: "Optimized for code generation", SizeHint: "3.8 GB"},
+	}
+	for _, m := range models {
+		_, _ = s.db.Exec(
+			"INSERT OR IGNORE INTO local_model_catalog (id, name, description, size_hint) VALUES (?, ?, ?, ?)",
+			m.ID, m.Name, m.Description, m.SizeHint)
+	}
+}
+
+// ListCatalog returns all models in the catalog, pinned first.
+func (s *StateDB) ListCatalog() []CatalogEntry {
+	rows, err := s.db.Query(
+		"SELECT id, name, description, size_hint, pinned FROM local_model_catalog ORDER BY pinned DESC, name ASC")
+	if err != nil {
+		slog.Warn("state db: list catalog", "error", err)
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []CatalogEntry
+	for rows.Next() {
+		var e CatalogEntry
+		if err := rows.Scan(&e.ID, &e.Name, &e.Description, &e.SizeHint, &e.Pinned); err != nil {
+			continue
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+// AddToCatalog adds a model to the catalog.
+func (s *StateDB) AddToCatalog(e CatalogEntry) error {
+	_, err := s.db.Exec(
+		"INSERT OR REPLACE INTO local_model_catalog (id, name, description, size_hint, pinned) VALUES (?, ?, ?, ?, ?)",
+		e.ID, e.Name, e.Description, e.SizeHint, e.Pinned)
+	return err
+}
+
+// RemoveFromCatalog removes a model from the catalog.
+func (s *StateDB) RemoveFromCatalog(id string) error {
+	_, err := s.db.Exec("DELETE FROM local_model_catalog WHERE id = ?", id)
+	return err
 }

--- a/cmd/candela-local/state_test.go
+++ b/cmd/candela-local/state_test.go
@@ -146,3 +146,92 @@ func TestStateDB_CreatesMissingDirs(t *testing.T) {
 	}
 	_ = db.Close()
 }
+
+func TestStateDB_CatalogSeeded(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := openStateDB(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	entries := db.ListCatalog()
+	if len(entries) != 8 {
+		t.Fatalf("seeded catalog = %d entries, want 8", len(entries))
+	}
+
+	// Verify a known entry exists.
+	found := false
+	for _, e := range entries {
+		if e.ID == "llama3.2:3b" {
+			found = true
+			if e.Name != "Llama 3.2 3B" {
+				t.Errorf("name = %q, want Llama 3.2 3B", e.Name)
+			}
+			if e.SizeHint != "2.0 GB" {
+				t.Errorf("sizeHint = %q, want 2.0 GB", e.SizeHint)
+			}
+		}
+	}
+	if !found {
+		t.Error("llama3.2:3b not found in seeded catalog")
+	}
+}
+
+func TestStateDB_CatalogAddRemove(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := openStateDB(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// Add a custom entry.
+	err = db.AddToCatalog(CatalogEntry{
+		ID:          "custom-model:latest",
+		Name:        "Custom Model",
+		Description: "A test model",
+		SizeHint:    "1.0 GB",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entries := db.ListCatalog()
+	if len(entries) != 9 { // 8 seeded + 1 custom
+		t.Fatalf("catalog = %d entries, want 9", len(entries))
+	}
+
+	// Remove it.
+	if err := db.RemoveFromCatalog("custom-model:latest"); err != nil {
+		t.Fatal(err)
+	}
+	entries = db.ListCatalog()
+	if len(entries) != 8 {
+		t.Fatalf("after remove: catalog = %d entries, want 8", len(entries))
+	}
+}
+
+func TestStateDB_CatalogPinnedOrder(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	db, err := openStateDB(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// Pin a model that sorts last alphabetically.
+	err = db.AddToCatalog(CatalogEntry{
+		ID:     "zzz-model:latest",
+		Name:   "ZZZ Model",
+		Pinned: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entries := db.ListCatalog()
+	if entries[0].ID != "zzz-model:latest" {
+		t.Errorf("first entry = %q, want zzz-model:latest (pinned should sort first)", entries[0].ID)
+	}
+}

--- a/cmd/candela-local/ui/app.js
+++ b/cmd/candela-local/ui/app.js
@@ -138,11 +138,17 @@ function renderModels(models) {
       action = `<button class="btn btn-sm btn-model" disabled><span class="spinner"></span> Loading…</button>`;
     } else if (pending === 'unloading') {
       action = `<button class="btn btn-sm btn-model" disabled><span class="spinner"></span> Unloading…</button>`;
+    } else if (pending === 'deleting') {
+      action = `<button class="btn btn-sm btn-model" disabled><span class="spinner"></span> Deleting…</button>`;
     } else if (loaded) {
       action = `<button class="btn btn-sm btn-model" data-action="unload" data-model-id="${escapeAttr(m.id)}">Unload</button>`;
     } else {
       action = `<button class="btn btn-sm btn-model" data-action="load" data-model-id="${escapeAttr(m.id)}">Load</button>`;
     }
+
+    const deleteBtn = pending
+      ? ''
+      : `<button class="btn btn-sm btn-danger" data-action="delete" data-model-id="${escapeAttr(m.id)}" title="Delete model from disk">🗑</button>`;
 
     return `
       <div class="model-row">
@@ -151,7 +157,10 @@ function renderModels(models) {
           <span class="model-name">${escapeHtml(m.id)}</span>
           <span class="model-meta">${escapeHtml(meta)} · ${statusText}</span>
         </div>
-        ${action}
+        <div class="model-actions">
+          ${action}
+          ${deleteBtn}
+        </div>
       </div>
     `;
   }).join('');
@@ -161,7 +170,8 @@ function renderModels(models) {
     btn.addEventListener('click', () => {
       const modelId = btn.getAttribute('data-model-id');
       if (btn.dataset.action === 'load') loadModel(modelId, btn);
-      else unloadModel(modelId, btn);
+      else if (btn.dataset.action === 'unload') unloadModel(modelId, btn);
+      else if (btn.dataset.action === 'delete') deleteModel(modelId, btn);
     });
   });
 }
@@ -192,12 +202,21 @@ function renderActivePulls(pulls) {
     } else if (p.status === 'failed') {
       statusClass = 'pull-failed';
       label = `Failed: ${escapeHtml(p.error)}`;
+    } else if (p.status === 'cancelled') {
+      statusClass = 'pull-failed';
+      label = 'Cancelled';
     }
+
+    const cancelBtn = (p.status === 'pulling')
+      ? `<button class="btn btn-sm btn-danger pull-cancel" data-action="cancel-pull" data-model-id="${escapeAttr(p.model)}" title="Cancel pull">✕</button>`
+      : '';
+
     return `
       <div class="pull-row ${statusClass}">
         <div class="pull-info">
           <span class="pull-model">${escapeHtml(p.model)}</span>
           <span class="pull-label">${label}</span>
+          ${cancelBtn}
         </div>
         <div class="pull-bar-track">
           <div class="pull-bar-fill" style="width: ${pct}%"></div>
@@ -212,6 +231,11 @@ function renderActivePulls(pulls) {
     $('#models-list').prepend(container);
   }
   container.innerHTML = html;
+
+  // Bind cancel buttons.
+  container.querySelectorAll('[data-action="cancel-pull"]').forEach(btn => {
+    btn.addEventListener('click', () => cancelPull(btn.getAttribute('data-model-id')));
+  });
 
   // Start fast-polling (every 2s) while pulls are active.
   if (!pullPollTimer) {
@@ -406,6 +430,32 @@ async function pullModel(modelId) {
   }
 }
 
+async function cancelPull(modelId) {
+  try {
+    await rpc('CancelPull', { model: modelId });
+    await refreshPulls();
+  } catch (err) {
+    alert('Cancel failed: ' + err.message);
+  }
+}
+
+async function deleteModel(modelId, btn) {
+  if (!confirm(`Delete "${modelId}" from disk? This cannot be undone.`)) return;
+  pendingModels.set(modelId, 'deleting');
+  if (btn) {
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner"></span>';
+  }
+  try {
+    await rpc('DeleteModel', { model: modelId });
+  } catch (err) {
+    alert('Delete failed: ' + err.message);
+  } finally {
+    pendingModels.delete(modelId);
+    await refreshModels();
+  }
+}
+
 async function resetState() {
   if (!confirm('Reset all local state? This clears preferences and pull history. Your config file is not affected.')) {
     return;
@@ -419,36 +469,36 @@ async function resetState() {
   }
 }
 
-// ── Popular Models Catalog ──
+// ── Models Catalog ──
 
-const POPULAR_MODELS = [
-  { id: 'llama3.2:3b',       size: '2 GB',  desc: 'Fast & lightweight general-purpose' },
-  { id: 'llama3.2:8b',       size: '5 GB',  desc: 'Strong general-purpose, great quality' },
-  { id: 'mistral:7b',        size: '4 GB',  desc: 'Excellent quality/speed balance' },
-  { id: 'qwen2.5-coder:7b',  size: '4 GB',  desc: 'Code completion & generation' },
-  { id: 'codellama:13b',     size: '7 GB',  desc: 'Advanced code generation' },
-  { id: 'gemma2:9b',         size: '5 GB',  desc: 'Google, strong reasoning' },
-  { id: 'phi3:mini',         size: '2 GB',  desc: 'Microsoft, compact reasoning' },
-  { id: 'deepseek-coder:6.7b', size: '4 GB', desc: 'Code-focused, multi-language' },
-];
-
-function renderPopularModels() {
+async function renderPopularModels() {
   const grid = $('#popular-grid');
-  grid.innerHTML = POPULAR_MODELS.map(m => `
-    <button class="popular-item" data-model="${escapeAttr(m.id)}" title="Click to fill pull input">
-      <span class="popular-name">${escapeHtml(m.id)}</span>
-      <span class="popular-desc">${escapeHtml(m.desc)}</span>
-      <span class="popular-size">${escapeHtml(m.size)}</span>
-    </button>
-  `).join('');
+  try {
+    const data = await rpc('ListCatalog');
+    const models = data.models || [];
+    if (models.length === 0) {
+      grid.innerHTML = '<div class="empty-state">No catalog models.</div>';
+      return;
+    }
+    grid.innerHTML = models.map(m => `
+      <button class="popular-item" data-model="${escapeAttr(m.id)}" title="Click to fill pull input">
+        <span class="popular-name">${escapeHtml(m.id)}</span>
+        <span class="popular-desc">${escapeHtml(m.description)}</span>
+        <span class="popular-size">${escapeHtml(m.sizeHint)}</span>
+      </button>
+    `).join('');
 
-  grid.querySelectorAll('.popular-item').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const input = $('#pull-input');
-      input.value = btn.dataset.model;
-      input.focus();
+    grid.querySelectorAll('.popular-item').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const input = $('#pull-input');
+        input.value = btn.dataset.model;
+        input.focus();
+      });
     });
-  });
+  } catch (err) {
+    console.error('ListCatalog failed:', err);
+    grid.innerHTML = '<div class="empty-state">Failed to load catalog.</div>';
+  }
 }
 
 // ── Event listeners ──
@@ -471,15 +521,13 @@ $('#pull-form').addEventListener('submit', (e) => {
 // ── Initialize ──
 
 async function init() {
-  // Render static content.
-  renderPopularModels();
-
   // Fire all initial data loads in parallel.
   await Promise.allSettled([
     refreshHealth(),
     refreshModels(),
     refreshBackends(),
     refreshPulls(),
+    renderPopularModels(),
   ]);
 
   // Poll health every 5 seconds (updates badge only, not models).

--- a/cmd/candela-local/ui/style.css
+++ b/cmd/candela-local/ui/style.css
@@ -687,6 +687,34 @@ main {
   font-size: 0.72rem;
 }
 
+.model-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.btn-danger {
+  background: transparent;
+  color: #f87171;
+  border: 1px solid rgba(248, 113, 113, 0.3);
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.72rem;
+  transition: all 0.2s;
+}
+.btn-danger:hover {
+  background: rgba(248, 113, 113, 0.15);
+  border-color: #f87171;
+}
+
+.pull-cancel {
+  margin-left: auto;
+  padding: 0.15rem 0.4rem;
+  font-size: 0.65rem;
+  line-height: 1;
+}
+
 /* ── Footer ── */
 footer {
   display: flex;

--- a/cmd/candela-local/ui_integration_test.go
+++ b/cmd/candela-local/ui_integration_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestEmbeddedUI_ServesHTML verifies that the embedded management UI is served
+// correctly at /_local/ and that the HTML contains the expected structure.
+func TestEmbeddedUI_ServesHTML(t *testing.T) {
+	mux := http.NewServeMux()
+	uiContent, err := fs.Sub(uiFS, "ui")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux.Handle("/_local/", http.StripPrefix("/_local/", http.FileServer(http.FS(uiContent))))
+
+	req := httptest.NewRequest(http.MethodGet, "/_local/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	body, _ := io.ReadAll(w.Body)
+	html := string(body)
+
+	// Core structure.
+	checks := []string{
+		"Candela",
+		"app.js",
+		"style.css",
+		"models-list",
+		"popular-grid",
+		"pull-form",
+		"pull-input",
+		"btn-start",
+		"btn-stop",
+		"btn-reset",
+	}
+	for _, want := range checks {
+		if !strings.Contains(html, want) {
+			t.Errorf("HTML missing expected content: %q", want)
+		}
+	}
+}
+
+// TestEmbeddedUI_ServesCSS verifies that style.css is served.
+func TestEmbeddedUI_ServesCSS(t *testing.T) {
+	mux := http.NewServeMux()
+	uiContent, err := fs.Sub(uiFS, "ui")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux.Handle("/_local/", http.StripPrefix("/_local/", http.FileServer(http.FS(uiContent))))
+
+	req := httptest.NewRequest(http.MethodGet, "/_local/style.css", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	body, _ := io.ReadAll(w.Body)
+	css := string(body)
+
+	// Verify new UI classes exist.
+	cssChecks := []string{
+		".model-actions",
+		".btn-danger",
+		".pull-cancel",
+		".model-row",
+		".popular-item",
+	}
+	for _, want := range cssChecks {
+		if !strings.Contains(css, want) {
+			t.Errorf("CSS missing expected class: %q", want)
+		}
+	}
+}
+
+// TestEmbeddedUI_ServesJS verifies that app.js is served and contains the
+// new feature APIs (DeleteModel, CancelPull, ListCatalog).
+func TestEmbeddedUI_ServesJS(t *testing.T) {
+	mux := http.NewServeMux()
+	uiContent, err := fs.Sub(uiFS, "ui")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux.Handle("/_local/", http.StripPrefix("/_local/", http.FileServer(http.FS(uiContent))))
+
+	req := httptest.NewRequest(http.MethodGet, "/_local/app.js", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	body, _ := io.ReadAll(w.Body)
+	js := string(body)
+
+	// Verify new feature RPC calls are present.
+	jsChecks := []struct {
+		name string
+		want string
+	}{
+		{"DeleteModel RPC call", "'DeleteModel'"},
+		{"CancelPull RPC call", "'CancelPull'"},
+		{"ListCatalog RPC call", "'ListCatalog'"},
+		{"deleteModel function", "async function deleteModel"},
+		{"cancelPull function", "async function cancelPull"},
+		{"renderPopularModels is async", "async function renderPopularModels"},
+		{"delete confirmation", "Delete"},
+		{"cancel button", "cancel-pull"},
+		{"trash icon button", "btn-danger"},
+	}
+	for _, tc := range jsChecks {
+		if !strings.Contains(js, tc.want) {
+			t.Errorf("JS missing %s: expected to find %q", tc.name, tc.want)
+		}
+	}
+
+	// Verify hardcoded POPULAR_MODELS is gone.
+	if strings.Contains(js, "const POPULAR_MODELS") {
+		t.Error("JS still contains hardcoded POPULAR_MODELS; should use ListCatalog RPC")
+	}
+}

--- a/pkg/runtime/lmstudio/lmstudio.go
+++ b/pkg/runtime/lmstudio/lmstudio.go
@@ -187,3 +187,8 @@ func (r *Runtime) UnloadModel(ctx context.Context, modelID string) error {
 	slog.Info("model unloaded", "model", modelID, "backend", "lmstudio")
 	return nil
 }
+
+// DeleteModel is not supported by LM Studio (use the LM Studio GUI).
+func (r *Runtime) DeleteModel(_ context.Context, _ string) error {
+	return fmt.Errorf("lmstudio: delete not supported (use the LM Studio GUI)")
+}

--- a/pkg/runtime/manager_test.go
+++ b/pkg/runtime/manager_test.go
@@ -73,6 +73,7 @@ func (m *mockRuntime) PullModel(_ context.Context, modelID string, progress chan
 
 func (m *mockRuntime) LoadModel(_ context.Context, _ string) error   { return nil }
 func (m *mockRuntime) UnloadModel(_ context.Context, _ string) error { return nil }
+func (m *mockRuntime) DeleteModel(_ context.Context, _ string) error { return nil }
 
 func TestManagerAutoStart(t *testing.T) {
 	mock := &mockRuntime{

--- a/pkg/runtime/ollama/ollama.go
+++ b/pkg/runtime/ollama/ollama.go
@@ -313,11 +313,12 @@ func (r *Runtime) DeleteModel(ctx context.Context, modelID string) error {
 		return fmt.Errorf("ollama: delete %q: %w", modelID, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	_, _ = io.Copy(io.Discard, resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("ollama: delete %q: status %d", modelID, resp.StatusCode)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("ollama: delete %q: status %d: %s", modelID, resp.StatusCode, respBody)
 	}
+	_, _ = io.Copy(io.Discard, resp.Body)
 	slog.Info("model deleted", "model", modelID, "backend", "ollama")
 	return nil
 }

--- a/pkg/runtime/ollama/ollama.go
+++ b/pkg/runtime/ollama/ollama.go
@@ -290,3 +290,34 @@ func (r *Runtime) sendKeepAlive(ctx context.Context, modelID string, keepAlive i
 	slog.Info("model "+action+"ed", "model", modelID, "backend", "ollama")
 	return nil
 }
+
+// DeleteModel removes a model from disk via the Ollama API.
+func (r *Runtime) DeleteModel(ctx context.Context, modelID string) error {
+	reqBody := struct {
+		Name string `json:"name"`
+	}{Name: modelID}
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
+		r.baseURL()+"/api/delete", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("ollama: delete %q: %w", modelID, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("ollama: delete %q: status %d", modelID, resp.StatusCode)
+	}
+	slog.Info("model deleted", "model", modelID, "backend", "ollama")
+	return nil
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -96,4 +96,9 @@ type Runtime interface {
 	// UnloadModel removes a model from GPU memory.
 	// For vLLM this stops the process entirely.
 	UnloadModel(ctx context.Context, modelID string) error
+
+	// DeleteModel removes a model from disk entirely.
+	// Only supported by runtimes that manage their own model storage
+	// (e.g. Ollama). Returns an error for unsupported runtimes.
+	DeleteModel(ctx context.Context, modelID string) error
 }

--- a/pkg/runtime/vllm/vllm.go
+++ b/pkg/runtime/vllm/vllm.go
@@ -216,3 +216,8 @@ func (r *Runtime) UnloadModel(ctx context.Context, modelID string) error {
 	slog.Info("vllm: unloading model (stopping process)", "model", modelID)
 	return r.Stop(ctx)
 }
+
+// DeleteModel is not supported by vLLM (models live in HuggingFace cache).
+func (r *Runtime) DeleteModel(_ context.Context, _ string) error {
+	return fmt.Errorf("vllm: delete not supported (remove from HuggingFace cache manually)")
+}

--- a/proto/candela/v1/runtime_service.proto
+++ b/proto/candela/v1/runtime_service.proto
@@ -45,6 +45,12 @@ service RuntimeService {
   // Poll GetHealth or ListModels to see when the model appears.
   rpc PullModel(PullModelRequest) returns (PullModelResponse);
 
+  // CancelPull cancels an in-flight model download.
+  rpc CancelPull(CancelPullRequest) returns (CancelPullResponse);
+
+  // DeleteModel removes a model from disk. Only supported by Ollama.
+  rpc DeleteModel(DeleteModelRequest) returns (DeleteModelResponse);
+
   // ── Discovery ──
 
   // ListBackends returns registered runtime backends and their install status.
@@ -55,6 +61,11 @@ service RuntimeService {
   // ResetState clears all local state (preferences, pull history) from the
   // state database. The YAML config file is not affected.
   rpc ResetState(ResetStateRequest) returns (ResetStateResponse);
+
+  // ── Catalog ──
+
+  // ListCatalog returns the user's model catalog (suggested models to pull).
+  rpc ListCatalog(ListCatalogRequest) returns (ListCatalogResponse);
 }
 
 // ── Shared types ──
@@ -177,3 +188,37 @@ message ListBackendsResponse {
 message ResetStateRequest {}
 
 message ResetStateResponse {}
+
+message CancelPullRequest {
+  // Model whose pull should be cancelled.
+  string model = 1;
+}
+
+message CancelPullResponse {}
+
+message DeleteModelRequest {
+  // Model to delete from disk (e.g. "llama3.2:3b").
+  string model = 1;
+}
+
+message DeleteModelResponse {}
+
+// CatalogModel describes a suggested model in the user's catalog.
+message CatalogModel {
+  // Model identifier (e.g. "llama3.2:3b").
+  string id = 1;
+  // Display name.
+  string name = 2;
+  // Short description.
+  string description = 3;
+  // Approximate download size (e.g. "2.0 GB").
+  string size_hint = 4;
+  // User-pinned favorite.
+  bool pinned = 5;
+}
+
+message ListCatalogRequest {}
+
+message ListCatalogResponse {
+  repeated CatalogModel models = 1;
+}


### PR DESCRIPTION
## Summary

Adds three new model lifecycle features to `candela-local`:

### Delete Model
- `DeleteModel` RPC via ConnectRPC
- Ollama implementation using `DELETE /api/delete`
- vLLM/LM Studio stubs return "not supported"
- UI: 🗑 trash icon on each model row with confirm dialog

### Cancel Pull
- `CancelPull` RPC with per-pull `context.WithCancel`
- Cancelling fires the cancel func stored on `pullStatus`, which propagates to the runtime's `PullModel` call
- UI: ✕ cancel button on active pull progress bars
- Pull status correctly distinguishes "cancelled" vs "failed"

### State DB Catalog (`local_model_catalog`)
- New `local_model_catalog` table in SQLite, seeded with 8 popular models on first run
- `ListCatalog` RPC replaces the hardcoded JS `POPULAR_MODELS` array
- `AddToCatalog` / `RemoveFromCatalog` DB methods for future use
- Table named `local_model_catalog` (not `model_catalog`) to leave room for a future remote catalog

### Tests (12 new)
| Layer | Tests |
|-------|-------|
| RPC Handlers | DeleteModel (happy + empty), CancelPull (cancel + not-found), ListCatalog (data + nil-db) |
| State DB | Seeded catalog, Add/Remove, Pinned ordering |
| UI Integration | HTML structure, CSS classes, JS API references, no hardcoded models |

Also fixed mock `PullModel` to respect `ctx.Done()` (was using `time.Sleep` which ignored cancellation).

All 15 packages pass with `-race`.