### PR TITLE
fix: model management polish

### DIFF
--- a/cmd/candela-local/runtime_handler.go
+++ b/cmd/candela-local/runtime_handler.go
@@ -193,6 +193,7 @@ func (h *runtimeHandler) PullModel(
 	// Use a progress channel so we can track download percent.
 	progress := make(chan runtime.PullProgress, 16)
 	go func() {
+		defer pullCancel() // always release context resources
 		// Drain progress updates.
 		progressDone := make(chan struct{})
 		go func() {
@@ -313,8 +314,14 @@ func (h *runtimeHandler) DeleteModel(
 	if model == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errModelRequired)
 	}
-	if _, pulling := h.activePulls.Load(model); pulling {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("cannot delete model %q while it is being pulled", model))
+	if val, ok := h.activePulls.Load(model); ok {
+		ps := val.(*pullStatus)
+		ps.mu.Lock()
+		status := ps.Status
+		ps.mu.Unlock()
+		if status == "pulling" {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("cannot delete model %q while it is being pulled", model))
+		}
 	}
 	if err := h.mgr.Runtime().DeleteModel(ctx, model); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -336,6 +343,12 @@ func (h *runtimeHandler) CancelPull(
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("no active pull for %q", model))
 	}
 	ps := val.(*pullStatus)
+	ps.mu.Lock()
+	status := ps.Status
+	ps.mu.Unlock()
+	if status != "pulling" {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("pull for %q is already %s", model, status))
+	}
 	ps.mu.Lock()
 	if ps.cancel != nil {
 		ps.cancel()

--- a/cmd/candela-local/runtime_handler_test.go
+++ b/cmd/candela-local/runtime_handler_test.go
@@ -779,3 +779,100 @@ func TestRPC_ListCatalog_NoStateDB(t *testing.T) {
 		t.Errorf("code = %v, want FailedPrecondition", connect.CodeOf(err))
 	}
 }
+
+func TestRPC_DeleteModel_AllowedAfterPullComplete(t *testing.T) {
+	mock := &rpcMockRuntime{healthy: true}
+	mgr := runtime.NewManager(mock, runtime.ManagerConfig{HealthCheck: 10 * time.Second})
+	if err := mgr.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	h := newRuntimeHandler(mgr, nil, context.Background())
+
+	// Simulate a completed pull sitting in activePulls (status="complete").
+	ps := &pullStatus{Model: "llama3.2:8b", Status: "complete", Percent: 100}
+	h.activePulls.Store("llama3.2:8b", ps)
+
+	mux := http.NewServeMux()
+	path, handler := candelav1connect.NewRuntimeServiceHandler(h)
+	mux.Handle(path, handler)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	client := candelav1connect.NewRuntimeServiceClient(http.DefaultClient, srv.URL)
+
+	// Delete should succeed — pull is complete, not active.
+	_, err := client.DeleteModel(context.Background(),
+		connect.NewRequest(&v1.DeleteModelRequest{Model: "llama3.2:8b"}))
+	if err != nil {
+		t.Fatalf("delete should succeed after pull completes, got: %v", err)
+	}
+}
+
+func TestRPC_DeleteModel_BlockedDuringActivePull(t *testing.T) {
+	mock := &rpcMockRuntime{healthy: true, pullDelay: 5 * time.Second}
+	mgr := runtime.NewManager(mock, runtime.ManagerConfig{HealthCheck: 10 * time.Second})
+	if err := mgr.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	h := newRuntimeHandler(mgr, nil, context.Background())
+
+	mux := http.NewServeMux()
+	path, handler := candelav1connect.NewRuntimeServiceHandler(h)
+	mux.Handle(path, handler)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	client := candelav1connect.NewRuntimeServiceClient(http.DefaultClient, srv.URL)
+
+	// Start a pull.
+	_, err := client.PullModel(context.Background(),
+		connect.NewRequest(&v1.PullModelRequest{Model: "big-model:70b"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	// Delete should be blocked while pulling.
+	_, err = client.DeleteModel(context.Background(),
+		connect.NewRequest(&v1.DeleteModelRequest{Model: "big-model:70b"}))
+	if err == nil {
+		t.Fatal("delete should be blocked during active pull")
+	}
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+}
+
+func TestRPC_CancelPull_RejectsCompletedPull(t *testing.T) {
+	mock := &rpcMockRuntime{healthy: true}
+	mgr := runtime.NewManager(mock, runtime.ManagerConfig{HealthCheck: 10 * time.Second})
+	if err := mgr.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	h := newRuntimeHandler(mgr, nil, context.Background())
+
+	// Simulate a completed pull.
+	ps := &pullStatus{Model: "done-model:7b", Status: "complete", Percent: 100}
+	h.activePulls.Store("done-model:7b", ps)
+
+	mux := http.NewServeMux()
+	path, handler := candelav1connect.NewRuntimeServiceHandler(h)
+	mux.Handle(path, handler)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	client := candelav1connect.NewRuntimeServiceClient(http.DefaultClient, srv.URL)
+
+	// Cancel should fail — pull already completed.
+	_, err := client.CancelPull(context.Background(),
+		connect.NewRequest(&v1.CancelPullRequest{Model: "done-model:7b"}))
+	if err == nil {
+		t.Fatal("cancel should reject already-completed pull")
+	}
+	if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", connect.CodeOf(err))
+	}
+}

--- a/cmd/candela-local/ui/app.js
+++ b/cmd/candela-local/ui/app.js
@@ -50,6 +50,8 @@ function formatUptime(seconds) {
 
 let currentHealth = null;
 let pollTimer = null;
+let pullPollTimer = null;
+const completedPulls = new Set(); // tracks models we've already refreshed for
 
 // ── Render functions ──
 
@@ -178,8 +180,6 @@ function renderModels(models) {
 
 // ── Active Pulls ──
 
-let pullPollTimer = null;
-
 function renderActivePulls(pulls) {
   let container = $('#models-list').querySelector('.active-pulls');
   if (!pulls || pulls.length === 0) {
@@ -248,6 +248,23 @@ async function refreshPulls() {
     const resp = await fetch('/_local/api/pulls');
     const pulls = await resp.json();
     renderActivePulls(pulls);
+
+    // Auto-refresh model list when a pull completes.
+    if (pulls) {
+      let needsRefresh = false;
+      for (const p of pulls) {
+        if (p.status === 'complete' && !completedPulls.has(p.model)) {
+          completedPulls.add(p.model);
+          needsRefresh = true;
+        }
+      }
+      if (needsRefresh) refreshModels();
+      // Clean up completed entries that are no longer in the list.
+      const activeModels = new Set(pulls.map(p => p.model));
+      for (const m of completedPulls) {
+        if (!activeModels.has(m)) completedPulls.delete(m);
+      }
+    }
   } catch (err) {
     console.error('refreshPulls failed:', err);
   }

--- a/cmd/candela-local/ui_integration_test.go
+++ b/cmd/candela-local/ui_integration_test.go
@@ -120,6 +120,8 @@ func TestEmbeddedUI_ServesJS(t *testing.T) {
 		{"delete confirmation", "Delete"},
 		{"cancel button", "cancel-pull"},
 		{"trash icon button", "btn-danger"},
+		{"auto-refresh on complete", "completedPulls"},
+		{"refreshModels on pull complete", "refreshModels()"},
 	}
 	for _, tc := range jsChecks {
 		if !strings.Contains(js, tc.want) {

--- a/pkg/runtime/ollama/ollama_test.go
+++ b/pkg/runtime/ollama/ollama_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/candelahq/candela/pkg/runtime"
@@ -203,5 +204,62 @@ func TestLoadModel_ServerDown(t *testing.T) {
 	err := rt.LoadModel(context.Background(), "llama3.2:8b")
 	if err == nil {
 		t.Fatal("LoadModel() should return error when server is down")
+	}
+}
+
+func TestDeleteModel(t *testing.T) {
+	var receivedMethod, receivedModel string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/delete", func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		var body struct {
+			Name string `json:"name"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		receivedModel = body.Name
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rt := testServer(t, mux)
+
+	if err := rt.DeleteModel(context.Background(), "llama3.2:8b"); err != nil {
+		t.Fatalf("DeleteModel() error: %v", err)
+	}
+	if receivedMethod != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", receivedMethod)
+	}
+	if receivedModel != "llama3.2:8b" {
+		t.Errorf("model = %q, want %q", receivedModel, "llama3.2:8b")
+	}
+}
+
+func TestDeleteModel_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/delete", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"model 'nonexistent' not found"}`))
+	})
+
+	rt := testServer(t, mux)
+
+	err := rt.DeleteModel(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("DeleteModel() should return error for 404")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("error should contain model name, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should contain response body, got: %v", err)
+	}
+}
+
+func TestDeleteModel_ServerDown(t *testing.T) {
+	rt, _ := New(runtime.Config{Host: "127.0.0.1", Port: 19999})
+
+	err := rt.DeleteModel(context.Background(), "llama3.2:8b")
+	if err == nil {
+		t.Fatal("DeleteModel() should return error when server is down")
 	}
 }


### PR DESCRIPTION
## Summary

Three polish items for the model management feature:

### 1. Ollama DeleteModel HTTP tests
Added mock server tests in `ollama_test.go`:
- **TestDeleteModel** — verifies DELETE method, `/api/delete` path, and request body
- **TestDeleteModel_NotFound** — 404 response includes error body in message
- **TestDeleteModel_ServerDown** — connection refused returns error

### 2. Auto-refresh model list on pull complete
When the 2s pull poller detects a status change to `complete`, it now automatically calls `refreshModels()` so the new model appears in the list without manual refresh. Uses a `completedPulls` Set to avoid duplicate refresh calls.

### 3. Context leak fix
Added `defer pullCancel()` at the top of the pull goroutine so the context is always released — success, failure, or cancel. Previously the cancel func was only called via the CancelPull RPC.

Also fixed a duplicate `pullPollTimer` variable declaration in app.js.