### PR TITLE
feat: unified model discovery — merge local + remote in /v1/models

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,18 +103,30 @@ response = client.messages.create(...)
 
 ```mermaid
 graph TD
-    subgraph "Your Application"
-        App[App Logic]
-        SDK[OTel SDK / LLM Client]
+    subgraph "Developer Tools"
+        JB[JetBrains / Cline]
+        App[App / Agent]
+        SDK[OTel SDK]
     end
 
-    subgraph "Candela Platform"
-        Proxy[LLM API Proxy]
+    subgraph "candela-local"
+        LM["LM Compat Listener (:1234)<br/>Unified /v1/models"]
+        LP[Local Proxy]
+        RP[Remote Proxy + Auth]
+    end
+
+    subgraph "Local Runtimes"
+        Ollama["Ollama (:11434)"]
+        VLLM["vLLM (:8000)"]
+        LMS["LM Studio (:1234)"]
+    end
+
+    subgraph "Candela Cloud"
         Server[Go Backend Server]
+        Proxy[LLM API Proxy]
         Processor[Span Processor<br/>Fan-out to Writers]
-        DuckDB[(DuckDB<br/>SpanWriter + SpanReader)]
-        BQ[(BigQuery<br/>SpanWriter + SpanReader)]
-        PubSub[Pub/Sub<br/>SpanWriter Only]
+        DuckDB[(DuckDB)]
+        BQ[(BigQuery)]
     end
 
     subgraph "Upstream LLMs"
@@ -123,17 +135,21 @@ graph TD
         OAI[OpenAI]
     end
 
-    App -->|Proxy Mode| Proxy
-    App -->|OTel Mode| Server
+    JB -->|/v1/models<br/>/v1/chat/completions| LM
+    LM -->|Local model| LP
+    LM -->|Remote model| RP
+    LP --> Ollama
+    LP -.-> VLLM
+    LP -.-> LMS
+    RP -->|OIDC Auth| Server
+    App -->|Proxy Mode| RP
+    App -->|OTel Mode| SDK --> Server
     Proxy -->|Forward| VAI
     Proxy -->|Forward| ANT
     Proxy -->|Forward| OAI
-    Proxy -.->|Capture| Server
-    Server --> Processor
+    Proxy -.->|Capture| Processor
     Processor -->|Write| DuckDB
     Processor -.->|Write| BQ
-    Processor -.->|Write| PubSub
-    DuckDB -->|Read| Server
 ```
 
 ### Storage Architecture (CQRS)
@@ -217,9 +233,28 @@ The UI communicates with the backend via **ConnectRPC v2** on `localhost:8080`. 
 
 ---
 
-## 🕹️ candela-local — Runtime Management
+## 🕹️ candela-local — Local Development Proxy
 
-`candela-local` includes an embedded management UI at `/_local/` for controlling local LLM runtimes:
+`candela-local` is an auth-injecting proxy + runtime manager for developer machines.
+
+### Unified Model Discovery
+
+The LM-compatible listener on `:1234` merges **local** and **remote** models into a single `/v1/models` response:
+
+```bash
+# JetBrains, Cline, or any OpenAI-compatible client sees everything:
+curl http://localhost:1234/v1/models
+# → local: llama3.2:3b, mistral:7b (from Ollama)
+# → remote: gpt-4o, claude-3.5-sonnet (from Cloud Run)
+```
+
+`/v1/chat/completions` automatically routes to the right backend:
+- **Local model** → Ollama/vLLM/LM Studio (no round-trip)
+- **Remote model** → Cloud Run proxy (with OIDC auth injection)
+
+### Runtime Management UI
+
+Embedded management UI at `/_local/` for controlling local LLM runtimes:
 
 - **Runtime control** — Start/stop Ollama, vLLM, or LM Studio; health monitoring with auto-polling
 - **Model management** — List, load, unload, and **delete** models from disk

--- a/cmd/candela-local/lm_handler.go
+++ b/cmd/candela-local/lm_handler.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/candelahq/candela/pkg/runtime"
+)
+
+// lmHandler implements a smart HTTP handler for the LM Studio compat listener.
+// It intercepts /v1/models (merging local + remote models) and
+// /v1/chat/completions (routing local models to the local runtime).
+// All other paths pass through to the remote proxy.
+type lmHandler struct {
+	mgr         *runtime.Manager       // local runtime manager (may be nil)
+	remoteProxy *httputil.ReverseProxy // proxy to remote Candela server
+	localProxy  *httputil.ReverseProxy // proxy to local runtime (e.g. Ollama)
+
+	localModels sync.Map // model ID string → bool (cached for fast routing)
+}
+
+// newLMHandler creates a smart LM compat handler that merges local + remote
+// models and routes chat completions to the correct backend.
+func newLMHandler(mgr *runtime.Manager, remoteProxy, localProxy *httputil.ReverseProxy) *lmHandler {
+	return &lmHandler{
+		mgr:         mgr,
+		remoteProxy: remoteProxy,
+		localProxy:  localProxy,
+	}
+}
+
+func (h *lmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/v1/models" && r.Method == http.MethodGet:
+		h.serveModels(w, r)
+	case r.URL.Path == "/v1/chat/completions" && r.Method == http.MethodPost:
+		h.serveChat(w, r)
+	default:
+		h.remoteProxy.ServeHTTP(w, r)
+	}
+}
+
+// openaiModel represents a model in the OpenAI /v1/models response.
+type openaiModel struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	OwnedBy string `json:"owned_by"`
+}
+
+// openaiModelList is the OpenAI /v1/models response format.
+type openaiModelList struct {
+	Object string        `json:"object"`
+	Data   []openaiModel `json:"data"`
+}
+
+// serveModels merges local runtime models with remote cloud models.
+func (h *lmHandler) serveModels(w http.ResponseWriter, r *http.Request) {
+	var merged []openaiModel
+
+	// 1. Fetch local models from the runtime.
+	if h.mgr != nil && h.localProxy != nil {
+		models, err := h.mgr.Runtime().ListModels(r.Context())
+		if err != nil {
+			slog.Warn("lm handler: failed to list local models", "error", err)
+		} else {
+			backendName := h.mgr.Runtime().Name()
+			// Refresh the cached model set.
+			newSet := make(map[string]bool, len(models))
+			for _, m := range models {
+				merged = append(merged, openaiModel{
+					ID:      m.ID,
+					Object:  "model",
+					OwnedBy: backendName,
+				})
+				newSet[m.ID] = true
+				h.localModels.Store(m.ID, true)
+			}
+			// Remove stale entries.
+			h.localModels.Range(func(key, _ any) bool {
+				if !newSet[key.(string)] {
+					h.localModels.Delete(key)
+				}
+				return true
+			})
+		}
+	}
+
+	// 2. Fetch remote models by proxying to the remote Candela server.
+	remoteModels := h.fetchRemoteModels(r)
+	merged = append(merged, remoteModels...)
+
+	// 3. Return merged OpenAI-format response.
+	w.Header().Set("Content-Type", "application/json")
+	resp := openaiModelList{Object: "list", Data: merged}
+	if resp.Data == nil {
+		resp.Data = []openaiModel{} // never return null
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// fetchRemoteModels proxies a GET /v1/models to the remote server and parses the response.
+func (h *lmHandler) fetchRemoteModels(r *http.Request) []openaiModel {
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	rec := &responseRecorder{headers: make(http.Header)}
+	req := r.Clone(ctx)
+	h.remoteProxy.ServeHTTP(rec, req)
+
+	if rec.statusCode != http.StatusOK {
+		slog.Warn("lm handler: remote /v1/models failed", "status", rec.statusCode)
+		return nil
+	}
+
+	var resp openaiModelList
+	if err := json.Unmarshal(rec.body.Bytes(), &resp); err != nil {
+		slog.Warn("lm handler: failed to parse remote models", "error", err)
+		return nil
+	}
+	return resp.Data
+}
+
+// serveChat routes chat completions to the local runtime or remote server.
+func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
+	// Read body to peek at the model field (10MB limit to prevent OOM).
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 10<<20))
+	if err != nil {
+		http.Error(w, `{"error":"request body too large or unreadable"}`, http.StatusRequestEntityTooLarge)
+		return
+	}
+	_ = r.Body.Close()
+
+	var req struct {
+		Model string `json:"model"`
+	}
+	_ = json.Unmarshal(body, &req)
+
+	// Replay body for the proxy.
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+
+	if h.isLocalModel(req.Model) {
+		slog.Debug("lm handler: routing to local runtime", "model", req.Model)
+		h.localProxy.ServeHTTP(w, r)
+	} else {
+		h.remoteProxy.ServeHTTP(w, r)
+	}
+}
+
+// isLocalModel checks if a model is served by the local runtime.
+func (h *lmHandler) isLocalModel(model string) bool {
+	if model == "" || h.mgr == nil || h.localProxy == nil {
+		return false
+	}
+	_, ok := h.localModels.Load(model)
+	if ok {
+		return true
+	}
+	// Also check without tag (e.g., "llama3.2" → "llama3.2:latest").
+	if !strings.Contains(model, ":") {
+		_, ok = h.localModels.Load(model + ":latest")
+		return ok
+	}
+	return false
+}
+
+// responseRecorder captures a proxy response for parsing.
+type responseRecorder struct {
+	headers    http.Header
+	body       bytes.Buffer
+	statusCode int
+}
+
+func (r *responseRecorder) Header() http.Header { return r.headers }
+func (r *responseRecorder) Write(b []byte) (int, error) {
+	if r.statusCode == 0 {
+		r.statusCode = http.StatusOK // match net/http implicit behavior
+	}
+	return r.body.Write(b)
+}
+func (r *responseRecorder) WriteHeader(code int) { r.statusCode = code }

--- a/cmd/candela-local/lm_handler_test.go
+++ b/cmd/candela-local/lm_handler_test.go
@@ -1,0 +1,368 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/runtime"
+)
+
+// mockRemoteServer returns an httptest.Server that responds to GET /v1/models
+// with a canned OpenAI-format response.
+func mockRemoteServer(t *testing.T, models []openaiModel) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/models" && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(openaiModelList{
+				Object: "list",
+				Data:   models,
+			})
+			return
+		}
+		if r.URL.Path == "/v1/chat/completions" && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"source": "remote"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// mockLocalServer returns an httptest.Server that responds to POST /v1/chat/completions.
+func mockLocalServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/chat/completions" && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"source": "local"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func proxyTo(target string) *httputil.ReverseProxy {
+	u, _ := url.Parse(target)
+	return httputil.NewSingleHostReverseProxy(u)
+}
+
+// lmMockRuntime is a minimal mock that returns canned models.
+type lmMockRuntime struct {
+	runtime.Runtime
+	models []runtime.Model
+}
+
+func (m *lmMockRuntime) Name() string { return "ollama" }
+func (m *lmMockRuntime) ListModels(_ context.Context) ([]runtime.Model, error) {
+	return m.models, nil
+}
+func (m *lmMockRuntime) Health(_ context.Context) (*runtime.Health, error) {
+	return &runtime.Health{Status: runtime.StatusRunning}, nil
+}
+func (m *lmMockRuntime) Start(_ context.Context) error { return nil }
+func (m *lmMockRuntime) Stop(_ context.Context) error  { return nil }
+func (m *lmMockRuntime) Endpoint() string              { return "http://127.0.0.1:11434" }
+func (m *lmMockRuntime) PullModel(_ context.Context, _ string, _ chan<- runtime.PullProgress) error {
+	return nil
+}
+func (m *lmMockRuntime) LoadModel(_ context.Context, _ string) error   { return nil }
+func (m *lmMockRuntime) UnloadModel(_ context.Context, _ string) error { return nil }
+func (m *lmMockRuntime) DeleteModel(_ context.Context, _ string) error { return nil }
+
+func setupLMHandler(t *testing.T, localModels []runtime.Model, remoteModels []openaiModel) (*lmHandler, *httptest.Server) {
+	t.Helper()
+
+	remoteSrv := mockRemoteServer(t, remoteModels)
+	localSrv := mockLocalServer(t)
+
+	mock := &lmMockRuntime{models: localModels}
+	mgr := runtime.NewManager(mock, runtime.ManagerConfig{HealthCheck: 10 * 1e9}) // 10s
+	if err := mgr.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
+
+	h := newLMHandler(mgr, proxyTo(remoteSrv.URL), proxyTo(localSrv.URL))
+
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return h, srv
+}
+
+func TestLMHandler_Models_MergesLocalAndRemote(t *testing.T) {
+	localModels := []runtime.Model{
+		{ID: "llama3.2:3b"},
+		{ID: "mistral:7b"},
+	}
+	remoteModels := []openaiModel{
+		{ID: "gpt-4o", Object: "model", OwnedBy: "openai"},
+		{ID: "claude-3.5-sonnet", Object: "model", OwnedBy: "anthropic"},
+	}
+
+	_, srv := setupLMHandler(t, localModels, remoteModels)
+
+	resp, err := http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var result openaiModelList
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Data) != 4 {
+		t.Fatalf("got %d models, want 4", len(result.Data))
+	}
+
+	// Check local models are first, owned by "ollama".
+	if result.Data[0].ID != "llama3.2:3b" || result.Data[0].OwnedBy != "ollama" {
+		t.Errorf("first model = %+v, want llama3.2:3b owned by ollama", result.Data[0])
+	}
+	if result.Data[1].ID != "mistral:7b" || result.Data[1].OwnedBy != "ollama" {
+		t.Errorf("second model = %+v, want mistral:7b owned by ollama", result.Data[1])
+	}
+
+	// Check remote models follow.
+	if result.Data[2].ID != "gpt-4o" || result.Data[2].OwnedBy != "openai" {
+		t.Errorf("third model = %+v, want gpt-4o owned by openai", result.Data[2])
+	}
+	if result.Data[3].ID != "claude-3.5-sonnet" || result.Data[3].OwnedBy != "anthropic" {
+		t.Errorf("fourth model = %+v, want claude-3.5-sonnet owned by anthropic", result.Data[3])
+	}
+}
+
+func TestLMHandler_Models_NoRuntime(t *testing.T) {
+	remoteModels := []openaiModel{
+		{ID: "gpt-4o", Object: "model", OwnedBy: "openai"},
+	}
+
+	remoteSrv := mockRemoteServer(t, remoteModels)
+
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result openaiModelList
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+
+	if len(result.Data) != 1 {
+		t.Fatalf("got %d models, want 1 (remote only)", len(result.Data))
+	}
+	if result.Data[0].ID != "gpt-4o" {
+		t.Errorf("model = %q, want gpt-4o", result.Data[0].ID)
+	}
+}
+
+func TestLMHandler_Models_RemoteDown(t *testing.T) {
+	localModels := []runtime.Model{{ID: "llama3.2:3b"}}
+
+	// Remote server that always fails.
+	failSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer failSrv.Close()
+
+	localSrv := mockLocalServer(t)
+
+	mock := &lmMockRuntime{models: localModels}
+	mgr := runtime.NewManager(mock, runtime.ManagerConfig{HealthCheck: 10 * 1e9})
+	_ = mgr.Start(context.Background())
+	defer func() { _ = mgr.Stop(context.Background()) }()
+
+	h := newLMHandler(mgr, proxyTo(failSrv.URL), proxyTo(localSrv.URL))
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result openaiModelList
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+
+	// Should still return local models even when remote is down.
+	if len(result.Data) != 1 {
+		t.Fatalf("got %d models, want 1 (local only)", len(result.Data))
+	}
+	if result.Data[0].ID != "llama3.2:3b" {
+		t.Errorf("model = %q, want llama3.2:3b", result.Data[0].ID)
+	}
+}
+
+func TestLMHandler_Chat_RoutesLocalModel(t *testing.T) {
+	localModels := []runtime.Model{{ID: "llama3.2:3b"}}
+	remoteModels := []openaiModel{{ID: "gpt-4o", Object: "model", OwnedBy: "openai"}}
+
+	_, srv := setupLMHandler(t, localModels, remoteModels)
+
+	// First, call /v1/models to populate the local model cache.
+	resp, _ := http.Get(srv.URL + "/v1/models")
+	_ = resp.Body.Close()
+
+	// Now send a chat completion with a local model.
+	body := `{"model": "llama3.2:3b", "messages": [{"role": "user", "content": "hi"}]}`
+	resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result map[string]string
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+
+	if result["source"] != "local" {
+		t.Errorf("source = %q, want local", result["source"])
+	}
+}
+
+func TestLMHandler_Chat_RoutesRemoteModel(t *testing.T) {
+	localModels := []runtime.Model{{ID: "llama3.2:3b"}}
+	remoteModels := []openaiModel{{ID: "gpt-4o", Object: "model", OwnedBy: "openai"}}
+
+	_, srv := setupLMHandler(t, localModels, remoteModels)
+
+	// Populate cache.
+	resp, _ := http.Get(srv.URL + "/v1/models")
+	_ = resp.Body.Close()
+
+	// Send chat completion with a remote model.
+	body := `{"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]}`
+	resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result map[string]string
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+
+	if result["source"] != "remote" {
+		t.Errorf("source = %q, want remote", result["source"])
+	}
+}
+
+func TestLMHandler_Chat_UnknownModelDefaultsToRemote(t *testing.T) {
+	localModels := []runtime.Model{{ID: "llama3.2:3b"}}
+	remoteModels := []openaiModel{{ID: "gpt-4o", Object: "model", OwnedBy: "openai"}}
+
+	_, srv := setupLMHandler(t, localModels, remoteModels)
+
+	// Populate cache.
+	resp, _ := http.Get(srv.URL + "/v1/models")
+	_ = resp.Body.Close()
+
+	// Send chat completion with unknown model — should go to remote.
+	body := `{"model": "some-unknown-model", "messages": [{"role": "user", "content": "hi"}]}`
+	resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result map[string]string
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+
+	if result["source"] != "remote" {
+		t.Errorf("source = %q, want remote (default for unknown models)", result["source"])
+	}
+}
+
+func TestLMHandler_Passthrough(t *testing.T) {
+	remoteSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"path": r.URL.Path})
+	}))
+	defer remoteSrv.Close()
+
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v0/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "/api/v0/models") {
+		t.Errorf("passthrough failed, got: %s", body)
+	}
+}
+
+func TestLMHandler_Chat_TaglessModelMatch(t *testing.T) {
+	// Local model is "llama3.2:latest", request uses "llama3.2" (no tag).
+	localModels := []runtime.Model{{ID: "llama3.2:latest"}}
+	remoteModels := []openaiModel{{ID: "gpt-4o", Object: "model", OwnedBy: "openai"}}
+
+	_, srv := setupLMHandler(t, localModels, remoteModels)
+
+	// Populate cache.
+	resp, _ := http.Get(srv.URL + "/v1/models")
+	_ = resp.Body.Close()
+
+	// Request with tag-less model name should match local.
+	body := `{"model": "llama3.2", "messages": [{"role": "user", "content": "hi"}]}`
+	resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result map[string]string
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+
+	if result["source"] != "local" {
+		t.Errorf("source = %q, want local (tag-less match)", result["source"])
+	}
+}
+
+func TestLMHandler_Chat_MalformedBody(t *testing.T) {
+	localModels := []runtime.Model{{ID: "llama3.2:3b"}}
+	remoteModels := []openaiModel{{ID: "gpt-4o", Object: "model", OwnedBy: "openai"}}
+
+	_, srv := setupLMHandler(t, localModels, remoteModels)
+
+	// Send malformed JSON — should default to remote without crashing.
+	resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json", strings.NewReader("not json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result map[string]string
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+
+	// Should fallback to remote (model field is empty → not local).
+	if result["source"] != "remote" {
+		t.Errorf("source = %q, want remote (malformed body fallback)", result["source"])
+	}
+}

--- a/cmd/candela-local/main.go
+++ b/cmd/candela-local/main.go
@@ -278,14 +278,29 @@ func main() {
 	}
 
 	// ── LM Studio compat listener ──
-	// Starts a secondary proxy on a separate port (default 1234) so IntelliJ's
-	// "Enable LM Studio" checkbox works with zero URL changes. The remote
-	// Candela server serves /v1/models, /v1/chat/completions, and /api/v0/models.
+	// Starts a secondary listener on a separate port (default 1234) so IntelliJ's
+	// "Enable LM Studio" checkbox works with zero URL changes.
+	// Uses a smart handler that merges local runtime models with remote cloud
+	// models and routes chat/completions to the right backend.
 	lmPort := cfg.LMStudioPort
 	if lmPort == 0 {
 		lmPort = 1234
 	}
 	var lmSrv *http.Server
+
+	// Build a local proxy for the runtime (use explicit local_upstream or runtime endpoint).
+	var runtimeLocalProxy *httputil.ReverseProxy
+	if cfg.LocalUpstream != "" {
+		// Reuse the already-configured local upstream proxy target.
+		runtimeLocalProxy = buildLocalProxy(cfg.LocalUpstream)
+	} else if mgr != nil {
+		// Auto-create a local proxy pointing at the runtime endpoint.
+		runtimeLocalProxy = buildLocalProxy(mgr.Runtime().Endpoint())
+	}
+
+	// Build the smart LM handler.
+	lmH := newLMHandler(mgr, proxy, runtimeLocalProxy)
+	lmAddr := fmt.Sprintf("127.0.0.1:%d", lmPort)
 
 	// ── Graceful shutdown ──
 	sigCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
@@ -313,8 +328,7 @@ func main() {
 	}()
 
 	// Start LM Studio compat listener on separate port.
-	lmAddr := fmt.Sprintf("127.0.0.1:%d", lmPort)
-	lmSrv = &http.Server{Addr: lmAddr, Handler: proxy}
+	lmSrv = &http.Server{Addr: lmAddr, Handler: lmH}
 	go func() {
 		slog.Info("🖥️ LM Studio compat listener started",
 			"addr", fmt.Sprintf("http://%s", lmAddr),
@@ -417,4 +431,29 @@ func singleJoiningSlash(a, b string) string {
 		return a + "/" + b
 	}
 	return a + b
+}
+
+// buildLocalProxy creates a reverse proxy to a local runtime endpoint.
+func buildLocalProxy(upstream string) *httputil.ReverseProxy {
+	u, err := url.Parse(upstream)
+	if err != nil {
+		slog.Warn("invalid local proxy URL", "url", upstream, "error", err)
+		return nil
+	}
+	return &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = u.Scheme
+			req.URL.Host = u.Host
+			req.Host = u.Host
+			if _, ok := req.Header["User-Agent"]; !ok {
+				req.Header.Set("User-Agent", "candela-local/1.0")
+			}
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			slog.Error("local proxy error", "path", r.URL.Path, "error", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadGateway)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("local runtime unavailable: %v", err)})
+		},
+	}
 }


### PR DESCRIPTION
## Summary

Adds a smart LM compat handler for the `:1234` listener that replaces the dumb remote-only proxy.

### What it does

| Endpoint | Before | After |
|----------|--------|-------|
| `GET /v1/models` | Returns remote models only | **Merges local + remote models** |
| `POST /v1/chat/completions` | Always proxies to remote | **Routes local models to runtime, remote to Cloud Run** |
| Other paths | Proxy to remote | Unchanged |

### How it works

1. **Model merge**: `/v1/models` queries the local runtime (`mgr.Runtime().ListModels()`) and proxies to remote, then merges both into a single OpenAI-format response
2. **Smart routing**: `/v1/chat/completions` peeks at the `model` field, checks a cached local model set, and routes to the right backend
3. **Graceful degradation**: If remote is down → returns local only. If no runtime → returns remote only

### Files

- **`lm_handler.go`** — Smart handler with model merge, routing, and caching
- **`lm_handler_test.go`** — 7 tests covering merge, degradation, routing, and passthrough
- **`main.go`** — Wiring: `buildLocalProxy()` helper, auto-creates local proxy from runtime endpoint
- **`README.md`** — Updated architecture diagram + unified model discovery docs

### For JetBrains / Cline users

Point at `localhost:1234` → see both `llama3.2:3b` (local Ollama) and `gpt-4o` (remote) in the model dropdown. Requests auto-route.