### PR TITLE
feat: solo mode — run candela-local without a remote server

### DIFF
--- a/cmd/candela-local/lm_handler.go
+++ b/cmd/candela-local/lm_handler.go
@@ -44,7 +44,13 @@ func (h *lmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case r.URL.Path == "/v1/chat/completions" && r.Method == http.MethodPost:
 		h.serveChat(w, r)
 	default:
-		h.remoteProxy.ServeHTTP(w, r)
+		if h.remoteProxy != nil {
+			h.remoteProxy.ServeHTTP(w, r)
+		} else {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "solo mode — no remote server configured"})
+		}
 	}
 }
 
@@ -108,6 +114,10 @@ func (h *lmHandler) serveModels(w http.ResponseWriter, r *http.Request) {
 
 // fetchRemoteModels proxies a GET /v1/models to the remote server and parses the response.
 func (h *lmHandler) fetchRemoteModels(r *http.Request) []openaiModel {
+	if h.remoteProxy == nil {
+		return nil // solo mode — no remote
+	}
+
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 	defer cancel()
 
@@ -150,8 +160,12 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 	if h.isLocalModel(req.Model) {
 		slog.Debug("lm handler: routing to local runtime", "model", req.Model)
 		h.localProxy.ServeHTTP(w, r)
-	} else {
+	} else if h.remoteProxy != nil {
 		h.remoteProxy.ServeHTTP(w, r)
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "model not found locally and no remote server configured"})
 	}
 }
 

--- a/cmd/candela-local/lm_handler_test.go
+++ b/cmd/candela-local/lm_handler_test.go
@@ -366,3 +366,111 @@ func TestLMHandler_Chat_MalformedBody(t *testing.T) {
 		t.Errorf("source = %q, want remote (malformed body fallback)", result["source"])
 	}
 }
+
+func setupSoloLMHandler(t *testing.T, localModels []runtime.Model) *httptest.Server {
+	t.Helper()
+
+	localSrv := mockLocalServer(t)
+
+	mock := &lmMockRuntime{models: localModels}
+	mgr := runtime.NewManager(mock, runtime.ManagerConfig{HealthCheck: 10 * 1e9})
+	if err := mgr.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
+
+	// Solo mode: nil remote proxy.
+	h := newLMHandler(mgr, nil, proxyTo(localSrv.URL))
+
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestLMHandler_SoloMode_ModelsLocalOnly(t *testing.T) {
+	localModels := []runtime.Model{
+		{ID: "llama3.2:3b"},
+		{ID: "mistral:7b"},
+	}
+
+	srv := setupSoloLMHandler(t, localModels)
+
+	resp, err := http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result openaiModelList
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+
+	// Should return only local models, no remote.
+	if len(result.Data) != 2 {
+		t.Fatalf("got %d models, want 2 (local only)", len(result.Data))
+	}
+	if result.Data[0].ID != "llama3.2:3b" {
+		t.Errorf("first model = %q, want llama3.2:3b", result.Data[0].ID)
+	}
+}
+
+func TestLMHandler_SoloMode_ChatLocalRoutes(t *testing.T) {
+	localModels := []runtime.Model{{ID: "llama3.2:3b"}}
+	srv := setupSoloLMHandler(t, localModels)
+
+	// Populate cache.
+	resp, _ := http.Get(srv.URL + "/v1/models")
+	_ = resp.Body.Close()
+
+	body := `{"model": "llama3.2:3b", "messages": [{"role": "user", "content": "hi"}]}`
+	resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result map[string]string
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+
+	if result["source"] != "local" {
+		t.Errorf("source = %q, want local", result["source"])
+	}
+}
+
+func TestLMHandler_SoloMode_ChatUnknownModel404(t *testing.T) {
+	localModels := []runtime.Model{{ID: "llama3.2:3b"}}
+	srv := setupSoloLMHandler(t, localModels)
+
+	body := `{"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]}`
+	resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (no remote in solo mode)", resp.StatusCode)
+	}
+}
+
+func TestLMHandler_SoloMode_PassthroughNoPanic(t *testing.T) {
+	localModels := []runtime.Model{{ID: "llama3.2:3b"}}
+	srv := setupSoloLMHandler(t, localModels)
+
+	// Unknown path in solo mode should return 404, not panic.
+	resp, err := http.Get(srv.URL + "/api/v0/whatever")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (solo mode passthrough)", resp.StatusCode)
+	}
+
+	// Verify it's proper JSON.
+	var result map[string]string
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+	if result["error"] == "" {
+		t.Error("expected JSON error body")
+	}
+}

--- a/cmd/candela-local/main.go
+++ b/cmd/candela-local/main.go
@@ -100,80 +100,87 @@ func main() {
 		cfg.Port = 8181
 	}
 
-	// ── Validate ──
-	if cfg.Remote == "" {
-		slog.Error("remote URL is required (set in ~/.candela.yaml or --remote)")
-		os.Exit(1)
-	}
-	if cfg.Audience == "" {
-		slog.Error("audience is required (set in ~/.candela.yaml or --audience)")
-		os.Exit(1)
-	}
-
-	remoteURL, err := url.Parse(cfg.Remote)
-	if err != nil {
-		slog.Error("invalid remote URL", "url", cfg.Remote, "error", err)
-		os.Exit(1)
-	}
-
-	// ── Get OIDC ID token source via ADC ──
-	// Strategy 1: idtoken.NewTokenSource (works for service accounts).
-	// Strategy 2: google.DefaultTokenSource with openid scope (works for user credentials).
+	// ── Validate & mode detection ──
 	ctx := context.Background()
-	var tokenSource oauth2.TokenSource
-	useIDToken := false
+	soloMode := cfg.Remote == ""
 
-	ts, err := idtoken.NewTokenSource(ctx, cfg.Audience)
-	if err == nil {
-		slog.Info("using service account ID token source")
-		tokenSource = ts
-		useIDToken = true
+	var proxy *httputil.ReverseProxy
+
+	if soloMode {
+		slog.Info("🏠 solo mode — no remote server configured, local-only operation")
+		if cfg.Audience != "" {
+			slog.Warn("audience is set but remote is empty — audience will be ignored")
+		}
 	} else {
-		slog.Info("idtoken unavailable (user credentials), using OAuth2 with openid scope", "reason", err)
-		ts2, err2 := google.DefaultTokenSource(ctx, "openid", "email")
-		if err2 != nil {
-			slog.Error("failed to get credentials — run 'gcloud auth application-default login' first",
-				"error", err2)
+		if cfg.Audience == "" {
+			slog.Error("audience is required when remote is set (set in ~/.candela.yaml or --audience)")
 			os.Exit(1)
 		}
-		tokenSource = ts2
-	}
 
-	// ── Build reverse proxy ──
-	proxy := &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			// Rewrite the request to point at the remote server.
-			req.URL.Scheme = remoteURL.Scheme
-			req.URL.Host = remoteURL.Host
-			req.Host = remoteURL.Host
+		remoteURL, err := url.Parse(cfg.Remote)
+		if err != nil {
+			slog.Error("invalid remote URL", "url", cfg.Remote, "error", err)
+			os.Exit(1)
+		}
 
-			// Inject OIDC identity token for IAP.
-			// For user credentials (OAuth2), the ID token is in token.Extra("id_token").
-			// For service account credentials (idtoken pkg), AccessToken IS the ID token.
-			token, err := tokenSource.Token()
-			if err != nil {
-				slog.Error("failed to get identity token", "error", err)
-				return
+		// ── Get OIDC ID token source via ADC ──
+		// Strategy 1: idtoken.NewTokenSource (works for service accounts).
+		// Strategy 2: google.DefaultTokenSource with openid scope (works for user credentials).
+		var tokenSource oauth2.TokenSource
+		useIDToken := false
+
+		ts, err := idtoken.NewTokenSource(ctx, cfg.Audience)
+		if err == nil {
+			slog.Info("using service account ID token source")
+			tokenSource = ts
+			useIDToken = true
+		} else {
+			slog.Info("idtoken unavailable (user credentials), using OAuth2 with openid scope", "reason", err)
+			ts2, err2 := google.DefaultTokenSource(ctx, "openid", "email")
+			if err2 != nil {
+				slog.Error("failed to get credentials — run 'gcloud auth application-default login' first",
+					"error", err2)
+				os.Exit(1)
 			}
-			bearerToken := token.AccessToken
-			if useIDToken {
-				if idToken, ok := token.Extra("id_token").(string); ok && idToken != "" {
-					bearerToken = idToken
+			tokenSource = ts2
+		}
+
+		// ── Build reverse proxy ──
+		proxy = &httputil.ReverseProxy{
+			Director: func(req *http.Request) {
+				// Rewrite the request to point at the remote server.
+				req.URL.Scheme = remoteURL.Scheme
+				req.URL.Host = remoteURL.Host
+				req.Host = remoteURL.Host
+
+				// Inject OIDC identity token for IAP.
+				// For user credentials (OAuth2), the ID token is in token.Extra("id_token").
+				// For service account credentials (idtoken pkg), AccessToken IS the ID token.
+				token, err := tokenSource.Token()
+				if err != nil {
+					slog.Error("failed to get identity token", "error", err)
+					return
 				}
-			}
-			req.Header.Set("Authorization", "Bearer "+bearerToken)
+				bearerToken := token.AccessToken
+				if useIDToken {
+					if idToken, ok := token.Extra("id_token").(string); ok && idToken != "" {
+						bearerToken = idToken
+					}
+				}
+				req.Header.Set("Authorization", "Bearer "+bearerToken)
 
-			// Preserve the original path.
-			if _, ok := req.Header["User-Agent"]; !ok {
-				req.Header.Set("User-Agent", "candela-local/1.0")
-			}
-		},
-		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
-			slog.Error("proxy error", "path", r.URL.Path, "error", err)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadGateway)
-			_ = json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("proxy error: %v", err)})
-		},
+				// Preserve the original path.
+				if _, ok := req.Header["User-Agent"]; !ok {
+					req.Header.Set("User-Agent", "candela-local/1.0")
+				}
+			},
+			ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+				slog.Error("proxy error", "path", r.URL.Path, "error", err)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadGateway)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("proxy error: %v", err)})
+			},
+		}
 	}
 
 	// ── Local runtime proxy ──
@@ -223,7 +230,7 @@ func main() {
 	if statePath == "" {
 		statePath = "~/.candela/state.db"
 	}
-	stateDB, err = openStateDB(statePath)
+	stateDB, err := openStateDB(statePath)
 	if err != nil {
 		slog.Warn("state DB unavailable (running without persistence)", "error", err)
 		stateDB = nil
@@ -268,8 +275,16 @@ func main() {
 		"ui", fmt.Sprintf("http://127.0.0.1:%d/_local/", cfg.Port),
 		"rpc", rpcPath)
 
-	// Everything else → remote Candela server.
-	mux.Handle("/", proxy)
+	// Everything else → remote Candela server (if configured).
+	if proxy != nil {
+		mux.Handle("/", proxy)
+	} else {
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "solo mode — no remote server configured"})
+		})
+	}
 
 	addr := fmt.Sprintf("127.0.0.1:%d", cfg.Port)
 	srv := &http.Server{
@@ -307,19 +322,24 @@ func main() {
 	defer stop()
 
 	go func() {
-		slog.Info("🕯️ candela-local proxy started",
-			"local", fmt.Sprintf("http://%s", addr),
-			"remote", cfg.Remote,
-			"audience", cfg.Audience[:min(20, len(cfg.Audience))]+"...")
-		logFields := []any{
-			"openai", fmt.Sprintf("http://%s/proxy/openai/v1", addr),
-			"anthropic", fmt.Sprintf("http://%s/proxy/anthropic/", addr),
-			"google", fmt.Sprintf("http://%s/proxy/google/", addr),
+		if soloMode {
+			slog.Info("🕯️ candela-local started (solo mode)",
+				"local", fmt.Sprintf("http://%s", addr))
+		} else {
+			slog.Info("🕯️ candela-local proxy started",
+				"local", fmt.Sprintf("http://%s", addr),
+				"remote", cfg.Remote,
+				"audience", cfg.Audience[:min(20, len(cfg.Audience))]+"...")
+			logFields := []any{
+				"openai", fmt.Sprintf("http://%s/proxy/openai/v1", addr),
+				"anthropic", fmt.Sprintf("http://%s/proxy/anthropic/", addr),
+				"google", fmt.Sprintf("http://%s/proxy/google/", addr),
+			}
+			if cfg.LocalUpstream != "" {
+				logFields = append(logFields, "local", fmt.Sprintf("http://%s/proxy/local/v1", addr))
+			}
+			slog.Info("Point your tools at:", logFields...)
 		}
-		if cfg.LocalUpstream != "" {
-			logFields = append(logFields, "local", fmt.Sprintf("http://%s/proxy/local/v1", addr))
-		}
-		slog.Info("Point your tools at:", logFields...)
 
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("server error", "error", err)


### PR DESCRIPTION
## Summary

Makes `remote` and `audience` config fields optional. When `remote` is empty, candela-local starts in **solo mode**.

### Solo mode behavior

| Feature | Solo mode | Team mode (with remote) |
|---------|-----------|------------------------|
| Runtime management | ✅ | ✅ |
| Management UI (`/_local/`) | ✅ | ✅ |
| LM compat listener (`:1234`) | ✅ (local only) | ✅ (local + remote) |
| `/v1/models` | Local models only | Merged local + remote |
| `chat/completions` local model | ✅ routes to runtime | ✅ routes to runtime |
| `chat/completions` unknown model | 404 | Proxied to Cloud Run |
| OIDC auth / cloud proxy | Skipped | ✅ |
| GCP credentials required | ❌ | ✅ |

### Usage

```yaml
# Solo mode — just omit remote
runtime_backend: ollama
runtime_config:
  port: 11434
```

### Changes

- **`main.go`** — Conditional OIDC/proxy setup, solo mode log, nil-safe catch-all
- **`lm_handler.go`** — Nil guards for `remoteProxy` in fetch + routing
- **`lm_handler_test.go`** — 3 new solo-mode tests (12 total)

### Tests
All 15 packages pass with `-race`.