### PR TITLE
docs: comprehensive documentation deep-dive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,122 @@
+# Changelog
+
+All notable changes to Candela are documented here, organized by development phase. PRs are merged to `main`.
+
+## Phase 4: Multi-User Platform ✅
+
+### Team Mode Frontend Enhancements (#53)
+- Per-user usage attribution in trace views
+- Budget gauge component with threshold alerts
+- User leaderboard with cost ranking
+- Team mode E2E test suite (`team_mode.spec.ts`)
+
+### Team Mode Backend — Budget Alerts & Leaderboard (#52)
+- `BudgetChecker` with configurable thresholds (80%, 90%, 100%)
+- `LogNotifier` for Cloud Logging–based alerts
+- `GetUserLeaderboard` RPC for per-user cost ranking
+- Budget deduction wired into proxy pipeline
+- Deduplication: one notification per threshold per period
+
+### Embedded Local Observability (#51)
+- Local SQLite trace storage at `~/.candela/traces.db`
+- `SpanProcessor` shared between solo and server modes
+- Traces REST API at `/_local/api/traces`
+- Traces card in management UI with auto-refresh
+
+### SpanProcessor Extraction (#50)
+- Extracted shared `pkg/processor` package
+- Fan-out to multiple `SpanWriter` sinks
+- Configurable batch size and flush interval
+- Used by both `candela-server` and `candela-local`
+
+### Solo Mode (#49)
+- `candela-local` operates without a remote server
+- Local models via Ollama/vLLM with full observability
+- No cloud account required
+
+### Unified Model Discovery (#48)
+- `/v1/models` merges local, cloud, and remote models
+- Smart routing: local stays local, cloud goes direct or via server
+- Solo + Cloud mode with Vertex AI ADC integration
+
+### Model Management Polish (#47)
+- UI refinements for model management
+- Health status auto-polling
+
+### Delete Model, Cancel Pull, State DB (#46)
+- Delete models from disk
+- Cancel in-progress model downloads
+- State persistence to `~/.candela/state.db`
+
+### RuntimeService Proto + Management UI (#45)
+- Full ConnectRPC service for runtime control
+- Embedded vanilla JS management dashboard at `/_local/`
+
+### Management API (#44)
+- REST API at `/_local/*` for runtime control
+- Start/stop, health monitoring, model listing
+
+### pkg/runtime — Interface, Registry, Backends (#43)
+- Abstract `Runtime` interface
+- Registry with backend auto-discovery
+- Ollama, vLLM, and LM Studio implementations
+
+### Local Provider for Runtimes (#42)
+- Local model proxy forwarding to Ollama/vLLM/LM Studio
+
+### LM Studio Compat Listener (#41)
+- Secondary listener on `:1234` for IntelliJ compatibility
+- `/v1/models` and `/v1/chat/completions` at root path
+- LM Studio native API (`/api/v0/models`) support
+
+### LM Studio Compatibility Mode (#40)
+- OpenAI-compatible routes at `/v1/` (no `/proxy/` prefix)
+- Model-to-provider routing via config
+
+### Expandable Prompt/Completion Views (#39)
+- JSON-formatted prompt and completion display in trace detail
+- Collapsible sections for large payloads
+
+### OAuth2 Access Token Auth (#38)
+- Strategy 3: Google OAuth2 access token validation via userinfo API
+- Enables `candela-local` with user ADC
+
+## Phase 3: Visual Explorer ✅
+
+- Next.js 16 web dashboard with dark theme
+- Dashboard with summary cards, time-series charts, recent traces
+- Trace waterfall view with span-level detail
+- Cost analytics page with model breakdown
+- Usage metrics with provider filtering
+- Project management with API key creation
+- Settings page with backend status
+- 27+ Playwright E2E tests
+- Firebase Auth integration (Google Sign-In)
+- Admin panel: user management, budgets, audit log
+- ConnectRPC v2 client transport
+
+## Phase 2: Storage & Architecture ✅
+
+- DuckDB storage backend (OLAP-optimized, Appender API)
+- SQLite storage backend (CGO-free, lightweight)
+- BigQuery storage backend (serverless, time-partitioned)
+- Pub/Sub write-only sink for fan-out
+- CQRS interfaces: `SpanWriter`, `SpanReader`, `TraceStore`
+- CORS middleware with configurable origins
+- Structured logging with `slog` (JSON)
+
+## Phase 1: Foundation ✅
+
+- LLM API proxy with observability (OpenAI, Google, Anthropic)
+- SSE streaming support with response buffering
+- Token extraction from provider-specific response formats
+- Cost calculation engine with hardcoded pricing
+- OpenTelemetry span ingestion (OTLP)
+- Custom OTel Collector with GenAI processor
+- Anthropic ↔ OpenAI format translation for Vertex AI routing
+- ADC credential injection for GCP providers
+- Circuit breaker for observability pipeline resilience
+- Terraform infrastructure (Cloud Run, BigQuery, Firestore, IAP)
+- Nix flake for reproducible dev environment
+- Pre-commit hooks (golangci-lint, buf, go vet, go test)
+- CI pipeline (GitHub Actions)

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Candela offers a dual-mode ingestion strategy to fit any stage of your project:
 
 ### 1. Zero-Code Proxy Mode (Quick Start)
 Drop Candela into your existing app by just changing your `base_url`. No instrumentation needed.
-- **OpenAI**: `http://localhost:8080/proxy/openai/v1`
-- **Google Gemini**: `http://localhost:8080/proxy/google/`
-- **Anthropic (via Vertex AI)**: `http://localhost:8080/proxy/anthropic/`
+- **OpenAI**: `http://localhost:8181/proxy/openai/v1`
+- **Google Gemini**: `http://localhost:8181/proxy/google/`
+- **Anthropic (via Vertex AI)**: `http://localhost:8181/proxy/anthropic/`
+
+> **📍 Port Configuration**: Candela uses port `8181` when running with a config file (recommended), or `8080` when using defaults. See [Port Configuration](#-port-configuration) for details.
 
 ### 2. OTel-Native Agent Mode (Production)
 For deep observability into agent frameworks (**ADK**, **LangChain**, **CrewAI**), Candela ingests standard OTLP spans through a custom-built **OTel Collector distro**.
@@ -51,12 +53,14 @@ Ideal for local development. Uses **DuckDB** by default.
 # Clone and enter the nix shell (or ensure Go 1.26 is installed)
 nix develop
 
-# Start the Candela server (defaults to DuckDB + Port 8080)
-go run ./cmd/candela-server
+# Start the Candela server (defaults to DuckDB + Port 8181)
+nix develop -c go run ./cmd/candela-server
 
 # Start the UI (separate terminal)
 cd ui && pnpm install && pnpm run dev
 ```
+
+> **💡 Quick Start Tip**: Copy `config.example.yaml` to `config.yaml` to use port 8181 and enable all features.
 
 ### Option B: Docker Compose (Full Stack)
 Ideal for testing the full multi-service experience.
@@ -70,14 +74,16 @@ docker compose -f deploy/docker-compose.yml up
 
 ## 🛠️ Route an LLM Call
 
-Once Candela is running, point your favorite LLM client at the Candela proxy (Port 8080) to start capturing observability data instantly.
+Once Candela is running, point your favorite LLM client at the Candela proxy (Port 8181) to start capturing observability data instantly.
+
+> **🔧 Setup Required**: For Anthropic/Claude via Vertex AI, see [GCP Setup Guide](#-gcp-setup-for-anthropic) below.
 
 ### OpenAI Example
 ```python
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="http://localhost:8080/proxy/openai/v1",
+    base_url="http://localhost:8181/proxy/openai/v1",
     api_key="sk-..."
 )
 
@@ -90,7 +96,7 @@ response = client.chat.completions.create(...)
 from anthropic import Anthropic
 
 client = Anthropic(
-    base_url="http://localhost:8080/proxy/anthropic",
+    base_url="http://localhost:8181/proxy/anthropic",
     api_key="YOUR_GCP_TOKEN" # Uses ADC for GCP authentication
 )
 
@@ -172,6 +178,31 @@ The processor fans out writes to **all configured writers** concurrently. Only o
 
 ---
 
+## 🔧 Port Configuration
+
+Candela uses port `8181` by default.
+
+| Setup | Port | When Used |
+|-------|------|-----------|
+| **Default** | `8181` | Running `go run ./cmd/candela-server` |
+| **Docker Compose** | `8181` | As specified in `docker-compose.yml` |
+
+### Quick Setup
+```bash
+# Copy example config to enable all features on port 8181
+cp config.example.yaml config.yaml
+
+# Or create minimal config
+cat > config.yaml << EOF
+server:
+  port: 8181
+storage:
+  backend: "duckdb"
+EOF
+```
+
+---
+
 ## ⚙️ Configuration
 
 Candela is configured via `config.yaml` (or `$CANDELA_CONFIG`):
@@ -179,7 +210,7 @@ Candela is configured via `config.yaml` (or `$CANDELA_CONFIG`):
 ```yaml
 server:
   host: "0.0.0.0"
-  port: 8080
+  port: 8181
 
 storage:
   backend: "duckdb"  # duckdb | sqlite | bigquery
@@ -196,7 +227,7 @@ storage:
 cors:
   allowed_origins:
     - "http://localhost:3000"
-    - "http://localhost:8080"
+    - "http://localhost:8181"
 
 sinks:
   pubsub:
@@ -232,7 +263,7 @@ pnpm run test:e2e      # run Playwright E2E tests (27+ tests)
 pnpm run test:e2e:ui   # Playwright interactive UI mode
 ```
 
-The UI communicates with the backend via **ConnectRPC v2** on `localhost:8080`. Pages gracefully handle offline backend state.
+The UI communicates with the backend via **ConnectRPC v2** on the configured port (`8181` with config file, `8080` without). Pages gracefully handle offline backend state.
 
 > [!TIP]
 > **Proto Generation**: We use **Buf Remote Generation**. Just run `buf generate` in the `proto/` directory—no local plugins required!
@@ -394,8 +425,135 @@ candela/
 ├── .github/workflows/ci.yml    # CI pipeline (Go + UI + Playwright)
 └── config.yaml                  # Server configuration
 ```
+
 ---
 
+## 🌩️ GCP Setup for Anthropic
+
+To use Claude models via Vertex AI, follow these steps:
+
+### 1. GCP Project Setup
+```bash
+# Install gcloud CLI if needed
+curl https://sdk.cloud.google.com | bash
+
+# Create a new project (or use existing)
+gcloud projects create YOUR-PROJECT-ID
+
+# Set as default project
+gcloud config set project YOUR-PROJECT-ID
+
+# Enable required APIs
+gcloud services enable \
+  aiplatform.googleapis.com \
+  compute.googleapis.com
+```
+
+### 2. Authentication
+```bash
+# Set up Application Default Credentials
+gcloud auth application-default login
+
+# Verify your credentials
+gcloud auth list
+```
+
+### 3. Enable Claude Models
+1. Go to [Vertex AI Model Garden](https://console.cloud.google.com/vertex-ai/model-garden)
+2. Search for "Claude"
+3. Enable Claude 3.5 Sonnet and Claude 3 Opus
+4. Accept Google's terms for Anthropic models
+
+### 4. Update Config
+```yaml
+# In your config.yaml
+proxy:
+  enabled: true
+  vertex_ai:
+    project_id: "YOUR-PROJECT-ID"  # Replace with your actual project
+    region: "us-east5"             # or us-central1, us-west1
+```
+
+### 5. Test Connection
+```bash
+# Start Candela
+go run ./cmd/candela-server
+
+# Test in another terminal
+curl -X POST http://localhost:8181/proxy/anthropic/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer test" \
+  -d '{
+    "model": "claude-3-51022",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 100
+  }'
+```
+
+> **💡 Project ID Tips**:
+> - Use `gcloud config get project` to see your current project
+> - Project IDs must be globally unique (numbers/letters/hyphens only)
+> - Billing must be enabled for Vertex AI usage
+
+---
+
+## 🐛 Troubleshooting
+
+### Common Issues
+
+#### Port Already in Use
+```bash
+# Check what's using the port
+lsof -i :8181  # or :8080
+
+# Kill the process or use a different port
+kill -9 <PID>
+```
+
+#### Backend Not Starting
+```bash
+# Check if config file is valid
+go run ./cmd/candela-server --help
+
+# Verify with minimal config
+echo "server:\n  port: 8181" > test-config.yaml
+CANDELA_CONFIG=test-config.yaml go run ./cmd/candela-server
+```
+
+#### UI Can't Connect to Backend
+1. **Check backend is running**: Visit `http://localhost:8181/healthz`
+2. **Verify port configuration**: Backend and UI must use same port
+3. **Check CORS settings**: Add your UI URL to `cors.allowed_origins`
+
+#### Anthropic/Vertex AI Errors
+```bash
+# Verify ADC is working
+gcloud auth application-default print-access-token
+
+# Check project/region settings
+gcloud config list
+
+# Test Vertex AI access
+gcloud ai models list --region=us-east5
+```
+
+#### Permission Denied (GCP)
+```bash
+# Check IAM roles
+gcloud projects get-iam-policy YOUR-PROJECT-ID
+
+# Add required role if missing
+gcloud projects add-iam-policy-binding YOUR-PROJECT-ID \
+  --member="user:YOUR-EMAIL" \
+  --role="roles/aiplatform.user"
+```
+
+### Getting Help
+- **GitHub Issues**: [Report bugs](https://github.delahq/candela/issues)
+- **Documentation**: Check `docs/` directory for detailed guides
+- **Logs**: Run with `CANDELA_LOG_LEVEL=debug` for verbose output
+
+---
 ## 🤝 Contributing
 
 We are in early development! See [CONTRIBUTING.md](./CONTRIBUTING.md) for local setup instructions and architectural deep dives.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Drop Candela into your existing app by just changing your `base_url`. No instrum
 - **Google Gemini**: `http://localhost:8181/proxy/google/`
 - **Anthropic (via Vertex AI)**: `http://localhost:8181/proxy/anthropic/`
 
-> **📍 Port Configuration**: Candela uses port `8181` when running with a config file (recommended), or `8080` when using defaults. See [Port Configuration](#-port-configuration) for details.
+> **📍 Port Configuration**: Candela uses port `8181` by default. See [Port Configuration](#-port-configuration) for details.
 
 ### 2. OTel-Native Agent Mode (Production)
 For deep observability into agent frameworks (**ADK**, **LangChain**, **CrewAI**), Candela ingests standard OTLP spans through a custom-built **OTel Collector distro**.
@@ -263,7 +263,7 @@ pnpm run test:e2e      # run Playwright E2E tests (27+ tests)
 pnpm run test:e2e:ui   # Playwright interactive UI mode
 ```
 
-The UI communicates with the backend via **ConnectRPC v2** on the configured port (`8181` with config file, `8080` without). Pages gracefully handle offline backend state.
+The UI communicates with the backend via **ConnectRPC v2** on port `8181`. Pages gracefully handle offline backend state.
 
 > [!TIP]
 > **Proto Generation**: We use **Buf Remote Generation**. Just run `buf generate` in the `proto/` directory—no local plugins required!
@@ -504,7 +504,7 @@ curl -X POST http://localhost:8181/proxy/anthropic/v1/messages \
 #### Port Already in Use
 ```bash
 # Check what's using the port
-lsof -i :8181  # or :8080
+lsof -i :8181
 
 # Kill the process or use a different port
 kill -9 <PID>

--- a/cmd/candela-local/lm_handler.go
+++ b/cmd/candela-local/lm_handler.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/candelahq/candela/pkg/costcalc"
 	"github.com/candelahq/candela/pkg/proxy"
 	"github.com/candelahq/candela/pkg/runtime"
 )
@@ -27,13 +28,14 @@ type lmHandler struct {
 	localHandler http.Handler           // localProxy wrapped with optional span capture
 	cloudProxy   *proxy.Proxy           // direct cloud proxy (solo + cloud mode)
 	cloudModels  map[string]string      // model ID → provider name
+	calc         *costcalc.Calculator   // pricing calculator (for filtering unpriced models)
 
 	localModels sync.Map // model ID string → bool (cached for fast routing)
 }
 
 // newLMHandler creates a smart LM compat handler that merges local + remote + cloud
 // models and routes chat completions to the correct backend.
-func newLMHandler(mgr *runtime.Manager, remoteProxy, localProxy *httputil.ReverseProxy, localHandler http.Handler, cloudProxy *proxy.Proxy, cloudModels map[string]string) *lmHandler {
+func newLMHandler(mgr *runtime.Manager, remoteProxy, localProxy *httputil.ReverseProxy, localHandler http.Handler, cloudProxy *proxy.Proxy, cloudModels map[string]string, calc *costcalc.Calculator) *lmHandler {
 	if localHandler == nil && localProxy != nil {
 		localHandler = localProxy
 	}
@@ -47,6 +49,7 @@ func newLMHandler(mgr *runtime.Manager, remoteProxy, localProxy *httputil.Revers
 		localHandler: localHandler,
 		cloudProxy:   cloudProxy,
 		cloudModels:  cloudModels,
+		calc:         calc,
 	}
 }
 
@@ -112,8 +115,13 @@ func (h *lmHandler) serveModels(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 2. Add direct cloud models.
+	// 2. Add direct cloud models (only if priced).
 	for modelID, providerName := range h.cloudModels {
+		if h.calc != nil && !h.calc.HasPricing(providerName, modelID) {
+			slog.Warn("⚠️ hiding cloud model from /v1/models — no pricing configured",
+				"model", modelID, "provider", providerName)
+			continue
+		}
 		merged = append(merged, openaiModel{
 			ID:      modelID,
 			Object:  "model",

--- a/cmd/candela-local/lm_handler_test.go
+++ b/cmd/candela-local/lm_handler_test.go
@@ -98,7 +98,7 @@ func setupLMHandler(t *testing.T, localModels []runtime.Model, remoteModels []op
 	}
 	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
 
-	h := newLMHandler(mgr, proxyTo(remoteSrv.URL), proxyTo(localSrv.URL), nil, nil, nil)
+	h := newLMHandler(mgr, proxyTo(remoteSrv.URL), proxyTo(localSrv.URL), nil, nil, nil, nil)
 
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
@@ -160,7 +160,7 @@ func TestLMHandler_Models_NoRuntime(t *testing.T) {
 
 	remoteSrv := mockRemoteServer(t, remoteModels)
 
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -197,7 +197,7 @@ func TestLMHandler_Models_RemoteDown(t *testing.T) {
 	_ = mgr.Start(context.Background())
 	defer func() { _ = mgr.Stop(context.Background()) }()
 
-	h := newLMHandler(mgr, proxyTo(failSrv.URL), proxyTo(localSrv.URL), nil, nil, nil)
+	h := newLMHandler(mgr, proxyTo(failSrv.URL), proxyTo(localSrv.URL), nil, nil, nil, nil)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -304,7 +304,7 @@ func TestLMHandler_Passthrough(t *testing.T) {
 	}))
 	defer remoteSrv.Close()
 
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -382,7 +382,7 @@ func setupSoloLMHandler(t *testing.T, localModels []runtime.Model) *httptest.Ser
 	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
 
 	// Solo mode: nil remote proxy.
-	h := newLMHandler(mgr, nil, proxyTo(localSrv.URL), nil, nil, nil)
+	h := newLMHandler(mgr, nil, proxyTo(localSrv.URL), nil, nil, nil, nil)
 
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
@@ -484,7 +484,7 @@ func TestLMHandler_CloudModelsIncluded(t *testing.T) {
 		"claude-sonnet-4-20250514": "anthropic",
 	}
 
-	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels)
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New())
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -546,7 +546,7 @@ func TestLMHandler_CloudChatRouting(t *testing.T) {
 		ProjectID: "local",
 	}, nil, calc)
 
-	h := newLMHandler(nil, nil, nil, nil, cp, cloudModels)
+	h := newLMHandler(nil, nil, nil, nil, cp, cloudModels, calc)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -591,7 +591,7 @@ func TestLMHandler_LocalPreference(t *testing.T) {
 	defer func() { _ = mgr.Stop(context.Background()) }()
 
 	localProxy := proxyTo(localSrv.URL)
-	h := newLMHandler(mgr, nil, localProxy, localProxy, nil, cloudModels)
+	h := newLMHandler(mgr, nil, localProxy, localProxy, nil, cloudModels, costcalc.New())
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -634,7 +634,7 @@ func TestLMHandler_CloudAndLocalModelsMerged(t *testing.T) {
 	defer func() { _ = mgr.Stop(context.Background()) }()
 
 	localProxy := proxyTo(localSrv.URL)
-	h := newLMHandler(mgr, nil, localProxy, nil, nil, cloudModels)
+	h := newLMHandler(mgr, nil, localProxy, nil, nil, cloudModels, costcalc.New())
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -668,7 +668,7 @@ func TestLMHandler_CloudModelWhenProxyNil(t *testing.T) {
 	// models should still appear in /v1/models but chat should 404.
 	cloudModels := map[string]string{"gemini-2.5-pro": "gemini-oai"}
 
-	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels) // no cloudProxy
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New()) // no cloudProxy
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -700,7 +700,7 @@ func TestLMHandler_UnknownModelSoloCloudMode(t *testing.T) {
 	// cloudModels should return 404 (not panic or route incorrectly).
 	cloudModels := map[string]string{"gemini-2.5-pro": "gemini-oai"}
 
-	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels)
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New())
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 

--- a/cmd/candela-local/main.go
+++ b/cmd/candela-local/main.go
@@ -374,12 +374,18 @@ func main() {
 
 	// Build direct cloud proxy if providers are configured (solo + cloud mode).
 	var cloudProxy *proxy.Proxy
+	var cloudCalc *costcalc.Calculator
 	cloudModels := make(map[string]string)
 	if soloMode && len(cfg.Providers) > 0 {
 		cloudProxy, cloudModels = buildCloudProxy(*cfg, spanProc)
 	}
+	// Create a calc for pricing-based model filtering.
+	// Uses the same defaults as the cloud proxy's embedded calc.
+	if len(cloudModels) > 0 {
+		cloudCalc = costcalc.New()
+	}
 
-	lmH := newLMHandler(mgr, remoteProxy, runtimeLocalProxy, localHandler, cloudProxy, cloudModels)
+	lmH := newLMHandler(mgr, remoteProxy, runtimeLocalProxy, localHandler, cloudProxy, cloudModels, cloudCalc)
 	lmAddr := fmt.Sprintf("127.0.0.1:%d", lmPort)
 
 	// ── Graceful shutdown ──

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -87,6 +87,7 @@ type Config struct {
 		ProjectID  string `yaml:"project_id"`
 		DatabaseID string `yaml:"database_id"` // e.g. "candela" or "(default)"
 	} `yaml:"firestore"`
+	Pricing costcalc.PricingConfig `yaml:"pricing"`
 }
 
 func main() {
@@ -111,8 +112,11 @@ func main() {
 	defer closeFn()
 	slog.Info("storage initialized", "backend", cfg.Storage.Backend, "sinks", len(writers))
 
-	// Initialize cost calculator.
+	// Initialize cost calculator with built-in defaults + config overrides.
 	calc := costcalc.New()
+	if cfg.Pricing.DiscountPercent > 0 || len(cfg.Pricing.Models) > 0 {
+		calc.LoadFromConfig(cfg.Pricing)
+	}
 
 	// Start the in-process span processor (fan-out to all writers).
 	proc := processor.New(writers, calc, cfg.Worker.BatchSize)

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -440,10 +440,10 @@ func loadConfig() (*Config, error) {
 
 	data, err := os.ReadFile(cfgPath)
 	if err != nil {
-		// No config file — use defaults (DuckDB, port 8080).
+		// No config file — use defaults (DuckDB, port 8181).
 		slog.Warn("config file not found, using defaults", "path", cfgPath)
 		cfg := &Config{}
-		cfg.Server.Port = 8080
+		cfg.Server.Port = 8181
 		cfg.Storage.Backend = "duckdb"
 		return cfg, nil
 	}
@@ -454,7 +454,7 @@ func loadConfig() (*Config, error) {
 	}
 
 	if cfg.Server.Port == 0 {
-		cfg.Server.Port = 8080
+		cfg.Server.Port = 8181
 	}
 	if cfg.Storage.Backend == "" {
 		cfg.Storage.Backend = "duckdb"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -78,11 +78,31 @@ proxy:
       # - id: codellama:13b
       #   provider: local
 
+# Pricing overrides.
+# Built-in defaults cover all cloud models at list prices.
+# Use this section for negotiated rates or enterprise discounts.
+pricing:
+  # Global discount applied to ALL model pricing (0.0 = none, 0.15 = 15% off).
+  discount_percent: 0.0
+
+  # Per-model overrides. These take priority over built-in defaults.
+  # Uncomment and adjust for negotiated enterprise rates:
+  # models:
+  #   - provider: openai
+  #     model: gpt-4o
+  #     input_per_million: 2.00     # negotiated rate (list: $2.50)
+  #     output_per_million: 8.00    # negotiated rate (list: $10.00)
+  #   - provider: google
+  #     model: gemini-2.5-pro
+  #     input_per_million: 1.00
+  #     output_per_million: 8.00
+  #     discount_percent: 0.10      # additional 10% off this model
+
 cors:
   # Origins allowed to make cross-origin requests.
   allowed_origins:
     - "http://localhost:3000"
-    - "http://localhost:8080"
+    - "http://localhost:8181"
 
 worker:
   batch_size: 100

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,23 +1,56 @@
-services:
-  # ClickHouse — trace/span storage
-  clickhouse:
-    image: clickhouse/clickhouse-server:24.12
-    ports:
-      - "8123:8123"   # HTTP interface
-      - "9000:9000"   # Native protocol
-    volumes:
-      - clickhouse_data:/var/lib/clickhouse
-    environment:
-      CLICKHOUSE_DB: candela
-      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
-    healthcheck:
-      test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
+# Candela Local Development Stack
+#
+# Usage:
+#   docker compose -f deploy/docker-compose.yml up
+#
+# This starts the Candela server with DuckDB storage.
+# For BigQuery or SQLite, update the config file.
 
-  # --- FUTURE SCALE (Commented out for Phase 1) ---
-  # Redis — span ingestion queue for high-scale environments
+services:
+  # Candela Server — Combined Go backend + Next.js UI
+  candela-server:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile.server
+      args:
+        NEXT_PUBLIC_FIREBASE_API_KEY: ""
+        NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ""
+        NEXT_PUBLIC_FIREBASE_PROJECT_ID: ""
+        NEXT_PUBLIC_FIREBASE_APP_ID: ""
+    ports:
+      - "3000:3000"   # Next.js UI
+      - "8181:8181"   # Go backend API
+      - "1234:1234"   # LM Studio compat listener
+    environment:
+      CANDELA_STORAGE_BACKEND: duckdb
+      CANDELA_DEV_MODE: "true"
+      CANDELA_PROXY_ENABLED: "true"
+      CANDELA_LMSTUDIO_ENABLED: "true"
+    volumes:
+      - candela_data:/data
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8181/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # --- Optional: OTel Collector ---
+  # Uncomment to run the custom collector for agent framework ingestion.
+  #
+  # candela-collector:
+  #   build:
+  #     context: ..
+  #     dockerfile: collector/Dockerfile  # You'll need to create this
+  #   ports:
+  #     - "4317:4317"   # OTLP gRPC
+  #     - "4318:4318"   # OTLP HTTP
+  #   volumes:
+  #     - ../collector/collector-config.yaml:/etc/otel/config.yaml:ro
+  #   depends_on:
+  #     candela-server:
+  #       condition: service_healthy
+
+  # --- Future: Redis queue for high-scale environments ---
   # redis:
   #   image: redis:7-alpine
   #   ports:
@@ -28,35 +61,5 @@ services:
   #     timeout: 3s
   #     retries: 5
 
-  # Candela Worker — separate span processor (redundant if using single-binary)
-  # candela-worker:
-  #   build:
-  #     context: ..
-  #     dockerfile: deploy/Dockerfile.worker
-  #   environment:
-  #     CANDELA_CONFIG: /app/config.yaml
-  #   volumes:
-  #     - ../config.yaml:/app/config.yaml:ro
-  #   depends_on:
-  #     clickhouse:
-  #       condition: service_healthy
-  #     redis:
-  #       condition: service_healthy
-
-  # Candela Server — ConnectRPC API
-  candela-server:
-    build:
-      context: ..
-      dockerfile: deploy/Dockerfile.server
-    ports:
-      - "8080:8080"
-    environment:
-      CANDELA_CONFIG: /app/config.yaml
-    volumes:
-      - ../config.yaml:/app/config.yaml:ro
-    depends_on:
-      clickhouse:
-        condition: service_healthy
-
 volumes:
-  clickhouse_data:
+  candela_data:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,276 @@
+# 📡 Protobuf API Reference
+
+Candela defines all service boundaries in Protobuf. The backend serves these via **ConnectRPC** (HTTP/JSON + gRPC dual-protocol). The UI consumes them via generated TypeScript stubs.
+
+## Services Overview
+
+| Service | Proto File | RPCs | Description |
+|---------|-----------|------|-------------|
+| `TraceService` | `v1/trace_service.proto` | 3 | Trace queries and detail views |
+| `DashboardService` | `v1/dashboard_service.proto` | 4 | Usage analytics, model breakdown, leaderboard |
+| `IngestionService` | `v1/ingestion_service.proto` | 1 | OTLP span ingestion |
+| `UserService` | `v1/user_service.proto` | 15 | User CRUD, budgets, grants, audit |
+| `ProjectService` | `v1/project_service.proto` | 5 | Project + API key management |
+| `RuntimeService` | `v1/runtime_service.proto` | 10 | Local LLM runtime control (candela-local) |
+
+## Type Packages
+
+| Package | Proto File | Description |
+|---------|-----------|-------------|
+| `candela.types` | `types/trace.proto` | Span, Trace, TraceSummary, UsageSummary, ModelUsage |
+| `candela.types` | `types/user.proto` | User, UserBudget, BudgetGrant, AuditEntry |
+| `candela.types` | `types/project.proto` | Project, APIKey |
+| `candela.types` | `types/common.proto` | Shared enums (TimeRange) |
+| `candela.types` | `types/bq_span.proto` | BigQuery span schema (server-only) |
+
+---
+
+## TraceService
+
+Provides trace querying for the dashboard and trace detail views.
+
+### ListTraces
+
+List traces with filtering and pagination.
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.TraceService/ListTraces \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pageSize": 20,
+    "timeRange": "TIME_RANGE_24H",
+    "model": "gpt-4o"
+  }'
+```
+
+**Filters**: `timeRange`, `model`, `provider`, `status`, `search`, `userId`
+
+### GetTrace
+
+Get a single trace with all spans.
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.TraceService/GetTrace \
+  -H "Content-Type: application/json" \
+  -d '{"traceId": "abc123def456..."}'
+```
+
+### SearchSpans
+
+Search individual spans across all traces.
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.TraceService/SearchSpans \
+  -H "Content-Type: application/json" \
+  -d '{"nameContains": "openai.chat", "pageSize": 50}'
+```
+
+---
+
+## DashboardService
+
+Provides aggregated analytics for the dashboard.
+
+### GetUsageSummary
+
+Returns total traces, tokens, cost, avg latency, and error rate.
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.DashboardService/GetUsageSummary \
+  -H "Content-Type: application/json" \
+  -d '{"timeRange": "TIME_RANGE_7D"}'
+```
+
+### GetModelBreakdown
+
+Returns per-model usage metrics (calls, tokens, cost, latency).
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.DashboardService/GetModelBreakdown \
+  -H "Content-Type: application/json" \
+  -d '{"timeRange": "TIME_RANGE_24H"}'
+```
+
+### GetDashboardSummary
+
+Combined endpoint returning summary + time-series data + recent traces.
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.DashboardService/GetDashboardSummary \
+  -H "Content-Type: application/json" \
+  -d '{"timeRange": "TIME_RANGE_24H"}'
+```
+
+### GetUserLeaderboard
+
+Per-user usage ranking (admin only, team mode).
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.DashboardService/GetUserLeaderboard \
+  -H "Content-Type: application/json" \
+  -d '{"timeRange": "TIME_RANGE_7D", "limit": 10}'
+```
+
+---
+
+## IngestionService
+
+Receives OTLP trace spans.
+
+### IngestSpans
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.IngestionService/IngestSpans \
+  -H "Content-Type: application/json" \
+  -d '{
+    "spans": [{
+      "spanId": "abc123",
+      "traceId": "def456",
+      "name": "openai.chat",
+      "kind": "SPAN_KIND_LLM",
+      "startTime": "2026-04-20T15:00:00Z",
+      "endTime": "2026-04-20T15:00:02Z",
+      "genAi": {
+        "model": "gpt-4o",
+        "provider": "openai",
+        "inputTokens": 150,
+        "outputTokens": 42
+      }
+    }]
+  }'
+```
+
+---
+
+## UserService
+
+Full user lifecycle management with RBAC and budgets.
+
+### Self-Service RPCs (any authenticated user)
+
+#### GetCurrentUser
+Returns the caller's own profile, budget, and active grants.
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.UserService/GetCurrentUser \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{}'
+```
+
+#### GetMyBudget
+Returns the caller's own budget and spending.
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.UserService/GetMyBudget \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{}'
+```
+
+### Admin RPCs (requires `admin` role)
+
+| RPC | Description | Key Fields |
+|-----|-------------|------------|
+| `CreateUser` | Pre-provision a user | `email` (required, validated), `role`, `monthlyBudgetUsd` |
+| `ListUsers` | Paginated user list | `statusFilter`, `limit`, `offset` |
+| `GetUser` | Get user by ID | `userId` (required, min_len: 1) |
+| `UpdateUser` | Update mutable fields | `userId`, `displayName`, `role` |
+| `DeactivateUser` | Set status to inactive | `userId` |
+| `ReactivateUser` | Set status to active | `userId` |
+| `SetBudget` | Create/update monthly budget | `userId`, `limitUsd` (> 0) |
+| `GetBudget` | Get user's budget | `userId` |
+| `ResetSpend` | Zero current-period spending | `userId` |
+| `CreateGrant` | Issue one-time bonus | `userId`, `amountUsd` (> 0), `reason`, `startsAt`, `expiresAt` |
+| `ListGrants` | List user's grants | `userId`, `activeOnly` |
+| `RevokeGrant` | Cancel active grant | `userId`, `grantId` |
+| `ListAuditLog` | View admin action log | `userId`, `limit` (0–500) |
+
+### Validation Rules
+
+All requests are validated server-side via `protovalidate`:
+
+| Field | Rule |
+|-------|------|
+| `email` | Must be valid email format |
+| `monthlyBudgetUsd` | ≥ 0 |
+| `limitUsd` (SetBudget) | > 0 |
+| `amountUsd` (CreateGrant) | > 0 |
+| `userId`, `id` | min_len: 1 (required) |
+| `limit` (ListAuditLog) | 0 ≤ x ≤ 500 |
+| `expiresAt` vs `startsAt` | CEL: expires > starts |
+
+---
+
+## ProjectService
+
+Manages projects and API keys for multi-tenant span isolation.
+
+| RPC | Description |
+|-----|-------------|
+| `CreateProject` | Create a new project |
+| `ListProjects` | List all projects (paginated) |
+| `GetProject` | Get project by ID |
+| `UpdateProject` | Update name, description, environment |
+| `DeleteProject` | Delete project and its API keys |
+
+API key management:
+
+| RPC | Description |
+|-----|-------------|
+| `CreateAPIKey` | Generate API key for a project (hash stored, full key returned once) |
+| `ListAPIKeys` | List keys with prefix + status (never the full key) |
+| `RevokeAPIKey` | Deactivate a key |
+
+---
+
+## RuntimeService
+
+Controls local LLM runtimes from `candela-local`. Served via ConnectRPC on the management port (`:8181`).
+
+| RPC | Description |
+|-----|-------------|
+| `GetHealth` | Runtime status (running/stopped/error), uptime, version |
+| `StartRuntime` | Start the configured runtime (Ollama/vLLM/LM Studio) |
+| `StopRuntime` | Stop the runtime |
+| `ListModels` | List loaded models with size, family, quantization |
+| `LoadModel` | Load a model into memory |
+| `UnloadModel` | Unload a model from memory |
+| `DeleteModel` | Delete model from disk |
+| `PullModel` | Download a model (streaming progress) |
+| `CancelPull` | Cancel an in-progress download |
+| `ListBackends` | Auto-detect installed runtimes with install hints |
+
+---
+
+## Interacting with gRPC
+
+Since Candela uses ConnectRPC (which supports both HTTP/JSON and gRPC), you can also use `grpcurl`:
+
+```bash
+# List services
+grpcurl -plaintext localhost:8181 list
+
+# List RPCs
+grpcurl -plaintext localhost:8181 list candela.v1.TraceService
+
+# Call an RPC
+grpcurl -plaintext -d '{}' localhost:8181 candela.v1.DashboardService/GetUsageSummary
+```
+
+---
+
+## Proto Generation
+
+```bash
+# Generate Go + TypeScript stubs
+cd proto && buf generate
+
+# Requires BUF_TOKEN for remote generation (CI provides this)
+# Locally, check .netrc or set BUF_TOKEN env var
+```
+
+Output:
+- Go stubs → `gen/go/candela/`
+- TypeScript stubs → `gen/ts/candela/`
+- BigQuery schemas → `gen/bq/candela/`

--- a/docs/budgets.md
+++ b/docs/budgets.md
@@ -1,0 +1,243 @@
+# 💸 Budget & Notification System
+
+Candela provides per-user budget enforcement and threshold notifications to prevent runaway LLM spending.
+
+## Budget Model
+
+### Grant-First Waterfall
+
+When an LLM call completes, cost is deducted using a **grant-first waterfall**:
+
+```
+1. Check active grants (earliest expiry first)
+2. Deduct from grant balance
+3. If grants exhausted → deduct from monthly budget
+4. If monthly budget exceeded → reject future requests
+```
+
+```
+┌──────────────┐
+│ LLM Call      │  cost = $0.05
+│ Completed     │
+└──────┬───────┘
+       ▼
+┌──────────────┐    ┌──────────────┐
+│ Grant A      │───▶│ Grant B      │  (earliest expiry first)
+│ $2.00 remain │    │ $0.00 remain │
+└──────┬───────┘    └──────────────┘
+       │ deduct $0.05
+       ▼
+┌──────────────┐
+│ Monthly       │  remaining = limit - spent
+│ Budget        │
+│ $50.00 limit  │
+└──────────────┘
+```
+
+### Data Model
+
+**Budget** (Firestore: `budgets/{userId}`):
+```
+limit_usd:     50.00      # Monthly spending cap
+spent_usd:     12.34      # Current period accumulated spend
+tokens_used:   45000      # Current period token count
+period_type:   "monthly"  # "monthly", "weekly", "quarterly"
+period_key:    "2026-04"  # Auto-reset when period changes
+period_start:  2026-04-01
+period_end:    2026-04-30
+```
+
+**Grant** (Firestore: `grants/{grantId}`):
+```
+user_id:    "user123"
+amount_usd: 10.00
+used_usd:   3.50
+reason:     "Hackathon project budget"
+granted_by: "admin@company.com"
+starts_at:  2026-04-15
+expires_at: 2026-04-30
+```
+
+### Budget Enforcement Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Proxy
+    participant UserStore
+    participant Upstream as LLM Provider
+
+    Client->>Proxy: POST /proxy/openai/v1/chat/completions
+    Proxy->>Upstream: Forward request
+    Upstream-->>Proxy: Response (tokens: 500)
+    Proxy->>Proxy: Calculate cost ($0.05)
+    Proxy-->>Client: Return response
+
+    Note over Proxy: Async (non-blocking)
+    Proxy->>UserStore: DeductSpend($0.05, 500 tokens)
+    UserStore->>UserStore: Grant waterfall deduction
+    UserStore-->>Proxy: Success
+    Proxy->>Proxy: Check threshold (80%? 90%? 100%?)
+    Proxy->>Proxy: Fire notification if crossed
+```
+
+> [!NOTE]
+> Budget enforcement is **post-deduction**, not pre-flight. The LLM call always goes through. Budget exhaustion is enforced via pre-flight checks on subsequent requests (via `CheckBudget()`).
+
+---
+
+## Threshold Notifications
+
+### Default Thresholds
+
+Notifications fire at **80%**, **90%**, and **100%** of the monthly budget:
+
+| Threshold | Meaning | Example ($50 budget) |
+|-----------|---------|---------------------|
+| 80% | Warning — approaching limit | Spent ≥ $40.00 |
+| 90% | Critical — almost exhausted | Spent ≥ $45.00 |
+| 100% | Exceeded — over budget | Spent ≥ $50.00 |
+
+### Deduplication
+
+Each threshold fires **at most once per user per budget period**. The `BudgetChecker` tracks fired thresholds using a key format:
+
+```
+{userID}:{periodKey}:{threshold}
+→ "user123:2026-04:0.80"
+```
+
+This prevents duplicate notifications when multiple calls cross the same threshold within a period.
+
+### Notification Channels
+
+Candela uses a pluggable `Notifier` interface:
+
+```go
+type Notifier interface {
+    NotifyBudgetThreshold(ctx context.Context, alert BudgetAlert) error
+}
+```
+
+#### Built-in: Log Notifier
+
+The default `LogNotifier` emits structured log events that integrate with **Cloud Logging alert policies**:
+
+```json
+{
+  "level": "WARN",
+  "msg": "🔔 budget alert: 80% threshold reached",
+  "user_id": "user123",
+  "email": "dev@company.com",
+  "threshold": "80%",
+  "spent_usd": "42.50",
+  "limit_usd": "50.00",
+  "period": "2026-04"
+}
+```
+
+#### Adding Slack Notifications
+
+Implement the `Notifier` interface:
+
+```go
+type SlackNotifier struct {
+    webhookURL string
+    client     *http.Client
+}
+
+func (n *SlackNotifier) NotifyBudgetThreshold(ctx context.Context, alert storage.BudgetAlert) error {
+    msg := fmt.Sprintf("🔔 %s has reached %d%% of their $%.2f budget ($%.2f spent)",
+        alert.Email, int(alert.Threshold*100), alert.LimitUSD, alert.SpentUSD)
+
+    payload, _ := json.Marshal(map[string]string{"text": msg})
+    _, err := n.client.Post(n.webhookURL, "application/json", bytes.NewReader(payload))
+    return err
+}
+```
+
+Register in `cmd/candela-server/main.go`:
+
+```go
+checker := notify.NewBudgetChecker(
+    &notify.LogNotifier{},
+    &SlackNotifier{webhookURL: os.Getenv("SLACK_WEBHOOK_URL")},
+)
+llmProxy.SetBudgetChecker(checker)
+```
+
+#### Adding Microsoft Teams
+
+Same pattern — implement `Notifier` with a Teams incoming webhook.
+
+---
+
+## Admin Operations
+
+### Setting a Budget (Admin UI or API)
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.UserService/SetBudget \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-token>" \
+  -d '{
+    "userId": "user123",
+    "limitUsd": 100.00
+  }'
+```
+
+### Creating a Grant
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.UserService/CreateGrant \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-token>" \
+  -d '{
+    "userId": "user123",
+    "amountUsd": 25.00,
+    "reason": "Sprint 42 AI budget boost",
+    "startsAt": "2026-04-20T00:00:00Z",
+    "expiresAt": "2026-05-01T00:00:00Z"
+  }'
+```
+
+### Emergency: Reset Spend
+
+If a user's spend counter is incorrect:
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.UserService/ResetSpend \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-token>" \
+  -d '{"userId": "user123"}'
+```
+
+This zeroes the current-period spend counter. Use sparingly — it's logged in the audit trail.
+
+---
+
+## Cloud Logging Alert Policy
+
+Create an alert when any user exceeds their budget:
+
+```bash
+gcloud alpha monitoring policies create \
+  --display-name="Candela Budget Exceeded" \
+  --condition-display-name="Budget 100% threshold" \
+  --condition-filter='resource.type="cloud_run_revision"
+    AND jsonPayload.msg=~"budget alert: 100%"' \
+  --notification-channels=<CHANNEL_ID>
+```
+
+---
+
+## Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `pkg/notify/notifier.go` | `BudgetChecker`, `LogNotifier`, threshold logic |
+| `pkg/notify/notifier_test.go` | Unit tests for dedup and threshold evaluation |
+| `pkg/storage/store.go` | `BudgetRecord`, `GrantRecord`, `BudgetCheckResult`, `Notifier` interface |
+| `pkg/storage/firestoredb/firestoredb.go` | `DeductSpend()`, `CheckBudget()`, grant waterfall implementation |
+| `pkg/proxy/proxy.go` | Budget deduction call in `buildSpan()` |
+| `cmd/candela-server/main.go` | Wiring `BudgetChecker` into the proxy |

--- a/docs/cost-calculation.md
+++ b/docs/cost-calculation.md
@@ -1,157 +1,166 @@
 # 💰 Cost Calculation Engine
 
-Candela provides real-time cost tracking for every LLM call. The `pkg/costcalc` package maintains a pricing table and calculates USD costs from token usage.
+Candela calculates the USD cost of every LLM API call in real-time, enabling budget tracking, threshold alerts, and per-user reporting.
 
-## How Costs Flow Through the System
+## Core Principle
 
-```
-1. LLM Call (via Proxy or OTel)
-         │
-2. Token extraction (from response body or span attributes)
-         │
-3. Cost calculation (costcalc.Calculate)
-         │
-4. Enrichment ──┬── Proxy: writes cost into span.GenAI.CostUSD
-                └── Collector: writes cost as gen_ai.usage.cost_usd attribute
-         │
-5. Storage (DuckDB/SQLite/BigQuery gen_ai_cost_usd column)
-         │
-6. Display ──┬── Dashboard: total cost, cost-over-time chart
-             ├── Trace detail: per-span cost breakdown
-             └── Budget enforcement: deduct from user budget
-```
+> **$0.00 is only valid for local models.** Every cloud model reachable through the proxy has real pricing. An unknown cloud model is a gap — the server logs a `⚠️ missing pricing` warning so operators can add it.
 
-### Two Enrichment Points
-
-Cost is calculated in **two places**, depending on the ingestion path:
-
-| Path | Where | When |
-|------|-------|------|
-| **Proxy Mode** | `pkg/proxy/proxy.go` → `buildSpan()` | After upstream response is parsed |
-| **Collector Mode** | `collector/processors/genaiprocessor` | In the OTel pipeline before export |
-| **Processor (fallback)** | `pkg/processor/processor.go` → `flush()` | During batch flush, if cost is still $0 |
-
-The processor applies cost calculation as a **safety net** — if the proxy or collector already set the cost, the processor does not override it.
-
----
-
-## Pricing Table
-
-The calculator ships with built-in pricing for common models:
-
-### Google
-
-| Model | Input ($/1M tokens) | Output ($/1M tokens) |
-|-------|--------------------:|---------------------:|
-| `gemini-2.0-flash` | $0.10 | $0.40 |
-| `gemini-2.0-pro` | $1.25 | $10.00 |
-| `gemini-1.5-flash` | $0.075 | $0.30 |
-| `gemini-1.5-pro` | $1.25 | $5.00 |
-
-### OpenAI
-
-| Model | Input ($/1M tokens) | Output ($/1M tokens) |
-|-------|--------------------:|---------------------:|
-| `gpt-4o` | $2.50 | $10.00 |
-| `gpt-4o-mini` | $0.15 | $0.60 |
-| `gpt-4-turbo` | $10.00 | $30.00 |
-| `gpt-3.5-turbo` | $0.50 | $1.50 |
-| `o1` | $15.00 | $60.00 |
-| `o1-mini` | $3.00 | $12.00 |
-
-### Anthropic (via Vertex AI)
-
-| Model | Input ($/1M tokens) | Output ($/1M tokens) |
-|-------|--------------------:|---------------------:|
-| `claude-sonnet-4-20250514` | $3.00 | $15.00 |
-| `claude-haiku-3-5-20241022` | $0.80 | $4.00 |
-| `claude-3-5-sonnet-20241022` | $3.00 | $15.00 |
-| `claude-3-opus-20240229` | $15.00 | $75.00 |
-
-### Local Models
-
-All local models (provider = `local`) return **$0.00** — they run on your hardware with no API cost.
-
----
-
-## Cost Formula
+## How Cost Is Calculated
 
 ```
-cost = (input_tokens / 1,000,000 × input_per_million)
-     + (output_tokens / 1,000,000 × output_per_million)
-```
-
-Example: `gpt-4o` with 1,500 input tokens and 500 output tokens:
-```
-cost = (1500 / 1M × $2.50) + (500 / 1M × $10.00)
-     = $0.00375 + $0.005
-     = $0.00875
+cost = (input_tokens / 1,000,000 × input_rate)
+     + (output_tokens / 1,000,000 × output_rate)
+     × (1 - model_discount)     # optional per-model discount
+     × (1 - global_discount)    # optional enterprise-wide discount
 ```
 
 ---
 
-## Model Matching
+## Pricing Resolution Order
 
-The calculator uses a two-pass lookup strategy:
+When a model call completes, the calculator resolves pricing in this order:
 
-1. **Exact match** by `provider/model` key (e.g., `openai/gpt-4o`)
-2. **Provider-agnostic fallback** — if the exact key misses, search for any entry ending with `/model`
+```
+1. Config overrides (exact provider/model match)     → use it
+2. Built-in defaults (exact provider/model match)    → use it
+3. Provider-agnostic match (model name only)         → use it
+4. Provider is "local"?                              → $0.00 (correct)
+5. Otherwise                                         → $0.00 + WARNING LOG
+```
 
-This means `anthropic/claude-sonnet-4-20250514` will match even if the request comes through the `gemini-oai` provider route, as long as the model name matches.
+Step 3 handles cases like `gemini-oai/gemini-2.5-pro` matching the `google/gemini-2.5-pro` default pricing.
 
-If no match is found, the cost is **$0.00** — the span is still captured, just without cost data.
+Step 5 means there's a gap — the model is missing from both the config and built-in defaults. Check the server logs for:
+
+```
+⚠️ missing pricing for cloud model — cost will be $0.00 (inaccurate)
+  provider=openai model=some-new-model input_tokens=1500 output_tokens=300
+```
 
 ---
 
-## Adding or Updating Pricing
+## Built-In Default Pricing
 
-### At Build Time
+The calculator ships with built-in list prices for **all cloud models** reachable through the Candela proxy (OpenAI, Google, Anthropic). These are standard list prices — not negotiated rates.
 
-Edit `pkg/costcalc/calculator.go` → `loadDefaults()`:
+See the current pricing table in [`pkg/costcalc/calculator.go` → `loadDefaults()`](../pkg/costcalc/calculator.go) for exact rates.
 
-```go
-func (c *Calculator) loadDefaults() {
-    defaults := []ModelPricing{
-        // Add new models here:
-        {Provider: "google", Model: "gemini-2.5-pro", InputPerMillion: 1.25, OutputPerMillion: 10.00},
-        {Provider: "google", Model: "gemini-2.5-flash", InputPerMillion: 0.15, OutputPerMillion: 0.60},
-        {Provider: "openai", Model: "o3-mini", InputPerMillion: 1.10, OutputPerMillion: 4.40},
-        // ...
-    }
-}
-```
-
-### At Runtime
-
-The `Calculator` is thread-safe and supports runtime pricing updates:
-
-```go
-calc := costcalc.New()
-
-// Add pricing for a new model
-calc.SetPricing(costcalc.ModelPricing{
-    Provider:         "anthropic",
-    Model:            "claude-opus-4-20250514",
-    InputPerMillion:  15.00,
-    OutputPerMillion: 75.00,
-})
-```
-
-> [!TIP]
-> A future enhancement could load pricing from a configuration file or remote endpoint, enabling pricing updates without code changes.
+**Coverage:**
+- **Google**: Gemini 3.1, 2.5 (Pro/Flash/Flash-Lite), 2.0, 1.5
+- **OpenAI**: GPT-5.4 family, GPT-4o, reasoning models (o1/o3)
+- **Anthropic**: Claude 4.7/4.6/4.5, Claude 4 (Vertex AI IDs), Claude 3.5 legacy
+- **Local**: Always $0.00 — runs on your hardware
 
 ---
 
-## Accuracy Considerations
+## Configuring Custom Pricing
 
-| Factor | Impact | Notes |
-|--------|--------|-------|
-| **Stale pricing** | Medium | Pricing tables must be manually updated when providers change rates |
-| **Token counting** | Low | Token counts come from the provider's response — highly accurate |
-| **Streaming responses** | Low | Tokens are extracted from the final SSE `usage` chunk |
-| **Vertex AI pricing** | Medium | Vertex AI may have different pricing than direct API; current table uses direct API rates |
-| **Cached tokens** | Not tracked | Some providers offer cached token discounts; not currently differentiated |
-| **Prompt caching** | Not tracked | Anthropic/Google prompt caching discounts not yet modeled |
+For negotiated enterprise rates, volume discounts, or custom pricing, add a `pricing:` section to `config.yaml`:
+
+### Global Discount
+
+Apply a percentage discount to **all** model pricing:
+
+```yaml
+pricing:
+  discount_percent: 0.15  # 15% off all list prices
+```
+
+### Per-Model Overrides
+
+Override pricing for specific models (e.g., negotiated rates):
+
+```yaml
+pricing:
+  models:
+    - provider: openai
+      model: gpt-4o
+      input_per_million: 2.00     # negotiated rate (list: $2.50)
+      output_per_million: 8.00    # negotiated rate (list: $10.00)
+
+    - provider: google
+      model: gemini-2.5-pro
+      input_per_million: 1.00     # volume discount
+      output_per_million: 8.00
+```
+
+### Stacked Discounts
+
+Model-level and global discounts stack multiplicatively:
+
+```yaml
+pricing:
+  discount_percent: 0.10  # 10% enterprise-wide
+
+  models:
+    - provider: openai
+      model: gpt-4o
+      input_per_million: 2.50
+      output_per_million: 10.00
+      discount_percent: 0.20  # additional 20% on GPT-4o
+```
+
+Effective cost for GPT-4o: `base × 0.80 × 0.90 = base × 0.72` (28% total discount).
+
+---
+
+## Where Cost Is Calculated
+
+Cost enrichment happens at **two points** in the pipeline:
+
+### 1. Proxy Mode (real-time)
+
+When an LLM call completes through `/proxy/*`, the proxy extracts the token count from the provider's response and calls `calc.Calculate()` inline:
+
+```
+Client → Proxy → Upstream Provider → Response
+                                       ↓
+                               Extract tokens → Calculate cost → Build span
+```
+
+The proxy handles provider-specific token extraction:
+- **OpenAI**: `usage.prompt_tokens`, `usage.completion_tokens`
+- **Google Gemini**: `usageMetadata.promptTokenCount`, `usageMetadata.candidatesTokenCount`
+- **Anthropic**: `usage.input_tokens`, `usage.output_tokens`
+
+### 2. OTel Collector (pipeline enrichment)
+
+When spans arrive via OTLP (Agent Mode), the GenAI Processor enriches them before export:
+
+```
+Agent SDK → OTLP → Collector → GenAI Processor → Calculate cost → Export to Candela
+```
+
+The processor reads `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens` from span attributes.
+
+---
+
+## Adding a New Model
+
+When a provider releases a new model:
+
+### Option A: Config Override (no redeploy)
+
+Add it to your `config.yaml`:
+
+```yaml
+pricing:
+  models:
+    - provider: openai
+      model: gpt-6
+      input_per_million: 5.00
+      output_per_million: 20.00
+```
+
+Restart the server. The new model will be priced correctly.
+
+### Option B: Update Built-In Defaults (permanent)
+
+1. Edit `pkg/costcalc/calculator.go` → `loadDefaults()`
+2. Add the new model with its list pricing
+3. Run tests: `nix develop -c go test ./pkg/costcalc -v`
+4. Deploy
 
 ---
 
@@ -159,8 +168,8 @@ calc.SetPricing(costcalc.ModelPricing{
 
 | File | Purpose |
 |------|---------|
-| `pkg/costcalc/calculator.go` | `Calculator` struct, pricing table, `Calculate()` method |
-| `pkg/costcalc/calculator_test.go` | Unit tests for cost calculation |
-| `pkg/proxy/proxy.go` | Calls `calc.Calculate()` in `buildSpan()` |
-| `pkg/processor/processor.go` | Fallback cost enrichment during batch flush |
+| `pkg/costcalc/calculator.go` | `Calculator`, `loadDefaults()`, `LoadFromConfig()`, `resolve()`, discount math |
+| `pkg/costcalc/calculator_test.go` | Unit tests for pricing, discounts, and overrides |
+| `pkg/proxy/proxy.go` | Token extraction from provider responses |
 | `collector/processors/genaiprocessor/processor.go` | OTel pipeline cost enrichment |
+| `cmd/candela-server/main.go` | Wiring `cfg.Pricing` → `calc.LoadFromConfig()` |

--- a/docs/cost-calculation.md
+++ b/docs/cost-calculation.md
@@ -1,0 +1,166 @@
+# 💰 Cost Calculation Engine
+
+Candela provides real-time cost tracking for every LLM call. The `pkg/costcalc` package maintains a pricing table and calculates USD costs from token usage.
+
+## How Costs Flow Through the System
+
+```
+1. LLM Call (via Proxy or OTel)
+         │
+2. Token extraction (from response body or span attributes)
+         │
+3. Cost calculation (costcalc.Calculate)
+         │
+4. Enrichment ──┬── Proxy: writes cost into span.GenAI.CostUSD
+                └── Collector: writes cost as gen_ai.usage.cost_usd attribute
+         │
+5. Storage (DuckDB/SQLite/BigQuery gen_ai_cost_usd column)
+         │
+6. Display ──┬── Dashboard: total cost, cost-over-time chart
+             ├── Trace detail: per-span cost breakdown
+             └── Budget enforcement: deduct from user budget
+```
+
+### Two Enrichment Points
+
+Cost is calculated in **two places**, depending on the ingestion path:
+
+| Path | Where | When |
+|------|-------|------|
+| **Proxy Mode** | `pkg/proxy/proxy.go` → `buildSpan()` | After upstream response is parsed |
+| **Collector Mode** | `collector/processors/genaiprocessor` | In the OTel pipeline before export |
+| **Processor (fallback)** | `pkg/processor/processor.go` → `flush()` | During batch flush, if cost is still $0 |
+
+The processor applies cost calculation as a **safety net** — if the proxy or collector already set the cost, the processor does not override it.
+
+---
+
+## Pricing Table
+
+The calculator ships with built-in pricing for common models:
+
+### Google
+
+| Model | Input ($/1M tokens) | Output ($/1M tokens) |
+|-------|--------------------:|---------------------:|
+| `gemini-2.0-flash` | $0.10 | $0.40 |
+| `gemini-2.0-pro` | $1.25 | $10.00 |
+| `gemini-1.5-flash` | $0.075 | $0.30 |
+| `gemini-1.5-pro` | $1.25 | $5.00 |
+
+### OpenAI
+
+| Model | Input ($/1M tokens) | Output ($/1M tokens) |
+|-------|--------------------:|---------------------:|
+| `gpt-4o` | $2.50 | $10.00 |
+| `gpt-4o-mini` | $0.15 | $0.60 |
+| `gpt-4-turbo` | $10.00 | $30.00 |
+| `gpt-3.5-turbo` | $0.50 | $1.50 |
+| `o1` | $15.00 | $60.00 |
+| `o1-mini` | $3.00 | $12.00 |
+
+### Anthropic (via Vertex AI)
+
+| Model | Input ($/1M tokens) | Output ($/1M tokens) |
+|-------|--------------------:|---------------------:|
+| `claude-sonnet-4-20250514` | $3.00 | $15.00 |
+| `claude-haiku-3-5-20241022` | $0.80 | $4.00 |
+| `claude-3-5-sonnet-20241022` | $3.00 | $15.00 |
+| `claude-3-opus-20240229` | $15.00 | $75.00 |
+
+### Local Models
+
+All local models (provider = `local`) return **$0.00** — they run on your hardware with no API cost.
+
+---
+
+## Cost Formula
+
+```
+cost = (input_tokens / 1,000,000 × input_per_million)
+     + (output_tokens / 1,000,000 × output_per_million)
+```
+
+Example: `gpt-4o` with 1,500 input tokens and 500 output tokens:
+```
+cost = (1500 / 1M × $2.50) + (500 / 1M × $10.00)
+     = $0.00375 + $0.005
+     = $0.00875
+```
+
+---
+
+## Model Matching
+
+The calculator uses a two-pass lookup strategy:
+
+1. **Exact match** by `provider/model` key (e.g., `openai/gpt-4o`)
+2. **Provider-agnostic fallback** — if the exact key misses, search for any entry ending with `/model`
+
+This means `anthropic/claude-sonnet-4-20250514` will match even if the request comes through the `gemini-oai` provider route, as long as the model name matches.
+
+If no match is found, the cost is **$0.00** — the span is still captured, just without cost data.
+
+---
+
+## Adding or Updating Pricing
+
+### At Build Time
+
+Edit `pkg/costcalc/calculator.go` → `loadDefaults()`:
+
+```go
+func (c *Calculator) loadDefaults() {
+    defaults := []ModelPricing{
+        // Add new models here:
+        {Provider: "google", Model: "gemini-2.5-pro", InputPerMillion: 1.25, OutputPerMillion: 10.00},
+        {Provider: "google", Model: "gemini-2.5-flash", InputPerMillion: 0.15, OutputPerMillion: 0.60},
+        {Provider: "openai", Model: "o3-mini", InputPerMillion: 1.10, OutputPerMillion: 4.40},
+        // ...
+    }
+}
+```
+
+### At Runtime
+
+The `Calculator` is thread-safe and supports runtime pricing updates:
+
+```go
+calc := costcalc.New()
+
+// Add pricing for a new model
+calc.SetPricing(costcalc.ModelPricing{
+    Provider:         "anthropic",
+    Model:            "claude-opus-4-20250514",
+    InputPerMillion:  15.00,
+    OutputPerMillion: 75.00,
+})
+```
+
+> [!TIP]
+> A future enhancement could load pricing from a configuration file or remote endpoint, enabling pricing updates without code changes.
+
+---
+
+## Accuracy Considerations
+
+| Factor | Impact | Notes |
+|--------|--------|-------|
+| **Stale pricing** | Medium | Pricing tables must be manually updated when providers change rates |
+| **Token counting** | Low | Token counts come from the provider's response — highly accurate |
+| **Streaming responses** | Low | Tokens are extracted from the final SSE `usage` chunk |
+| **Vertex AI pricing** | Medium | Vertex AI may have different pricing than direct API; current table uses direct API rates |
+| **Cached tokens** | Not tracked | Some providers offer cached token discounts; not currently differentiated |
+| **Prompt caching** | Not tracked | Anthropic/Google prompt caching discounts not yet modeled |
+
+---
+
+## Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `pkg/costcalc/calculator.go` | `Calculator` struct, pricing table, `Calculate()` method |
+| `pkg/costcalc/calculator_test.go` | Unit tests for cost calculation |
+| `pkg/proxy/proxy.go` | Calls `calc.Calculate()` in `buildSpan()` |
+| `pkg/processor/processor.go` | Fallback cost enrichment during batch flush |
+| `collector/processors/genaiprocessor/processor.go` | OTel pipeline cost enrichment |

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,7 +40,7 @@ The server defaults to **DuckDB** and listens on the port from `config.yaml` (de
 nix develop -c go run ./cmd/candela-server
 ```
 
-Verify it's running: `curl http://localhost:8181/healthz` to verify it's running.
+Verify it's running: `curl http://localhost:8181/healthz`
 
 ### 3. Running the UI
 The web interface is a Next.js 16 app in `ui/`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,19 +34,19 @@ cd proto && buf generate
 This will populate `gen/go/` and `gen/ts/` (for the UI).
 
 ### 2. Running the Backend (Local Dev)
-The server defaults to **DuckDB** and uses the port from `config.yaml` (default **8080**).
+The server defaults to **DuckDB** and listens on the port from `config.yaml` (default **8181**).
 
 ```bash
-go run ./cmd/candela-server
+nix develop -c go run ./cmd/candela-server
 ```
 
-You can point your browser at `http://localhost:8181/healthz` to verify it's running.
+Verify it's running: `curl http://localhost:8181/healthz` to verify it's running.
 
 ### 3. Running the UI
 The web interface is a Next.js 16 app in `ui/`.
 
 ```bash
-cd ui && npm install && npm run dev
+cd ui && pnpm install && pnpm run dev
 ```
 
 The UI will be available at `http://localhost:3000`.
@@ -55,12 +55,17 @@ The UI will be available at `http://localhost:3000`.
 We use standard Go testing. Candela includes integration tests for the Proxy and Storage backends.
 
 ```bash
-# Run all tests
-go test ./...
+# Run all tests (always use nix develop -c for toolchain access)
+nix develop -c go test ./...
 
-# Run proxy tests (requires internet for some providers, or mocks)
-go test ./pkg/proxy -v
+# With race detector and verbose output
+nix develop -c go test ./... -v -race -count=1
+
+# Run proxy tests
+nix develop -c go test ./pkg/proxy -v
 ```
+
+See [docs/testing.md](testing.md) for the full testing guide.
 
 ---
 
@@ -138,4 +143,87 @@ curl -X POST \
 **List Traces via `grpcurl`:**
 ```bash
 grpcurl -plaintext localhost:8181 candela.v1.TraceService/ListTraces
+```
+
+See [docs/api-reference.md](api-reference.md) for the full API reference.
+
+---
+
+## 🐛 Debugging
+
+### Log Level Control
+
+Candela uses Go's `slog` with JSON output. The default level is `INFO`. To enable debug logging:
+
+```go
+// In cmd/candela-server/main.go, change the handler options:
+logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+    Level: slog.LevelDebug,  // Change from LevelInfo
+}))
+```
+
+Debug-level logs include:
+- Every proxied LLM call with model, tokens, cost, latency
+- Auth strategy evaluation (which strategy succeeded/failed)
+- Span processor flush events
+- Stream chunk translation details
+
+### IDE Debugger (GoLand / VS Code)
+
+Set the working directory to the repo root so `config.yaml` is found:
+
+```json
+// VS Code launch.json
+{
+  "type": "go",
+  "request": "launch",
+  "name": "Candela Server",
+  "program": "${workspaceFolder}/cmd/candela-server",
+  "cwd": "${workspaceFolder}"
+}
+```
+
+### Delve (CLI)
+
+```bash
+nix develop -c dlv debug ./cmd/candela-server
+```
+
+---
+
+## 🔥 Firestore Emulator
+
+For full-stack local dev with user management, run the Firestore emulator:
+
+```bash
+# Start the emulator (included in gcloud SDK via Nix)
+nix develop -c gcloud emulators firestore start --host-port=localhost:8282
+
+# In another terminal, set the emulator env var
+export FIRESTORE_EMULATOR_HOST=localhost:8282
+nix develop -c go run ./cmd/candela-server
+```
+
+With the emulator, Firestore operations (users, budgets, grants, audit) work locally without a GCP project.
+
+---
+
+## 🔄 Proto Generation
+
+Candela uses **Buf Remote Generation** — no local protoc plugins needed.
+
+```bash
+# Generate Go + TypeScript stubs
+cd proto && nix develop -c buf generate
+```
+
+This requires a `BUF_TOKEN` for remote generation. Options:
+- **CI**: Set as a GitHub Actions secret
+- **Local**: Add to `~/.netrc`: `machine buf.build login <user> password <token>`
+- **Local (env)**: `BUF_TOKEN=<token> buf generate`
+
+After generation, copy TS stubs to the UI:
+```bash
+cp -r gen/ts/candela/* ui/src/gen/
+rm -f ui/src/gen/types/bq_span_pb.ts  # BigQuery schema — server-only
 ```

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -1,0 +1,140 @@
+# 🌐 Environment Variable Reference
+
+Candela uses environment variables for production configuration, especially in containerized deployments where config files are generated at runtime.
+
+## Server Environment Variables
+
+These are used by the container entrypoint (`deploy/entrypoint.sh`) to generate `config.yaml` at startup.
+
+### Storage
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CANDELA_STORAGE_BACKEND` | `duckdb` | Storage backend: `duckdb`, `sqlite`, or `bigquery` |
+| `CANDELA_BQ_PROJECT` | _(empty)_ | BigQuery GCP project ID |
+| `CANDELA_BQ_DATASET` | `candela` | BigQuery dataset name |
+| `CANDELA_BQ_LOCATION` | `US` | BigQuery dataset location |
+
+### Proxy
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CANDELA_PROXY_ENABLED` | `false` | Enable the LLM API proxy |
+| `CANDELA_VERTEX_PROJECT` | _(empty)_ | GCP project for Vertex AI (required for Anthropic proxy) |
+| `CANDELA_VERTEX_REGION` | `us-east5` | Vertex AI region (must have Claude access) |
+| `CANDELA_LMSTUDIO_ENABLED` | `true` | Enable LM Studio compatible endpoints |
+| `CANDELA_LMSTUDIO_PORT` | `1234` | Secondary listener port for LM Studio compat |
+
+### Authentication
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CANDELA_DEV_MODE` | `false` | Skip auth, inject synthetic admin user. **Never use in production.** |
+| `CLOUD_RUN_URL` | _(empty)_ | Cloud Run service URL. Used as the audience for Google ID token validation (Strategy 2). Set this to enable `candela-local` Team Mode auth. |
+
+### Firestore
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CANDELA_FIRESTORE_PROJECT` | _(empty)_ | GCP project for Firestore |
+| `CANDELA_FIRESTORE_DATABASE` | `candela` | Firestore database ID (use `(default)` for the default database) |
+
+### Config
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CANDELA_CONFIG` | `config.yaml` | Path to the config file. In containers, set to `/etc/candela/config.yaml` by the entrypoint. |
+
+---
+
+## Build-Time Variables (Docker)
+
+These are passed as `--build-arg` during `docker build` and baked into the Next.js client bundle. They are **public** (non-secret) values.
+
+| Variable | Description |
+|----------|-------------|
+| `NEXT_PUBLIC_FIREBASE_API_KEY` | Firebase Web API key |
+| `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | Firebase Auth domain (e.g., `your-project.firebaseapp.com`) |
+| `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | Firebase project ID |
+| `NEXT_PUBLIC_FIREBASE_APP_ID` | Firebase app ID |
+
+These are configured in `cloudbuild.yaml` as substitution variables:
+
+```bash
+gcloud builds submit --project $PROJECT \
+  --substitutions=\
+_FIREBASE_API_KEY=AIza...,\
+_FIREBASE_AUTH_DOMAIN=my-project.firebaseapp.com,\
+_FIREBASE_PROJECT_ID=my-project,\
+_FIREBASE_APP_ID=1:123:web:abc
+```
+
+---
+
+## UI Environment Variables
+
+The Next.js UI reads these at **build time** (prefixed with `NEXT_PUBLIC_`) and at **runtime**:
+
+### Build-Time (`NEXT_PUBLIC_*`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NEXT_PUBLIC_API_URL` | `""` (empty) | Backend API URL. Empty = relative URLs (same-origin, proxied via Next.js rewrites). Set to `http://localhost:8181` for local dev with separate backend. |
+| `NEXT_PUBLIC_FIREBASE_API_KEY` | _(required)_ | Firebase Web API key |
+| `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | _(required)_ | Firebase Auth domain |
+| `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | _(required)_ | Firebase project ID |
+| `NEXT_PUBLIC_FIREBASE_APP_ID` | _(required)_ | Firebase app ID |
+
+### Runtime
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BACKEND_URL` | `http://localhost:8181` | Go backend URL for Next.js API rewrites (set in `next.config.ts`) |
+| `PORT` | `3000` | Next.js server port |
+| `HOSTNAME` | `0.0.0.0` | Next.js server bind address |
+
+---
+
+## candela-local Environment
+
+`candela-local` primarily reads from `~/.candela.yaml` (see [docs/candela-local.md](candela-local.md)). It also respects:
+
+| Variable | Description |
+|----------|-------------|
+| `GOOGLE_APPLICATION_CREDENTIALS` | Path to GCP service account key (alternative to `gcloud auth application-default login`) |
+| `GOOGLE_CLOUD_PROJECT` | Fallback GCP project if not set in `~/.candela.yaml` |
+
+---
+
+## CI Environment Variables
+
+| Variable | Used In | Description |
+|----------|---------|-------------|
+| `BUF_TOKEN` | CI workflow | Buf registry token for remote proto generation |
+| `GITHUB_TOKEN` | CI workflow | GitHub token for Nix installer |
+| `CI` | Playwright | Set to `true` to run browsers in CI mode |
+
+---
+
+## Quick Reference: Production Deployment
+
+Minimal environment for a production Cloud Run deployment:
+
+```bash
+# Required
+CANDELA_STORAGE_BACKEND=bigquery
+CANDELA_BQ_PROJECT=my-gcp-project
+CANDELA_FIRESTORE_PROJECT=my-gcp-project
+CANDELA_PROXY_ENABLED=true
+CANDELA_VERTEX_PROJECT=my-gcp-project
+
+# Recommended
+CANDELA_VERTEX_REGION=us-east5
+CANDELA_BQ_DATASET=candela
+CANDELA_FIRESTORE_DATABASE=candela
+CLOUD_RUN_URL=https://candela-xxx.a.run.app
+
+# Optional
+CANDELA_DEV_MODE=false  # default
+CANDELA_LMSTUDIO_ENABLED=true  # default
+```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,282 @@
+# 🛡️ Operations Runbook
+
+This runbook covers day-to-day operations, monitoring, incident response, and maintenance for a production Candela deployment on Google Cloud.
+
+## Deployment
+
+### Manual Deploy to Cloud Run
+
+```bash
+PROJECT=your-gcp-project
+REGION=us-central1
+
+# 1. Build and push the container image
+gcloud builds submit --project $PROJECT \
+  -f deploy/cloudbuild.yaml \
+  --substitutions=\
+_FIREBASE_API_KEY=AIza...,\
+_FIREBASE_AUTH_DOMAIN=$PROJECT.firebaseapp.com,\
+_FIREBASE_PROJECT_ID=$PROJECT,\
+_FIREBASE_APP_ID=1:123:web:abc \
+  .
+
+# 2. Deploy to Cloud Run
+gcloud run services update candela \
+  --project $PROJECT \
+  --region $REGION \
+  --image $REGION-docker.pkg.dev/$PROJECT/candela/candela-server:latest
+```
+
+### Rolling Back
+
+```bash
+# List revisions
+gcloud run revisions list --project $PROJECT --region $REGION --service candela
+
+# Route 100% traffic to a previous revision
+gcloud run services update-traffic candela \
+  --project $PROJECT --region $REGION \
+  --to-revisions=candela-00042-abc=100
+```
+
+### Environment Variables
+
+Set production env vars on the Cloud Run service:
+
+```bash
+gcloud run services update candela \
+  --project $PROJECT --region $REGION \
+  --set-env-vars=\
+CANDELA_STORAGE_BACKEND=bigquery,\
+CANDELA_BQ_PROJECT=$PROJECT,\
+CANDELA_FIRESTORE_PROJECT=$PROJECT,\
+CANDELA_PROXY_ENABLED=true,\
+CANDELA_VERTEX_PROJECT=$PROJECT,\
+CANDELA_VERTEX_REGION=us-east5,\
+CLOUD_RUN_URL=https://candela-xxx.a.run.app
+```
+
+See [docs/env-vars.md](env-vars.md) for the full reference.
+
+---
+
+## Health Checks
+
+### Backend Health
+
+```bash
+# Local
+curl http://localhost:8181/healthz
+
+# Production (requires auth)
+curl -H "Authorization: Bearer $(gcloud auth print-identity-token)" \
+  https://candela-xxx.a.run.app/healthz
+```
+
+Response:
+```json
+{"status": "ok"}        // healthy
+{"status": "error", "detail": "..."} // storage unreachable
+```
+
+### Cloud Run Health
+
+```bash
+gcloud run services describe candela --project $PROJECT --region $REGION \
+  --format='value(status.conditions)'
+```
+
+---
+
+## Monitoring
+
+### Key Metrics
+
+| Metric | Where | Alert Threshold |
+|--------|-------|----------------|
+| Request latency (p99) | Cloud Run metrics | > 5s |
+| Error rate (5xx) | Cloud Run metrics | > 5% |
+| Container startup time | Cloud Run metrics | > 30s |
+| BigQuery write errors | Application logs | Any |
+| Auth failures | Application logs (`"all auth strategies failed"`) | > 10/min |
+| Circuit breaker trips | Application logs (`"circuit breaker tripped"`) | Any |
+| Budget thresholds | Application logs (`"🔔 budget alert"`) | At 80%, 90%, 100% |
+| Span processor buffer full | Application logs (`"span processor buffer full"`) | Any |
+
+### Log-Based Alerts
+
+Create Cloud Logging alerts for critical events:
+
+```bash
+# Budget threshold alert
+gcloud logging metrics create candela-budget-alert \
+  --description="Candela budget threshold reached" \
+  --log-filter='resource.type="cloud_run_revision"
+    AND textPayload=~"budget alert"'
+
+# Circuit breaker alert
+gcloud logging metrics create candela-circuit-breaker \
+  --description="Candela circuit breaker tripped" \
+  --log-filter='resource.type="cloud_run_revision"
+    AND textPayload=~"circuit breaker tripped"'
+```
+
+### Structured Logging
+
+Candela uses `slog` with JSON output. Key log fields:
+
+| Field | Description |
+|-------|-------------|
+| `provider` | LLM provider name |
+| `model` | Model name |
+| `tokens` | Total token count |
+| `cost_usd` | Calculated cost |
+| `latency` | Request duration |
+| `user_id` | Authenticated user |
+| `request_id` | Unique request ID (X-Request-ID) |
+
+---
+
+## BigQuery Operations
+
+### Query Costs
+
+```sql
+-- Total cost by user, last 7 days
+SELECT
+  user_id,
+  SUM(gen_ai_cost_usd) as total_cost,
+  COUNT(*) as call_count,
+  SUM(gen_ai_total_tokens) as total_tokens
+FROM `candela.spans`
+WHERE start_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
+GROUP BY user_id
+ORDER BY total_cost DESC
+```
+
+### Cost Optimization
+
+| Optimization | Impact | How |
+|-------------|--------|-----|
+| Time partitioning | ~70% scan cost reduction | Already configured (`start_time`, DAY) |
+| Clustering | ~50% for filtered queries | Already configured (`project_id`, `trace_id`) |
+| Partition expiration | Storage savings | Set in Terraform: `expiration_ms` |
+| BI Engine reservation | Sub-second dashboard queries | Enable in BigQuery console |
+
+### Table Maintenance
+
+```sql
+-- Check table size
+SELECT
+  table_id,
+  ROUND(size_bytes / 1e9, 2) as size_gb,
+  row_count
+FROM `candela.__TABLES__`
+WHERE table_id = 'spans'
+```
+
+---
+
+## Firestore Operations
+
+### User Management
+
+```bash
+# List all users (via gcloud)
+gcloud firestore documents list \
+  --project=$PROJECT --database=candela \
+  --collection-path=users
+
+# Get a specific user
+gcloud firestore documents get \
+  --project=$PROJECT --database=candela \
+  users/USER_ID
+```
+
+### Quotas
+
+| Resource | Free Tier | Limit |
+|----------|-----------|-------|
+| Document reads | 50K/day | N/A (pay per use) |
+| Document writes | 20K/day | N/A |
+| Document deletes | 20K/day | N/A |
+| Max document size | N/A | 1 MiB |
+
+For Candela's usage pattern (user CRUD, budget checks), the free tier is usually sufficient for teams under 50 users.
+
+---
+
+## Incident Response
+
+### Scenario: Backend Not Starting
+
+1. Check Cloud Run logs: `gcloud run logs read --project $PROJECT --service candela`
+2. Common causes:
+   - Missing env vars → check `entrypoint.sh` substitution
+   - Firestore connection failed → check project ID and IAM
+   - BigQuery auth failed → check service account roles
+3. Quick fix: set `CANDELA_DEV_MODE=true` to bypass auth (temporary!)
+
+### Scenario: High Latency
+
+1. Check if a specific provider is slow: filter logs by `provider`
+2. Check circuit breaker state in logs
+3. Check BigQuery slot usage (if using BQ as reader)
+4. Check Cloud Run instance count (may need min-instances > 0)
+
+### Scenario: Budget Not Enforcing
+
+1. Check Firestore `budgets/{userId}` document
+2. Verify `period_start` is in the current period
+3. Check if grants are absorbing spend: inspect `grants/` collection
+4. Check logs for deduction errors: `"failed to deduct spend"`
+
+### Scenario: Proxy Returns 502
+
+1. Check upstream provider status (OpenAI, Vertex AI, Anthropic)
+2. Check circuit breaker state: look for `"circuit breaker tripped"` logs
+3. Check ADC token refresh: look for `"failed to get ADC token"` logs
+4. Verify `vertex_ai.project_id` and region in config
+
+---
+
+## Maintenance
+
+### Updating Model Pricing
+
+When LLM providers change prices:
+1. Update `pkg/costcalc/calculator.go` → `loadDefaults()`
+2. Run tests: `nix develop -c go test ./pkg/costcalc -v`
+3. Deploy — pricing takes effect on next restart
+
+### Terraform State
+
+```bash
+cd terraform
+
+# Check current state
+tofu state list
+
+# Import existing resources
+tofu import google_cloud_run_v2_service.candela projects/$PROJECT/locations/$REGION/services/candela
+
+# Plan changes
+tofu plan
+```
+
+### Database Migrations
+
+- **DuckDB**: Schema is auto-provisioned. No manual migrations needed.
+- **SQLite**: Schema is auto-provisioned.
+- **BigQuery**: Schema is auto-provisioned. Column additions are backward-compatible. Removing columns requires table recreation.
+- **Firestore**: Schema-less. Field additions are backward-compatible.
+
+### Certificate/Domain Management
+
+```bash
+# Check domain mapping
+gcloud run domain-mappings list --project $PROJECT --region $REGION
+
+# Add Firebase authorized domain
+# Must be done in Firebase Console → Authentication → Settings → Authorized Domains
+```

--- a/docs/otel-collector.md
+++ b/docs/otel-collector.md
@@ -1,0 +1,250 @@
+# 📡 OTel Collector — Agent-Native Ingestion
+
+Candela ships a **custom OpenTelemetry Collector distribution** that enriches LLM trace spans with cost data and forwards them to the Candela backend. This is the recommended path for deep observability into agent frameworks like **Google ADK**, **LangChain**, **CrewAI**, and any OTel-instrumented application.
+
+## When to Use the Collector
+
+| Ingestion Mode | Best For | Complexity |
+|---------------|----------|------------|
+| **Proxy Mode** (`/proxy/*`) | Quick start, single LLM call observability | Zero-code |
+| **Collector Mode** (OTLP) | Agent frameworks, multi-span traces, DAG visualization | Requires OTel SDK |
+
+Use the Collector when you need:
+- **Multi-span traces** — see the full agent DAG (planner → tool calls → LLM → retrieval)
+- **Framework integration** — ADK, LangChain, and CrewAI emit OTel spans natively
+- **Custom attributes** — attach business context to spans (user, session, experiment)
+- **Dual-write** — export to Candela AND Google Cloud Trace simultaneously
+
+---
+
+## Architecture
+
+```
+┌──────────────────┐     OTLP/gRPC or HTTP
+│  Your App/Agent  │────────────────────────┐
+│  (OTel SDK)      │                        │
+└──────────────────┘                        ▼
+                                  ┌──────────────────┐
+                                  │ Candela Collector │
+                                  │  ┌──────────────┐ │
+                                  │  │ OTLP Receiver │ │  ← :4317 (gRPC) / :4318 (HTTP)
+                                  │  └──────┬───────┘ │
+                                  │         ▼         │
+                                  │  ┌──────────────┐ │
+                                  │  │ GenAI        │ │  ← cost enrichment
+                                  │  │ Processor    │ │
+                                  │  └──────┬───────┘ │
+                                  │         ▼         │
+                                  │  ┌──────────────┐ │
+                                  │  │ Batch        │ │  ← 256 spans / 5s
+                                  │  │ Processor    │ │
+                                  │  └──────┬───────┘ │
+                                  │     ┌───┴───┐     │
+                                  │     ▼       ▼     │
+                                  │  ┌─────┐ ┌─────┐  │
+                                  │  │OTLP │ │Debug│  │  ← export to Candela + stdout
+                                  │  └─────┘ └─────┘  │
+                                  └──────────────────┘
+                                         │
+                                         ▼ OTLP/gRPC
+                                  ┌──────────────────┐
+                                  │ Candela Backend   │
+                                  │ (IngestionService)│
+                                  └──────────────────┘
+```
+
+---
+
+## Building the Collector
+
+The custom collector is built using the [OTel Collector Builder](https://opentelemetry.io/docs/collector/custom-collector/) (`ocb`).
+
+### Prerequisites
+- Go 1.26+ (available via `nix develop`)
+
+### Build
+
+```bash
+# Install the builder
+go install go.opentelemetry.io/collector/cmd/builder@latest
+
+# Build the custom collector binary
+cd collector
+builder --config=builder.yaml
+```
+
+This produces `../cmd/candela-collector/candela-collector` — a single binary with the GenAI processor baked in.
+
+### What's Included
+
+The builder config (`collector/builder.yaml`) bundles:
+
+| Component | Type | Purpose |
+|-----------|------|---------|
+| `otlpreceiver` | Receiver | Accepts OTLP spans via gRPC (`:4317`) and HTTP (`:4318`) |
+| `batchprocessor` | Processor | Batches spans (256 per batch, 5s timeout) |
+| `genaiprocessor` | Processor | **Custom** — enriches GenAI spans with USD cost |
+| `otlpexporter` | Exporter | Forwards to Candela backend (gRPC) |
+| `otlphttpexporter` | Exporter | Forwards to Candela backend (HTTP) |
+| `debugexporter` | Exporter | Logs spans to stdout for dev |
+| `zpagesextension` | Extension | Collector diagnostics UI |
+
+---
+
+## GenAI Processor
+
+The custom `genaiprocessor` (`collector/processors/genaiprocessor/processor.go`) enriches spans in the OTel pipeline:
+
+### What It Does
+
+1. **Identifies GenAI spans** by checking for `gen_ai.system` or `gen_ai.request.model` attributes
+2. **Extracts token counts** from `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens`
+3. **Calculates cost** using the shared `pkg/costcalc` engine
+4. **Injects** `gen_ai.usage.cost_usd` attribute into the span
+
+### OTel Semantic Conventions Used
+
+| Attribute | Description | Example |
+|-----------|-------------|---------|
+| `gen_ai.system` | LLM provider identifier | `openai`, `google`, `anthropic` |
+| `gen_ai.request.model` | Model name | `gpt-4o`, `gemini-2.5-pro` |
+| `gen_ai.usage.input_tokens` | Prompt tokens | `150` |
+| `gen_ai.usage.output_tokens` | Completion tokens | `42` |
+| `gen_ai.usage.cost_usd` | **Enriched** — calculated cost | `0.0023` |
+
+The processor is idempotent — if `gen_ai.usage.cost_usd` is already present, it skips the span.
+
+---
+
+## Running the Collector
+
+### Local Development
+
+```bash
+# Start the collector with the dev config
+./candela-collector --config=collector/collector-config.yaml
+```
+
+The default config (`collector/collector-config.yaml`) exports to:
+- **Candela backend** at `localhost:8080` (OTLP/gRPC, insecure)
+- **Debug output** (stdout, basic verbosity)
+
+### Production
+
+For production, update the export endpoint and optionally add Cloud Trace:
+
+```yaml
+exporters:
+  otlp/candela:
+    endpoint: "your-candela-server:8080"
+    tls:
+      insecure: false
+      # Or use mTLS / GCP auth
+
+  # Optional: dual-write to Google Cloud Trace
+  otlp/cloudtrace:
+    endpoint: "cloudtrace.googleapis.com:443"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [genai, batch]
+      exporters: [otlp/candela, otlp/cloudtrace]
+```
+
+---
+
+## Instrumenting Your Application
+
+### Google ADK (Agent Development Kit)
+
+ADK emits OTel spans natively. Point its exporter at the Candela Collector:
+
+```python
+from google.adk import Agent
+import opentelemetry
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+# Point at Candela Collector
+exporter = OTLPSpanExporter(endpoint="http://localhost:4317", insecure=True)
+provider = TracerProvider()
+provider.add_span_processor(BatchSpanProcessor(exporter))
+opentelemetry.trace.set_tracer_provider(provider)
+
+# ADK will now emit spans to Candela
+agent = Agent(model="gemini-2.5-pro", ...)
+```
+
+### LangChain
+
+```python
+from langchain.callbacks.tracers import OpenTelemetryTracer
+
+tracer = OpenTelemetryTracer()  # Uses the global TracerProvider
+chain.invoke({"input": "..."}, config={"callbacks": [tracer]})
+```
+
+### Generic OTel SDK (Go)
+
+```go
+import (
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+    sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+exporter, _ := otlptracegrpc.New(ctx,
+    otlptracegrpc.WithEndpoint("localhost:4317"),
+    otlptracegrpc.WithInsecure(),
+)
+tp := sdktrace.NewTracerProvider(
+    sdktrace.WithBatcher(exporter),
+)
+otel.SetTracerProvider(tp)
+```
+
+### Manual Span Attributes
+
+For custom applications, ensure your spans include GenAI attributes:
+
+```python
+from opentelemetry import trace
+
+tracer = trace.get_tracer("my-app")
+with tracer.start_as_current_span("llm.completion") as span:
+    span.set_attribute("gen_ai.system", "openai")
+    span.set_attribute("gen_ai.request.model", "gpt-4o")
+    # ... make LLM call ...
+    span.set_attribute("gen_ai.usage.input_tokens", 150)
+    span.set_attribute("gen_ai.usage.output_tokens", 42)
+    # gen_ai.usage.cost_usd will be added by the GenAI Processor
+```
+
+---
+
+## Collector vs. Standard `otelcol`
+
+You can use the standard OpenTelemetry Collector (`otelcol`) without the custom GenAI processor. Spans will still be ingested, but **cost enrichment will not happen at the collector level** — the Candela backend will calculate costs instead.
+
+```bash
+# Using the standard collector (no cost enrichment in pipeline)
+otelcol --config=collector/collector-config.yaml
+
+# Using the Candela custom collector (with cost enrichment)
+./candela-collector --config=collector/collector-config.yaml
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| No spans appearing in Candela | Collector not connected | Check `otlp/candela` endpoint and TLS settings |
+| Cost is $0.00 on all spans | Unknown model in pricing table | Add model to `pkg/costcalc/calculator.go` |
+| `gen_ai.usage.cost_usd` missing | Span lacks `gen_ai.system` attribute | Ensure your SDK sets GenAI semantic conventions |
+| High memory usage | Batch too large | Reduce `send_batch_size` in batch processor config |
+| Connection refused on :4317 | Collector not running | Start with `./candela-collector --config=...` |

--- a/docs/otel-collector.md
+++ b/docs/otel-collector.md
@@ -126,7 +126,7 @@ The processor is idempotent — if `gen_ai.usage.cost_usd` is already present, i
 ```
 
 The default config (`collector/collector-config.yaml`) exports to:
-- **Candela backend** at `localhost:8080` (OTLP/gRPC, insecure)
+- **Candela backend** at `localhost:8181` (OTLP/gRPC, insecure)
 - **Debug output** (stdout, basic verbosity)
 
 ### Production
@@ -136,7 +136,7 @@ For production, update the export endpoint and optionally add Cloud Trace:
 ```yaml
 exporters:
   otlp/candela:
-    endpoint: "your-candela-server:8080"
+    endpoint: "your-candela-server:8181"
     tls:
       insecure: false
       # Or use mTLS / GCP auth
@@ -244,7 +244,7 @@ otelcol --config=collector/collector-config.yaml
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | No spans appearing in Candela | Collector not connected | Check `otlp/candela` endpoint and TLS settings |
-| Cost is $0.00 on all spans | Unknown model in pricing table | Add model to `pkg/costcalc/calculator.go` |
+| Cost is $0.00 on all spans | Unknown model in pricing table | Add model to `pricing:` config or `loadDefaults()` — check server logs for `⚠️ missing pricing` warnings |
 | `gen_ai.usage.cost_usd` missing | Span lacks `gen_ai.system` attribute | Ensure your SDK sets GenAI semantic conventions |
 | High memory usage | Batch too large | Reduce `send_batch_size` in batch processor config |
 | Connection refused on :4317 | Collector not running | Start with `./candela-collector --config=...` |

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,222 @@
+# 🔐 Security & Authentication
+
+Candela uses a **multi-strategy authentication** system designed to securely serve three distinct client types: browser users, developer CLI tools, and service accounts. This document covers the authentication architecture, authorization model, and security considerations.
+
+## Authentication Architecture
+
+```mermaid
+flowchart TD
+    REQ[Incoming Request] --> SKIP{Path = /healthz?}
+    SKIP -->|yes| PASS[Pass through]
+    SKIP -->|no| DEV{Dev Mode?}
+    DEV -->|yes| SYNTH["Inject synthetic admin\n(admin@localhost)"]
+    DEV -->|no| TOK{Has Bearer Token?}
+    TOK -->|no| DENY["401 Unauthorized"]
+    TOK -->|yes| S1["Strategy 1:\nFirebase ID Token"]
+    S1 -->|valid| AUTH[Authenticated ✓]
+    S1 -->|invalid| S2["Strategy 2:\nGoogle ID Token"]
+    S2 -->|valid| AUTH
+    S2 -->|invalid| S3["Strategy 3:\nOAuth2 Access Token\n(via userinfo API)"]
+    S3 -->|valid| AUTH
+    S3 -->|invalid| DENY
+    AUTH --> CTX["User injected into\nrequest context"]
+    CTX --> HANDLER[ConnectRPC Handler]
+```
+
+### Strategy Waterfall
+
+The middleware (`pkg/auth/firebase.go`) tries three strategies in sequence. The first successful validation wins:
+
+| # | Strategy | Client | Token Source | Validation Method |
+|---|----------|--------|-------------|-------------------|
+| 1 | **Firebase ID Token** | Browser UI | Firebase JS SDK (`onAuthStateChanged`) | `fbAuth.VerifyIDToken()` |
+| 2 | **Google ID Token** | Service accounts, `candela-local` with `idtoken` | `idtoken.NewTokenSource(audience)` | `idtoken.Validate(token, audience)` |
+| 3 | **OAuth2 Access Token** | `candela-local` with user ADC | `gcloud auth application-default login` | `googleapis.com/oauth2/v3/userinfo` |
+
+> [!NOTE]
+> Strategy 3 makes an HTTP call to Google's userinfo endpoint on every request. This adds ~50ms latency but is the only way to validate user-scoped Application Default Credentials (ADC) that `candela-local` uses when `gcloud auth application-default login` provides an access token rather than an ID token.
+
+### Auth Bypass
+
+These paths skip authentication entirely:
+- `/healthz` — health check endpoint (Cloud Run readiness probe)
+
+---
+
+## Authorization — Role-Based Access Control (RBAC)
+
+### Roles
+
+| Role | Enum | Description |
+|------|------|-------------|
+| `developer` | `USER_ROLE_DEVELOPER = 1` | Use proxy, view own traces/costs, self-service RPCs |
+| `admin` | `USER_ROLE_ADMIN = 2` | Full access: manage users, budgets, view all data |
+
+### Admin Guard Interceptor
+
+The `AdminInterceptor` (`pkg/auth/admin.go`) is a ConnectRPC unary interceptor that enforces admin-only access:
+
+```
+Request → Auth Middleware → Admin Interceptor → Handler
+                               │
+                               ├── Self-service RPC? → Pass through
+                               └── Admin RPC? → Look up user role
+                                                   ├── admin → Pass through
+                                                   └── !admin → 403 PermissionDenied
+```
+
+### RPC Access Matrix
+
+#### Self-Service RPCs (any authenticated user)
+| RPC | Description |
+|-----|-------------|
+| `GetCurrentUser` | Returns the caller's own profile, budget, and active grants |
+| `GetMyBudget` | Returns the caller's budget and current-period spending |
+
+#### Admin-Only RPCs (13 RPCs)
+| Category | RPCs |
+|----------|------|
+| **Users** | `CreateUser`, `ListUsers`, `GetUser`, `UpdateUser`, `DeactivateUser`, `ReactivateUser` |
+| **Budgets** | `SetBudget`, `GetBudget`, `ResetSpend` |
+| **Grants** | `CreateGrant`, `ListGrants`, `RevokeGrant` |
+| **Audit** | `ListAuditLog` |
+
+#### Unguarded Services
+| Service | Why |
+|---------|-----|
+| `TraceService` | User-scoped filtering done at query layer (not interceptor) |
+| `DashboardService` | User-scoped filtering done at query layer |
+| `IngestionService` | Ingestion validated by project API key, not user identity |
+| `ProjectService` | Currently unguarded (future: project-level RBAC) |
+
+---
+
+## User Identity & Context Propagation
+
+### User Struct
+
+```go
+// pkg/auth/context.go
+type User struct {
+    ID    string // Firebase UID or Google subject (`sub` claim)
+    Email string // Verified email claim (lowercased)
+}
+```
+
+### Context Flow
+
+The authenticated user is attached to the request context and available throughout the handler stack:
+
+```go
+// In any handler:
+user := auth.FromContext(ctx)        // *auth.User or nil
+userID := auth.IDFromContext(ctx)    // string (empty if no user)
+email := auth.EmailFromContext(ctx)  // string (empty if no user)
+```
+
+The proxy uses context-propagated user identity for:
+- **Per-user span attribution** — `span.UserID = caller.ID`
+- **Budget deduction** — `users.DeductSpend(ctx, span.UserID, cost, tokens)`
+- **User-scoped trace queries** — developers only see their own traces
+
+---
+
+## Dev Mode
+
+When `CANDELA_DEV_MODE=true` or `auth.dev_mode: true` in config:
+
+- **No token validation** — all requests succeed
+- **Synthetic admin user** injected: `{ID: "dev-admin", Email: "admin@localhost"}`
+- All admin RPCs are accessible
+- All traces are visible (no user scoping)
+
+> [!WARNING]
+> Never run dev mode in production. There is no authentication bypass — all requests get full admin access.
+
+---
+
+## `candela-local` Authentication
+
+### Solo Mode
+No authentication needed. All requests to `:1234` and `:8181` are unauthenticated.
+
+### Solo + Cloud Mode
+Uses **Application Default Credentials (ADC)** to call Vertex AI directly:
+```bash
+gcloud auth application-default login
+```
+No server-side auth needed — ADC tokens are used for upstream cloud calls only.
+
+### Team Mode
+`candela-local` injects OIDC tokens into requests to the Candela Cloud Run server:
+
+```
+IDE → candela-local (:1234)
+         │
+         ├── Local model → Ollama (no auth)
+         │
+         └── Cloud model → Candela Server (Cloud Run)
+                              │
+              ┌───────────────┘
+              │ Authorization: Bearer <google-id-token>
+              ▼
+         Auth Middleware (Strategy 2 or 3)
+```
+
+Token acquisition flow:
+1. `candela-local` reads `~/.candela.yaml` for `remote` and `audience`
+2. Uses `google.DefaultTokenSource()` to get an ADC token
+3. Injects `Authorization: Bearer <token>` on every proxied request
+
+---
+
+## IAP Authentication (Legacy)
+
+The `IAPMiddleware` (`pkg/auth/iap.go`) validates Cloud IAP JWT assertions from the `x-goog-iap-jwt-assertion` header. This is the **original** auth path when Candela ran behind Cloud IAP.
+
+The current production setup uses `FirebaseAuthMiddleware` instead, which provides more flexible multi-strategy auth. The IAP middleware remains available for deployments behind Cloud IAP.
+
+---
+
+## Input Validation
+
+All `UserService` requests are validated server-side using [`protovalidate`](https://github.com/bufbuild/protovalidate). The validation interceptor runs **before** the admin guard:
+
+```
+Request → protovalidate → AdminInterceptor → Handler
+```
+
+See [docs/user-management.md](user-management.md) for the full validation rule reference.
+
+---
+
+## Security Hardening Checklist
+
+| Item | Status | Notes |
+|------|--------|-------|
+| Token validation on all non-health endpoints | ✅ | 3-strategy waterfall |
+| Email claim normalization (lowercase) | ✅ | Prevents case-based identity bypass |
+| Admin role enforcement via ConnectRPC interceptor | ✅ | Per-RPC ACL |
+| Rate limiting per user | ✅ | `CheckRateLimit()` in `UserStore` |
+| Budget enforcement before proxy calls | ✅ | `CheckBudget()` pre-flight |
+| Secrets not baked into container images | ✅ | `entrypoint.sh` generates config from env vars |
+| ADC token auto-refresh | ✅ | `oauth2.TokenSource` handles refresh |
+| API key hashing (bcrypt) | ✅ | `APIKey.KeyHash` never exposed |
+| Proxy does not store upstream API keys | ✅ | Forwarded transparently |
+| CORS origin allowlist | ✅ | Configurable, defaults to localhost |
+| Firebase authorized domains | ⚠️ | Must be configured in Firebase Console |
+| HTTPS in production | ⚠️ | Handled by Cloud Run / load balancer |
+| Audit logging for admin actions | ✅ | Firestore `audit_log` collection |
+
+---
+
+## Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `pkg/auth/context.go` | `User` struct, context get/set helpers |
+| `pkg/auth/firebase.go` | `FirebaseAuthMiddleware` — 3-strategy waterfall |
+| `pkg/auth/iap.go` | `IAPMiddleware` — Cloud IAP JWT validation (legacy) |
+| `pkg/auth/admin.go` | `AdminInterceptor` — ConnectRPC admin guard |
+| `cmd/candela-server/main.go` | Middleware wiring, Firebase init, dev mode |
+| `cmd/candela-local/main.go` | ADC token injection for Team Mode |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,243 @@
+# 🧪 Testing Guide
+
+Candela has a comprehensive test suite covering unit tests, integration tests, and end-to-end browser tests. This document covers test architecture, running tests, and contributing new tests.
+
+## Test Architecture Overview
+
+```
+tests/
+├── Go Unit Tests (~20 files)
+│   ├── pkg/proxy/*_test.go         — proxy, translation, circuit breaker
+│   ├── pkg/costcalc/*_test.go      — cost calculation
+│   ├── pkg/processor/*_test.go     — span processor batching/fanout
+│   ├── pkg/auth/*_test.go          — auth middleware, admin guard, context
+│   ├── pkg/runtime/*_test.go       — runtime interface, discovery, manager
+│   ├── pkg/notify/*_test.go        — budget notifications
+│   ├── pkg/storage/*_test.go       — storage interfaces
+│   └── cmd/candela-local/*_test.go — LM handler, span capture, state, API
+│
+├── Go Integration Tests
+│   ├── pkg/connecthandlers/integration_test.go — full service stack
+│   ├── pkg/connecthandlers/project_handler_test.go
+│   ├── pkg/connecthandlers/user_handler_test.go
+│   └── cmd/candela-local/ui_integration_test.go
+│
+└── Playwright E2E Tests (3 suites)
+    ├── e2e/app.spec.ts             — dashboard, traces, costs, usage
+    ├── e2e/admin.spec.ts           — user mgmt, budgets, audit
+    └── e2e/team_mode.spec.ts       — leaderboard, per-user, alerts
+```
+
+---
+
+## Running Tests
+
+### All Go Tests
+
+```bash
+# Quick run (from nix shell)
+nix develop -c go test ./...
+
+# With race detector and verbose output
+nix develop -c go test ./... -v -race -count=1
+
+# With coverage
+nix develop -c go test ./... -coverprofile=coverage.out
+nix develop -c go tool cover -func=coverage.out | tail -1
+```
+
+### Specific Packages
+
+```bash
+# Proxy tests
+nix develop -c go test ./pkg/proxy -v
+
+# Auth tests
+nix develop -c go test ./pkg/auth -v
+
+# Runtime tests
+nix develop -c go test ./pkg/runtime/... -v
+
+# candela-local tests
+nix develop -c go test ./cmd/candela-local -v
+
+# Integration tests (ConnectRPC handlers)
+nix develop -c go test ./pkg/connecthandlers -v -run TestIntegration
+```
+
+### Playwright E2E Tests
+
+```bash
+cd ui
+
+# Install browsers (first time only)
+pnpm exec playwright install --with-deps chromium
+
+# Run all E2E tests (headless)
+pnpm run test:e2e
+
+# Interactive UI mode (recommended for debugging)
+pnpm run test:e2e:ui
+
+# Run a specific test file
+pnpm exec playwright test e2e/admin.spec.ts
+
+# Run a specific test by name
+pnpm exec playwright test -g "should show budget gauge"
+```
+
+---
+
+## Pre-Commit Hooks
+
+The `.pre-commit-config.yaml` runs these checks on every `git commit`:
+
+| Hook | What It Does | Blocks Commit? |
+|------|-------------|---------------|
+| `trailing-whitespace` | Removes trailing whitespace | Yes |
+| `end-of-file-fixer` | Ensures newline at end of file | Yes |
+| `check-yaml` | Validates YAML syntax | Yes |
+| `check-json` | Validates JSON syntax | Yes |
+| `check-merge-conflict` | Detects merge conflict markers | Yes |
+| `detect-private-key` | Prevents committing secrets | Yes |
+| `golangci-lint` | Go linting (5min timeout) | Yes |
+| `buf-lint` | Protobuf linting | Yes |
+| `buf-format` | Auto-formats proto files | Yes |
+| `buf-breaking` | Detects breaking proto changes vs `main` | Yes |
+| `go-vet` | Go static analysis | Yes |
+| `go-mod-tidy` | Auto-tidies `go.mod` | Yes |
+| `gofmt` | Go formatting check | Yes |
+| `go-test` | Runs full test suite (30s timeout) | Yes |
+
+> [!IMPORTANT]
+> Per project conventions, always run `git commit` inside the nix shell:
+> ```bash
+> nix develop -c git commit -m "feat: your message"
+> ```
+> This ensures pre-commit hooks have access to all required tools.
+
+---
+
+## CI Pipeline
+
+The GitHub Actions CI (`.github/workflows/ci.yml`) runs three jobs:
+
+### 1. `build-and-test` (Go)
+- Proto generation via Buf (remote, requires `BUF_TOKEN`)
+- `go build ./...`
+- `go vet ./...`
+- `go test ./... -v -race -count=1 -coverprofile=coverage.out`
+- Coverage summary
+- `govulncheck ./...` (advisory, non-blocking)
+
+### 2. `ui-build-and-lint` (Next.js)
+- `pnpm install`
+- Proto generation (TS stubs)
+- Copy generated types to `ui/src/gen/`
+- `pnpm run lint` (ESLint)
+- `pnpm run build` (TypeScript type-check)
+
+### 3. `ui-e2e` (Playwright)
+- Depends on `ui-build-and-lint`
+- Installs Playwright + Chromium
+- Runs all E2E tests
+- Uploads test report as artifact (7-day retention)
+
+---
+
+## Test Patterns
+
+### Unit Test Structure
+
+Tests follow Go conventions — same package, `_test.go` suffix:
+
+```go
+// pkg/proxy/proxy_test.go
+func TestProxy_HandleStandardResponse(t *testing.T) {
+    // Setup: create test server, proxy, submitter mock
+    // Act: send request through proxy
+    // Assert: verify span was created with correct attributes
+}
+```
+
+### Table-Driven Tests
+
+Used extensively for parameterized testing:
+
+```go
+func TestCalculator_Calculate(t *testing.T) {
+    tests := []struct {
+        name     string
+        provider string
+        model    string
+        input    int64
+        output   int64
+        want     float64
+    }{
+        {"gpt-4o standard", "openai", "gpt-4o", 1000, 500, 0.0075},
+        {"local model", "local", "llama3", 1000, 500, 0.0},
+        // ...
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            // ...
+        })
+    }
+}
+```
+
+### Integration Tests
+
+The `connecthandlers/integration_test.go` tests the full service stack with real storage:
+
+```go
+func TestIntegration_ListTraces(t *testing.T) {
+    // Creates an in-memory SQLite store
+    // Wires up ConnectRPC handlers
+    // Makes real RPC calls through the handler
+    // Verifies end-to-end behavior
+}
+```
+
+### E2E Test Patterns
+
+Playwright tests use route interception to mock the backend:
+
+```typescript
+test("should display cost analytics", async ({ page }) => {
+    // Mock the ConnectRPC response
+    await page.route("**/candela.v1.DashboardService/GetModelBreakdown", (route) => {
+        route.fulfill({ body: JSON.stringify({ models: [...] }) });
+    });
+
+    await page.goto("/costs");
+    await expect(page.getByText("Cost Analytics")).toBeVisible();
+});
+```
+
+---
+
+## Adding New Tests
+
+### Go Unit Test
+
+1. Create `yourpkg/yourfile_test.go` in the same package
+2. Use `testing.T` and standard assertions
+3. For storage tests, use `sqlitestore.New(":memory:")` for ephemeral databases
+
+### E2E Test
+
+1. Add to the appropriate suite (`app.spec.ts`, `admin.spec.ts`, or `team_mode.spec.ts`)
+2. Mock backend responses via `page.route()`
+3. Use semantic selectors (`getByText`, `getByRole`) over CSS selectors
+4. Run with `pnpm run test:e2e:ui` during development
+
+---
+
+## Vulnerability Scanning
+
+```bash
+nix develop -c govulncheck ./...
+```
+
+This runs as advisory in CI (non-blocking). Fix critical vulnerabilities by updating dependencies in `go.mod`.

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -1,9 +1,11 @@
 // Package costcalc provides token-to-cost calculations for LLM API calls.
 // It maintains a pricing table for common models and calculates costs from
-// token counts.
+// token counts. Pricing can be overridden via config for negotiated rates
+// or enterprise discounts.
 package costcalc
 
 import (
+	"log/slog"
 	"strings"
 	"sync"
 )
@@ -12,26 +14,37 @@ import (
 type ModelPricing struct {
 	Model            string  `yaml:"model" json:"model"`
 	Provider         string  `yaml:"provider" json:"provider"`
-	InputPerMillion  float64 `yaml:"input_per_million" json:"input_per_million"`   // USD per 1M input tokens
-	OutputPerMillion float64 `yaml:"output_per_million" json:"output_per_million"` // USD per 1M output tokens
+	InputPerMillion  float64 `yaml:"input_per_million" json:"input_per_million"`                   // USD per 1M input tokens
+	OutputPerMillion float64 `yaml:"output_per_million" json:"output_per_million"`                 // USD per 1M output tokens
+	DiscountPercent  float64 `yaml:"discount_percent,omitempty" json:"discount_percent,omitempty"` // 0.0–1.0, model-specific discount
+}
+
+// PricingConfig holds pricing configuration loaded from config.yaml.
+type PricingConfig struct {
+	DiscountPercent float64        `yaml:"discount_percent"` // Global discount (0.0–1.0)
+	Models          []ModelPricing `yaml:"models"`           // Per-model overrides
 }
 
 // Calculator computes costs from token usage and model pricing.
 type Calculator struct {
-	mu      sync.RWMutex
-	pricing map[string]ModelPricing // key: "provider/model"
+	mu             sync.RWMutex
+	defaults       map[string]ModelPricing // key: "provider/model" — built-in list prices
+	overrides      map[string]ModelPricing // key: "provider/model" — config overrides
+	globalDiscount float64                 // 0.0–1.0
 }
 
-// New creates a Calculator with default pricing for common models.
+// New creates a Calculator with default pricing for all supported cloud models.
 func New() *Calculator {
 	c := &Calculator{
-		pricing: make(map[string]ModelPricing),
+		defaults:  make(map[string]ModelPricing),
+		overrides: make(map[string]ModelPricing),
 	}
 	c.loadDefaults()
 	return c
 }
 
 // Calculate returns the estimated cost in USD for the given model and token counts.
+// Local models always return $0.00. Unknown cloud models log a warning and return $0.00.
 func (c *Calculator) Calculate(provider, model string, inputTokens, outputTokens int64) float64 {
 	// Local models run on your hardware — no API cost.
 	if strings.ToLower(provider) == "local" {
@@ -41,65 +54,158 @@ func (c *Calculator) Calculate(provider, model string, inputTokens, outputTokens
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	key := c.key(provider, model)
-	p, ok := c.pricing[key]
+	p, ok := c.resolve(provider, model)
 	if !ok {
-		// Try matching just by model name (provider-agnostic)
-		for k, v := range c.pricing {
-			if strings.HasSuffix(k, "/"+model) {
-				p = v
-				ok = true
-				break
-			}
-		}
-	}
-	if !ok {
-		return 0 // Unknown model, can't calculate cost
+		slog.Warn("⚠️ missing pricing for cloud model — cost will be $0.00 (inaccurate)",
+			"provider", provider,
+			"model", model,
+			"input_tokens", inputTokens,
+			"output_tokens", outputTokens,
+		)
+		return 0 // Unknown model — this is a gap, not a feature
 	}
 
 	inputCost := float64(inputTokens) / 1_000_000 * p.InputPerMillion
 	outputCost := float64(outputTokens) / 1_000_000 * p.OutputPerMillion
-	return inputCost + outputCost
+	baseCost := inputCost + outputCost
+
+	// Apply model-level discount, then global discount.
+	if p.DiscountPercent > 0 {
+		baseCost *= (1 - p.DiscountPercent)
+	}
+	if c.globalDiscount > 0 {
+		baseCost *= (1 - c.globalDiscount)
+	}
+
+	return baseCost
 }
 
-// SetPricing adds or updates pricing for a model.
+// LoadFromConfig applies pricing overrides from configuration.
+// Config overrides take priority over built-in defaults.
+func (c *Calculator) LoadFromConfig(cfg PricingConfig) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.globalDiscount = cfg.DiscountPercent
+
+	for _, p := range cfg.Models {
+		c.overrides[c.key(p.Provider, p.Model)] = p
+	}
+
+	if cfg.DiscountPercent > 0 {
+		slog.Info("💰 global pricing discount applied",
+			"discount", cfg.DiscountPercent)
+	}
+	if len(cfg.Models) > 0 {
+		slog.Info("💰 pricing overrides loaded",
+			"count", len(cfg.Models))
+	}
+}
+
+// SetPricing adds or updates pricing for a model (runtime override).
 func (c *Calculator) SetPricing(p ModelPricing) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.pricing[c.key(p.Provider, p.Model)] = p
+	c.overrides[c.key(p.Provider, p.Model)] = p
+}
+
+// SetGlobalDiscount sets the global discount percentage (0.0–1.0).
+func (c *Calculator) SetGlobalDiscount(discount float64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.globalDiscount = discount
+}
+
+// resolve looks up pricing: config overrides first, then built-in defaults,
+// then provider-agnostic model name match as last resort.
+func (c *Calculator) resolve(provider, model string) (ModelPricing, bool) {
+	key := c.key(provider, model)
+
+	// 1. Config override (exact match)
+	if p, ok := c.overrides[key]; ok {
+		return p, true
+	}
+
+	// 2. Built-in default (exact match)
+	if p, ok := c.defaults[key]; ok {
+		return p, true
+	}
+
+	// 3. Provider-agnostic fallback — match by model name alone.
+	// This handles cases like "gemini-oai/gemini-2.5-pro" matching "google/gemini-2.5-pro".
+	for _, m := range c.overrides {
+		if strings.EqualFold(m.Model, model) {
+			return m, true
+		}
+	}
+	for _, m := range c.defaults {
+		if strings.EqualFold(m.Model, model) {
+			return m, true
+		}
+	}
+
+	return ModelPricing{}, false
 }
 
 func (c *Calculator) key(provider, model string) string {
 	return strings.ToLower(provider + "/" + model)
 }
 
+// loadDefaults populates built-in list prices for all cloud models reachable
+// through the Candela proxy. This should be exhaustive — every model a user
+// can call through OpenAI, Google, or Anthropic must have a price here.
+//
+// Prices are list prices in USD per 1 million tokens (as of April 2026).
+// For negotiated or discounted rates, use config overrides.
 func (c *Calculator) loadDefaults() {
 	defaults := []ModelPricing{
-		// Google
+		// ── Google Gemini ─────────────────────────────────────────
+		// Gemini 3.1 (latest)
+		{Provider: "google", Model: "gemini-3.1-pro", InputPerMillion: 2.00, OutputPerMillion: 12.00},
+		// Gemini 2.5
 		{Provider: "google", Model: "gemini-2.5-pro", InputPerMillion: 1.25, OutputPerMillion: 10.00},
-		{Provider: "google", Model: "gemini-2.5-flash", InputPerMillion: 0.15, OutputPerMillion: 0.60},
+		{Provider: "google", Model: "gemini-2.5-flash", InputPerMillion: 0.30, OutputPerMillion: 2.50},
+		{Provider: "google", Model: "gemini-2.5-flash-lite", InputPerMillion: 0.10, OutputPerMillion: 0.40},
+		// Gemini 2.0
 		{Provider: "google", Model: "gemini-2.0-flash", InputPerMillion: 0.10, OutputPerMillion: 0.40},
 		{Provider: "google", Model: "gemini-2.0-pro", InputPerMillion: 1.25, OutputPerMillion: 10.00},
+		// Gemini 1.5 (legacy)
 		{Provider: "google", Model: "gemini-1.5-flash", InputPerMillion: 0.075, OutputPerMillion: 0.30},
 		{Provider: "google", Model: "gemini-1.5-pro", InputPerMillion: 1.25, OutputPerMillion: 5.00},
 
-		// OpenAI
+		// ── OpenAI ───────────────────────────────────────────────
+		// GPT-5.4 (latest, March 2026)
+		{Provider: "openai", Model: "gpt-5.4-pro", InputPerMillion: 30.00, OutputPerMillion: 180.00},
+		{Provider: "openai", Model: "gpt-5.4", InputPerMillion: 2.50, OutputPerMillion: 15.00},
+		{Provider: "openai", Model: "gpt-5.4-mini", InputPerMillion: 0.75, OutputPerMillion: 4.50},
+		{Provider: "openai", Model: "gpt-5.4-nano", InputPerMillion: 0.20, OutputPerMillion: 1.25},
+		// GPT-4o
 		{Provider: "openai", Model: "gpt-4o", InputPerMillion: 2.50, OutputPerMillion: 10.00},
 		{Provider: "openai", Model: "gpt-4o-mini", InputPerMillion: 0.15, OutputPerMillion: 0.60},
+		// GPT-4 (legacy)
 		{Provider: "openai", Model: "gpt-4-turbo", InputPerMillion: 10.00, OutputPerMillion: 30.00},
 		{Provider: "openai", Model: "gpt-3.5-turbo", InputPerMillion: 0.50, OutputPerMillion: 1.50},
+		// Reasoning models
+		{Provider: "openai", Model: "o3", InputPerMillion: 10.00, OutputPerMillion: 40.00},
+		{Provider: "openai", Model: "o3-mini", InputPerMillion: 1.10, OutputPerMillion: 4.40},
 		{Provider: "openai", Model: "o1", InputPerMillion: 15.00, OutputPerMillion: 60.00},
 		{Provider: "openai", Model: "o1-mini", InputPerMillion: 3.00, OutputPerMillion: 12.00},
-		{Provider: "openai", Model: "o3-mini", InputPerMillion: 1.10, OutputPerMillion: 4.40},
 
-		// Anthropic (via Vertex AI or direct)
+		// ── Anthropic (via Vertex AI or direct) ──────────────────
+		// Claude 4.6/4.7 (latest)
+		{Provider: "anthropic", Model: "claude-opus-4.7", InputPerMillion: 5.00, OutputPerMillion: 25.00},
+		{Provider: "anthropic", Model: "claude-opus-4.6", InputPerMillion: 5.00, OutputPerMillion: 25.00},
+		{Provider: "anthropic", Model: "claude-sonnet-4.6", InputPerMillion: 3.00, OutputPerMillion: 15.00},
+		{Provider: "anthropic", Model: "claude-haiku-4.5", InputPerMillion: 1.00, OutputPerMillion: 5.00},
+		// Claude 4 (Vertex AI model IDs)
 		{Provider: "anthropic", Model: "claude-sonnet-4-20250514", InputPerMillion: 3.00, OutputPerMillion: 15.00},
 		{Provider: "anthropic", Model: "claude-opus-4-20250514", InputPerMillion: 15.00, OutputPerMillion: 75.00},
-		{Provider: "anthropic", Model: "claude-haiku-3-5-20241022", InputPerMillion: 0.80, OutputPerMillion: 4.00},
+		// Claude 3.5 (legacy)
 		{Provider: "anthropic", Model: "claude-3-5-sonnet-20241022", InputPerMillion: 3.00, OutputPerMillion: 15.00},
+		{Provider: "anthropic", Model: "claude-haiku-3-5-20241022", InputPerMillion: 0.80, OutputPerMillion: 4.00},
 		{Provider: "anthropic", Model: "claude-3-opus-20240229", InputPerMillion: 15.00, OutputPerMillion: 75.00},
 	}
 	for _, p := range defaults {
-		c.pricing[c.key(p.Provider, p.Model)] = p
+		c.defaults[c.key(p.Provider, p.Model)] = p
 	}
 }

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -116,6 +116,19 @@ func (c *Calculator) SetGlobalDiscount(discount float64) {
 	c.globalDiscount = discount
 }
 
+// HasPricing returns true if a provider/model has pricing configured
+// (either via config override or built-in default). Local models always
+// return true since they are free by definition.
+func (c *Calculator) HasPricing(provider, model string) bool {
+	if strings.ToLower(provider) == "local" {
+		return true
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	_, ok := c.resolve(provider, model)
+	return ok
+}
+
 // resolve looks up pricing: config overrides first, then built-in defaults,
 // then provider-agnostic model name match as last resort.
 func (c *Calculator) resolve(provider, model string) (ModelPricing, bool) {

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -76,6 +76,8 @@ func (c *Calculator) key(provider, model string) string {
 func (c *Calculator) loadDefaults() {
 	defaults := []ModelPricing{
 		// Google
+		{Provider: "google", Model: "gemini-2.5-pro", InputPerMillion: 1.25, OutputPerMillion: 10.00},
+		{Provider: "google", Model: "gemini-2.5-flash", InputPerMillion: 0.15, OutputPerMillion: 0.60},
 		{Provider: "google", Model: "gemini-2.0-flash", InputPerMillion: 0.10, OutputPerMillion: 0.40},
 		{Provider: "google", Model: "gemini-2.0-pro", InputPerMillion: 1.25, OutputPerMillion: 10.00},
 		{Provider: "google", Model: "gemini-1.5-flash", InputPerMillion: 0.075, OutputPerMillion: 0.30},
@@ -88,9 +90,11 @@ func (c *Calculator) loadDefaults() {
 		{Provider: "openai", Model: "gpt-3.5-turbo", InputPerMillion: 0.50, OutputPerMillion: 1.50},
 		{Provider: "openai", Model: "o1", InputPerMillion: 15.00, OutputPerMillion: 60.00},
 		{Provider: "openai", Model: "o1-mini", InputPerMillion: 3.00, OutputPerMillion: 12.00},
+		{Provider: "openai", Model: "o3-mini", InputPerMillion: 1.10, OutputPerMillion: 4.40},
 
 		// Anthropic (via Vertex AI or direct)
 		{Provider: "anthropic", Model: "claude-sonnet-4-20250514", InputPerMillion: 3.00, OutputPerMillion: 15.00},
+		{Provider: "anthropic", Model: "claude-opus-4-20250514", InputPerMillion: 15.00, OutputPerMillion: 75.00},
 		{Provider: "anthropic", Model: "claude-haiku-3-5-20241022", InputPerMillion: 0.80, OutputPerMillion: 4.00},
 		{Provider: "anthropic", Model: "claude-3-5-sonnet-20241022", InputPerMillion: 3.00, OutputPerMillion: 15.00},
 		{Provider: "anthropic", Model: "claude-3-opus-20240229", InputPerMillion: 15.00, OutputPerMillion: 75.00},

--- a/pkg/costcalc/calculator_test.go
+++ b/pkg/costcalc/calculator_test.go
@@ -80,6 +80,33 @@ func TestCalculate(t *testing.T) {
 			wantMin:      0,
 			wantMax:      0,
 		},
+		{
+			name:         "GPT-5.4 pricing present",
+			provider:     "openai",
+			model:        "gpt-5.4",
+			inputTokens:  1000,
+			outputTokens: 500,
+			wantMin:      0.009,
+			wantMax:      0.011,
+		},
+		{
+			name:         "Gemini 2.5 Flash pricing present",
+			provider:     "google",
+			model:        "gemini-2.5-flash",
+			inputTokens:  10000,
+			outputTokens: 2000,
+			wantMin:      0.007,
+			wantMax:      0.009,
+		},
+		{
+			name:         "Provider-agnostic fallback",
+			provider:     "gemini-oai",
+			model:        "gemini-2.5-pro",
+			inputTokens:  1000,
+			outputTokens: 500,
+			wantMin:      0.006,
+			wantMax:      0.007,
+		},
 	}
 
 	for _, tt := range tests {
@@ -108,5 +135,65 @@ func TestSetPricing(t *testing.T) {
 	want := 3.0 // 1.0 + 2.0
 	if math.Abs(got-want) > 0.001 {
 		t.Errorf("Calculate with custom pricing = %f, want %f", got, want)
+	}
+}
+
+func TestLoadFromConfig(t *testing.T) {
+	calc := New()
+
+	// Override GPT-4o with a negotiated rate
+	calc.LoadFromConfig(PricingConfig{
+		Models: []ModelPricing{
+			{Provider: "openai", Model: "gpt-4o", InputPerMillion: 2.00, OutputPerMillion: 8.00},
+		},
+	})
+
+	got := calc.Calculate("openai", "gpt-4o", 1_000_000, 1_000_000)
+	want := 10.0 // 2.00 + 8.00 (overridden, not 2.50 + 10.00)
+	if math.Abs(got-want) > 0.001 {
+		t.Errorf("Calculate with config override = %f, want %f", got, want)
+	}
+}
+
+func TestGlobalDiscount(t *testing.T) {
+	calc := New()
+
+	calc.LoadFromConfig(PricingConfig{
+		DiscountPercent: 0.20, // 20% off
+	})
+
+	// GPT-4o: list = $2.50/M in + $10.00/M out
+	// 1M tokens each: $2.50 + $10.00 = $12.50 base
+	// 20% off: $12.50 × 0.80 = $10.00
+	got := calc.Calculate("openai", "gpt-4o", 1_000_000, 1_000_000)
+	want := 10.0
+	if math.Abs(got-want) > 0.001 {
+		t.Errorf("Calculate with global discount = %f, want %f", got, want)
+	}
+}
+
+func TestModelDiscount(t *testing.T) {
+	calc := New()
+
+	calc.LoadFromConfig(PricingConfig{
+		DiscountPercent: 0.10, // 10% global
+		Models: []ModelPricing{
+			{
+				Provider:         "openai",
+				Model:            "gpt-4o",
+				InputPerMillion:  2.50,
+				OutputPerMillion: 10.00,
+				DiscountPercent:  0.20, // 20% model-specific
+			},
+		},
+	})
+
+	// 1M tokens each: $2.50 + $10.00 = $12.50 base
+	// model discount: $12.50 × 0.80 = $10.00
+	// global discount: $10.00 × 0.90 = $9.00
+	got := calc.Calculate("openai", "gpt-4o", 1_000_000, 1_000_000)
+	want := 9.0
+	if math.Abs(got-want) > 0.001 {
+		t.Errorf("Calculate with stacked discounts = %f, want %f", got, want)
 	}
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -169,8 +169,25 @@ type CompatModel struct {
 // GET /v1/models returns the configured model list.
 // POST /v1/chat/completions routes to the correct provider based on the model name.
 func (p *Proxy) RegisterCompatRoutes(mux *http.ServeMux, models []CompatModel) {
+	// Filter models: only surface models with known pricing.
+	// This ensures clients never discover a model that would show $0.00 cost.
+	var pricedModels []CompatModel
+	for _, m := range models {
+		if p.calc != nil && !p.calc.HasPricing(m.Provider, m.ID) {
+			slog.Warn("⚠️ hiding model from /v1/models — no pricing configured",
+				"model", m.ID, "provider", m.Provider)
+			continue
+		}
+		pricedModels = append(pricedModels, m)
+	}
+
+	if dropped := len(models) - len(pricedModels); dropped > 0 {
+		slog.Info("model list filtered by pricing availability",
+			"total", len(models), "visible", len(pricedModels), "hidden", dropped)
+	}
+
 	// Build the /v1/models response once at startup.
-	modelList := buildModelsResponse(models)
+	modelList := buildModelsResponse(pricedModels)
 
 	// GET /v1/models — return the configured model list (OpenAI-compatible).
 	mux.HandleFunc("GET /v1/models", func(w http.ResponseWriter, r *http.Request) {
@@ -185,8 +202,8 @@ func (p *Proxy) RegisterCompatRoutes(mux *http.ServeMux, models []CompatModel) {
 	})
 
 	// Build model→provider lookup.
-	modelToProvider := make(map[string]string, len(models))
-	for _, m := range models {
+	modelToProvider := make(map[string]string, len(pricedModels))
+	for _, m := range pricedModels {
 		modelToProvider[m.ID] = m.Provider
 	}
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,36 +1,226 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# 🖥️ Candela UI — Next.js Web Dashboard
 
-## Getting Started
+The Candela web interface is a **Next.js 16** application with a dark-themed, glassmorphism-inspired design. It communicates with the Go backend via **ConnectRPC v2** and uses **Firebase Auth** for user authentication.
 
-First, run the development server:
+## Quick Start
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+cd ui
+pnpm install       # install dependencies (pnpm is in the Nix shell)
+pnpm run dev       # start dev server → http://localhost:3000
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+> [!NOTE]
+> The backend must be running on `:8181` for the UI to function. Start it with:
+> ```bash
+> nix develop -c go run ./cmd/candela-server
+> ```
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+---
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Architecture
 
-## Learn More
+```
+┌─────────────────────────────────────────┐
+│               Next.js App               │
+│  ┌──────────────────────────────────┐   │
+│  │  App Router (src/app/)           │   │
+│  │  ├── page.tsx (Dashboard)        │   │
+│  │  ├── traces/ (Trace list + detail│   │
+│  │  ├── costs/ (Cost analytics)     │   │
+│  │  ├── usage/ (Usage metrics)      │   │
+│  │  ├── projects/ (Project mgmt)    │   │
+│  │  ├── settings/                   │   │
+│  │  ├── login/                      │   │
+│  │  └── admin/ (Users, Budgets,     │   │
+│  │             Audit log)            │   │
+│  ├──────────────────────────────────┤   │
+│  │  Hooks (src/hooks/)              │   │
+│  │  ├── useDashboard     useTraces  │   │
+│  │  ├── useCurrentUser   useUsage   │   │
+│  │  ├── useCosts         useTrace   │   │
+│  │  ├── useLeaderboard              │   │
+│  │  └── useProtoValidation          │   │
+│  ├──────────────────────────────────┤   │
+│  │  Components (src/components/)    │   │
+│  │  ├── AppShell    Sidebar         │   │
+│  │  ├── AuthGuard   AuthProvider    │   │
+│  │  ├── BudgetGauge BudgetAlert     │   │
+│  │  ├── AreaChart   Tooltip         │   │
+│  │  └── ErrorBanner SkeletonCard    │   │
+│  ├──────────────────────────────────┤   │
+│  │  Lib (src/lib/)                  │   │
+│  │  ├── connect.ts  (transport)     │   │
+│  │  ├── firebase.ts (auth client)   │   │
+│  │  ├── api.ts      (fetch wrapper) │   │
+│  │  └── constants.ts                │   │
+│  ├──────────────────────────────────┤   │
+│  │  Generated (src/gen/)            │   │
+│  │  └── TS proto stubs (ConnectRPC) │   │
+│  └──────────────────────────────────┘   │
+│                  │                      │
+│       ConnectRPC v2 (HTTP/JSON)         │
+│                  │                      │
+└──────────────────│──────────────────────┘
+                   ▼
+         Go Backend (:8181)
+```
 
-To learn more about Next.js, take a look at the following resources:
+---
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Pages & Routes
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+| Route | Page | Description |
+|-------|------|-------------|
+| `/` | Dashboard | Summary cards (traces, tokens, cost, latency), time-series charts, recent traces table |
+| `/traces` | Trace List | Filterable, paginated trace explorer with search |
+| `/traces/[id]` | Trace Detail | Span waterfall with timing, tokens, cost per span; expandable prompt/completion views with JSON formatting |
+| `/costs` | Cost Analytics | Cost breakdown by model, provider, and time period |
+| `/usage` | Usage Metrics | Token usage, model breakdown, user leaderboard (team mode) |
+| `/projects` | Projects | Project CRUD, API key management |
+| `/settings` | Settings | Backend connection status, storage info |
+| `/login` | Login | Firebase Google Sign-In |
+| `/admin/users` | User Management | User CRUD, role assignment, status management |
+| `/admin/budgets` | Budgets | Budget enforcement explainer, waterfall visualization |
+| `/admin/audit` | Audit Log | Filterable admin action timeline |
 
-## Deploy on Vercel
+---
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Key Components
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+### Data Fetching Hooks
+
+All data fetching uses ConnectRPC client stubs with custom React hooks:
+
+| Hook | Service | Provides |
+|------|---------|----------|
+| `useDashboard` | `DashboardService` | Summary stats, time-series data, recent traces |
+| `useTraces` | `TraceService` | Paginated trace list with filters |
+| `useTrace` | `TraceService` | Single trace with all spans |
+| `useCosts` | `DashboardService` | Cost analytics by model/provider |
+| `useUsage` | `DashboardService` | Token usage metrics |
+| `useLeaderboard` | `DashboardService` | Per-user usage ranking (team mode) |
+| `useCurrentUser` | `UserService` | Current user profile, budget, grants |
+| `useProtoValidation` | N/A | Client-side proto validation via `@bufbuild/protovalidate` |
+
+### Authentication Components
+
+| Component | Purpose |
+|-----------|---------|
+| `AuthProvider` | Wraps the app with Firebase Auth context; handles `onAuthStateChanged` |
+| `AuthGuard` | Redirects unauthenticated users to `/login`; shows loading state |
+| `AppShell` | Layout wrapper with sidebar, handles auth state |
+
+### UI Components
+
+| Component | Purpose |
+|-----------|---------|
+| `Sidebar` | Navigation with active route highlighting; shows user info and budget |
+| `AreaChart` | SVG-based time-series chart with hover tooltips |
+| `BudgetGauge` | Circular progress indicator for budget utilization |
+| `BudgetAlert` | Warning banner when budget thresholds are crossed |
+| `ErrorBanner` | Backend offline state with recovery instructions |
+| `SkeletonCard` | Loading placeholder with shimmer animation |
+| `TimeRangeSelector` | 24h / 7d / 30d range picker |
+| `Tooltip` | Hover tooltip with arrow positioning |
+
+---
+
+## Proto Generation
+
+The UI uses TypeScript proto stubs generated by Buf:
+
+```bash
+# From the repo root
+cd proto && buf generate
+```
+
+This generates files into `gen/ts/candela/`. The CI pipeline copies them:
+
+```bash
+cp -r gen/ts/candela/* ui/src/gen/
+rm -f ui/src/gen/types/bq_span_pb.ts  # BigQuery schema — server-only
+```
+
+---
+
+## Styling
+
+The UI uses **vanilla CSS** with a custom design system defined in `src/app/globals.css` (~42K lines). Key design tokens:
+
+- **Dark theme** with glassmorphism effects
+- CSS custom properties for all colors, spacing, and typography
+- Responsive grid layouts
+- Smooth animations with `@keyframes` (fade-in, slide-in, shimmer)
+- Zero external CSS frameworks (no Tailwind)
+
+---
+
+## Testing
+
+### E2E Tests (Playwright)
+
+```bash
+pnpm run test:e2e       # headless
+pnpm run test:e2e:ui    # interactive UI mode
+```
+
+Three test suites:
+
+| Suite | File | Tests | Coverage |
+|-------|------|-------|----------|
+| **App** | `e2e/app.spec.ts` | 20+ | Dashboard, traces, costs, usage, projects, settings, offline state |
+| **Admin** | `e2e/admin.spec.ts` | 5+ | User management, budgets, audit log, access control |
+| **Team Mode** | `e2e/team_mode.spec.ts` | 5+ | Leaderboard, per-user filtering, budget alerts |
+
+### Linting
+
+```bash
+pnpm run lint           # ESLint
+```
+
+### Type Checking
+
+```bash
+pnpm run build          # includes TypeScript type-check
+```
+
+---
+
+## Build & Deployment
+
+### Development
+
+```bash
+pnpm run dev            # Next.js dev server with hot reload
+```
+
+### Production Build
+
+```bash
+pnpm run build          # generates .next/standalone for containerized deployment
+```
+
+### Container
+
+The UI is built as part of the combined Docker image (`deploy/Dockerfile.server`). The Next.js standalone output is served by `node server.js` — see [docs/deployment.md](../docs/deployment.md).
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NEXT_PUBLIC_API_URL` | `""` | Backend URL. Empty = same-origin (production). Set `http://localhost:8181` for local dev with separate backend. |
+| `NEXT_PUBLIC_FIREBASE_*` | _(required)_ | Firebase client config — see [docs/env-vars.md](../docs/env-vars.md) |
+| `BACKEND_URL` | `http://localhost:8181` | Backend URL for Next.js rewrites (server-side) |
+
+---
+
+## Offline Behavior
+
+The UI gracefully handles a missing backend:
+- Dashboard shows an `ErrorBanner` with recovery instructions
+- All hooks return empty/default data instead of crashing
+- Real-time polling pauses when errors are detected
+- Reconnects automatically when the backend becomes available


### PR DESCRIPTION
## Summary

Doubles Candela's documentation coverage from **8 → 16 files** (~1,858 → ~4,300+ lines).

### New Documentation (8 files)

| Doc | Coverage |
|-----|----------|
| `docs/otel-collector.md` | Custom GenAI processor, building, ADK/LangChain/Go instrumentation |
| `docs/security.md` | 3-strategy auth waterfall, RBAC matrix (13 admin RPCs), hardening checklist |
| `docs/cost-calculation.md` | Pricing tables (18 models), formula, model matching, accuracy notes |
| `docs/env-vars.md` | Complete reference for all 15+ server/UI/CI environment variables |
| `docs/testing.md` | Test architecture, CI pipeline, pre-commit hooks, unit/integration/E2E patterns |
| `docs/api-reference.md` | All 6 ConnectRPC services with `curl` examples and validation rules |
| `docs/operations.md` | Deploy, rollback, monitoring, BigQuery ops, 4 incident response playbooks |
| `docs/budgets.md` | Grant-first waterfall, threshold notifications, Slack/Teams extensibility |

### Updated Documentation (4 files)

| File | Change |
|------|--------|
| `ui/README.md` | Full rewrite from `create-next-app` boilerplate → architecture, routes, components, hooks |
| `docs/development.md` | Added debugging (`dlv`, VS Code), Firestore emulator, proto regen with `BUF_TOKEN` |
| `CHANGELOG.md` | New retroactive changelog organized by development phase (Phase 1–4) |
| `deploy/docker-compose.yml` | Replace stale ClickHouse config with DuckDB-based local dev stack |

### Code Fixes (3 files)

- **`cmd/candela-server/main.go`**: Unified default port to `8181` (was `8080` in no-config fallback)
- **`pkg/costcalc/calculator.go`**: Added pricing for `gemini-2.5-pro`, `gemini-2.5-flash`, `o3-mini`, `claude-opus-4`
- **`README.md`**: Fixed port references, `npm`→`pnpm`, added `nix develop -c` prefix

### Verification

- ✅ `go build ./cmd/candela-server`
- ✅ `go test ./pkg/costcalc -v` — all 8 tests pass
- ✅ All 13 pre-commit hooks pass