### PR TITLE
fix: address PR #61 review feedback

### DIFF
--- a/pkg/connecthandlers/integration_test.go
+++ b/pkg/connecthandlers/integration_test.go
@@ -182,6 +182,12 @@ func (s *integrationStore) LogAction(_ context.Context, a *storage.AuditRecord) 
 	return nil
 }
 
+func (s *integrationStore) LogGlobalAction(_ context.Context, a *storage.AuditRecord) error {
+	a.ID = fmt.Sprintf("global_audit_%d", len(s.audit["_global"])+1)
+	s.audit["_global"] = append(s.audit["_global"], a)
+	return nil
+}
+
 func (s *integrationStore) ListAuditLog(_ context.Context, userID string, limit int) ([]*storage.AuditRecord, error) {
 	return s.audit[userID], nil
 }

--- a/pkg/connecthandlers/user_handler.go
+++ b/pkg/connecthandlers/user_handler.go
@@ -275,16 +275,19 @@ func (h *UserHandler) DeleteUser(
 			fmt.Errorf("confirmation email does not match user email"))
 	}
 
-	// Log audit BEFORE deletion so the entry exists in the subcollection
-	// at the time of write. Note: deletion below will remove this entry
-	// too, so we also emit a structured log for persistent audit trail.
+	// Persist audit to global collection (survives user deletion).
 	auditDetails := mustJSON(map[string]string{"email": user.Email})
-	h.logAudit(ctx, &storage.AuditRecord{
+	auditEntry := &storage.AuditRecord{
 		UserID:     user.ID,
 		ActorEmail: auth.EmailFromContext(ctx),
 		Action:     "delete_user",
 		Details:    auditDetails,
-	})
+	}
+	if err := h.store.LogGlobalAction(ctx, auditEntry); err != nil {
+		slog.WarnContext(ctx, "failed to write global audit log for delete_user",
+			"error", err,
+			"user_id", user.ID)
+	}
 	slog.InfoContext(ctx, "user deleted",
 		"user_id", user.ID,
 		"actor", auth.EmailFromContext(ctx),
@@ -691,13 +694,13 @@ func stringToPeriod(_ string) typespb.BudgetPeriod {
 	return typespb.BudgetPeriod_BUDGET_PERIOD_DAILY
 }
 
-// mustJSON marshals v to a JSON string, falling back to a JSON-safe
-// error string if marshalling fails.
+// mustJSON marshals v to a JSON string, falling back to a structured
+// JSON error object if marshalling fails.
 func mustJSON(v any) string {
 	b, err := json.Marshal(v)
 	if err != nil {
-		errMsg, _ := json.Marshal(fmt.Sprintf("%v", v))
-		return string(errMsg)
+		slog.Warn("failed to marshal data for audit log", "value", v, "error", err)
+		return `{"error":"failed to marshal audit details"}`
 	}
 	return string(b)
 }

--- a/pkg/connecthandlers/user_handler_test.go
+++ b/pkg/connecthandlers/user_handler_test.go
@@ -211,6 +211,15 @@ func (m *mockUserStore) LogAction(_ context.Context, entry *storage.AuditRecord)
 	return nil
 }
 
+func (m *mockUserStore) LogGlobalAction(_ context.Context, entry *storage.AuditRecord) error {
+	if entry.ID == "" {
+		entry.ID = fmt.Sprintf("global_audit_%d", len(m.audit["_global"])+1)
+	}
+	entry.Timestamp = time.Now().UTC()
+	m.audit["_global"] = append(m.audit["_global"], entry)
+	return nil
+}
+
 func (m *mockUserStore) ListAuditLog(_ context.Context, userID string, limit int) ([]*storage.AuditRecord, error) {
 	entries := m.audit[userID]
 	if limit > 0 && limit < len(entries) {
@@ -794,5 +803,71 @@ func TestPeriodConversion(t *testing.T) {
 	}
 	if got := stringToPeriod("anything"); got != typespb.BudgetPeriod_BUDGET_PERIOD_DAILY {
 		t.Errorf("stringToPeriod(anything) = %v, want DAILY", got)
+	}
+}
+
+func TestMustJSON_Success(t *testing.T) {
+	got := mustJSON(map[string]string{"email": "test@example.com"})
+	if got != `{"email":"test@example.com"}` {
+		t.Errorf("mustJSON = %q, want valid JSON", got)
+	}
+}
+
+func TestMustJSON_Fallback(t *testing.T) {
+	// Channels cannot be marshalled to JSON.
+	got := mustJSON(make(chan int))
+	expected := `{"error":"failed to marshal audit details"}`
+	if got != expected {
+		t.Errorf("mustJSON fallback = %q, want %q", got, expected)
+	}
+}
+
+func TestUserHandler_DeleteUser_GlobalAudit(t *testing.T) {
+	store := newMockUserStore()
+	handler := NewUserHandler(store)
+	ctx := authedCtx("admin@example.com")
+
+	// Create and deactivate user.
+	createResp, _ := handler.CreateUser(ctx, connect.NewRequest(&v1.CreateUserRequest{
+		Email: "audit-test@example.com",
+	}))
+	userID := createResp.Msg.User.Id
+
+	_, _ = handler.DeactivateUser(ctx,
+		connect.NewRequest(&v1.DeactivateUserRequest{Id: userID}))
+
+	// Delete user.
+	_, err := handler.DeleteUser(ctx, connect.NewRequest(&v1.DeleteUserRequest{
+		Id:           userID,
+		ConfirmEmail: "audit-test@example.com",
+	}))
+	if err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+
+	// Verify global audit entry was written.
+	globalEntries := store.audit["_global"]
+	if len(globalEntries) == 0 {
+		t.Fatal("expected global audit entry for delete_user")
+	}
+
+	found := false
+	for _, entry := range globalEntries {
+		if entry.Action == "delete_user" && entry.UserID == userID {
+			found = true
+			if entry.ActorEmail != "admin@example.com" {
+				t.Errorf("actor_email = %q, want admin@example.com", entry.ActorEmail)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("delete_user action not found in global audit log")
+	}
+
+	// Verify user-level audit is gone (deleted with user).
+	userEntries := store.audit[userID]
+	if len(userEntries) != 0 {
+		t.Errorf("expected user audit entries to be deleted, got %d", len(userEntries))
 	}
 }

--- a/pkg/storage/firestoredb/firestoredb.go
+++ b/pkg/storage/firestoredb/firestoredb.go
@@ -29,11 +29,12 @@ import (
 )
 
 const (
-	usersCol     = "users"
-	budgetsCol   = "budgets"
-	grantsCol    = "grants"
-	auditCol     = "audit"
-	rateLimitCol = "rate_limit"
+	usersCol       = "users"
+	budgetsCol     = "budgets"
+	grantsCol      = "grants"
+	auditCol       = "audit"
+	globalAuditCol = "global_audit"
+	rateLimitCol   = "rate_limit"
 
 	defaultRateLimit = 60 // requests/minute
 )
@@ -231,6 +232,8 @@ func (s *Store) DeleteUser(ctx context.Context, id string) error {
 	userRef := s.client.Collection(usersCol).Doc(id)
 
 	// Discover and delete all subcollections (Firestore doesn't cascade).
+	// Use a single BulkWriter across all subcollections for efficiency.
+	bw := s.client.BulkWriter(ctx)
 	collIter := userRef.Collections(ctx)
 	for {
 		collRef, err := collIter.Next()
@@ -238,32 +241,28 @@ func (s *Store) DeleteUser(ctx context.Context, id string) error {
 			break
 		}
 		if err != nil {
-			slog.WarnContext(ctx, "error listing subcollections during delete",
-				"user", id, "error", err)
-			break
+			bw.End()
+			return fmt.Errorf("firestoredb: listing subcollections: %w", err)
 		}
 
-		// Bulk-delete docs in this subcollection.
-		bw := s.client.BulkWriter(ctx)
-		docIter := collRef.Documents(ctx)
+		// Use DocumentRefs — we only need refs for deletion, not full snapshots.
+		docIter := collRef.DocumentRefs(ctx)
 		for {
-			doc, err := docIter.Next()
+			docRef, err := docIter.Next()
 			if err == iterator.Done {
 				break
 			}
 			if err != nil {
-				slog.WarnContext(ctx, "error iterating subcollection during delete",
-					"collection", collRef.ID, "error", err)
-				break
+				bw.End()
+				return fmt.Errorf("firestoredb: iterating subcollection %s: %w", collRef.ID, err)
 			}
-			if _, err := bw.Delete(doc.Ref); err != nil {
+			if _, err := bw.Delete(docRef); err != nil {
 				slog.WarnContext(ctx, "bulk delete enqueue failed",
-					"collection", collRef.ID, "doc", doc.Ref.ID, "error", err)
+					"collection", collRef.ID, "doc", docRef.ID, "error", err)
 			}
 		}
-		bw.Flush()
-		bw.End()
 	}
+	bw.End()
 
 	// Delete the user document.
 	if _, err := userRef.Delete(ctx); err != nil {
@@ -555,6 +554,21 @@ func (s *Store) LogAction(ctx context.Context, entry *storage.AuditRecord) error
 	_, err := ref.Create(ctx, entry)
 	if err != nil {
 		return fmt.Errorf("firestoredb: logging action: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) LogGlobalAction(ctx context.Context, entry *storage.AuditRecord) error {
+	if entry.ID == "" {
+		entry.ID = uuid.New().String()
+	}
+	if entry.Timestamp.IsZero() {
+		entry.Timestamp = time.Now().UTC()
+	}
+	ref := s.client.Collection(globalAuditCol).Doc(entry.ID)
+	_, err := ref.Set(ctx, entry)
+	if err != nil {
+		return fmt.Errorf("firestoredb: logging global action: %w", err)
 	}
 	return nil
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -337,7 +337,7 @@ type BudgetRecord struct {
 	LimitUSD    float64   `json:"limit_usd,omitempty" firestore:"limit_usd,omitempty"`
 	SpentUSD    float64   `json:"spent_usd,omitempty" firestore:"spent_usd,omitempty"`
 	TokensUsed  int64     `json:"tokens_used,omitempty" firestore:"tokens_used,omitempty"`
-	PeriodType  string    `json:"period_type,omitempty" firestore:"period_type,omitempty"` // "monthly", "weekly", "quarterly"
+	PeriodType  string    `json:"period_type,omitempty" firestore:"period_type,omitempty"` // "daily"
 	PeriodKey   string    `json:"period_key,omitempty" firestore:"period_key,omitempty"`   // "2026-04", "2026-W15"
 	PeriodStart time.Time `json:"period_start,omitempty" firestore:"period_start,omitempty"`
 	PeriodEnd   time.Time `json:"period_end,omitempty" firestore:"period_end,omitempty"`
@@ -450,8 +450,13 @@ type UserStore interface {
 
 	// ── Audit ──
 
-	// LogAction records an admin action in the audit trail.
+	// LogAction records an admin action in the user's audit subcollection.
 	LogAction(ctx context.Context, entry *AuditRecord) error
+
+	// LogGlobalAction records an audit entry in a global collection that
+	// persists even after the target user is deleted. Use this for
+	// destructive actions like user deletion.
+	LogGlobalAction(ctx context.Context, entry *AuditRecord) error
 
 	// ListAuditLog returns the audit trail for a user.
 	ListAuditLog(ctx context.Context, userID string, limit int) ([]*AuditRecord, error)


### PR DESCRIPTION
## Summary

Addresses outstanding review feedback from PR #61 (daily budget period + delete user).

### Changes

**firestoredb.go — `DeleteUser` improvements:**
- Return errors instead of log-and-break on iterator failures (prevents orphaned subcollections)
- Use single `BulkWriter` across all subcollections (efficiency)
- Remove redundant `Flush()` before `End()`
- Use `DocumentRefs` instead of `Documents` (only need refs for deletion, not full snapshots)

**user_handler.go:**
- `DeleteUser`: write audit to `global_audit` collection so the delete_user record survives user deletion
- `mustJSON`: return structured JSON error object on marshal failure instead of `fmt.Sprintf` fallback

**store.go:**
- Add `LogGlobalAction` to `UserStore` interface for persistent audit entries
- Update `BudgetRecord.PeriodType` doc to reflect daily-only model

### Review Feedback Addressed
| # | Priority | File | Issue | Status |
|---|----------|------|-------|--------|
| 1 | 🔴 High | user_handler.go | Audit log deleted with user | ✅ Global audit collection |
| 2 | 🟡 Medium | firestoredb.go | DeleteUser error handling | ✅ Return errors |
| 3 | 🟡 Medium | firestoredb.go | Single BulkWriter | ✅ Reused across subcollections |
| 4 | 🟡 Medium | firestoredb.go | Redundant Flush() | ✅ Removed |
| 5 | 🟡 Medium | user_handler.go | mustJSON invalid JSON fallback | ✅ Structured error |
| 6 | 🟡 Medium | firestoredb.go | Use DocumentRefs | ✅ Refs only |
