### PR TITLE
feat(users): configurable default daily budget for new users

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -88,6 +88,9 @@ type Config struct {
 		DatabaseID string `yaml:"database_id"` // e.g. "candela" or "(default)"
 	} `yaml:"firestore"`
 	Pricing costcalc.PricingConfig `yaml:"pricing"`
+	Users   struct {
+		DefaultDailyBudgetUSD float64 `yaml:"default_daily_budget_usd"` // auto-assigned to new users (0 = no default)
+	} `yaml:"users"`
 }
 
 func main() {
@@ -157,10 +160,12 @@ func main() {
 		validateInterceptor := validate.NewInterceptor()
 
 		userPath, userH := candelav1connect.NewUserServiceHandler(
-			connecthandlers.NewUserHandler(fStore),
+			connecthandlers.NewUserHandler(fStore, cfg.Users.DefaultDailyBudgetUSD),
 			connect.WithInterceptors(validateInterceptor, auth.AdminInterceptor(fStore)))
 		mux.Handle(userPath, userH)
-		slog.Info("UserService registered", "path", userPath, "admin_guard", true, "validation", true)
+		slog.Info("UserService registered", "path", userPath,
+			"admin_guard", true, "validation", true,
+			"default_daily_budget", cfg.Users.DefaultDailyBudgetUSD)
 	} else {
 		slog.Info("Firestore disabled — UserService not available, all users see all traces")
 	}

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -68,6 +68,9 @@ firestore:
 worker:
   batch_size: 100
   flush_interval: "2s"
+
+users:
+  default_daily_budget_usd: ${CANDELA_DEFAULT_DAILY_BUDGET:-5.00}
 EOF
 
 export CANDELA_CONFIG="$CONFIG_PATH"

--- a/pkg/connecthandlers/integration_test.go
+++ b/pkg/connecthandlers/integration_test.go
@@ -227,7 +227,7 @@ func startTestServer(t *testing.T, store *integrationStore) candelav1connect.Use
 
 	mux := http.NewServeMux()
 	path, handler := candelav1connect.NewUserServiceHandler(
-		connecthandlers.NewUserHandler(store),
+		connecthandlers.NewUserHandler(store, 0),
 		connect.WithInterceptors(validateInterceptor, adminInterceptor),
 	)
 	mux.Handle(path, handler)
@@ -275,7 +275,7 @@ func startTestServerWithClient(t *testing.T, store *integrationStore, email stri
 
 	mux := http.NewServeMux()
 	path, handler := candelav1connect.NewUserServiceHandler(
-		connecthandlers.NewUserHandler(store),
+		connecthandlers.NewUserHandler(store, 0),
 		connect.WithInterceptors(validateInterceptor, adminInterceptor),
 	)
 	mux.Handle(path, handler)

--- a/pkg/connecthandlers/user_handler.go
+++ b/pkg/connecthandlers/user_handler.go
@@ -22,12 +22,13 @@ import (
 // backed by a storage.UserStore (Firestore in production).
 type UserHandler struct {
 	candelav1connect.UnimplementedUserServiceHandler
-	store storage.UserStore
+	store                 storage.UserStore
+	defaultDailyBudgetUSD float64 // applied to new users when no explicit budget is set
 }
 
 // NewUserHandler creates a new UserHandler.
-func NewUserHandler(store storage.UserStore) *UserHandler {
-	return &UserHandler{store: store}
+func NewUserHandler(store storage.UserStore, defaultDailyBudgetUSD float64) *UserHandler {
+	return &UserHandler{store: store, defaultDailyBudgetUSD: defaultDailyBudgetUSD}
 }
 
 // logAudit writes an audit entry and logs a warning if it fails.
@@ -75,11 +76,15 @@ func (h *UserHandler) CreateUser(
 		User: userToProto(user),
 	}
 
-	// Optionally set an initial budget (daily by default).
-	if req.Msg.DailyBudgetUsd > 0 {
+	// Set initial daily budget: use explicit value, fall back to server default.
+	budgetUSD := req.Msg.DailyBudgetUsd
+	if budgetUSD == 0 && h.defaultDailyBudgetUSD > 0 {
+		budgetUSD = h.defaultDailyBudgetUSD
+	}
+	if budgetUSD > 0 {
 		budget := &storage.BudgetRecord{
 			UserID:     user.ID,
-			LimitUSD:   req.Msg.DailyBudgetUsd,
+			LimitUSD:   budgetUSD,
 			PeriodType: "daily",
 		}
 		if err := h.store.SetBudget(ctx, budget); err != nil {
@@ -487,6 +492,19 @@ func (h *UserHandler) GetCurrentUser(
 		}
 		if createErr := h.store.CreateUser(ctx, user); createErr != nil {
 			return nil, connect.NewError(connect.CodeInternal, createErr)
+		}
+
+		// Apply default daily budget to auto-provisioned users.
+		if h.defaultDailyBudgetUSD > 0 {
+			budget := &storage.BudgetRecord{
+				UserID:     user.ID,
+				LimitUSD:   h.defaultDailyBudgetUSD,
+				PeriodType: "daily",
+			}
+			if err := h.store.SetBudget(ctx, budget); err != nil {
+				slog.WarnContext(ctx, "failed to set default budget for auto-provisioned user",
+					"user_id", user.ID, "error", err)
+			}
 		}
 	}
 

--- a/pkg/connecthandlers/user_handler_test.go
+++ b/pkg/connecthandlers/user_handler_test.go
@@ -243,7 +243,7 @@ func authedCtx(email string) context.Context {
 
 func TestUserHandler_CreateUser(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	resp, err := handler.CreateUser(ctx, connect.NewRequest(&v1.CreateUserRequest{
@@ -264,7 +264,7 @@ func TestUserHandler_CreateUser(t *testing.T) {
 
 func TestUserHandler_CreateUser_WithBudget(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	resp, err := handler.CreateUser(ctx, connect.NewRequest(&v1.CreateUserRequest{
@@ -282,9 +282,71 @@ func TestUserHandler_CreateUser_WithBudget(t *testing.T) {
 	}
 }
 
+func TestUserHandler_CreateUser_DefaultBudget(t *testing.T) {
+	store := newMockUserStore()
+	handler := NewUserHandler(store, 5.0) // $5 default
+	ctx := authedCtx("admin@example.com")
+
+	// Create user WITHOUT specifying a budget — should get $5 default.
+	resp, err := handler.CreateUser(ctx, connect.NewRequest(&v1.CreateUserRequest{
+		Email: "default@example.com",
+	}))
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if resp.Msg.Budget == nil {
+		t.Fatal("expected default budget to be set, got nil")
+	}
+	if resp.Msg.Budget.LimitUsd != 5.0 {
+		t.Errorf("default budget = %f, want 5.0", resp.Msg.Budget.LimitUsd)
+	}
+}
+
+func TestUserHandler_CreateUser_ExplicitOverridesDefault(t *testing.T) {
+	store := newMockUserStore()
+	handler := NewUserHandler(store, 5.0) // $5 default
+	ctx := authedCtx("admin@example.com")
+
+	// Explicit budget should override the default.
+	resp, err := handler.CreateUser(ctx, connect.NewRequest(&v1.CreateUserRequest{
+		Email:          "explicit@example.com",
+		DailyBudgetUsd: 20.0,
+	}))
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if resp.Msg.Budget == nil {
+		t.Fatal("expected budget to be set, got nil")
+	}
+	if resp.Msg.Budget.LimitUsd != 20.0 {
+		t.Errorf("budget = %f, want 20.0 (explicit override)", resp.Msg.Budget.LimitUsd)
+	}
+}
+
+func TestUserHandler_GetCurrentUser_AutoProvisionDefaultBudget(t *testing.T) {
+	store := newMockUserStore()
+	handler := NewUserHandler(store, 5.0) // $5 default
+	ctx := authedCtx("autoprov@example.com")
+
+	// GetCurrentUser auto-provisions new users — should also get the default budget.
+	resp, err := handler.GetCurrentUser(ctx, connect.NewRequest(&v1.GetCurrentUserRequest{}))
+	if err != nil {
+		t.Fatalf("GetCurrentUser: %v", err)
+	}
+	if resp.Msg.User == nil {
+		t.Fatal("expected user to be auto-provisioned")
+	}
+	if resp.Msg.Budget == nil {
+		t.Fatal("expected default budget on auto-provisioned user, got nil")
+	}
+	if resp.Msg.Budget.LimitUsd != 5.0 {
+		t.Errorf("auto-provisioned budget = %f, want 5.0", resp.Msg.Budget.LimitUsd)
+	}
+}
+
 func TestUserHandler_CreateUser_MissingEmail(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	_, err := handler.CreateUser(ctx, connect.NewRequest(&v1.CreateUserRequest{
@@ -304,7 +366,7 @@ func TestUserHandler_CreateUser_MissingEmail(t *testing.T) {
 
 func TestUserHandler_CreateUser_DuplicateEmail(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	// First creation succeeds.
@@ -333,7 +395,7 @@ func TestUserHandler_CreateUser_DuplicateEmail(t *testing.T) {
 
 func TestUserHandler_GetUser_NotFound(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 
 	_, err := handler.GetUser(context.Background(),
 		connect.NewRequest(&v1.GetUserRequest{Id: "nonexistent"}))
@@ -351,7 +413,7 @@ func TestUserHandler_GetUser_NotFound(t *testing.T) {
 
 func TestUserHandler_DeactivateAndReactivate(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	// Create user.
@@ -384,7 +446,7 @@ func TestUserHandler_DeactivateAndReactivate(t *testing.T) {
 
 func TestUserHandler_BudgetLifecycle(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	// Create user.
@@ -432,7 +494,7 @@ func TestUserHandler_BudgetLifecycle(t *testing.T) {
 
 func TestUserHandler_GrantLifecycle(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	// Create user.
@@ -492,7 +554,7 @@ func TestUserHandler_GrantLifecycle(t *testing.T) {
 
 func TestUserHandler_AuditLog(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	// Create user (triggers audit).
@@ -520,7 +582,7 @@ func TestUserHandler_AuditLog(t *testing.T) {
 
 func TestUserHandler_GetCurrentUser_AutoProvision(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 
 	// Authed as a new user who doesn't exist yet.
 	ctx := authedCtx("newuser@example.com")
@@ -547,7 +609,7 @@ func TestUserHandler_GetCurrentUser_AutoProvision(t *testing.T) {
 
 func TestUserHandler_GetCurrentUser_Unauthenticated(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 
 	_, err := handler.GetCurrentUser(context.Background(),
 		connect.NewRequest(&v1.GetCurrentUserRequest{}))
@@ -565,7 +627,7 @@ func TestUserHandler_GetCurrentUser_Unauthenticated(t *testing.T) {
 
 func TestUserHandler_ListUsers(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	// Create 3 users.
@@ -620,7 +682,7 @@ func TestUserHandler_ListUsers(t *testing.T) {
 
 func TestUserHandler_UpdateUser_FieldMask(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	createResp, _ := handler.CreateUser(ctx, connect.NewRequest(&v1.CreateUserRequest{
@@ -652,7 +714,7 @@ func TestUserHandler_UpdateUser_FieldMask(t *testing.T) {
 
 func TestUserHandler_GetMyBudget_Unauthenticated(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 
 	_, err := handler.GetMyBudget(context.Background(),
 		connect.NewRequest(&v1.GetMyBudgetRequest{}))
@@ -705,7 +767,7 @@ func TestStatusConversion(t *testing.T) {
 
 func TestUserHandler_DeleteUser_HappyPath(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	// Create and deactivate user.
@@ -735,7 +797,7 @@ func TestUserHandler_DeleteUser_HappyPath(t *testing.T) {
 
 func TestUserHandler_DeleteUser_ActiveUserBlocked(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	// Create user but DON'T deactivate.
@@ -762,7 +824,7 @@ func TestUserHandler_DeleteUser_ActiveUserBlocked(t *testing.T) {
 
 func TestUserHandler_DeleteUser_WrongEmailBlocked(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	// Create and deactivate user.
@@ -824,7 +886,7 @@ func TestMustJSON_Fallback(t *testing.T) {
 
 func TestUserHandler_DeleteUser_GlobalAudit(t *testing.T) {
 	store := newMockUserStore()
-	handler := NewUserHandler(store)
+	handler := NewUserHandler(store, 0)
 	ctx := authedCtx("admin@example.com")
 
 	// Create and deactivate user.


### PR DESCRIPTION
Every new user auto-gets a $5/day budget unless the admin specifies a different amount at creation time.

## Changes
- `UserHandler` accepts `defaultDailyBudgetUSD` — falls back to this when `DailyBudgetUsd` is 0
- Configurable via `config.yaml`: `users.default_daily_budget_usd: 5.00`
- Cloud Run env var: `CANDELA_DEFAULT_DAILY_BUDGET` (default: 5.00)
- All existing users unaffected

## Config
```yaml
users:
  default_daily_budget_usd: 5.00
```