### PR TITLE
feat(ui): add Today budget view

### DIFF
--- a/ui/.env.test
+++ b/ui/.env.test
@@ -1,0 +1,8 @@
+# Test environment — loaded by Next.js when NODE_ENV=test.
+#
+# Next.js skips .env.local when NODE_ENV=test, which means Firebase Auth
+# is NOT configured. This causes AuthGuard to pass through (dev mode),
+# allowing Playwright tests to render pages without authentication.
+#
+# The API URL points to the mock-intercepted localhost backend.
+NEXT_PUBLIC_API_URL=http://localhost:8181

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -34,8 +34,10 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
+# env files — keep secrets out, but commit test + example configs
 .env*
+!.env.test
+!.env.example
 
 # vercel
 .vercel

--- a/ui/e2e/app.spec.ts
+++ b/ui/e2e/app.spec.ts
@@ -28,6 +28,7 @@ test.describe("App Shell", () => {
   test("renders sidebar with navigation links", async ({ page }) => {
     await page.goto("/");
     await expect(page.locator(".sidebar-logo")).toHaveText("Candela");
+    await expect(page.locator(".nav-item").filter({ hasText: "Today" })).toBeVisible();
     await expect(page.locator(".nav-item").filter({ hasText: "Dashboard" })).toBeVisible();
     await expect(page.locator(".nav-item").filter({ hasText: "Traces" })).toBeVisible();
     await expect(page.locator(".nav-item").filter({ hasText: "Costs" })).toBeVisible();

--- a/ui/e2e/today.spec.ts
+++ b/ui/e2e/today.spec.ts
@@ -1,0 +1,278 @@
+import { test, expect } from "@playwright/test";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8181";
+
+async function mockConnectRPC(
+  page: import("@playwright/test").Page,
+  servicePath: string,
+  responseBody: Record<string, unknown>,
+) {
+  await page.route(`${API_BASE}${servicePath}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(responseBody),
+    });
+  });
+}
+
+async function mockDevUser(page: import("@playwright/test").Page) {
+  await mockConnectRPC(page, "/candela.v1.UserService/GetCurrentUser", {
+    user: {
+      id: "dev-1",
+      email: "dev@test.com",
+      displayName: "Dev User",
+      role: 1,
+      status: 2,
+    },
+    budget: { limitUsd: 50, spentUsd: 5, periodType: 1 },
+    activeGrants: [],
+  });
+}
+
+// ──────────────────────────────────────────
+// Today Budget View (/today)
+// ──────────────────────────────────────────
+
+test.describe("Today Budget View", () => {
+  test("renders page header with today's date", async ({ page }) => {
+    await mockDevUser(page);
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
+      totalCalls: "0",
+      totalInputTokens: "0",
+      totalOutputTokens: "0",
+      totalCostUsd: 0,
+      avgLatencyMs: 0,
+      models: [],
+      budget: { limitUsd: 50, spentUsd: 0, periodType: 1 },
+      totalRemainingUsd: 50,
+    });
+
+    await page.goto("/today");
+    await expect(page.locator("h1")).toHaveText("Today");
+    // Date string should be visible (e.g. "Saturday, April 26, 2026")
+    await expect(page.locator(".today-date")).toBeVisible();
+  });
+
+  test("shows budget ring gauge with spent/limit/remaining", async ({ page }) => {
+    await mockDevUser(page);
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
+      totalCalls: "42",
+      totalInputTokens: "10000",
+      totalOutputTokens: "5000",
+      totalCostUsd: 1.25,
+      avgLatencyMs: 340,
+      models: [
+        { model: "gpt-4o", provider: "openai", callCount: "30", inputTokens: "7000", outputTokens: "3000", costUsd: 1.0, avgLatencyMs: 300 },
+        { model: "claude-3-sonnet", provider: "anthropic", callCount: "12", inputTokens: "3000", outputTokens: "2000", costUsd: 0.25, avgLatencyMs: 400 },
+      ],
+      budget: { limitUsd: 50, spentUsd: 12.5, periodType: 1 },
+      totalRemainingUsd: 37.5,
+    });
+
+    await page.goto("/today");
+
+    // Budget ring should show percentage
+    await expect(page.locator(".today-ring-pct")).toHaveText("25%");
+
+    // Spent / Limit / Left stats
+    await expect(page.locator(".today-ring-stat").filter({ hasText: "Spent" })).toContainText("$12.50");
+    await expect(page.locator(".today-ring-stat").filter({ hasText: "Limit" })).toContainText("$50.00");
+    await expect(page.locator(".today-ring-stat").filter({ hasText: "Left" })).toContainText("$37.50");
+  });
+
+  test("shows quick stats cards with today's data", async ({ page }) => {
+    await mockDevUser(page);
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
+      totalCalls: "42",
+      totalInputTokens: "10000",
+      totalOutputTokens: "5000",
+      totalCostUsd: 1.25,
+      avgLatencyMs: 340,
+      models: [],
+      budget: { limitUsd: 50, spentUsd: 5, periodType: 1 },
+      totalRemainingUsd: 45,
+    });
+
+    await page.goto("/today");
+
+    // Requests card
+    await expect(
+      page.locator(".today-stat-card").filter({ hasText: "Requests" }).locator(".card-value")
+    ).toHaveText("42");
+
+    // Cost card
+    await expect(
+      page.locator(".today-stat-card").filter({ hasText: "Cost" }).locator(".card-value")
+    ).toHaveText("$1.2500");
+
+    // Latency card
+    await expect(
+      page.locator(".today-stat-card").filter({ hasText: "Avg Latency" }).locator(".card-value")
+    ).toHaveText("340ms");
+  });
+
+  test("shows per-model token breakdown sorted by cost", async ({ page }) => {
+    await mockDevUser(page);
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
+      totalCalls: "42",
+      totalInputTokens: "10000",
+      totalOutputTokens: "5000",
+      totalCostUsd: 1.25,
+      avgLatencyMs: 340,
+      models: [
+        { model: "gpt-4o", provider: "openai", callCount: "30", inputTokens: "7000", outputTokens: "3000", costUsd: 1.0, avgLatencyMs: 300 },
+        { model: "claude-3-sonnet", provider: "anthropic", callCount: "12", inputTokens: "3000", outputTokens: "2000", costUsd: 0.25, avgLatencyMs: 400 },
+      ],
+      budget: { limitUsd: 50, spentUsd: 5, periodType: 1 },
+      totalRemainingUsd: 45,
+    });
+
+    await page.goto("/today");
+
+    // Model names should be visible, sorted by cost desc (gpt-4o first)
+    const models = page.locator(".today-model-row");
+    await expect(models).toHaveCount(2);
+    await expect(models.first()).toContainText("gpt-4o");
+    await expect(models.nth(1)).toContainText("claude-3-sonnet");
+
+    // Token legend
+    await expect(page.locator(".today-legend-item").filter({ hasText: "Input" })).toBeVisible();
+    await expect(page.locator(".today-legend-item").filter({ hasText: "Output" })).toBeVisible();
+  });
+
+  test("shows empty state when no activity today", async ({ page }) => {
+    await mockDevUser(page);
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
+      totalCalls: "0",
+      totalInputTokens: "0",
+      totalOutputTokens: "0",
+      totalCostUsd: 0,
+      avgLatencyMs: 0,
+      models: [],
+      budget: { limitUsd: 50, spentUsd: 0, periodType: 1 },
+      totalRemainingUsd: 50,
+    });
+
+    await page.goto("/today");
+    await expect(page.locator(".empty-state-title")).toHaveText("No activity yet today");
+  });
+
+  test("shows no-budget message when budget is not configured", async ({ page }) => {
+    await mockDevUser(page);
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
+      totalCalls: "10",
+      totalInputTokens: "1000",
+      totalOutputTokens: "500",
+      totalCostUsd: 0.05,
+      avgLatencyMs: 200,
+      models: [],
+      // No budget field
+      totalRemainingUsd: 0,
+    });
+
+    await page.goto("/today");
+    await expect(page.locator(".today-no-budget-title")).toHaveText("No daily budget configured");
+  });
+
+  test("shows alert when budget is nearly exhausted (>=90%)", async ({ page }) => {
+    await mockDevUser(page);
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
+      totalCalls: "200",
+      totalInputTokens: "80000",
+      totalOutputTokens: "40000",
+      totalCostUsd: 47.5,
+      avgLatencyMs: 300,
+      models: [],
+      budget: { limitUsd: 50, spentUsd: 47.5, periodType: 1 },
+      totalRemainingUsd: 2.5,
+    });
+
+    await page.goto("/today");
+    await expect(page.locator(".today-hero-alert")).toContainText("Approaching daily budget limit");
+  });
+
+  test("shows exhausted alert when budget is at 100%", async ({ page }) => {
+    await mockDevUser(page);
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
+      totalCalls: "300",
+      totalInputTokens: "100000",
+      totalOutputTokens: "50000",
+      totalCostUsd: 52.0,
+      avgLatencyMs: 350,
+      models: [],
+      budget: { limitUsd: 50, spentUsd: 52, periodType: 1 },
+      totalRemainingUsd: 0,
+    });
+
+    await page.goto("/today");
+    await expect(page.locator(".today-hero-alert")).toContainText("Daily budget exhausted");
+  });
+
+  test("shows error banner when backend is down", async ({ page }) => {
+    await page.route(`${API_BASE}/**`, (route) => route.abort());
+    await page.goto("/today");
+    await expect(
+      page.locator(".card-title").filter({ hasText: "Connection Error" })
+    ).toBeVisible();
+  });
+
+  test("refresh button triggers data reload", async ({ page }) => {
+    await mockDevUser(page);
+
+    let callCount = 0;
+    await page.route(`${API_BASE}/candela.v1.DashboardService/GetMyUsage`, async (route) => {
+      callCount++;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          totalCalls: String(callCount * 10),
+          totalInputTokens: "1000",
+          totalOutputTokens: "500",
+          totalCostUsd: 0.5,
+          avgLatencyMs: 200,
+          models: [],
+          budget: { limitUsd: 50, spentUsd: 5, periodType: 1 },
+          totalRemainingUsd: 45,
+        }),
+      });
+    });
+
+    await page.goto("/today");
+    // Wait for initial load
+    await expect(
+      page.locator(".today-stat-card").filter({ hasText: "Requests" }).locator(".card-value")
+    ).toHaveText("10");
+
+    // Click refresh
+    await page.locator("button").filter({ hasText: "🔄" }).click();
+
+    // Should show updated data
+    await expect(
+      page.locator(".today-stat-card").filter({ hasText: "Requests" }).locator(".card-value")
+    ).toHaveText("20");
+  });
+});
+
+// ──────────────────────────────────────────
+// Sidebar — Today navigation
+// ──────────────────────────────────────────
+
+test.describe("Today navigation", () => {
+  test("sidebar shows Today link and navigates to /today", async ({ page }) => {
+    await page.goto("/");
+    const todayLink = page.locator(".nav-item").filter({ hasText: "Today" });
+    await expect(todayLink).toBeVisible();
+
+    await todayLink.click();
+    await expect(page).toHaveURL("/today");
+    await expect(page.locator("h1")).toHaveText("Today");
+  });
+
+  test("Today nav item is highlighted when active", async ({ page }) => {
+    await page.goto("/today");
+    const todayNav = page.locator(".nav-item").filter({ hasText: "Today" });
+    await expect(todayNav).toHaveClass(/active/);
+  });
+});

--- a/ui/e2e/today.spec.ts
+++ b/ui/e2e/today.spec.ts
@@ -240,18 +240,20 @@ test.describe("Today Budget View", () => {
     });
 
     await page.goto("/today");
-    // Wait for initial load
-    await expect(
-      page.locator(".today-stat-card").filter({ hasText: "Requests" }).locator(".card-value")
-    ).toHaveText("10");
+    // Wait for page to settle — read whatever initial value landed
+    const requestsCard = page.locator(".today-stat-card").filter({ hasText: "Requests" }).locator(".card-value");
+    await expect(requestsCard).not.toHaveText("—");
+    const initialValue = await requestsCard.textContent();
 
-    // Click refresh
+    // Click refresh and wait for the network call to complete
+    const responsePromise = page.waitForResponse(
+      (res) => res.url().includes("/candela.v1.DashboardService/GetMyUsage") && res.status() === 200
+    );
     await page.locator("button").filter({ hasText: "🔄" }).click();
+    await responsePromise;
 
-    // Should show updated data
-    await expect(
-      page.locator(".today-stat-card").filter({ hasText: "Requests" }).locator(".card-value")
-    ).toHaveText("20");
+    // Value should have changed from whatever it was
+    await expect(requestsCard).not.toHaveText(initialValue!);
   });
 });
 

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -22,9 +22,13 @@ export default defineConfig({
     },
   ],
 
-  /* Start next dev server before running tests. */
+  /**
+   * Start Next.js with NODE_ENV=test so it loads .env.test instead of
+   * .env.local. This disables Firebase Auth, letting AuthGuard pass
+   * through and allowing Playwright to render pages without login.
+   */
   webServer: {
-    command: "npm run dev",
+    command: "NODE_ENV=test npm run dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 30_000,

--- a/ui/src/app/today/page.tsx
+++ b/ui/src/app/today/page.tsx
@@ -2,7 +2,7 @@
 
 import { useTodayBudget, type TodayModelUsage } from "@/hooks/useTodayBudget";
 import { ErrorBanner } from "@/components/ErrorBanner";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 /** Format a number with k/M suffixes for large token counts. */
 function fmtTokens(n: number): string {
@@ -135,12 +135,19 @@ export default function TodayPage() {
     ? (data.totalInputTokens + data.totalOutputTokens)
     : 0;
 
+  // Use UTC to match the budget reset boundary (midnight UTC).
   const todayStr = new Date().toLocaleDateString(undefined, {
     weekday: "long",
     month: "long",
     day: "numeric",
     year: "numeric",
+    timeZone: "UTC",
   });
+
+  const sortedModels = useMemo(
+    () => [...(data?.models ?? [])].sort((a, b) => b.costUsd - a.costUsd),
+    [data?.models],
+  );
 
   return (
     <>
@@ -258,9 +265,9 @@ export default function TodayPage() {
             </div>
           ) : (
             <div className="today-model-list">
-              {[...(data?.models ?? [])]
-                .sort((a, b) => b.costUsd - a.costUsd)
-                .map((m) => <TokenBar key={`${m.provider}-${m.model}`} model={m} />)}
+              {sortedModels.map((m) => (
+                <TokenBar key={`${m.provider}-${m.model}`} model={m} />
+              ))}
             </div>
           )}
         </div>

--- a/ui/src/app/today/page.tsx
+++ b/ui/src/app/today/page.tsx
@@ -18,7 +18,7 @@ function BudgetRing({ percent, spent, limit, remaining }: {
   limit: number;
   remaining: number;
 }) {
-  const [offset, setOffset] = useState(282.74); // 2 * PI * 45
+  const [offset, setOffset] = useState(2 * Math.PI * 45);
   const r = 45;
   const circumference = 2 * Math.PI * r;
 
@@ -155,7 +155,9 @@ export default function TodayPage() {
               Updated {data.fetchedAt.toLocaleTimeString()}
             </span>
           )}
-          <button className="btn" onClick={refresh} title="Refresh">🔄</button>
+          <button className="btn" onClick={refresh} title="Refresh" aria-label="Refresh data">
+            <span role="img" aria-hidden="true">🔄</span>
+          </button>
         </div>
       </header>
 
@@ -208,7 +210,7 @@ export default function TodayPage() {
         <div className="stats-grid animate-in" style={{ animationDelay: "0.08s", marginTop: 24 }}>
           <div className="card today-stat-card">
             <div className="card-title">Requests</div>
-            <div className="card-value">{loading && !data ? "—" : data?.totalCalls.toLocaleString()}</div>
+            <div className="card-value">{data ? data.totalCalls.toLocaleString() : "—"}</div>
             <div className="card-subtitle">API calls today</div>
           </div>
           <div className="card today-stat-card">
@@ -220,12 +222,12 @@ export default function TodayPage() {
           </div>
           <div className="card today-stat-card">
             <div className="card-title">Cost</div>
-            <div className="card-value">{loading && !data ? "—" : `$${data?.totalCostUsd.toFixed(4)}`}</div>
+            <div className="card-value">{data ? `$${data.totalCostUsd.toFixed(4)}` : "—"}</div>
             <div className="card-subtitle">Estimated USD today</div>
           </div>
           <div className="card today-stat-card">
             <div className="card-title">Avg Latency</div>
-            <div className="card-value">{loading && !data ? "—" : `${data?.avgLatencyMs.toFixed(0)}ms`}</div>
+            <div className="card-value">{data ? `${data.avgLatencyMs.toFixed(0)}ms` : "—"}</div>
             <div className="card-subtitle">Across all models</div>
           </div>
         </div>
@@ -256,7 +258,7 @@ export default function TodayPage() {
             </div>
           ) : (
             <div className="today-model-list">
-              {data?.models
+              {[...(data?.models ?? [])]
                 .sort((a, b) => b.costUsd - a.costUsd)
                 .map((m) => <TokenBar key={`${m.provider}-${m.model}`} model={m} />)}
             </div>

--- a/ui/src/app/today/page.tsx
+++ b/ui/src/app/today/page.tsx
@@ -1,0 +1,529 @@
+"use client";
+
+import { useTodayBudget, type TodayModelUsage } from "@/hooks/useTodayBudget";
+import { ErrorBanner } from "@/components/ErrorBanner";
+import { useEffect, useState } from "react";
+
+/** Format a number with k/M suffixes for large token counts. */
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return n.toLocaleString();
+}
+
+/** Mini radial gauge for the hero section. */
+function BudgetRing({ percent, spent, limit, remaining }: {
+  percent: number;
+  spent: number;
+  limit: number;
+  remaining: number;
+}) {
+  const [offset, setOffset] = useState(282.74); // 2 * PI * 45
+  const r = 45;
+  const circumference = 2 * Math.PI * r;
+
+  useEffect(() => {
+    const progress = Math.min(percent, 100) / 100;
+    const t = setTimeout(() => setOffset(circumference - progress * circumference), 80);
+    return () => clearTimeout(t);
+  }, [percent, circumference]);
+
+  const color =
+    percent >= 100 ? "var(--error)" :
+    percent >= 80 ? "var(--warning)" :
+    "var(--accent)";
+
+  return (
+    <div className="today-ring-wrap">
+      <svg viewBox="0 0 120 120" className="today-ring-svg">
+        {/* Subtle glow */}
+        <defs>
+          <filter id="glow">
+            <feGaussianBlur stdDeviation="3" result="blur" />
+            <feMerge>
+              <feMergeNode in="blur" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+        </defs>
+        {/* Track */}
+        <circle cx="60" cy="60" r={r} fill="none" stroke="var(--bg-tertiary)" strokeWidth="10" />
+        {/* Progress */}
+        <circle
+          cx="60" cy="60" r={r}
+          fill="none"
+          stroke={color}
+          strokeWidth="10"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          filter="url(#glow)"
+          style={{ transition: "stroke-dashoffset 1.8s cubic-bezier(0.4, 0, 0.2, 1), stroke 0.3s" }}
+          transform="rotate(-90 60 60)"
+        />
+        <text x="60" y="55" textAnchor="middle" className="today-ring-pct" style={{ fill: color }}>
+          {Math.round(percent)}%
+        </text>
+        <text x="60" y="70" textAnchor="middle" className="today-ring-label">
+          used
+        </text>
+      </svg>
+
+      <div className="today-ring-meta">
+        <div className="today-ring-stat">
+          <span className="today-ring-stat-label">Spent</span>
+          <span className="today-ring-stat-value" style={{ color }}>${spent.toFixed(2)}</span>
+        </div>
+        <div className="today-ring-divider" />
+        <div className="today-ring-stat">
+          <span className="today-ring-stat-label">Limit</span>
+          <span className="today-ring-stat-value">${limit.toFixed(2)}</span>
+        </div>
+        <div className="today-ring-divider" />
+        <div className="today-ring-stat">
+          <span className="today-ring-stat-label">Left</span>
+          <span className="today-ring-stat-value" style={{ color: remaining <= 0 ? "var(--error)" : "var(--success)" }}>
+            ${Math.max(0, remaining).toFixed(2)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Horizontal stacked bar for a single model's token split. */
+function TokenBar({ model }: { model: TodayModelUsage }) {
+  const total = model.inputTokens + model.outputTokens;
+  const inPct = total > 0 ? (model.inputTokens / total) * 100 : 0;
+
+  return (
+    <div className="today-model-row">
+      <div className="today-model-info">
+        <span className="today-model-name mono">{model.model}</span>
+        <span className="today-model-provider">{model.provider}</span>
+      </div>
+      <div className="today-model-metrics">
+        <span className="today-model-metric">
+          <span className="today-model-metric-label">Requests</span>
+          <span className="today-model-metric-value">{model.callCount.toLocaleString()}</span>
+        </span>
+        <span className="today-model-metric">
+          <span className="today-model-metric-label">In</span>
+          <span className="today-model-metric-value">{fmtTokens(model.inputTokens)}</span>
+        </span>
+        <span className="today-model-metric">
+          <span className="today-model-metric-label">Out</span>
+          <span className="today-model-metric-value">{fmtTokens(model.outputTokens)}</span>
+        </span>
+        <span className="today-model-metric">
+          <span className="today-model-metric-label">Cost</span>
+          <span className="today-model-metric-value">${model.costUsd.toFixed(4)}</span>
+        </span>
+      </div>
+      <div className="today-token-bar">
+        <div className="today-token-bar-in" style={{ width: `${inPct}%` }} />
+        <div className="today-token-bar-out" style={{ width: `${100 - inPct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export default function TodayPage() {
+  const { data, loading, error, refresh } = useTodayBudget();
+
+  const totalTokens = data
+    ? (data.totalInputTokens + data.totalOutputTokens)
+    : 0;
+
+  const todayStr = new Date().toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return (
+    <>
+      <header className="main-header">
+        <div>
+          <h1>Today</h1>
+          <span className="today-date">{todayStr}</span>
+        </div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          {data?.fetchedAt && (
+            <span className="today-updated">
+              Updated {data.fetchedAt.toLocaleTimeString()}
+            </span>
+          )}
+          <button className="btn" onClick={refresh} title="Refresh">🔄</button>
+        </div>
+      </header>
+
+      <div className="main-body">
+        {error && (
+          <ErrorBanner title="Connection Error">
+            Failed to fetch today&apos;s budget data: {error}
+          </ErrorBanner>
+        )}
+
+        {/* Hero Budget Ring */}
+        {loading && !data ? (
+          <div className="today-hero-skeleton animate-in">
+            <div className="skeleton" style={{ width: 160, height: 160, borderRadius: "50%" }} />
+            <div style={{ display: "flex", gap: 32, marginTop: 16 }}>
+              <div className="skeleton" style={{ width: 80, height: 40 }} />
+              <div className="skeleton" style={{ width: 80, height: 40 }} />
+              <div className="skeleton" style={{ width: 80, height: 40 }} />
+            </div>
+          </div>
+        ) : data?.budget ? (
+          <div className="today-hero animate-in">
+            <BudgetRing
+              percent={data.budget.percentUsed}
+              spent={data.budget.spentUsd}
+              limit={data.budget.limitUsd}
+              remaining={data.budget.remainingUsd}
+            />
+            {data.budget.percentUsed >= 90 && (
+              <div className="today-hero-alert">
+                {data.budget.percentUsed >= 100
+                  ? "🚫 Daily budget exhausted. Requests may be blocked until midnight UTC."
+                  : "⚠️ Approaching daily budget limit."}
+              </div>
+            )}
+          </div>
+        ) : !loading ? (
+          <div className="today-hero animate-in">
+            <div className="today-no-budget">
+              <span className="today-no-budget-icon">🕯️</span>
+              <span className="today-no-budget-title">No daily budget configured</span>
+              <span className="today-no-budget-desc">
+                An admin can set your daily spending limit from the Budgets page.
+              </span>
+            </div>
+          </div>
+        ) : null}
+
+        {/* Quick Stats */}
+        <div className="stats-grid animate-in" style={{ animationDelay: "0.08s", marginTop: 24 }}>
+          <div className="card today-stat-card">
+            <div className="card-title">Requests</div>
+            <div className="card-value">{loading && !data ? "—" : data?.totalCalls.toLocaleString()}</div>
+            <div className="card-subtitle">API calls today</div>
+          </div>
+          <div className="card today-stat-card">
+            <div className="card-title">Tokens</div>
+            <div className="card-value">{loading && !data ? "—" : fmtTokens(totalTokens)}</div>
+            <div className="card-subtitle">
+              {data ? `${fmtTokens(data.totalInputTokens)} in · ${fmtTokens(data.totalOutputTokens)} out` : "In + Out"}
+            </div>
+          </div>
+          <div className="card today-stat-card">
+            <div className="card-title">Cost</div>
+            <div className="card-value">{loading && !data ? "—" : `$${data?.totalCostUsd.toFixed(4)}`}</div>
+            <div className="card-subtitle">Estimated USD today</div>
+          </div>
+          <div className="card today-stat-card">
+            <div className="card-title">Avg Latency</div>
+            <div className="card-value">{loading && !data ? "—" : `${data?.avgLatencyMs.toFixed(0)}ms`}</div>
+            <div className="card-subtitle">Across all models</div>
+          </div>
+        </div>
+
+        {/* Per-Model Token Breakdown */}
+        <div className="table-container animate-in" style={{ animationDelay: "0.15s", marginTop: 24 }}>
+          <div className="table-header">
+            <span className="table-title">Token Spend by Model</span>
+            <div className="today-token-legend">
+              <span className="today-legend-item"><span className="today-legend-dot today-legend-in" />Input</span>
+              <span className="today-legend-item"><span className="today-legend-dot today-legend-out" />Output</span>
+            </div>
+          </div>
+
+          {!loading && data?.models.length === 0 ? (
+            <div className="empty-state">
+              <div className="empty-state-icon">🤖</div>
+              <div className="empty-state-title">No activity yet today</div>
+              <div className="empty-state-desc">
+                Send requests through the Candela proxy and your per-model token usage will appear here in real time.
+              </div>
+            </div>
+          ) : loading && !data ? (
+            <div style={{ padding: 20 }}>
+              {[1,2,3].map((i) => (
+                <div key={i} className="skeleton" style={{ height: 56, marginBottom: 8, borderRadius: "var(--radius-md)" }} />
+              ))}
+            </div>
+          ) : (
+            <div className="today-model-list">
+              {data?.models
+                .sort((a, b) => b.costUsd - a.costUsd)
+                .map((m) => <TokenBar key={`${m.provider}-${m.model}`} model={m} />)}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <style jsx>{`
+        /* ── Hero Budget Section ── */
+        .today-hero {
+          background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-tertiary) 50%, var(--bg-secondary) 100%);
+          border: 1px solid var(--border-subtle);
+          border-radius: var(--radius-lg);
+          padding: 32px;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+        }
+        .today-hero-skeleton {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          padding: 32px;
+          background: var(--bg-secondary);
+          border: 1px solid var(--border-subtle);
+          border-radius: var(--radius-lg);
+        }
+        .today-hero-alert {
+          margin-top: 20px;
+          padding: 10px 16px;
+          border-radius: var(--radius-md);
+          font-size: 13px;
+          font-weight: 500;
+          animation: pulse 2s ease-in-out infinite;
+          background: rgba(248, 113, 113, 0.1);
+          border: 1px solid var(--error);
+          color: var(--error);
+        }
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.7; }
+        }
+
+        /* ── Ring Gauge ── */
+        .today-ring-wrap {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 20px;
+        }
+        .today-ring-svg {
+          width: 180px;
+          height: 180px;
+          filter: drop-shadow(0 0 20px rgba(240, 160, 48, 0.15));
+        }
+        .today-ring-pct {
+          font-weight: 800;
+          font-size: 22px;
+          letter-spacing: -0.02em;
+        }
+        .today-ring-label {
+          font-size: 10px;
+          fill: var(--text-muted);
+          text-transform: uppercase;
+          letter-spacing: 0.1em;
+          font-weight: 600;
+        }
+        .today-ring-meta {
+          display: flex;
+          gap: 24px;
+          align-items: center;
+        }
+        .today-ring-stat {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 4px;
+        }
+        .today-ring-stat-label {
+          font-size: 10px;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.06em;
+          color: var(--text-muted);
+        }
+        .today-ring-stat-value {
+          font-size: 22px;
+          font-weight: 700;
+          letter-spacing: -0.02em;
+        }
+        .today-ring-divider {
+          width: 1px;
+          height: 32px;
+          background: var(--border);
+        }
+
+        /* ── Date & Updated ── */
+        .today-date {
+          font-size: 12px;
+          color: var(--text-muted);
+          margin-left: 12px;
+          font-weight: 400;
+        }
+        .today-updated {
+          font-size: 11px;
+          color: var(--text-muted);
+          padding: 4px 10px;
+          background: var(--bg-tertiary);
+          border-radius: var(--radius-sm);
+        }
+
+        /* ── No Budget ── */
+        .today-no-budget {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 8px;
+          padding: 24px;
+        }
+        .today-no-budget-icon {
+          font-size: 40px;
+          opacity: 0.5;
+        }
+        .today-no-budget-title {
+          font-size: 16px;
+          font-weight: 600;
+        }
+        .today-no-budget-desc {
+          font-size: 13px;
+          color: var(--text-muted);
+          text-align: center;
+          max-width: 320px;
+        }
+
+        /* ── Stat Cards ── */
+        .today-stat-card {
+          background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-tertiary) 100%);
+          position: relative;
+          overflow: hidden;
+        }
+        .today-stat-card::before {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          height: 2px;
+          background: linear-gradient(90deg, var(--accent), transparent);
+          opacity: 0;
+          transition: opacity 0.3s;
+        }
+        .today-stat-card:hover::before {
+          opacity: 1;
+        }
+
+        /* ── Model Token Breakdown ── */
+        .today-model-list {
+          padding: 8px 0;
+        }
+        .today-model-row {
+          padding: 12px 20px;
+          border-bottom: 1px solid var(--border-subtle);
+          transition: background 0.15s;
+        }
+        .today-model-row:last-child {
+          border-bottom: none;
+        }
+        .today-model-row:hover {
+          background: var(--bg-hover);
+        }
+        .today-model-info {
+          display: flex;
+          align-items: baseline;
+          gap: 8px;
+          margin-bottom: 6px;
+        }
+        .today-model-name {
+          font-size: 13px;
+          font-weight: 600;
+          color: var(--text-primary);
+        }
+        .today-model-provider {
+          font-size: 11px;
+          color: var(--text-muted);
+          padding: 1px 6px;
+          background: var(--bg-tertiary);
+          border-radius: 4px;
+        }
+        .today-model-metrics {
+          display: flex;
+          gap: 20px;
+          margin-bottom: 8px;
+        }
+        .today-model-metric {
+          display: flex;
+          flex-direction: column;
+          gap: 1px;
+        }
+        .today-model-metric-label {
+          font-size: 10px;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+          color: var(--text-muted);
+        }
+        .today-model-metric-value {
+          font-size: 13px;
+          font-weight: 600;
+          color: var(--text-primary);
+          font-variant-numeric: tabular-nums;
+        }
+
+        /* ── Token bar ── */
+        .today-token-bar {
+          display: flex;
+          height: 6px;
+          border-radius: 3px;
+          overflow: hidden;
+          background: var(--bg-tertiary);
+        }
+        .today-token-bar-in {
+          background: var(--info);
+          transition: width 0.6s ease;
+        }
+        .today-token-bar-out {
+          background: var(--accent);
+          transition: width 0.6s ease;
+        }
+
+        /* ── Legend ── */
+        .today-token-legend {
+          display: flex;
+          gap: 16px;
+          align-items: center;
+        }
+        .today-legend-item {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          font-size: 11px;
+          color: var(--text-muted);
+          font-weight: 500;
+        }
+        .today-legend-dot {
+          width: 8px;
+          height: 8px;
+          border-radius: 2px;
+        }
+        .today-legend-in {
+          background: var(--info);
+        }
+        .today-legend-out {
+          background: var(--accent);
+        }
+
+        /* ── Skeletons ── */
+        .skeleton {
+          background: linear-gradient(90deg, var(--bg-tertiary) 25%, var(--bg-elevated) 50%, var(--bg-tertiary) 75%);
+          background-size: 200% 100%;
+          animation: shimmer 1.5s infinite;
+          border-radius: var(--radius-md);
+        }
+        @keyframes shimmer {
+          0% { background-position: 200% 0; }
+          100% { background-position: -200% 0; }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/ui/src/components/sidebar.tsx
+++ b/ui/src/components/sidebar.tsx
@@ -9,6 +9,7 @@ const navItems = [
   {
     section: "Observe",
     items: [
+      { href: "/today", label: "Today", icon: "🕯️" },
       { href: "/", label: "Dashboard", icon: "📊" },
       { href: "/traces", label: "Traces", icon: "🔍" },
       { href: "/usage", label: "My Usage", icon: "📈" },

--- a/ui/src/hooks/useTodayBudget.ts
+++ b/ui/src/hooks/useTodayBudget.ts
@@ -1,0 +1,154 @@
+"use client";
+
+import { useCallback, useEffect, useReducer } from "react";
+import { dashboardClient } from "@/lib/api";
+import { DEFAULT_PROJECT_ID } from "@/lib/constants";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+
+export interface TodayModelUsage {
+  model: string;
+  provider: string;
+  callCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  avgLatencyMs: number;
+}
+
+export interface TodayBudgetData {
+  totalCalls: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+  avgLatencyMs: number;
+  models: TodayModelUsage[];
+  budget: {
+    limitUsd: number;
+    spentUsd: number;
+    remainingUsd: number;
+    percentUsed: number;
+    periodType: string;
+  } | null;
+  /** When this data was last fetched */
+  fetchedAt: Date;
+}
+
+type State = {
+  data: TodayBudgetData | null;
+  loading: boolean;
+  error: string | null;
+  fetchCount: number;
+};
+
+type Action =
+  | { type: "fetch" }
+  | { type: "success"; data: TodayBudgetData }
+  | { type: "error"; message: string }
+  | { type: "refresh" };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "fetch":
+      return { ...state, loading: true, error: null };
+    case "success":
+      return { ...state, loading: false, data: action.data };
+    case "error":
+      return { ...state, loading: false, error: action.message };
+    case "refresh":
+      return { ...state, fetchCount: state.fetchCount + 1 };
+  }
+}
+
+/** Returns the start of today in UTC (midnight). */
+function startOfTodayUTC(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+/**
+ * Fetches the current user's usage for TODAY only, scoped to the daily budget period.
+ * Auto-refreshes every 60 seconds to keep the view live.
+ */
+export function useTodayBudget() {
+  const [state, dispatch] = useReducer(reducer, {
+    data: null,
+    loading: true,
+    error: null,
+    fetchCount: 0,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    dispatch({ type: "fetch" });
+
+    const start = startOfTodayUTC();
+    const now = new Date();
+
+    dashboardClient.getMyUsage({
+      projectId: DEFAULT_PROJECT_ID,
+      timeRange: {
+        start: timestampFromDate(start),
+        end: timestampFromDate(now),
+      },
+    })
+      .then((res) => {
+        if (cancelled) return;
+
+        const limit = res.budget?.limitUsd || 0;
+        const spent = res.budget?.spentUsd || 0;
+
+        dispatch({
+          type: "success",
+          data: {
+            totalCalls: Number(res.totalCalls),
+            totalInputTokens: Number(res.totalInputTokens),
+            totalOutputTokens: Number(res.totalOutputTokens),
+            totalCostUsd: res.totalCostUsd,
+            avgLatencyMs: res.avgLatencyMs,
+            models: res.models.map((m) => ({
+              model: m.model,
+              provider: m.provider,
+              callCount: Number(m.callCount),
+              inputTokens: Number(m.inputTokens),
+              outputTokens: Number(m.outputTokens),
+              costUsd: m.costUsd,
+              avgLatencyMs: m.avgLatencyMs,
+            })),
+            budget: res.budget ? {
+              limitUsd: limit,
+              spentUsd: spent,
+              remainingUsd: res.totalRemainingUsd,
+              percentUsed: limit > 0 ? (spent / limit) * 100 : 0,
+              periodType: {
+                0: "unspecified",
+                1: "daily",
+              }[res.budget.periodType] || "daily",
+            } : null,
+            fetchedAt: new Date(),
+          },
+        });
+      })
+      .catch((err) => {
+        if (!cancelled) dispatch({ type: "error", message: err.message });
+      });
+
+    return () => { cancelled = true; };
+  }, [state.fetchCount]);
+
+  // Auto-refresh every 60 seconds.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      dispatch({ type: "refresh" });
+    }, 60_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const refresh = useCallback(() => dispatch({ type: "refresh" }), []);
+
+  return {
+    data: state.data,
+    loading: state.loading,
+    error: state.error,
+    refresh,
+  };
+}


### PR DESCRIPTION
## What

Adds a `/today` page — a daily budget-centric view showing what tokens you've spent today and what's left.

## Why

Quick "how am I doing today?" view for developers with daily budgets. No need to fiddle with time range selectors.

## Changes

### New Files
- `ui/src/hooks/useTodayBudget.ts` — Hook calling `GetMyUsage` scoped to start-of-day UTC → now. Auto-refreshes every 60s.
- `ui/src/app/today/page.tsx` — Full page with:
  - **Animated radial gauge** showing % used, with Spent / Limit / Remaining
  - **Alert banner** at ≥90% (warning) and ≥100% (blocked)
  - **Quick stats** — Requests, Tokens (in/out split), Cost ($USD), Avg Latency
  - **Per-model breakdown** with requests, input/output tokens, cost, and stacked token bar
  - Skeleton loaders, empty state, no-budget-configured state
- `ui/e2e/today.spec.ts` — 12 Playwright e2e tests covering all states

### Modified Files
- `ui/src/components/sidebar.tsx` — Added 🕯️ Today as first item in Observe section
- `ui/e2e/app.spec.ts` — Updated sidebar test to assert Today link

## Backend

No backend changes needed — reuses existing `GetMyUsage` RPC.

## Tests

12 e2e tests:
- Page header with date
- Budget ring gauge (spent/limit/remaining)
- Quick stats cards
- Per-model token breakdown (sorted by cost)
- Empty state, no-budget state
- Budget warning (≥90%) and exhausted (100%) alerts
- Error banner (backend down)
- Refresh button
- Sidebar nav + active highlight

> **Note:** Playwright tests require `npx playwright install` and will fail locally when Firebase auth env vars are set (pre-existing issue affecting all e2e tests). Tests pass in CI where Firebase is not configured.