### PR TITLE
feat: per-conversation session tracking (#69)

### DIFF
--- a/cmd/candela-local/main.go
+++ b/cmd/candela-local/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/candelahq/candela/pkg/processor"
 	"github.com/candelahq/candela/pkg/proxy"
 	"github.com/candelahq/candela/pkg/runtime"
+	"github.com/candelahq/candela/pkg/session"
 	"github.com/candelahq/candela/pkg/storage"
 
 	// Register runtime backends.
@@ -365,11 +366,17 @@ func main() {
 		runtimeLocalProxy = buildLocalProxy(mgr.Runtime().Endpoint())
 	}
 
+	// Create the session resolver chain for conversation tracking.
+	sessionResolver := session.NewChainResolver(
+		session.NewHeaderResolver(""),              // Explicit X-Session-Id header wins.
+		session.NewUserMsgResolver(30*time.Minute), // Heuristic: first user message fingerprint.
+	)
+
 	// Build the smart LM handler.
 	// In solo mode with traces enabled, wrap local proxy with span capture.
 	var localHandler http.Handler
 	if runtimeLocalProxy != nil {
-		localHandler = newSpanCapture(runtimeLocalProxy, spanProc)
+		localHandler = newSpanCapture(runtimeLocalProxy, spanProc, sessionResolver)
 	}
 
 	// Build direct cloud proxy if providers are configured (solo + cloud mode).

--- a/cmd/candela-local/span_capture.go
+++ b/cmd/candela-local/span_capture.go
@@ -70,10 +70,11 @@ func (s *spanCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var inputContent string
 	if len(msgs) > 0 {
 		last := msgs[len(msgs)-1]
-		inputContent = last.Content
-		if runeCount := len([]rune(inputContent)); runeCount > 500 {
-			runes := []rune(inputContent)
+		runes := []rune(last.Content)
+		if len(runes) > 500 {
 			inputContent = string(runes[:500]) + "..."
+		} else {
+			inputContent = last.Content
 		}
 	}
 

--- a/cmd/candela-local/span_capture.go
+++ b/cmd/candela-local/span_capture.go
@@ -51,21 +51,25 @@ func (s *spanCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.Body = io.NopCloser(bytes.NewReader(reqBody))
 	r.ContentLength = int64(len(reqBody))
 
-	// Parse request for model name and input content (extract early to avoid redundant unmarshal).
+	// Parse request for model name, input content, and raw messages.
 	var chatReq struct {
-		Model    string `json:"model"`
-		Stream   *bool  `json:"stream"`
-		Messages []struct {
-			Role    string `json:"role"`
-			Content string `json:"content"`
-		} `json:"messages"`
+		Model    string          `json:"model"`
+		Stream   *bool           `json:"stream"`
+		Messages json.RawMessage `json:"messages"`
 	}
 	_ = json.Unmarshal(reqBody, &chatReq)
 
+	// Decode messages for input content extraction.
+	var msgs []struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	_ = json.Unmarshal(chatReq.Messages, &msgs)
+
 	// Extract input content now to avoid re-parsing later.
 	var inputContent string
-	if len(chatReq.Messages) > 0 {
-		last := chatReq.Messages[len(chatReq.Messages)-1]
+	if len(msgs) > 0 {
+		last := msgs[len(msgs)-1]
 		inputContent = last.Content
 		if runeCount := len([]rune(inputContent)); runeCount > 500 {
 			runes := []rune(inputContent)
@@ -76,11 +80,10 @@ func (s *spanCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Resolve session ID.
 	var sessionID string
 	if s.resolver != nil {
-		msgsJSON, _ := json.Marshal(chatReq.Messages)
 		sessionID = s.resolver.Resolve(session.SessionInfo{
 			UserID:   r.Header.Get("X-User-Id"),
 			Model:    chatReq.Model,
-			Messages: msgsJSON,
+			Messages: chatReq.Messages, // pass raw JSON directly, no re-marshal
 			Headers:  r.Header,
 		})
 		// Inject header so downstream (lm_handler → remote proxy) can see it.

--- a/cmd/candela-local/span_capture.go
+++ b/cmd/candela-local/span_capture.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/candelahq/candela/pkg/processor"
+	"github.com/candelahq/candela/pkg/session"
 	"github.com/candelahq/candela/pkg/storage"
 )
 
@@ -18,16 +19,17 @@ import (
 // request/response data to emit observability spans via the span processor.
 // Handles both streaming (SSE) and non-streaming OpenAI-format responses.
 type spanCapture struct {
-	next http.Handler
-	proc *processor.SpanProcessor
+	next     http.Handler
+	proc     *processor.SpanProcessor
+	resolver session.SessionResolver
 }
 
 // newSpanCapture creates a span-capturing middleware.
-func newSpanCapture(next http.Handler, proc *processor.SpanProcessor) http.Handler {
+func newSpanCapture(next http.Handler, proc *processor.SpanProcessor, resolver session.SessionResolver) http.Handler {
 	if proc == nil {
 		return next // no processor → passthrough
 	}
-	return &spanCapture{next: next, proc: proc}
+	return &spanCapture{next: next, proc: proc, resolver: resolver}
 }
 
 func (s *spanCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -71,6 +73,22 @@ func (s *spanCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Resolve session ID.
+	var sessionID string
+	if s.resolver != nil {
+		msgsJSON, _ := json.Marshal(chatReq.Messages)
+		sessionID = s.resolver.Resolve(session.SessionInfo{
+			UserID:   r.Header.Get("X-User-Id"),
+			Model:    chatReq.Model,
+			Messages: msgsJSON,
+			Headers:  r.Header,
+		})
+		// Inject header so downstream (lm_handler → remote proxy) can see it.
+		if sessionID != "" {
+			r.Header.Set("X-Session-Id", sessionID)
+		}
+	}
+
 	// Capture response.
 	rec := &responseCapture{ResponseWriter: w}
 	s.next.ServeHTTP(rec, r)
@@ -78,10 +96,10 @@ func (s *spanCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	duration := time.Since(start)
 
 	// Build the span asynchronously to not block the response.
-	go s.buildSpan(chatReq.Model, chatReq.Stream, inputContent, rec.body.Bytes(), rec.statusCode, start, duration)
+	go s.buildSpan(chatReq.Model, chatReq.Stream, inputContent, rec.body.Bytes(), rec.statusCode, start, duration, sessionID)
 }
 
-func (s *spanCapture) buildSpan(model string, stream *bool, inputContent string, respBody []byte, statusCode int, start time.Time, duration time.Duration) {
+func (s *spanCapture) buildSpan(model string, stream *bool, inputContent string, respBody []byte, statusCode int, start time.Time, duration time.Duration, sessionID string) {
 	var inputTokens, outputTokens, totalTokens int64
 
 	isStreaming := stream != nil && *stream
@@ -124,6 +142,7 @@ func (s *spanCapture) buildSpan(model string, stream *bool, inputContent string,
 		EndTime:   start.Add(duration),
 		Duration:  duration,
 		ProjectID: "local",
+		SessionID: sessionID,
 		GenAI: &storage.GenAIAttributes{
 			Model:        model,
 			Provider:     "local",

--- a/cmd/candela-local/span_capture_test.go
+++ b/cmd/candela-local/span_capture_test.go
@@ -49,7 +49,7 @@ func TestSpanCapture_NonStreaming(t *testing.T) {
 	defer proc.Stop()
 
 	// Wrap upstream with span capture.
-	handler := newSpanCapture(proxyTo(upstream.URL), proc)
+	handler := newSpanCapture(proxyTo(upstream.URL), proc, nil)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -113,7 +113,7 @@ func TestSpanCapture_Passthrough(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	handler := newSpanCapture(proxyTo(upstream.URL), nil)
+	handler := newSpanCapture(proxyTo(upstream.URL), nil, nil)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -248,7 +248,7 @@ func TestSpanCapture_ErrorStatus(t *testing.T) {
 	go proc.Run(ctx)
 	defer proc.Stop()
 
-	handler := newSpanCapture(proxyTo(upstream.URL), proc)
+	handler := newSpanCapture(proxyTo(upstream.URL), proc, nil)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -294,6 +294,9 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		requestID = generateSpanID() + generateSpanID() // 32-char hex
 	}
 
+	// Accept session ID from candela-local (or other clients).
+	sessionID := r.Header.Get("X-Session-Id")
+
 	// Extract provider from path: /proxy/{provider}/v1/...
 	parts := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/proxy/"), "/", 2)
 	if len(parts) < 2 {
@@ -406,9 +409,9 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	cbAllow := p.breakers[providerName].AllowRequest()
 
 	if isStreaming && resp.StatusCode == http.StatusOK {
-		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, cbAllow)
+		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, cbAllow)
 	} else {
-		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, cbAllow)
+		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, cbAllow)
 	}
 }
 
@@ -436,6 +439,7 @@ func (p *Proxy) handleStandardResponse(
 	reqBody []byte, startTime time.Time,
 	ttfb time.Duration,
 	requestID string,
+	sessionID string,
 	cbAllow bool,
 ) {
 	// Read the full response.
@@ -476,7 +480,7 @@ func (p *Proxy) handleStandardResponse(
 
 	// Create observability span (async — don't block the response).
 	if cbAllow {
-		go p.createSpan(r.Context(), provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID)
+		go p.createSpan(r.Context(), provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID, sessionID)
 	} else {
 		slog.Debug("skipping span creation (circuit open)", "provider", provider.Name, "request_id", requestID)
 	}
@@ -488,6 +492,7 @@ func (p *Proxy) handleStreamingResponse(
 	reqBody []byte, startTime time.Time,
 	ttfb time.Duration,
 	requestID string,
+	sessionID string,
 	cbAllow bool,
 ) {
 	flusher, ok := w.(http.Flusher)
@@ -555,7 +560,7 @@ func (p *Proxy) handleStreamingResponse(
 
 	// Parse the accumulated stream to extract usage data.
 	if cbAllow {
-		go p.createStreamingSpan(r.Context(), provider, reqBody, streamBuffer.Bytes(), startTime, endTime, ttfb, ttft, requestID)
+		go p.createStreamingSpan(r.Context(), provider, reqBody, streamBuffer.Bytes(), startTime, endTime, ttfb, ttft, requestID, sessionID)
 	} else {
 		slog.Debug("skipping streaming span (circuit open)", "provider", provider.Name, "request_id", requestID)
 	}
@@ -567,6 +572,7 @@ func (p *Proxy) handleStreamingResponse(
 type spanParams struct {
 	provider      Provider
 	model         string
+	sessionID     string
 	inputContent  string
 	outputContent string
 	inputTokens   int64
@@ -622,6 +628,9 @@ func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 		span.UserID = caller.ID
 	}
 
+	// Set session ID for conversation grouping.
+	span.SessionID = params.sessionID
+
 	if p.submitter != nil {
 		p.submitter.SubmitBatch([]storage.Span{span})
 	}
@@ -675,6 +684,7 @@ func (p *Proxy) createSpan(
 	statusCode int,
 	ttfb time.Duration,
 	requestID string,
+	sessionID string,
 ) {
 	model, inputContent := extractRequestInfo(provider.Name, reqBody)
 	outputContent, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
@@ -696,6 +706,7 @@ func (p *Proxy) createSpan(
 		status:        status,
 		ttfb:          ttfb,
 		requestID:     requestID,
+		sessionID:     sessionID,
 		namePrefix:    fmt.Sprintf("%s.chat", provider.Name),
 		extraAttrs: map[string]string{
 			"http.status": fmt.Sprintf("%d", statusCode),
@@ -710,6 +721,7 @@ func (p *Proxy) createStreamingSpan(
 	ttfb time.Duration,
 	ttft time.Duration,
 	requestID string,
+	sessionID string,
 ) {
 	model, inputContent := extractRequestInfo(provider.Name, reqBody)
 	outputContent, inputTokens, outputTokens := extractStreamingUsage(provider.Name, streamData)
@@ -726,6 +738,7 @@ func (p *Proxy) createStreamingSpan(
 		status:        storage.SpanStatusOK,
 		ttfb:          ttfb,
 		requestID:     requestID,
+		sessionID:     sessionID,
 		namePrefix:    fmt.Sprintf("%s.chat.stream", provider.Name),
 		extraAttrs: map[string]string{
 			"proxy.streaming": "true",

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -88,22 +88,25 @@ type sessionEntry struct {
 // if the message count grew since the last request with the same
 // fingerprint, it's the same session.
 type UserMsgResolver struct {
-	mu      sync.Mutex
-	cache   map[string]*sessionEntry // fingerprint → entry
-	ttl     time.Duration
-	nowFunc func() time.Time // for testing
+	mu         sync.Mutex
+	cache      map[string]*sessionEntry // fingerprint → entry
+	ttl        time.Duration
+	maxEntries int              // safety cap; 0 means 1000
+	nowFunc    func() time.Time // for testing
 }
 
 // NewUserMsgResolver creates a resolver with the given in-memory TTL.
 // Entries not accessed within the TTL are evicted lazily on next lookup.
+// The cache is capped at 1000 entries to prevent unbounded growth.
 func NewUserMsgResolver(ttl time.Duration) *UserMsgResolver {
 	if ttl <= 0 {
 		ttl = 30 * time.Minute
 	}
 	return &UserMsgResolver{
-		cache:   make(map[string]*sessionEntry),
-		ttl:     ttl,
-		nowFunc: time.Now,
+		cache:      make(map[string]*sessionEntry),
+		ttl:        ttl,
+		maxEntries: 1000,
+		nowFunc:    time.Now,
 	}
 }
 
@@ -132,6 +135,9 @@ func (u *UserMsgResolver) Resolve(info SessionInfo) string {
 		// Fall through to create new session.
 	}
 
+	// Evict stale entries + enforce max size before inserting.
+	u.evictLocked(now)
+
 	// New session.
 	id := uuid.NewString()
 	u.cache[fp] = &sessionEntry{
@@ -142,37 +148,74 @@ func (u *UserMsgResolver) Resolve(info SessionInfo) string {
 	return id
 }
 
+// evictLocked removes expired entries and, if still over cap, evicts the
+// oldest entries. Must be called with u.mu held.
+func (u *UserMsgResolver) evictLocked(now time.Time) {
+	// Phase 1: remove expired entries.
+	for fp, entry := range u.cache {
+		if now.Sub(entry.lastAccess) > u.ttl {
+			delete(u.cache, fp)
+		}
+	}
+
+	// Phase 2: if still over cap, evict oldest.
+	max := u.maxEntries
+	if max <= 0 {
+		max = 1000
+	}
+	for len(u.cache) >= max {
+		var oldestFP string
+		var oldestTime time.Time
+		for fp, entry := range u.cache {
+			if oldestFP == "" || entry.lastAccess.Before(oldestTime) {
+				oldestFP = fp
+				oldestTime = entry.lastAccess
+			}
+		}
+		delete(u.cache, oldestFP)
+	}
+}
+
 // fingerprint extracts the first user message from the messages array
 // and hashes it with the user ID to produce a stable conversation key.
+// Handles both string content and multi-modal content (array of objects)
+// per the OpenAI API spec.
 func (u *UserMsgResolver) fingerprint(info SessionInfo) (string, int) {
 	if len(info.Messages) == 0 {
 		return "", 0
 	}
 
 	var msgs []struct {
-		Role    string `json:"role"`
-		Content string `json:"content"`
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
 	}
 	if err := json.Unmarshal(info.Messages, &msgs); err != nil {
 		return "", 0
 	}
 
 	// Find the first user message.
-	var firstUserMsg string
+	var contentBytes []byte
 	for _, m := range msgs {
-		if m.Role == "user" {
-			firstUserMsg = m.Content
+		if m.Role == "user" && len(m.Content) > 0 {
+			// Try to unmarshal as a plain string first (common case).
+			var s string
+			if err := json.Unmarshal(m.Content, &s); err == nil {
+				contentBytes = []byte(s)
+			} else {
+				// Multi-modal content (array of objects): use raw JSON as fingerprint.
+				contentBytes = m.Content
+			}
 			break
 		}
 	}
-	if firstUserMsg == "" {
+	if len(contentBytes) == 0 {
 		return "", len(msgs)
 	}
 
 	h := sha256.New()
 	h.Write([]byte(info.UserID))
 	h.Write([]byte{0}) // separator
-	h.Write([]byte(firstUserMsg))
+	h.Write(contentBytes)
 
 	return hex.EncodeToString(h.Sum(nil)), len(msgs)
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1,0 +1,186 @@
+// Package session provides pluggable session resolution for grouping
+// LLM requests into conversations. The default chain resolver tries
+// an explicit X-Session-ID header first, then falls back to a
+// message-prefix heuristic that fingerprints the first user message.
+package session
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SessionInfo carries the request context needed by resolvers.
+type SessionInfo struct {
+	UserID   string
+	Model    string
+	Messages json.RawMessage // raw JSON messages array
+	Headers  http.Header
+}
+
+// SessionResolver assigns a session ID to a proxied request.
+type SessionResolver interface {
+	Resolve(info SessionInfo) string
+}
+
+// ── Chain Resolver ──
+
+// ChainResolver tries resolvers in order; first non-empty result wins.
+type ChainResolver struct {
+	resolvers []SessionResolver
+}
+
+// NewChainResolver creates a resolver that tries each resolver in order.
+func NewChainResolver(resolvers ...SessionResolver) *ChainResolver {
+	return &ChainResolver{resolvers: resolvers}
+}
+
+func (c *ChainResolver) Resolve(info SessionInfo) string {
+	for _, r := range c.resolvers {
+		if id := r.Resolve(info); id != "" {
+			return id
+		}
+	}
+	return uuid.NewString()
+}
+
+// ── Header Resolver ──
+
+const defaultHeaderName = "X-Session-Id"
+
+// HeaderResolver reads the session ID from an HTTP header.
+type HeaderResolver struct {
+	headerName string
+}
+
+// NewHeaderResolver creates a resolver that reads the given header.
+// If headerName is empty, defaults to "X-Session-Id".
+func NewHeaderResolver(headerName string) *HeaderResolver {
+	if headerName == "" {
+		headerName = defaultHeaderName
+	}
+	return &HeaderResolver{headerName: headerName}
+}
+
+func (h *HeaderResolver) Resolve(info SessionInfo) string {
+	if info.Headers == nil {
+		return ""
+	}
+	return info.Headers.Get(h.headerName)
+}
+
+// ── User Message Resolver ──
+
+// sessionEntry tracks an active session in the in-memory cache.
+type sessionEntry struct {
+	sessionID    string
+	lastMsgCount int
+	lastAccess   time.Time
+}
+
+// UserMsgResolver fingerprints conversations by hashing the first user
+// message combined with the user ID. It uses the "superset" heuristic:
+// if the message count grew since the last request with the same
+// fingerprint, it's the same session.
+type UserMsgResolver struct {
+	mu      sync.Mutex
+	cache   map[string]*sessionEntry // fingerprint → entry
+	ttl     time.Duration
+	nowFunc func() time.Time // for testing
+}
+
+// NewUserMsgResolver creates a resolver with the given in-memory TTL.
+// Entries not accessed within the TTL are evicted lazily on next lookup.
+func NewUserMsgResolver(ttl time.Duration) *UserMsgResolver {
+	if ttl <= 0 {
+		ttl = 30 * time.Minute
+	}
+	return &UserMsgResolver{
+		cache:   make(map[string]*sessionEntry),
+		ttl:     ttl,
+		nowFunc: time.Now,
+	}
+}
+
+func (u *UserMsgResolver) Resolve(info SessionInfo) string {
+	fp, msgCount := u.fingerprint(info)
+	if fp == "" {
+		return ""
+	}
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	now := u.nowFunc()
+
+	if entry, ok := u.cache[fp]; ok {
+		// Lazy eviction: if stale, remove and treat as new.
+		if now.Sub(entry.lastAccess) > u.ttl {
+			delete(u.cache, fp)
+		} else if msgCount >= entry.lastMsgCount {
+			// Superset check: messages grew or stayed same → same session.
+			entry.lastMsgCount = msgCount
+			entry.lastAccess = now
+			return entry.sessionID
+		}
+		// Message count shrunk → likely compaction or new conversation.
+		// Fall through to create new session.
+	}
+
+	// New session.
+	id := uuid.NewString()
+	u.cache[fp] = &sessionEntry{
+		sessionID:    id,
+		lastMsgCount: msgCount,
+		lastAccess:   now,
+	}
+	return id
+}
+
+// fingerprint extracts the first user message from the messages array
+// and hashes it with the user ID to produce a stable conversation key.
+func (u *UserMsgResolver) fingerprint(info SessionInfo) (string, int) {
+	if len(info.Messages) == 0 {
+		return "", 0
+	}
+
+	var msgs []struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(info.Messages, &msgs); err != nil {
+		return "", 0
+	}
+
+	// Find the first user message.
+	var firstUserMsg string
+	for _, m := range msgs {
+		if m.Role == "user" {
+			firstUserMsg = m.Content
+			break
+		}
+	}
+	if firstUserMsg == "" {
+		return "", len(msgs)
+	}
+
+	h := sha256.New()
+	h.Write([]byte(info.UserID))
+	h.Write([]byte{0}) // separator
+	h.Write([]byte(firstUserMsg))
+
+	return hex.EncodeToString(h.Sum(nil)), len(msgs)
+}
+
+// CacheSize returns the number of entries in the in-memory cache.
+// Intended for testing and metrics.
+func (u *UserMsgResolver) CacheSize() int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return len(u.cache)
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 
@@ -149,7 +150,7 @@ func (u *UserMsgResolver) Resolve(info SessionInfo) string {
 }
 
 // evictLocked removes expired entries and, if still over cap, evicts the
-// oldest entries. Must be called with u.mu held.
+// oldest entries in a single sorted pass. Must be called with u.mu held.
 func (u *UserMsgResolver) evictLocked(now time.Time) {
 	// Phase 1: remove expired entries.
 	for fp, entry := range u.cache {
@@ -158,21 +159,30 @@ func (u *UserMsgResolver) evictLocked(now time.Time) {
 		}
 	}
 
-	// Phase 2: if still over cap, evict oldest.
+	// Phase 2: if still over cap, sort by lastAccess and evict oldest batch.
 	max := u.maxEntries
 	if max <= 0 {
 		max = 1000
 	}
-	for len(u.cache) >= max {
-		var oldestFP string
-		var oldestTime time.Time
-		for fp, entry := range u.cache {
-			if oldestFP == "" || entry.lastAccess.Before(oldestTime) {
-				oldestFP = fp
-				oldestTime = entry.lastAccess
-			}
-		}
-		delete(u.cache, oldestFP)
+	if len(u.cache) < max {
+		return
+	}
+
+	type fpEntry struct {
+		fp         string
+		lastAccess time.Time
+	}
+	entries := make([]fpEntry, 0, len(u.cache))
+	for fp, entry := range u.cache {
+		entries = append(entries, fpEntry{fp: fp, lastAccess: entry.lastAccess})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].lastAccess.Before(entries[j].lastAccess)
+	})
+	// Evict oldest entries to bring cache to 75% of max (avoid repeated eviction).
+	target := max * 3 / 4
+	for i := 0; i < len(entries) && len(u.cache) > target; i++ {
+		delete(u.cache, entries[i].fp)
 	}
 }
 

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -292,3 +292,115 @@ func TestCacheSize(t *testing.T) {
 		t.Errorf("cache size should be 1 after one session, got %d", r.CacheSize())
 	}
 }
+
+func TestUserMsgResolver_MultiModalContent(t *testing.T) {
+	r := NewUserMsgResolver(30 * time.Minute)
+
+	// Multi-modal message: content is an array of objects (e.g., vision API).
+	msgs := json.RawMessage(`[
+		{"role": "system", "content": "You are helpful."},
+		{"role": "user", "content": [
+			{"type": "text", "text": "What is in this image?"},
+			{"type": "image_url", "image_url": {"url": "https://example.com/img.png"}}
+		]}
+	]`)
+
+	id1 := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs})
+	if id1 == "" {
+		t.Error("multi-modal content should still produce a session ID")
+	}
+
+	// Same multi-modal message should match same session.
+	id2 := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs})
+	if id1 != id2 {
+		t.Errorf("same multi-modal content should match same session, got %q and %q", id1, id2)
+	}
+}
+
+func TestUserMsgResolver_MultiModalVsString(t *testing.T) {
+	r := NewUserMsgResolver(30 * time.Minute)
+
+	// String content.
+	stringMsgs := makeMessages(
+		msg("system", "sys"),
+		msg("user", "What is in this image?"),
+	)
+
+	// Multi-modal content with same text.
+	multiMsgs := json.RawMessage(`[
+		{"role": "system", "content": "sys"},
+		{"role": "user", "content": [
+			{"type": "text", "text": "What is in this image?"}
+		]}
+	]`)
+
+	id1 := r.Resolve(SessionInfo{UserID: "alice", Messages: stringMsgs})
+	id2 := r.Resolve(SessionInfo{UserID: "alice", Messages: multiMsgs})
+
+	// String and array content should produce different sessions
+	// because the raw bytes differ.
+	if id1 == id2 {
+		t.Error("string vs multi-modal content should produce different sessions")
+	}
+}
+
+func TestUserMsgResolver_CacheEviction(t *testing.T) {
+	r := NewUserMsgResolver(30 * time.Minute)
+	r.maxEntries = 5 // small cap for testing
+
+	// Fill cache with 5 unique sessions.
+	for i := range 5 {
+		msgs := makeMessages(
+			msg("system", "sys"),
+			msg("user", "msg-"+string(rune('a'+i))),
+		)
+		r.Resolve(SessionInfo{UserID: "alice", Messages: msgs})
+	}
+
+	if r.CacheSize() != 5 {
+		t.Errorf("cache should have 5 entries, got %d", r.CacheSize())
+	}
+
+	// Add one more — should evict oldest to stay at 5.
+	newMsgs := makeMessages(
+		msg("system", "sys"),
+		msg("user", "msg-new"),
+	)
+	r.Resolve(SessionInfo{UserID: "alice", Messages: newMsgs})
+
+	if r.CacheSize() != 5 {
+		t.Errorf("cache should stay at 5 after eviction, got %d", r.CacheSize())
+	}
+}
+
+func TestUserMsgResolver_CacheEvictionPrefersTTL(t *testing.T) {
+	now := time.Now()
+	r := NewUserMsgResolver(30 * time.Minute)
+	r.maxEntries = 5
+	r.nowFunc = func() time.Time { return now }
+
+	// Add 5 sessions.
+	for i := range 5 {
+		msgs := makeMessages(
+			msg("system", "sys"),
+			msg("user", "msg-"+string(rune('a'+i))),
+		)
+		r.Resolve(SessionInfo{UserID: "alice", Messages: msgs})
+	}
+
+	// Age 3 of them past TTL.
+	r.nowFunc = func() time.Time { return now.Add(31 * time.Minute) }
+
+	// Adding a new session should first evict the 3 expired ones.
+	newMsgs := makeMessages(
+		msg("system", "sys"),
+		msg("user", "msg-new"),
+	)
+	r.Resolve(SessionInfo{UserID: "alice", Messages: newMsgs})
+
+	// The 3 expired + 2 remaining could be evicted down to maxEntries.
+	// Since all 5 were created at the same time, all expired → cache should be just 1 (the new one).
+	if r.CacheSize() != 1 {
+		t.Errorf("expired entries should be evicted, cache should be 1, got %d", r.CacheSize())
+	}
+}

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -361,15 +361,19 @@ func TestUserMsgResolver_CacheEviction(t *testing.T) {
 		t.Errorf("cache should have 5 entries, got %d", r.CacheSize())
 	}
 
-	// Add one more — should evict oldest to stay at 5.
+	// Add one more — should trigger batch eviction to 75% of max (3),
+	// then add the new entry = 4 total.
 	newMsgs := makeMessages(
 		msg("system", "sys"),
 		msg("user", "msg-new"),
 	)
 	r.Resolve(SessionInfo{UserID: "alice", Messages: newMsgs})
 
-	if r.CacheSize() != 5 {
-		t.Errorf("cache should stay at 5 after eviction, got %d", r.CacheSize())
+	if got := r.CacheSize(); got > 5 {
+		t.Errorf("cache should not exceed max, got %d", got)
+	}
+	if got := r.CacheSize(); got < 2 {
+		t.Errorf("cache should retain recent entries, got %d", got)
 	}
 }
 

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -1,0 +1,294 @@
+package session
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// helper to build a messages JSON array.
+func makeMessages(msgs ...struct{ Role, Content string }) json.RawMessage {
+	b, _ := json.Marshal(msgs)
+	return b
+}
+
+func msg(role, content string) struct{ Role, Content string } {
+	return struct{ Role, Content string }{Role: role, Content: content}
+}
+
+func TestHeaderResolver_Present(t *testing.T) {
+	r := NewHeaderResolver("")
+	h := http.Header{}
+	h.Set("X-Session-Id", "abc-123")
+
+	got := r.Resolve(SessionInfo{Headers: h})
+	if got != "abc-123" {
+		t.Errorf("expected abc-123, got %q", got)
+	}
+}
+
+func TestHeaderResolver_Missing(t *testing.T) {
+	r := NewHeaderResolver("")
+	got := r.Resolve(SessionInfo{Headers: http.Header{}})
+	if got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestHeaderResolver_NilHeaders(t *testing.T) {
+	r := NewHeaderResolver("")
+	got := r.Resolve(SessionInfo{})
+	if got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestHeaderResolver_CustomName(t *testing.T) {
+	r := NewHeaderResolver("X-Custom-Session")
+	h := http.Header{}
+	h.Set("X-Custom-Session", "custom-id")
+
+	got := r.Resolve(SessionInfo{Headers: h})
+	if got != "custom-id" {
+		t.Errorf("expected custom-id, got %q", got)
+	}
+}
+
+func TestUserMsgResolver_SameConversationGrows(t *testing.T) {
+	r := NewUserMsgResolver(30 * time.Minute)
+
+	// Turn 1: system + user
+	msgs1 := makeMessages(
+		msg("system", "You are a helpful assistant."),
+		msg("user", "Explain auth code"),
+	)
+	id1 := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs1})
+
+	// Turn 2: same conversation grows
+	msgs2 := makeMessages(
+		msg("system", "You are a helpful assistant."),
+		msg("user", "Explain auth code"),
+		msg("assistant", "The auth code..."),
+		msg("user", "Refactor it"),
+	)
+	id2 := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs2})
+
+	if id1 != id2 {
+		t.Errorf("expected same session, got %q and %q", id1, id2)
+	}
+}
+
+func TestUserMsgResolver_ModelSwitchSameSession(t *testing.T) {
+	r := NewUserMsgResolver(30 * time.Minute)
+
+	msgs := makeMessages(
+		msg("system", "You are a helpful assistant."),
+		msg("user", "Explain auth code"),
+	)
+
+	id1 := r.Resolve(SessionInfo{UserID: "alice", Model: "gpt-4", Messages: msgs})
+	id2 := r.Resolve(SessionInfo{UserID: "alice", Model: "claude-3", Messages: msgs})
+
+	if id1 != id2 {
+		t.Errorf("model switch should not create new session, got %q and %q", id1, id2)
+	}
+}
+
+func TestUserMsgResolver_DifferentConversations(t *testing.T) {
+	r := NewUserMsgResolver(30 * time.Minute)
+
+	msgs1 := makeMessages(
+		msg("system", "You are a helpful assistant."),
+		msg("user", "Explain auth code"),
+	)
+	msgs2 := makeMessages(
+		msg("system", "You are a helpful assistant."),
+		msg("user", "Write a unit test"),
+	)
+
+	id1 := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs1})
+	id2 := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs2})
+
+	if id1 == id2 {
+		t.Errorf("different conversations should have different sessions")
+	}
+}
+
+func TestUserMsgResolver_DifferentUsers(t *testing.T) {
+	r := NewUserMsgResolver(30 * time.Minute)
+
+	msgs := makeMessages(
+		msg("system", "You are a helpful assistant."),
+		msg("user", "Explain auth code"),
+	)
+
+	id1 := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs})
+	id2 := r.Resolve(SessionInfo{UserID: "bob", Messages: msgs})
+
+	if id1 == id2 {
+		t.Errorf("different users should have different sessions")
+	}
+}
+
+func TestUserMsgResolver_DynamicSystemPrompt(t *testing.T) {
+	// Cline rebuilds messages[0] every turn — fingerprint should still match
+	// because we only hash the first USER message, not the system prompt.
+	r := NewUserMsgResolver(30 * time.Minute)
+
+	msgs1 := makeMessages(
+		msg("system", "You are Cline v1. CWD: /home/alice/project. OS: macOS."),
+		msg("user", "Explain auth code"),
+	)
+	msgs2 := makeMessages(
+		msg("system", "You are Cline v1. CWD: /home/alice/project. OS: macOS. Time: 12:00."),
+		msg("user", "Explain auth code"),
+		msg("assistant", "The auth code..."),
+		msg("user", "Refactor it"),
+	)
+
+	id1 := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs1})
+	id2 := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs2})
+
+	if id1 != id2 {
+		t.Errorf("dynamic system prompt should not break session, got %q and %q", id1, id2)
+	}
+}
+
+func TestUserMsgResolver_Timeout(t *testing.T) {
+	now := time.Now()
+	r := NewUserMsgResolver(30 * time.Minute)
+	r.nowFunc = func() time.Time { return now }
+
+	msgs := makeMessages(
+		msg("system", "sys"),
+		msg("user", "hello"),
+	)
+	id1 := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs})
+
+	// Advance past TTL.
+	r.nowFunc = func() time.Time { return now.Add(31 * time.Minute) }
+	id2 := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs})
+
+	if id1 == id2 {
+		t.Errorf("expired session should get new ID")
+	}
+}
+
+func TestUserMsgResolver_Compaction(t *testing.T) {
+	r := NewUserMsgResolver(30 * time.Minute)
+
+	// Long conversation: 6 messages
+	msgs1 := makeMessages(
+		msg("system", "sys"),
+		msg("user", "hello"),
+		msg("assistant", "hi"),
+		msg("user", "how are you"),
+		msg("assistant", "good"),
+		msg("user", "great"),
+	)
+	id1 := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs1})
+
+	// After compaction: messages shrunk but same first user message
+	msgs2 := makeMessages(
+		msg("system", "sys"),
+		msg("user", "hello"),
+		msg("assistant", "good"),
+		msg("user", "great"),
+	)
+	id2 := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs2})
+
+	// Compaction creates a new session (message count decreased).
+	if id1 == id2 {
+		t.Errorf("compaction (message count decrease) should create new session")
+	}
+}
+
+func TestUserMsgResolver_EmptyMessages(t *testing.T) {
+	r := NewUserMsgResolver(30 * time.Minute)
+	got := r.Resolve(SessionInfo{UserID: "alice", Messages: nil})
+	if got != "" {
+		t.Errorf("nil messages should return empty, got %q", got)
+	}
+}
+
+func TestUserMsgResolver_NoUserMessage(t *testing.T) {
+	r := NewUserMsgResolver(30 * time.Minute)
+	msgs := makeMessages(msg("system", "You are a helpful assistant."))
+	got := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs})
+	if got != "" {
+		t.Errorf("no user message should return empty, got %q", got)
+	}
+}
+
+func TestChainResolver_HeaderWins(t *testing.T) {
+	chain := NewChainResolver(
+		NewHeaderResolver(""),
+		NewUserMsgResolver(30*time.Minute),
+	)
+
+	h := http.Header{}
+	h.Set("X-Session-Id", "explicit-id")
+	msgs := makeMessages(
+		msg("system", "sys"),
+		msg("user", "hello"),
+	)
+
+	got := chain.Resolve(SessionInfo{
+		UserID:   "alice",
+		Messages: msgs,
+		Headers:  h,
+	})
+
+	if got != "explicit-id" {
+		t.Errorf("header should win, got %q", got)
+	}
+}
+
+func TestChainResolver_FallsThrough(t *testing.T) {
+	chain := NewChainResolver(
+		NewHeaderResolver(""), // no header → empty
+		NewUserMsgResolver(30*time.Minute),
+	)
+
+	msgs := makeMessages(
+		msg("system", "sys"),
+		msg("user", "hello"),
+	)
+
+	got := chain.Resolve(SessionInfo{
+		UserID:   "alice",
+		Messages: msgs,
+		Headers:  http.Header{},
+	})
+
+	if got == "" {
+		t.Error("chain should fall through to UserMsgResolver")
+	}
+}
+
+func TestChainResolver_FallbackUUID(t *testing.T) {
+	// No resolvers match → generates a UUID.
+	chain := NewChainResolver(
+		NewHeaderResolver(""),
+	)
+
+	got := chain.Resolve(SessionInfo{Headers: http.Header{}})
+	if got == "" {
+		t.Error("chain should generate fallback UUID")
+	}
+}
+
+func TestCacheSize(t *testing.T) {
+	r := NewUserMsgResolver(30 * time.Minute)
+	if r.CacheSize() != 0 {
+		t.Errorf("initial cache size should be 0")
+	}
+
+	msgs := makeMessages(msg("system", "sys"), msg("user", "hello"))
+	r.Resolve(SessionInfo{UserID: "alice", Messages: msgs})
+
+	if r.CacheSize() != 1 {
+		t.Errorf("cache size should be 1 after one session, got %d", r.CacheSize())
+	}
+}

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -105,6 +105,7 @@ type spanRow struct {
 	OutputContent string        `bigquery:"gen_ai_output_content"`
 	Attributes    []AttributeKV `bigquery:"attributes"`
 	UserID        string        `bigquery:"user_id"`
+	SessionID     string        `bigquery:"session_id"`
 }
 
 func spanToRow(span storage.Span) spanRow {
@@ -123,6 +124,7 @@ func spanToRow(span storage.Span) spanRow {
 		Environment:   span.Environment,
 		ServiceName:   span.ServiceName,
 		UserID:        span.UserID,
+		SessionID:     span.SessionID,
 	}
 
 	if span.GenAI != nil {
@@ -161,6 +163,7 @@ func rowToSpan(row spanRow) storage.Span {
 		Environment:   row.Environment,
 		ServiceName:   row.ServiceName,
 		UserID:        row.UserID,
+		SessionID:     row.SessionID,
 	}
 
 	if row.GenAIModel != "" {

--- a/pkg/storage/duckdb/duckdb.go
+++ b/pkg/storage/duckdb/duckdb.go
@@ -75,7 +75,9 @@ func (s *Store) migrate() error {
 			gen_ai_input_content  VARCHAR DEFAULT '',
 			gen_ai_output_content VARCHAR DEFAULT '',
 
-			attributes STRUCT(key VARCHAR, value VARCHAR)[]
+			attributes STRUCT(key VARCHAR, value VARCHAR)[],
+
+			session_id     VARCHAR DEFAULT ''
 
 			-- No PRIMARY KEY: OLAP convention. Duplicates are rare and handled
 			-- at query time (or via periodic compaction). This keeps the Appender
@@ -87,6 +89,8 @@ func (s *Store) migrate() error {
 		`CREATE INDEX IF NOT EXISTS idx_spans_user ON spans(user_id)`,
 		// Migration: add user_id column to existing tables.
 		`ALTER TABLE spans ADD COLUMN IF NOT EXISTS user_id VARCHAR DEFAULT ''`,
+		// Migration: add session_id column for conversation tracking.
+		`ALTER TABLE spans ADD COLUMN IF NOT EXISTS session_id VARCHAR DEFAULT ''`,
 	}
 
 	for _, q := range queries {
@@ -141,6 +145,7 @@ func (s *Store) IngestSpans(ctx context.Context, spans []storage.Span) error {
 				genAI.CostUSD, genAI.Temperature, genAI.MaxTokens,
 				genAI.InputContent, genAI.OutputContent,
 				attrs,
+				span.SessionID,
 			); err != nil {
 				return fmt.Errorf("appending span %s: %w", span.SpanID, err)
 			}
@@ -159,7 +164,7 @@ func (s *Store) GetTrace(ctx context.Context, traceID string) (*storage.Trace, e
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes
+			gen_ai_input_content, gen_ai_output_content, attributes, session_id
 		FROM spans WHERE trace_id = ? ORDER BY start_time ASC
 	`, traceID)
 	if err != nil {
@@ -245,7 +250,7 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes
+			gen_ai_input_content, gen_ai_output_content, attributes, session_id
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = 0 OR kind = ?)
@@ -405,6 +410,7 @@ func scanSpans(rows *sql.Rows) ([]storage.Span, error) {
 			&genAI.CostUSD, &genAI.Temperature, &genAI.MaxTokens,
 			&genAI.InputContent, &genAI.OutputContent,
 			&attrsAny,
+			&span.SessionID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scanning span: %w", err)

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -124,8 +124,8 @@ func (s *Store) IngestSpans(ctx context.Context, spans []storage.Span) error {
 		start_time, end_time, duration_ns, project_id, environment, service_name,
 		gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 		gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-		gen_ai_input_content, gen_ai_output_content, attributes_json
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		gen_ai_input_content, gen_ai_output_content, attributes_json, session_id
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("preparing stmt: %w", err)
 	}
@@ -154,6 +154,7 @@ func (s *Store) IngestSpans(ctx context.Context, spans []storage.Span) error {
 			genAI.CostUSD, genAI.Temperature, genAI.MaxTokens,
 			genAI.InputContent, genAI.OutputContent,
 			string(attrsJSON),
+			span.SessionID,
 		)
 		if err != nil {
 			return fmt.Errorf("inserting span: %w", err)

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -99,6 +99,8 @@ func (s *Store) migrate() error {
 		`CREATE INDEX IF NOT EXISTS idx_spans_kind ON spans(kind)`,
 		// Migration: add user_id column to existing tables.
 		`ALTER TABLE spans ADD COLUMN user_id TEXT DEFAULT ''`,
+		// Migration: add session_id column to existing tables.
+		`ALTER TABLE spans ADD COLUMN session_id TEXT DEFAULT ''`,
 	}
 
 	for _, q := range queries {

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -90,6 +90,8 @@ func (s *Store) migrate() error {
 
 			attributes_json TEXT DEFAULT '{}',
 
+			session_id     TEXT DEFAULT '',
+
 			PRIMARY KEY (trace_id, span_id)
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_spans_project_time ON spans(project_id, start_time)`,
@@ -167,7 +169,7 @@ func (s *Store) GetTrace(ctx context.Context, traceID string) (*storage.Trace, e
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes_json
+			gen_ai_input_content, gen_ai_output_content, attributes_json, session_id
 		FROM spans WHERE trace_id = ? ORDER BY start_time ASC
 	`, traceID)
 	if err != nil {
@@ -254,7 +256,7 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes_json
+			gen_ai_input_content, gen_ai_output_content, attributes_json, session_id
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = 0 OR kind = ?)
@@ -411,6 +413,7 @@ func scanSpans(rows *sql.Rows) ([]storage.Span, error) {
 			&genAI.CostUSD, &genAI.Temperature, &genAI.MaxTokens,
 			&genAI.InputContent, &genAI.OutputContent,
 			&attrsJSON,
+			&span.SessionID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scanning span: %w", err)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -93,6 +93,7 @@ type Span struct {
 	Environment   string            `json:"environment,omitempty"`
 	ServiceName   string            `json:"service_name,omitempty"`
 	UserID        string            `json:"user_id,omitempty"`
+	SessionID     string            `json:"session_id,omitempty"`
 }
 
 // TraceSummary is a lightweight summary for list views.
@@ -111,6 +112,7 @@ type TraceSummary struct {
 	PrimaryModel    string        `json:"primary_model"`
 	PrimaryProvider string        `json:"primary_provider"`
 	UserID          string        `json:"user_id,omitempty"`
+	SessionID       string        `json:"session_id,omitempty"`
 }
 
 // Trace is a complete trace with all spans.
@@ -127,6 +129,7 @@ type Trace struct {
 	RootSpanName string        `json:"root_span_name"`
 	Spans        []Span        `json:"spans"`
 	UserID       string        `json:"user_id,omitempty"`
+	SessionID    string        `json:"session_id,omitempty"`
 }
 
 // TraceQuery defines filters for listing traces.
@@ -144,6 +147,7 @@ type TraceQuery struct {
 	PageSize    int
 	PageToken   string
 	UserID      string // Filter by user (empty = all, for admins)
+	SessionID   string // Filter by session (empty = all)
 }
 
 // TraceResult is the paginated result of a trace query.


### PR DESCRIPTION
## Summary

Adds conversation-level session tracking so individual LLM calls can be grouped into multi-turn conversations. Every span now carries a `session_id` that identifies the conversation it belongs to.

Closes #69

## How it works

A **chain resolver** runs on each request at the `candela-local` proxy:

1. **HeaderResolver** — if the client sends `X-Session-Id`, use it (100% accurate, opt-in)
2. **UserMsgResolver** — hash the first `role:"user"` message + userID → stable fingerprint
3. **Fallback** — generate a new UUID

The fingerprint uses the first **user** message (not the system prompt) because Cline rebuilds `messages[0]` every turn with dynamic workspace context. The first user message is protected from truncation across all tested IDEs.

### Superset detection
If a request has the same fingerprint and message count ≥ last seen → same session. If message count dropped (compaction or new conversation) → new session.

### Team mode
`candela-local` resolves the session locally and injects `X-Session-Id` into requests forwarded to the Cloud Run proxy, which reads and stores it — no server-side heuristic needed.

## IDE Compatibility

Tested/analyzed against: **Cline, Continue, OpenCode, JetBrains AI, Zed, Aider, avante.nvim**

## Changes

### Commit 1: Data model (`pkg/storage`)
- `SessionID` field on `Span`, `TraceSummary`, `Trace`, `TraceQuery`
- SQLite, DuckDB, BigQuery: schema migration + INSERT/scan

### Commit 2: Resolver package (`pkg/session`) — NEW
- `SessionResolver` interface + `SessionInfo` struct
- `HeaderResolver`, `UserMsgResolver`, `ChainResolver`
- 17 unit tests: header priority, model switching, dynamic system prompts, timeout, compaction

### Commit 3: Server-side proxy (`pkg/proxy`)
- Read `X-Session-Id` header, thread through `createSpan`/`createStreamingSpan`, set on span

### Commit 4: Local integration (`cmd/candela-local`)
- Wire `ChainResolver` in `main.go`
- Resolve session in `span_capture.go`, inject header for team mode
- Update existing tests for new signature

## Test coverage

- **`pkg/session/`**: 17 tests covering all resolver logic
- **All existing tests pass** (storage, proxy, span_capture, processor, etc.)
- **Known gap**: integration tests for proxy header round-trip and span_capture session wiring are planned for follow-up

## Follow-up work

- StateDB persistence (sessions survive `candela-local` restart)
- Startup expiry (3-day cleanup) + row cap (1000)
- Integration tests for proxy + span_capture session wiring
- Dashboard UI grouping traces by session