### PR TITLE
docs: document OTLP export sink across all docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Candela are documented here, organized by development pha
 - New `pkg/storage/otlpexporter` package implementing `storage.SpanWriter`
 - Export Candela spans as standard OpenTelemetry traces via OTLP/HTTP
 - Maps GenAI fields to OTel `gen_ai.*` semantic conventions
-- Resource grouping by `(ProjectID, ServiceName)` per OTLP spec
+- Resource grouping by `(ProjectID, ServiceName, Environment)` per OTLP spec
 - Gzip compression by default, configurable per-export timeout
 - `sinks.otlp.required` flag for environments where export is mandatory
 - 25 tests: unit, integration (httptest OTLP receiver), config validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,36 @@ All notable changes to Candela are documented here, organized by development pha
 
 ## Phase 4: Multi-User Platform ✅
 
+### Today Budget Dashboard (#66)
+- Real-time "Today" budget card with spend vs. limit visualization
+- UTC-consistent date boundaries for budget calculations
+
+### Configurable Default Daily Budget (#64)
+- Admin-configurable default daily budget for new users
+- Applied automatically at user creation via Firestore
+
+### Daily Budget Period + Delete User (#61, #62)
+- Migrate budget model from monthly to daily-only
+- User deletion with Firestore subcollection cleanup via `BulkWriter`
+- Global audit collection for persistent deletion logs
+- Review feedback: null-safety, `DocumentRefs` optimization
+
+### Admin Fixes (#60)
+- Fix user count aggregation, `UpdateUser` `MergeAll` struct bug
+- Budget UI spacing and display fixes
+
+### Auth & Storage Fixes (#55, #58, #59)
+- Migrate to email-as-ID and fix `MergeAll` struct serialization (#55)
+- Handle Firestore reserved `__.*__` document ID pattern (#58)
+- Pass Firebase build args to Docker, improve login error handling (#59)
+
+### Documentation (#54, #65)
+- Comprehensive documentation deep-dive: architecture, development, deployment, proxy, env-vars, testing, cost-calculation, security, budgets, user-management, otel-collector, candela-local (#54)
+- `pkg/runtime` README: interface contract, registry pattern, backend implementations (#65)
+
+### Housekeeping (#57)
+- Remove binaries and temp files from git tracking
+
 ### Team Mode Frontend Enhancements (#53)
 - Per-user usage attribution in trace views
 - Budget gauge component with threshold alerts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Candela are documented here, organized by development phase. PRs are merged to `main`.
 
+## Latest
+
+### OTLP SpanWriter — Universal Export Sink (#70)
+- New `pkg/storage/otlpexporter` package implementing `storage.SpanWriter`
+- Export Candela spans as standard OpenTelemetry traces via OTLP/HTTP
+- Maps GenAI fields to OTel `gen_ai.*` semantic conventions
+- Resource grouping by `(ProjectID, ServiceName)` per OTLP spec
+- Gzip compression by default, configurable per-export timeout
+- `sinks.otlp.required` flag for environments where export is mandatory
+- 25 tests: unit, integration (httptest OTLP receiver), config validation
+- Enables write-once-export-everywhere to Datadog, Grafana Tempo, Jaeger, Elastic, Honeycomb, etc.
+
+### Per-Conversation Session Tracking (#71)
+- Heuristic-based `SessionResolver` with message-prefix fingerprinting
+- SQLite-backed session state persistence across restarts
+- `X-Session-ID` header propagation to remote proxy
+
+### UI Enhancements (#73)
+- Collapsible trace tree with inline cost metrics
+
 ## Phase 4: Multi-User Platform ✅
 
 ### Team Mode Frontend Enhancements (#53)
@@ -101,6 +121,7 @@ All notable changes to Candela are documented here, organized by development pha
 - SQLite storage backend (CGO-free, lightweight)
 - BigQuery storage backend (serverless, time-partitioned)
 - Pub/Sub write-only sink for fan-out
+- OTLP export sink for universal OTel backend forwarding
 - CQRS interfaces: `SpanWriter`, `SpanReader`, `TraceStore`
 - CORS middleware with configurable origins
 - Structured logging with `slog` (JSON)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For deep observability into agent frameworks (**ADK**, **LangChain**, **CrewAI**
 - **🗄️ Pluggable Storage**: **DuckDB** for high-performance local/edge; **BigQuery** for serverless production scale; **SQLite** for lightweight dev.
 - **📡 SSE Streaming Support**: Captures full streaming responses without interfering with user latency.
 - **📦 Single-Binary Edge-Ready**: In-process queuing and processing for low-overhead deployments.
-- **🔀 Fan-out Architecture**: CQRS-based design allows writing to multiple sinks simultaneously (e.g., DuckDB + Pub/Sub).
+- **🔀 Fan-out Architecture**: CQRS-based design allows writing to multiple sinks simultaneously (e.g., DuckDB + Pub/Sub + OTLP export to Datadog/Tempo/Jaeger).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,7 +141,7 @@ sinks:
 - **Driver**: `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`
 - **Wire format**: OTLP/HTTP protobuf with gzip compression (default)
 - **Semantic conventions**: Maps Candela GenAI fields to OTel `gen_ai.*` attributes
-- **Resource grouping**: Spans are grouped by `(ProjectID, ServiceName)` into separate `ResourceSpans`
+- **Resource grouping**: Spans are grouped by `(ProjectID, ServiceName, Environment)` into separate `ResourceSpans`
 - **Per-export timeout**: Configurable (default 30s) to prevent blocking the processor fan-out
 - **Non-fatal by default**: If the endpoint is unreachable, primary storage still works. Set `required: true` to make it fatal.
 - **Note**: Write-only `SpanWriter` — does NOT implement `SpanReader`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,9 +150,9 @@ sinks:
 sinks:
   otlp:
     enabled: true
-    endpoint: "http://localhost:4318"  # OTel Collector or backend
+    endpoint: "http://localhost:4318/v1/traces"  # OTel Collector or backend
     protocol: "http"                   # "http" (default) or "grpc" (planned)
-    compression: "gzip"               # "gzip" (default) or "none"
+    compression: "gzip"                # "gzip" (default) or "none"
     timeout_sec: 30
     required: false                    # fail startup if init fails
     headers:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,18 +43,20 @@ type TraceStore interface {
                     │  Processor  │  ← batches spans, applies cost calc
                     └──────┬──────┘
                            │
-              ┌────────────┼────────────┐
-              ▼            ▼            ▼
-        ┌──────────┐ ┌──────────┐ ┌──────────┐
-        │  DuckDB  │ │ BigQuery │ │  Pub/Sub │
-        │ (Writer  │ │ (Writer  │ │ (Writer  │
-        │ + Reader)│ │ + Reader)│ │  Only)   │
-        └──────────┘ └──────────┘ └──────────┘
-              │            │
-              ▼            ▼
-        ┌──────────────────────┐
-        │   Dashboard / API    │  ← reads from one SpanReader
-        │  (ConnectRPC + REST) │
+              ┌────────────┼────────────┬────────────┐
+              ▼            ▼            ▼            ▼
+        ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
+        │  DuckDB  │ │ BigQuery │ │  Pub/Sub │ │   OTLP   │
+        │ (Writer  │ │ (Writer  │ │ (Writer  │ │ (Writer  │
+        │ + Reader)│ │ + Reader)│ │  Only)   │ │  Only)   │
+        └──────────┘ └──────────┘ └──────────┘ └──────────┘
+              │            │                        │
+              ▼            ▼                        ▼
+        ┌──────────────────────┐          ┌──────────────────┐
+        │   Dashboard / API    │          │ External OTel    │
+        │  (ConnectRPC + REST) │          │ (Datadog, Tempo, │
+        │  ← reads from one   │          │  Jaeger, etc.)   │
+        │    SpanReader        │          └──────────────────┘
         └──────────────────────┘
 ```
 
@@ -130,6 +132,31 @@ sinks:
     enabled: true
     project_id: "my-gcp-project"
     topic: "candela-spans"
+```
+
+### OTLP Export (Sink Only)
+
+**Best for**: Forwarding Candela traces to any OpenTelemetry-compatible backend (Datadog, Grafana Tempo, Jaeger, Elastic, Honeycomb, New Relic, etc.).
+
+- **Driver**: `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`
+- **Wire format**: OTLP/HTTP protobuf with gzip compression (default)
+- **Semantic conventions**: Maps Candela GenAI fields to OTel `gen_ai.*` attributes
+- **Resource grouping**: Spans are grouped by `(ProjectID, ServiceName)` into separate `ResourceSpans`
+- **Per-export timeout**: Configurable (default 30s) to prevent blocking the processor fan-out
+- **Non-fatal by default**: If the endpoint is unreachable, primary storage still works. Set `required: true` to make it fatal.
+- **Note**: Write-only `SpanWriter` — does NOT implement `SpanReader`
+
+```yaml
+sinks:
+  otlp:
+    enabled: true
+    endpoint: "http://localhost:4318"  # OTel Collector or backend
+    protocol: "http"                   # "http" (default) or "grpc" (planned)
+    compression: "gzip"               # "gzip" (default) or "none"
+    timeout_sec: 30
+    required: false                    # fail startup if init fails
+    headers:
+      Authorization: "Bearer <token>"
 ```
 
 ## Schema Design

--- a/docs/development.md
+++ b/docs/development.md
@@ -133,7 +133,7 @@ Forward traces to any OTel-compatible backend (Datadog, Grafana Tempo, Jaeger, e
 sinks:
   otlp:
     enabled: true
-    endpoint: "http://localhost:4318"
+    endpoint: "http://localhost:4318/v1/traces"
     compression: "gzip"  # default
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,10 +4,10 @@ Candela uses a **Nix-first** development workflow. This ensures that every devel
 
 ## 📦 Prerequisites
 
-Ensure you have **Nix** with `flakes` enabled.
+Ensure you have **Nix** with `flakes` enabled. See [docs/nix-setup.md](nix-setup.md) for installation instructions, **direnv** auto-activation, and editor integration.
 
 ```bash
-# Enter the nix dev shell
+# Enter the nix dev shell (or use direnv for automatic activation)
 nix develop
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -126,6 +126,19 @@ storage:
     location: "US"
 ```
 
+### OTLP Export Sink
+Forward traces to any OTel-compatible backend (Datadog, Grafana Tempo, Jaeger, etc.) alongside your primary storage:
+
+```yaml
+sinks:
+  otlp:
+    enabled: true
+    endpoint: "http://localhost:4318"
+    compression: "gzip"  # default
+```
+
+See [docs/architecture.md](architecture.md) for full configuration options.
+
 ---
 
 ## 📡 API Interaction

--- a/docs/nix-setup.md
+++ b/docs/nix-setup.md
@@ -1,0 +1,194 @@
+# 🧊 Development Environment Setup
+
+Candela uses **Nix Flakes** for a fully reproducible dev environment. This means every contributor gets the exact same versions of Go, Node.js, Buf, Python, and all other tools — regardless of their OS or what's already installed.
+
+> **TL;DR**: Install Nix → `cd candela` → `nix develop` → everything works.
+
+---
+
+## What Is Nix?
+
+**Nix** is a purely functional package manager. Unlike Homebrew or apt, Nix:
+
+- **Never conflicts** — each package is isolated in its own path (`/nix/store/...`)
+- **Is reproducible** — the same inputs always produce the same outputs
+- **Doesn't pollute your system** — uninstall Nix and everything is gone
+
+You don't need to understand Nix deeply. Think of it as "Docker for your terminal" — it gives you a shell with all the right tools, without containers.
+
+## What Are Nix Flakes?
+
+**Flakes** are Nix's modern project definition format. Candela's `flake.nix` at the repo root defines:
+
+- **`devShells.default`** — the dev shell with all tools (Go, Node, Buf, Python, etc.)
+- **Lock file** (`flake.lock`) — pins exact versions of all dependencies
+
+When you run `nix develop`, Nix reads `flake.nix`, downloads the exact pinned versions, and drops you into a shell where everything is available.
+
+---
+
+## Installing Nix
+
+### Recommended: Determinate Nix Installer
+
+The [Determinate Systems installer](https://docs.determinate.systems/determinate-nix/) is the easiest way to install Nix with Flakes enabled by default.
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf -L \
+  https://install.determinate.systems/nix | sh -s -- install
+```
+
+This:
+- Installs Nix with **Flakes and the unified CLI enabled by default**
+- Works on macOS (Intel + Apple Silicon) and Linux
+- Sets up the Nix daemon as a system service
+- Is uninstallable: `/nix/nix-installer uninstall`
+
+### Alternative: Official Nix Installer
+
+If you prefer the official installer, you'll need to manually enable Flakes:
+
+```bash
+# Install Nix
+sh <(curl -L https://nixos.org/nix/install)
+
+# Enable flakes (add to ~/.config/nix/nix.conf)
+echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+```
+
+### Verify Installation
+
+```bash
+nix --version
+# nix (Nix) 2.x.x
+
+# Enter the Candela dev shell
+cd /path/to/candela
+nix develop
+
+# You should see:
+# 🕯️  Candela dev shell ready
+#    Go:     go1.26.1
+#    Buf:    1.67.0
+#    Node:   v22.22.2
+#    Python: 3.12.13
+```
+
+---
+
+## direnv — Automatic Shell Activation
+
+Manually typing `nix develop` every time you `cd` into the repo is tedious. **direnv** automates this — it activates the Nix dev shell automatically when you enter the directory.
+
+### What Is direnv?
+
+[direnv](https://direnv.net/) is a shell extension that loads environment variables based on the current directory. When combined with Nix, it:
+
+- **Auto-activates** the Nix dev shell when you `cd` into a project
+- **Auto-deactivates** when you leave
+- **Caches** the shell so re-entry is instant (no 10-second Nix eval)
+- **Works with** bash, zsh, fish, and most editors (VS Code, Zed, etc.)
+
+### Setup
+
+#### 1. Install direnv
+
+```bash
+# macOS
+brew install direnv
+
+# Or via Nix (globally)
+nix profile install nixpkgs#direnv
+```
+
+#### 2. Hook into your shell
+
+Add to your shell config:
+
+```bash
+# ~/.zshrc (macOS default)
+eval "$(direnv hook zsh)"
+
+# ~/.bashrc
+eval "$(direnv hook bash)"
+
+# ~/.config/fish/config.fish
+direnv hook fish | source
+```
+
+Restart your shell after adding the hook.
+
+#### 3. Install nix-direnv (recommended)
+
+**nix-direnv** dramatically improves caching. Without it, direnv re-evaluates the Nix expression on every shell entry.
+
+```bash
+# Add to ~/.config/direnv/direnvrc (create if needed)
+mkdir -p ~/.config/direnv
+cat >> ~/.config/direnv/direnvrc << 'EOF'
+# Use nix-direnv for cached Nix shells
+if type nix_direnv_version &>/dev/null; then
+  nix_direnv_version 3.0.6
+else
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" \
+    "sha256-RYcUJaRMf8oF5LznDrlCXbkOQrO8qIHIKjpZXb97gHc="
+fi
+EOF
+```
+
+#### 4. Allow the Candela `.envrc`
+
+Candela ships a `.envrc` at the repo root. The first time you enter the directory, direnv will ask you to approve it:
+
+```bash
+cd /path/to/candela
+# direnv: error /path/to/candela/.envrc is blocked. Run `direnv allow` to approve its content
+
+direnv allow
+# direnv: loading .envrc
+# direnv: using flake
+# 🕯️  Candela dev shell ready
+```
+
+After this, every time you `cd` into the repo (or open a terminal in your editor), the dev shell is automatically active.
+
+### Editor Integration
+
+Most editors support direnv natively or via plugins:
+
+| Editor | Setup |
+|--------|-------|
+| **VS Code** | Install the [direnv extension](https://marketplace.visualstudio.com/items?itemName=mkhl.direnv) |
+| **Zed** | Built-in direnv support (auto-detects `.envrc`) |
+| **Neovim** | [direnv.vim](https://github.com/direnv/direnv.vim) plugin |
+| **IntelliJ/GoLand** | [Direnv Integration](https://plugins.jetbrains.com/plugin/15285-direnv-integration) plugin |
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `nix develop` hangs | First run downloading dependencies | Wait — initial download is ~1GB, subsequent runs are cached |
+| `error: experimental Nix feature 'flakes' is disabled` | Flakes not enabled | Add `experimental-features = nix-command flakes` to `~/.config/nix/nix.conf` |
+| `direnv: error .envrc is blocked` | First-time security prompt | Run `direnv allow` |
+| `command not found: go` after `cd`-ing in | direnv not hooked into shell | Add `eval "$(direnv hook zsh)"` to `~/.zshrc` |
+| Nix shell is slow to activate | nix-direnv not installed | Follow step 3 above for cached shells |
+| `error: getting status of '/nix/store/...'` | Nix store corruption | Run `nix store verify --all --repair` |
+
+---
+
+## Without Nix (Not Recommended)
+
+If you can't install Nix, you can manually install the required tools:
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Go | 1.26+ | [go.dev/dl](https://go.dev/dl/) |
+| Node.js | 22+ | [nodejs.org](https://nodejs.org/) |
+| pnpm | 10+ | `npm install -g pnpm` |
+| Buf | 1.67+ | [buf.build/docs/installation](https://buf.build/docs/installation) |
+| Python | 3.12+ | [python.org](https://www.python.org/) |
+| uv | latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+
+> ⚠️ **Warning**: Without Nix, you're responsible for keeping tool versions in sync with the team. Pre-commit hooks may fail if your local versions differ from what CI uses.

--- a/docs/otel-collector.md
+++ b/docs/otel-collector.md
@@ -15,6 +15,8 @@ Use the Collector when you need:
 - **Custom attributes** — attach business context to spans (user, session, experiment)
 - **Dual-write** — export to Candela AND Google Cloud Trace simultaneously
 
+> **💡 Candela can also _export_ OTLP**: In addition to _receiving_ spans via the Collector, Candela can _forward_ its traces as standard OTLP to any OTel-compatible backend (Datadog, Grafana Tempo, Jaeger, etc.) using the built-in OTLP export sink. See [architecture.md](architecture.md#otlp-export-sink-only) for configuration.
+
 ---
 
 ## Architecture


### PR DESCRIPTION
Updates documentation to reflect the OTLP SpanWriter feature (PR #70).

### Files Updated

| Doc | Change |
|---|---|
| `docs/architecture.md` | Added OTLP to data flow diagram, new 'OTLP Export (Sink Only)' section with full config |
| `docs/development.md` | Added OTLP sink to storage backends section |
| `docs/otel-collector.md` | Added note about bidirectional OTLP (Candela can export, not just receive) |
| `README.md` | Updated fan-out feature line to include OTLP + backend examples |
| `CHANGELOG.md` | Added 'Latest' section with #70, #71, #73 entries |

No code changes — docs only.