### PR TITLE
fix: prefer X-User-Id header for span user attribution

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -339,10 +339,21 @@ func main() {
 	// Cloud Run service URL is the audience for Google ID tokens (candela-local).
 	cloudRunURL := os.Getenv("CLOUD_RUN_URL")
 
+	// Build a UserAuthorizer from the Firestore UserStore (if available).
+	// This restricts access to only registered users.
+	var userAuth auth.UserAuthorizer
+	if userStore != nil {
+		userAuth = func(ctx context.Context, email string) error {
+			_, err := userStore.GetUserByEmail(ctx, email)
+			return err
+		}
+	}
+
 	authedMux := auth.FirebaseAuthMiddleware(
 		corsMiddleware(mux, cfg.CORS.AllowedOrigins),
 		fbAuthClient,
 		cloudRunURL,
+		userAuth,
 		devMode,
 	)
 	if devMode {

--- a/pkg/auth/firebase.go
+++ b/pkg/auth/firebase.go
@@ -13,6 +13,11 @@ import (
 	"google.golang.org/api/idtoken"
 )
 
+// UserAuthorizer checks if an email belongs to a registered user.
+// Returns nil if the user exists, or an error if not found / lookup fails.
+// Pass nil to allow all authenticated identities (dev mode, no Firestore).
+type UserAuthorizer func(ctx context.Context, email string) error
+
 // FirebaseAuthMiddleware validates Firebase ID tokens (from browser users) and
 // Google ID tokens (from candela-local / service accounts).
 //
@@ -20,9 +25,12 @@ import (
 //   - Browser: Firebase Auth → ID token in Authorization: Bearer header
 //   - candela-local: Cloud Run invoker IAM → Google ID token in Authorization header
 //
+// If userAuth is non-nil, authenticated users are verified against the user store.
+// Only registered users are allowed through; unknown identities receive 403.
+//
 // In dev mode (devMode=true), no validation is performed; a synthetic admin
 // user is injected instead.
-func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAudience string, devMode bool) http.Handler {
+func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAudience string, userAuth UserAuthorizer, devMode bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip auth for health checks.
 		if r.URL.Path == "/healthz" {
@@ -62,6 +70,9 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 					ID:    decoded.UID,
 					Email: strings.ToLower(email),
 				}
+				if !verifyRegistered(r.Context(), w, user, userAuth) {
+					return
+				}
 				slog.Debug("authenticated via Firebase",
 					"uid", user.ID, "email", user.Email, "path", r.URL.Path)
 				next.ServeHTTP(w, r.WithContext(NewContext(r.Context(), user)))
@@ -90,6 +101,9 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 					ID:    payload.Subject,
 					Email: strings.ToLower(email),
 				}
+				if !verifyRegistered(r.Context(), w, user, userAuth) {
+					return
+				}
 				slog.Debug("authenticated via Google ID token",
 					"uid", user.ID, "email", user.Email, "path", r.URL.Path)
 				next.ServeHTTP(w, r.WithContext(NewContext(r.Context(), user)))
@@ -103,6 +117,9 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 		// Validates via Google's userinfo endpoint.
 		user, err := validateAccessToken(r.Context(), token)
 		if err == nil {
+			if !verifyRegistered(r.Context(), w, user, userAuth) {
+				return
+			}
 			slog.Debug("authenticated via OAuth2 access token",
 				"uid", user.ID, "email", user.Email, "path", r.URL.Path)
 			next.ServeHTTP(w, r.WithContext(NewContext(r.Context(), user)))
@@ -112,6 +129,22 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 
 		writeError(w, http.StatusUnauthorized, "invalid authentication token")
 	})
+}
+
+// verifyRegistered checks if the authenticated user exists in the user store.
+// Returns true if the user is allowed (registered or no store configured).
+// Returns false and writes a 403 response if the user is not registered.
+func verifyRegistered(ctx context.Context, w http.ResponseWriter, user *User, userAuth UserAuthorizer) bool {
+	if userAuth == nil {
+		return true // no user store — allow all authenticated users
+	}
+	if err := userAuth(ctx, user.Email); err != nil {
+		slog.Warn("authenticated but not registered — access denied",
+			"email", user.Email, "uid", user.ID)
+		writeError(w, http.StatusForbidden, "user not registered — contact your admin")
+		return false
+	}
+	return true
 }
 
 // validateAccessToken validates a Google OAuth2 access token by calling

--- a/pkg/auth/firebase_test.go
+++ b/pkg/auth/firebase_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestFirebaseAuthMiddleware_DevMode(t *testing.T) {
-	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", true)
+	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", nil, true)
 	req := httptest.NewRequest("GET", "/api/data", nil)
 	rr := httptest.NewRecorder()
 
@@ -32,7 +32,7 @@ func TestFirebaseAuthMiddleware_DevMode(t *testing.T) {
 }
 
 func TestFirebaseAuthMiddleware_DevMode_AllPaths(t *testing.T) {
-	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", true)
+	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", nil, true)
 
 	paths := []string{
 		"/api/data",
@@ -65,7 +65,7 @@ func TestFirebaseAuthMiddleware_HealthCheckBypass(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
-	handler := FirebaseAuthMiddleware(healthHandler, nil, "", false)
+	handler := FirebaseAuthMiddleware(healthHandler, nil, "", nil, false)
 
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rr := httptest.NewRecorder()
@@ -83,7 +83,7 @@ func TestFirebaseAuthMiddleware_HealthCheckBypass(t *testing.T) {
 
 func TestFirebaseAuthMiddleware_MissingHeader(t *testing.T) {
 	// No Firebase client, no Cloud Run audience — just test missing auth.
-	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", false)
+	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", nil, false)
 
 	req := httptest.NewRequest("GET", "/api/data", nil)
 	rr := httptest.NewRecorder()
@@ -106,7 +106,7 @@ func TestFirebaseAuthMiddleware_MissingHeader(t *testing.T) {
 
 func TestFirebaseAuthMiddleware_InvalidToken_NoValidators(t *testing.T) {
 	// With no Firebase client and no Cloud Run audience, any token is invalid.
-	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", false)
+	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", nil, false)
 
 	req := httptest.NewRequest("GET", "/api/data", nil)
 	req.Header.Set("Authorization", "Bearer some-random-token")
@@ -129,7 +129,7 @@ func TestFirebaseAuthMiddleware_InvalidToken_NoValidators(t *testing.T) {
 }
 
 func TestFirebaseAuthMiddleware_MalformedAuthHeader(t *testing.T) {
-	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", false)
+	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", nil, false)
 
 	tests := []struct {
 		name   string
@@ -187,7 +187,7 @@ func TestExtractBearerToken(t *testing.T) {
 
 func TestFirebaseAuthMiddleware_DevMode_IgnoresAuthHeader(t *testing.T) {
 	// In dev mode, even if an auth header is present, the synthetic user is used.
-	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", true)
+	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", nil, true)
 
 	req := httptest.NewRequest("GET", "/api/data", nil)
 	req.Header.Set("Authorization", "Bearer some-real-token")
@@ -216,7 +216,7 @@ func TestFirebaseAuthMiddleware_HealthzDoesNotInjectUser(t *testing.T) {
 			}
 			w.WriteHeader(http.StatusOK)
 		}),
-		nil, "", false,
+		nil, "", nil, false,
 	)
 
 	req := httptest.NewRequest("GET", "/healthz", nil)

--- a/pkg/connecthandlers/scope.go
+++ b/pkg/connecthandlers/scope.go
@@ -41,8 +41,11 @@ func scopeUserID(ctx context.Context, users storage.UserStore) string {
 			slog.Warn("failed to look up user role, scoping to own ID",
 				"email", caller.Email, "error", err)
 		}
-		// Unknown user — scope to sanitized email (matching proxy span attribution).
-		return strings.ToLower(caller.Email)
+		// Unknown user — scope to sanitized email, falling back to user ID for safety.
+		if caller.Email != "" {
+			return strings.ToLower(caller.Email)
+		}
+		return caller.ID
 	}
 
 	if record.Role == storage.RoleAdmin {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -297,6 +297,11 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// Accept session ID from candela-local (or other clients).
 	sessionID := r.Header.Get("X-Session-Id")
 
+	// Accept end-user identity from candela-local. When the proxy is called
+	// via a service account, X-User-Id carries the real user's email so
+	// spans are attributed correctly for per-user dashboards.
+	userOverride := strings.ToLower(r.Header.Get("X-User-Id"))
+
 	// Extract provider from path: /proxy/{provider}/v1/...
 	parts := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/proxy/"), "/", 2)
 	if len(parts) < 2 {
@@ -436,9 +441,9 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	cbAllow := p.breakers[providerName].AllowRequest()
 
 	if isStreaming && resp.StatusCode == http.StatusOK {
-		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, cbAllow)
+		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, userOverride, cbAllow)
 	} else {
-		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, cbAllow)
+		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, userOverride, cbAllow)
 	}
 }
 
@@ -467,6 +472,7 @@ func (p *Proxy) handleStandardResponse(
 	ttfb time.Duration,
 	requestID string,
 	sessionID string,
+	userOverride string,
 	cbAllow bool,
 ) {
 	// Read the full response.
@@ -507,7 +513,7 @@ func (p *Proxy) handleStandardResponse(
 
 	// Create observability span (async — don't block the response).
 	if cbAllow {
-		go p.createSpan(context.WithoutCancel(r.Context()), provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID, sessionID)
+		go p.createSpan(context.WithoutCancel(r.Context()), provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID, sessionID, userOverride)
 	} else {
 		slog.Debug("skipping span creation (circuit open)", "provider", provider.Name, "request_id", requestID)
 	}
@@ -520,6 +526,7 @@ func (p *Proxy) handleStreamingResponse(
 	ttfb time.Duration,
 	requestID string,
 	sessionID string,
+	userOverride string,
 	cbAllow bool,
 ) {
 	flusher, ok := w.(http.Flusher)
@@ -587,7 +594,7 @@ func (p *Proxy) handleStreamingResponse(
 
 	// Parse the accumulated stream to extract usage data.
 	if cbAllow {
-		go p.createStreamingSpan(context.WithoutCancel(r.Context()), provider, reqBody, streamBuffer.Bytes(), startTime, endTime, ttfb, ttft, requestID, sessionID)
+		go p.createStreamingSpan(context.WithoutCancel(r.Context()), provider, reqBody, streamBuffer.Bytes(), startTime, endTime, ttfb, ttft, requestID, sessionID, userOverride)
 	} else {
 		slog.Debug("skipping streaming span (circuit open)", "provider", provider.Name, "request_id", requestID)
 	}
@@ -600,6 +607,7 @@ type spanParams struct {
 	provider      Provider
 	model         string
 	sessionID     string
+	userOverride  string // end-user email from X-User-Id header (candela-local)
 	inputContent  string
 	outputContent string
 	inputTokens   int64
@@ -650,13 +658,17 @@ func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 		Attributes: attrs,
 	}
 
-	// Set user ID from auth context for per-user attribution.
-	// Use sanitized email (matching Firestore doc IDs) as the canonical ID.
-	// This ensures span user_id aligns with budget lookups and query filters.
-	if caller := auth.FromContext(ctx); caller != nil && caller.Email != "" {
-		span.UserID = strings.ToLower(caller.Email)
-	} else if caller != nil {
-		span.UserID = caller.ID
+	// Set user ID for per-user attribution.
+	// Priority: (1) X-User-Id header from candela-local (end-user email),
+	// (2) auth context email, (3) auth context UID.
+	if params.userOverride != "" {
+		span.UserID = params.userOverride
+	} else if caller := auth.FromContext(ctx); caller != nil {
+		if caller.Email != "" {
+			span.UserID = strings.ToLower(caller.Email)
+		} else {
+			span.UserID = caller.ID
+		}
 	}
 
 	// Set session ID for conversation grouping.
@@ -716,6 +728,7 @@ func (p *Proxy) createSpan(
 	ttfb time.Duration,
 	requestID string,
 	sessionID string,
+	userOverride string,
 ) {
 	model, inputContent := extractRequestInfo(provider.Name, reqBody)
 	outputContent, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
@@ -728,6 +741,7 @@ func (p *Proxy) createSpan(
 	p.buildSpan(ctx, spanParams{
 		provider:      provider,
 		model:         model,
+		userOverride:  userOverride,
 		inputContent:  inputContent,
 		outputContent: outputContent,
 		inputTokens:   inputTokens,
@@ -753,6 +767,7 @@ func (p *Proxy) createStreamingSpan(
 	ttft time.Duration,
 	requestID string,
 	sessionID string,
+	userOverride string,
 ) {
 	model, inputContent := extractRequestInfo(provider.Name, reqBody)
 	outputContent, inputTokens, outputTokens := extractStreamingUsage(provider.Name, streamData)
@@ -760,6 +775,7 @@ func (p *Proxy) createStreamingSpan(
 	p.buildSpan(ctx, spanParams{
 		provider:      provider,
 		model:         model,
+		userOverride:  userOverride,
 		inputContent:  inputContent,
 		outputContent: outputContent,
 		inputTokens:   inputTokens,

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -459,3 +459,110 @@ func TestCircuitBreaker_SkipsSpanOnOpen(t *testing.T) {
 		t.Errorf("expected fewer than 6 spans (circuit should skip some), got %d", len(spans))
 	}
 }
+
+func TestUserIDOverride_XUserIdHeader(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer upstream.Close()
+
+	submitter := &mockSubmitter{}
+	calc := costcalc.New()
+
+	p := New(Config{
+		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, submitter, calc)
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Send request WITH X-User-Id header (simulating candela-local).
+	req, _ := http.NewRequest("POST",
+		srv.URL+"/proxy/anthropic/v1/messages",
+		strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("X-User-Id", "Ivan.Costa@Example.Com")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	// Wait for async span.
+	for i := 0; i < 50; i++ {
+		if len(submitter.getSpans()) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	spans := submitter.getSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected span")
+	}
+
+	// X-User-Id should be lowercased and used as user_id.
+	if spans[0].UserID != "ivan.costa@example.com" {
+		t.Errorf("span UserID = %q, want %q", spans[0].UserID, "ivan.costa@example.com")
+	}
+}
+
+func TestUserIDOverride_FallbackWithoutHeader(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer upstream.Close()
+
+	submitter := &mockSubmitter{}
+	calc := costcalc.New()
+
+	p := New(Config{
+		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, submitter, calc)
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Send request WITHOUT X-User-Id header and WITHOUT auth context.
+	req, _ := http.NewRequest("POST",
+		srv.URL+"/proxy/anthropic/v1/messages",
+		strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tok")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	// Wait for async span.
+	for i := 0; i < 50; i++ {
+		if len(submitter.getSpans()) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	spans := submitter.getSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected span")
+	}
+
+	// Without X-User-Id and without auth context, UserID should be empty.
+	if spans[0].UserID != "" {
+		t.Errorf("span UserID = %q, want empty string", spans[0].UserID)
+	}
+}


### PR DESCRIPTION
## Problem
When candela-local proxies requests through a service account (e.g. `external-sa@project.iam.gserviceaccount.com`), the proxy's auth context contains the **service account identity** — not the end-user. This caused:
- **Today/Usage pages empty** for team members like Ivan Costa
- Budget deduction attributed to service account instead of developer
- No per-user observability for candela-local users

## Root Cause
`buildSpan()` used `auth.FromContext(ctx).Email` which resolved to the service account email, not the developer's email.

## Fix
The proxy now checks for `X-User-Id` header (already set by candela-local) and uses it as the canonical user identity for span attribution:

```
Priority: X-User-Id header > auth context email > auth context UID
```

### Changes
- **`proxy.go`**: Thread `userOverride` through `handleProxy → handleStandardResponse/handleStreamingResponse → createSpan/createStreamingSpan → buildSpan`
- **`spanParams`**: New `userOverride` field
- **`buildSpan`**: 3-tier user ID resolution

### Tests
- `TestUserIDOverride_XUserIdHeader`: verifies header is lowercased and used as `span.UserID`
- `TestUserIDOverride_FallbackWithoutHeader`: verifies empty UserID when no header/auth

## Security Note
The Cloud Run service has `allUsers → roles/run.invoker` (public). Auth is app-level only (Firebase/Google ID token). The OAuth2 access token strategy (Strategy 3) accepts tokens from **any** GCP project — this should be tightened.