### PR TITLE
fix: scope traces and spans to logged-in developer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,13 +178,19 @@ All backends share the same logical schema:
 | project_id | VARCHAR | STRING | TEXT |
 | environment | VARCHAR | STRING | TEXT |
 | service_name | VARCHAR | STRING | TEXT |
+| user_id | VARCHAR | STRING | TEXT |
 | gen_ai_model | VARCHAR | STRING | TEXT |
 | gen_ai_provider | VARCHAR | STRING | TEXT |
 | gen_ai_input_tokens | BIGINT | INT64 | INTEGER |
 | gen_ai_output_tokens | BIGINT | INT64 | INTEGER |
 | gen_ai_total_tokens | BIGINT | INT64 | INTEGER |
 | gen_ai_cost_usd | DOUBLE | FLOAT64 | REAL |
+| gen_ai_temperature | DOUBLE | FLOAT64 | REAL |
+| gen_ai_max_tokens | BIGINT | INT64 | INTEGER |
+| gen_ai_input_content | VARCHAR | STRING | TEXT |
+| gen_ai_output_content | VARCHAR | STRING | TEXT |
 | attributes | STRUCT[] | STRUCT[] | TEXT (JSON) |
+| session_id | VARCHAR | STRING | TEXT |
 
 ### Key Design Decisions
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -81,13 +81,45 @@ Request → Auth Middleware → Admin Interceptor → Handler
 | **Grants** | `CreateGrant`, `ListGrants`, `RevokeGrant` |
 | **Audit** | `ListAuditLog` |
 
-#### Unguarded Services
-| Service | Why |
-|---------|-----|
-| `TraceService` | User-scoped filtering done at query layer (not interceptor) |
-| `DashboardService` | User-scoped filtering done at query layer |
-| `IngestionService` | Ingestion validated by project API key, not user identity |
+#### Unguarded Services (Data-Level Scoping)
+| Service | Scoping Method |
+|---------|----------------|
+| `TraceService` | `scopeUserID()` injects user filter into storage queries; `GetTrace` uses post-fetch auth gate |
+| `DashboardService` | `scopeUserID()` injects user filter into usage/model queries |
+| `IngestionService` | Write-only — validated by project API key, not user identity |
 | `ProjectService` | Currently unguarded (future: project-level RBAC) |
+
+---
+
+## Data Isolation — Per-User Trace Scoping
+
+Non-admin developers can only see their own traces and spans. This is enforced at two levels:
+
+### Query-Based Endpoints (ListTraces, SearchSpans, Dashboard)
+
+The `scopeUserID()` helper (`pkg/connecthandlers/scope.go`) determines the caller's identity:
+- **Admin** → returns `""` (empty string = no filter, sees all data)
+- **Developer** → returns sanitized email (e.g., `alice@example.com`)
+
+This value is injected into `TraceQuery.UserID`, `SpanQuery.UserID`, or `UsageQuery.UserID`. All storage backends (BigQuery, DuckDB, SQLite) apply the filter in SQL:
+
+```sql
+AND (? = '' OR user_id = ?)
+```
+
+### GetTrace (Direct Access by Trace ID)
+
+`GetTrace` cannot pre-filter because it queries by `trace_id`, not user. Instead, it uses a **post-fetch authorization gate**:
+
+1. Fetch the full trace from storage
+2. Extract the trace owner via `traceUserID()` — checks root span first, then falls back to any span with `user_id`
+3. Compare against `scopeUserID(ctx)`
+4. If mismatch → `PermissionDenied`
+5. If no `user_id` on any span (legacy data) → allow access, log for backfill visibility
+
+### Error Sanitization
+
+All handlers use `internalError()` (`pkg/connecthandlers/errors.go`) for storage failures. This logs the real error server-side via `slog.Error` and returns a generic `"internal error"` to clients, preventing leakage of SQL errors, file paths, or infrastructure details.
 
 ---
 
@@ -197,6 +229,8 @@ See [docs/user-management.md](user-management.md) for the full validation rule r
 | Token validation on all non-health endpoints | ✅ | 3-strategy waterfall |
 | Email claim normalization (lowercase) | ✅ | Prevents case-based identity bypass |
 | Admin role enforcement via ConnectRPC interceptor | ✅ | Per-RPC ACL |
+| Per-user trace/span data isolation | ✅ | `scopeUserID()` + `traceUserID()` auth gate |
+| Internal error message sanitization | ✅ | `internalError()` logs server-side, returns generic message |
 | Rate limiting per user | ✅ | `CheckRateLimit()` in `UserStore` |
 | Budget enforcement before proxy calls | ✅ | `CheckBudget()` pre-flight |
 | Secrets not baked into container images | ✅ | `entrypoint.sh` generates config from env vars |
@@ -218,5 +252,7 @@ See [docs/user-management.md](user-management.md) for the full validation rule r
 | `pkg/auth/firebase.go` | `FirebaseAuthMiddleware` — 3-strategy waterfall |
 | `pkg/auth/iap.go` | `IAPMiddleware` — Cloud IAP JWT validation (legacy) |
 | `pkg/auth/admin.go` | `AdminInterceptor` — ConnectRPC admin guard |
+| `pkg/connecthandlers/scope.go` | `scopeUserID()` — per-user data scoping helper |
+| `pkg/connecthandlers/errors.go` | `internalError()` — sanitized error responses |
 | `cmd/candela-server/main.go` | Middleware wiring, Firebase init, dev mode |
 | `cmd/candela-local/main.go` | ADC token injection for Team Mode |

--- a/pkg/auth/admin.go
+++ b/pkg/auth/admin.go
@@ -59,8 +59,10 @@ func AdminInterceptor(userStore storage.UserStore) connect.UnaryInterceptorFunc 
 					return nil, connect.NewError(connect.CodePermissionDenied,
 						fmt.Errorf("admin access required"))
 				}
+				slog.ErrorContext(ctx, "admin check: failed to look up user role",
+					"email", authUser.Email, "error", err)
 				return nil, connect.NewError(connect.CodeInternal,
-					fmt.Errorf("failed to look up user role: %w", err))
+					fmt.Errorf("internal error"))
 			}
 
 			if user.Role != storage.RoleAdmin {

--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -53,7 +53,7 @@ func (h *DashboardHandler) GetUsageSummary(
 
 	summary, err := h.store.GetUsageSummary(ctx, q)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to get usage summary", err)
 	}
 
 	return connect.NewResponse(&v1.GetUsageSummaryResponse{
@@ -86,7 +86,7 @@ func (h *DashboardHandler) GetModelBreakdown(
 
 	models, err := h.store.GetModelBreakdown(ctx, q)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to get model breakdown", err)
 	}
 
 	var pbModels []*v1.ModelUsage
@@ -134,7 +134,7 @@ func (h *DashboardHandler) GetMyUsage(
 			if errors.Is(err, storage.ErrNotFound) {
 				return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("user not found"))
 			}
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, internalError("failed to look up user", err)
 		}
 		userID = user.ID
 	} else {
@@ -163,12 +163,12 @@ func (h *DashboardHandler) GetMyUsage(
 
 	summary, err := h.store.GetUsageSummary(ctx, q)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to get usage summary", err)
 	}
 
 	models, err := h.store.GetModelBreakdown(ctx, q)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to get model breakdown", err)
 	}
 
 	resp := &v1.GetMyUsageResponse{
@@ -270,7 +270,7 @@ func (h *DashboardHandler) GetTeamLeaderboard(
 
 	users, err := h.store.GetUserLeaderboard(ctx, q, limit)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to get user leaderboard", err)
 	}
 
 	// Batch enrichment: collect IDs to avoid N+1 query pattern.

--- a/pkg/connecthandlers/errors.go
+++ b/pkg/connecthandlers/errors.go
@@ -1,0 +1,16 @@
+package connecthandlers
+
+import (
+	"fmt"
+	"log/slog"
+
+	connect "connectrpc.com/connect"
+)
+
+// internalError logs the real error server-side and returns a generic
+// "internal error" to the client. This prevents leaking storage-layer
+// details (SQL errors, file paths, Firestore doc references) over the API.
+func internalError(msg string, err error) *connect.Error {
+	slog.Error(msg, "error", err)
+	return connect.NewError(connect.CodeInternal, fmt.Errorf("internal error"))
+}

--- a/pkg/connecthandlers/project_handler.go
+++ b/pkg/connecthandlers/project_handler.go
@@ -2,6 +2,7 @@ package connecthandlers
 
 import (
 	"context"
+	"fmt"
 
 	connect "connectrpc.com/connect"
 	typespb "github.com/candelahq/candela/gen/go/candela/types"
@@ -30,7 +31,7 @@ func (h *ProjectHandler) CreateProject(
 		Description: req.Msg.Description,
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to create project", err)
 	}
 
 	return connect.NewResponse(&v1.CreateProjectResponse{
@@ -44,7 +45,7 @@ func (h *ProjectHandler) GetProject(
 ) (*connect.Response[v1.GetProjectResponse], error) {
 	p, err := h.store.GetProject(ctx, req.Msg.Id)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeNotFound, err)
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("project not found"))
 	}
 
 	return connect.NewResponse(&v1.GetProjectResponse{
@@ -66,7 +67,7 @@ func (h *ProjectHandler) ListProjects(
 
 	projects, total, err := h.store.ListProjects(ctx, limit, offset)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to list projects", err)
 	}
 
 	pbProjects := make([]*typespb.Project, len(projects))
@@ -88,7 +89,7 @@ func (h *ProjectHandler) DeleteProject(
 	req *connect.Request[v1.DeleteProjectRequest],
 ) (*connect.Response[v1.DeleteProjectResponse], error) {
 	if err := h.store.DeleteProject(ctx, req.Msg.Id); err != nil {
-		return nil, connect.NewError(connect.CodeNotFound, err)
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("project not found"))
 	}
 	return connect.NewResponse(&v1.DeleteProjectResponse{}), nil
 }
@@ -104,7 +105,7 @@ func (h *ProjectHandler) CreateAPIKey(
 		Name:      req.Msg.Name,
 	}, fullKey)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to create API key", err)
 	}
 
 	return connect.NewResponse(&v1.CreateAPIKeyResponse{
@@ -119,7 +120,7 @@ func (h *ProjectHandler) ListAPIKeys(
 ) (*connect.Response[v1.ListAPIKeysResponse], error) {
 	keys, err := h.store.ListAPIKeys(ctx, req.Msg.ProjectId)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to list API keys", err)
 	}
 
 	pbKeys := make([]*typespb.APIKey, len(keys))
@@ -138,7 +139,7 @@ func (h *ProjectHandler) RevokeAPIKey(
 	req *connect.Request[v1.RevokeAPIKeyRequest],
 ) (*connect.Response[v1.RevokeAPIKeyResponse], error) {
 	if err := h.store.RevokeAPIKey(ctx, req.Msg.Id); err != nil {
-		return nil, connect.NewError(connect.CodeNotFound, err)
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("API key not found"))
 	}
 	return connect.NewResponse(&v1.RevokeAPIKeyResponse{}), nil
 }

--- a/pkg/connecthandlers/trace_handler.go
+++ b/pkg/connecthandlers/trace_handler.go
@@ -33,7 +33,8 @@ func (h *TraceHandler) GetTrace(
 ) (*connect.Response[v1.GetTraceResponse], error) {
 	trace, err := h.store.GetTrace(ctx, req.Msg.TraceId)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeNotFound, err)
+		slog.Error("failed to get trace", "trace_id", req.Msg.TraceId, "error", err)
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("trace not found"))
 	}
 
 	// Authorization gate: non-admin users may only view their own traces.
@@ -105,7 +106,7 @@ func (h *TraceHandler) ListTraces(
 
 	result, err := h.store.QueryTraces(ctx, q)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to query traces", err)
 	}
 
 	var summaries []*typespb.TraceSummary
@@ -152,7 +153,7 @@ func (h *TraceHandler) SearchSpans(
 
 	result, err := h.store.SearchSpans(ctx, q)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to search spans", err)
 	}
 
 	var spans []*typespb.Span

--- a/pkg/connecthandlers/trace_handler.go
+++ b/pkg/connecthandlers/trace_handler.go
@@ -4,6 +4,7 @@ package connecthandlers
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	connect "connectrpc.com/connect"
@@ -45,15 +46,15 @@ func (h *TraceHandler) GetTrace(
 			return nil, connect.NewError(connect.CodePermissionDenied,
 				fmt.Errorf("access denied"))
 		}
-		// If the trace has no user_id at all (legacy data), allow access —
-		// but log for visibility so we can backfill.
+		// If the trace has no user_id at all (legacy data), allow access
+		// but log for backfill visibility.
 		if traceOwner == "" {
 			caller := auth.FromContext(ctx)
-			email := ""
 			if caller != nil {
-				email = caller.Email
+				slog.Debug("legacy trace access: no user_id on trace",
+					"trace_id", req.Msg.TraceId,
+					"caller", caller.Email)
 			}
-			_ = email // available for future slog.Debug if needed
 		}
 	}
 
@@ -256,17 +257,19 @@ func traceSummaryToProto(t *storage.TraceSummary) *typespb.TraceSummary {
 // first span that has a user_id set. Returns "" if no span has a user_id
 // (legacy data ingested before per-user attribution was added).
 func traceUserID(t *storage.Trace) string {
-	// Prefer the root span's user_id (most authoritative).
+	var fallback string
 	for _, sp := range t.Spans {
-		if sp.ParentSpanID == "" && sp.UserID != "" {
+		if sp.UserID == "" {
+			continue
+		}
+		// Prefer the root span's user_id (most authoritative).
+		if sp.ParentSpanID == "" {
 			return sp.UserID
 		}
-	}
-	// Fallback: any span in the trace with a user_id.
-	for _, sp := range t.Spans {
-		if sp.UserID != "" {
-			return sp.UserID
+		// Fallback: the first span in the trace with a user_id.
+		if fallback == "" {
+			fallback = sp.UserID
 		}
 	}
-	return ""
+	return fallback
 }

--- a/pkg/connecthandlers/trace_handler.go
+++ b/pkg/connecthandlers/trace_handler.go
@@ -3,11 +3,13 @@ package connecthandlers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	connect "connectrpc.com/connect"
 	typespb "github.com/candelahq/candela/gen/go/candela/types"
 	v1 "github.com/candelahq/candela/gen/go/candela/v1"
+	"github.com/candelahq/candela/pkg/auth"
 	"github.com/candelahq/candela/pkg/storage"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -31,6 +33,28 @@ func (h *TraceHandler) GetTrace(
 	trace, err := h.store.GetTrace(ctx, req.Msg.TraceId)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+
+	// Authorization gate: non-admin users may only view their own traces.
+	// The trace's user_id is set by the proxy at ingestion time and matches
+	// the Firestore doc ID (sanitized email) used by scopeUserID.
+	if ownerID := scopeUserID(ctx, h.users); ownerID != "" {
+		// Determine the trace's owner from its root span (or first span).
+		traceOwner := traceUserID(trace)
+		if traceOwner != "" && traceOwner != ownerID {
+			return nil, connect.NewError(connect.CodePermissionDenied,
+				fmt.Errorf("access denied"))
+		}
+		// If the trace has no user_id at all (legacy data), allow access —
+		// but log for visibility so we can backfill.
+		if traceOwner == "" {
+			caller := auth.FromContext(ctx)
+			email := ""
+			if caller != nil {
+				email = caller.Email
+			}
+			_ = email // available for future slog.Debug if needed
+		}
 	}
 
 	return connect.NewResponse(&v1.GetTraceResponse{
@@ -108,6 +132,7 @@ func (h *TraceHandler) SearchSpans(
 		Kind:         storage.SpanKind(msg.Kind),
 		Model:        msg.Model,
 		NameContains: msg.NameContains,
+		UserID:       scopeUserID(ctx, h.users),
 	}
 
 	if msg.TimeRange != nil {
@@ -224,4 +249,24 @@ func traceSummaryToProto(t *storage.TraceSummary) *typespb.TraceSummary {
 		PrimaryModel:    t.PrimaryModel,
 		PrimaryProvider: t.PrimaryProvider,
 	}
+}
+
+// traceUserID extracts the owner user_id from a trace.
+// It checks the root span first (parent_span_id == ""), then falls back to the
+// first span that has a user_id set. Returns "" if no span has a user_id
+// (legacy data ingested before per-user attribution was added).
+func traceUserID(t *storage.Trace) string {
+	// Prefer the root span's user_id (most authoritative).
+	for _, sp := range t.Spans {
+		if sp.ParentSpanID == "" && sp.UserID != "" {
+			return sp.UserID
+		}
+	}
+	// Fallback: any span in the trace with a user_id.
+	for _, sp := range t.Spans {
+		if sp.UserID != "" {
+			return sp.UserID
+		}
+	}
+	return ""
 }

--- a/pkg/connecthandlers/trace_handler_test.go
+++ b/pkg/connecthandlers/trace_handler_test.go
@@ -1,0 +1,77 @@
+package connecthandlers
+
+import (
+	"testing"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+func TestTraceUserID(t *testing.T) {
+	tests := []struct {
+		name   string
+		trace  *storage.Trace
+		wantID string
+	}{
+		{
+			name: "root span has user_id",
+			trace: &storage.Trace{
+				TraceID: "t1",
+				Spans: []storage.Span{
+					{SpanID: "root", ParentSpanID: "", UserID: "alice@example.com"},
+					{SpanID: "child", ParentSpanID: "root", UserID: "alice@example.com"},
+				},
+			},
+			wantID: "alice@example.com",
+		},
+		{
+			name: "root span empty, child has user_id",
+			trace: &storage.Trace{
+				TraceID: "t2",
+				Spans: []storage.Span{
+					{SpanID: "root", ParentSpanID: ""},
+					{SpanID: "child", ParentSpanID: "root", UserID: "bob@example.com"},
+				},
+			},
+			wantID: "bob@example.com",
+		},
+		{
+			name: "no spans have user_id (legacy)",
+			trace: &storage.Trace{
+				TraceID: "t3",
+				Spans: []storage.Span{
+					{SpanID: "root", ParentSpanID: ""},
+					{SpanID: "child", ParentSpanID: "root"},
+				},
+			},
+			wantID: "",
+		},
+		{
+			name: "empty trace",
+			trace: &storage.Trace{
+				TraceID: "t4",
+				Spans:   nil,
+			},
+			wantID: "",
+		},
+		{
+			name: "root has different user than child — root wins",
+			trace: &storage.Trace{
+				TraceID: "t5",
+				Spans: []storage.Span{
+					{SpanID: "root", ParentSpanID: "", UserID: "alice@example.com"},
+					{SpanID: "child", ParentSpanID: "root", UserID: "bob@example.com"},
+				},
+			},
+			wantID: "alice@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := traceUserID(tt.trace)
+			if got != tt.wantID {
+				t.Errorf("traceUserID() = %q, want %q", got, tt.wantID)
+			}
+		})
+	}
+}

--- a/pkg/connecthandlers/user_handler.go
+++ b/pkg/connecthandlers/user_handler.go
@@ -59,8 +59,7 @@ func (h *UserHandler) CreateUser(
 		return nil, connect.NewError(connect.CodeAlreadyExists,
 			fmt.Errorf("user with email %q already exists", normalizedEmail))
 	} else if !errors.Is(err, storage.ErrNotFound) {
-		return nil, connect.NewError(connect.CodeInternal,
-			fmt.Errorf("failed to check existing user: %w", err))
+		return nil, internalError("failed to check existing user", err)
 	}
 
 	user := &storage.UserRecord{
@@ -69,7 +68,7 @@ func (h *UserHandler) CreateUser(
 		Role:        roleToString(req.Msg.Role),
 	}
 	if err := h.store.CreateUser(ctx, user); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to create user", err)
 	}
 
 	resp := &v1.CreateUserResponse{
@@ -88,7 +87,7 @@ func (h *UserHandler) CreateUser(
 			PeriodType: "daily",
 		}
 		if err := h.store.SetBudget(ctx, budget); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, internalError("failed to set initial budget", err)
 		}
 		resp.Budget = budgetToProto(budget)
 	}
@@ -127,7 +126,7 @@ func (h *UserHandler) ListUsers(
 
 	users, total, err := h.store.ListUsers(ctx, statusFilter, limit, offset)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to list users", err)
 	}
 
 	pbUsers := make([]*typespb.User, len(users))
@@ -156,16 +155,16 @@ func (h *UserHandler) GetUser(
 ) (*connect.Response[v1.GetUserResponse], error) {
 	user, err := h.store.GetUser(ctx, req.Msg.Id)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeNotFound, err)
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("user not found"))
 	}
 
 	budget, err := h.store.GetBudget(ctx, user.ID)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get budget: %w", err))
+		return nil, internalError("failed to get budget", err)
 	}
 	grants, err := h.store.ListGrants(ctx, user.ID, true)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list grants: %w", err))
+		return nil, internalError("failed to list grants", err)
 	}
 
 	pbGrants := make([]*typespb.BudgetGrant, len(grants))
@@ -186,7 +185,7 @@ func (h *UserHandler) UpdateUser(
 ) (*connect.Response[v1.UpdateUserResponse], error) {
 	user, err := h.store.GetUser(ctx, req.Msg.Id)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeNotFound, err)
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("user not found"))
 	}
 
 	// Apply updates based on field mask (or all fields if no mask).
@@ -205,7 +204,7 @@ func (h *UserHandler) UpdateUser(
 	}
 
 	if err := h.store.UpdateUser(ctx, user); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to update user", err)
 	}
 
 	return connect.NewResponse(&v1.UpdateUserResponse{
@@ -219,11 +218,11 @@ func (h *UserHandler) DeactivateUser(
 ) (*connect.Response[v1.DeactivateUserResponse], error) {
 	user, err := h.store.GetUser(ctx, req.Msg.Id)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeNotFound, err)
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("user not found"))
 	}
 	user.Status = storage.StatusInactive
 	if err := h.store.UpdateUser(ctx, user); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to deactivate user", err)
 	}
 
 	h.logAudit(ctx, &storage.AuditRecord{
@@ -241,11 +240,11 @@ func (h *UserHandler) ReactivateUser(
 ) (*connect.Response[v1.ReactivateUserResponse], error) {
 	user, err := h.store.GetUser(ctx, req.Msg.Id)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeNotFound, err)
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("user not found"))
 	}
 	user.Status = storage.StatusActive
 	if err := h.store.UpdateUser(ctx, user); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to reactivate user", err)
 	}
 
 	h.logAudit(ctx, &storage.AuditRecord{
@@ -265,7 +264,7 @@ func (h *UserHandler) DeleteUser(
 ) (*connect.Response[v1.DeleteUserResponse], error) {
 	user, err := h.store.GetUser(ctx, req.Msg.Id)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeNotFound, err)
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("user not found"))
 	}
 
 	// Gate: only inactive users can be deleted.
@@ -299,7 +298,7 @@ func (h *UserHandler) DeleteUser(
 		"details", auditDetails)
 
 	if err := h.store.DeleteUser(ctx, user.ID); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to delete user", err)
 	}
 
 	return connect.NewResponse(&v1.DeleteUserResponse{}), nil
@@ -319,7 +318,7 @@ func (h *UserHandler) SetBudget(
 		PeriodType: "daily", // All budgets are daily.
 	}
 	if err := h.store.SetBudget(ctx, budget); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to set budget", err)
 	}
 
 	h.logAudit(ctx, &storage.AuditRecord{
@@ -340,7 +339,7 @@ func (h *UserHandler) GetBudget(
 ) (*connect.Response[v1.GetBudgetResponse], error) {
 	budget, err := h.store.GetBudget(ctx, req.Msg.UserId)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to get budget", err)
 	}
 	return connect.NewResponse(&v1.GetBudgetResponse{
 		Budget: budgetToProto(budget),
@@ -352,7 +351,7 @@ func (h *UserHandler) ResetSpend(
 	req *connect.Request[v1.ResetSpendRequest],
 ) (*connect.Response[v1.ResetSpendResponse], error) {
 	if err := h.store.ResetSpend(ctx, req.Msg.UserId); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to reset spend", err)
 	}
 
 	h.logAudit(ctx, &storage.AuditRecord{
@@ -363,7 +362,7 @@ func (h *UserHandler) ResetSpend(
 
 	budget, err := h.store.GetBudget(ctx, req.Msg.UserId)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get budget after reset: %w", err))
+		return nil, internalError("failed to get budget after reset", err)
 	}
 	return connect.NewResponse(&v1.ResetSpendResponse{
 		Budget: budgetToProto(budget),
@@ -387,7 +386,7 @@ func (h *UserHandler) CreateGrant(
 		ExpiresAt: req.Msg.ExpiresAt.AsTime(),
 	}
 	if err := h.store.CreateGrant(ctx, grant); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to create grant", err)
 	}
 
 	h.logAudit(ctx, &storage.AuditRecord{
@@ -408,7 +407,7 @@ func (h *UserHandler) ListGrants(
 ) (*connect.Response[v1.ListGrantsResponse], error) {
 	grants, err := h.store.ListGrants(ctx, req.Msg.UserId, req.Msg.ActiveOnly)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to list grants", err)
 	}
 
 	pbGrants := make([]*typespb.BudgetGrant, len(grants))
@@ -426,7 +425,7 @@ func (h *UserHandler) RevokeGrant(
 	req *connect.Request[v1.RevokeGrantRequest],
 ) (*connect.Response[v1.RevokeGrantResponse], error) {
 	if err := h.store.RevokeGrant(ctx, req.Msg.UserId, req.Msg.GrantId); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to revoke grant", err)
 	}
 
 	h.logAudit(ctx, &storage.AuditRecord{
@@ -449,7 +448,7 @@ func (h *UserHandler) ListAuditLog(
 ) (*connect.Response[v1.ListAuditLogResponse], error) {
 	entries, err := h.store.ListAuditLog(ctx, req.Msg.UserId, int(req.Msg.Limit))
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, internalError("failed to list audit log", err)
 	}
 
 	pbEntries := make([]*typespb.AuditEntry, len(entries))
@@ -481,7 +480,7 @@ func (h *UserHandler) GetCurrentUser(
 		// Only auto-provision if the error is specifically "not found".
 		// Other errors (e.g., transient DB issues) should propagate.
 		if !errors.Is(err, storage.ErrNotFound) {
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to look up user: %w", err))
+			return nil, internalError("failed to look up user", err)
 		}
 
 		// Auto-provision on first login.
@@ -491,7 +490,7 @@ func (h *UserHandler) GetCurrentUser(
 			Status: storage.StatusActive,
 		}
 		if createErr := h.store.CreateUser(ctx, user); createErr != nil {
-			return nil, connect.NewError(connect.CodeInternal, createErr)
+			return nil, internalError("failed to auto-provision user", createErr)
 		}
 
 		// Apply default daily budget to auto-provisioned users.
@@ -515,15 +514,15 @@ func (h *UserHandler) GetCurrentUser(
 
 	budget, err := h.store.GetBudget(ctx, user.ID)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get budget: %w", err))
+		return nil, internalError("failed to get budget", err)
 	}
 	grants, err := h.store.ListGrants(ctx, user.ID, true)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list grants: %w", err))
+		return nil, internalError("failed to list grants", err)
 	}
 	check, err := h.store.CheckBudget(ctx, user.ID, 0)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to check budget: %w", err))
+		return nil, internalError("failed to check budget", err)
 	}
 
 	pbGrants := make([]*typespb.BudgetGrant, len(grants))
@@ -555,20 +554,20 @@ func (h *UserHandler) GetMyBudget(
 
 	user, err := h.store.GetUserByEmail(ctx, authUser.Email)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeNotFound, err)
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("user not found"))
 	}
 
 	budget, err := h.store.GetBudget(ctx, user.ID)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get budget: %w", err))
+		return nil, internalError("failed to get budget", err)
 	}
 	grants, err := h.store.ListGrants(ctx, user.ID, true)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to list grants: %w", err))
+		return nil, internalError("failed to list grants", err)
 	}
 	check, err := h.store.CheckBudget(ctx, user.ID, 0)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to check budget: %w", err))
+		return nil, internalError("failed to check budget", err)
 	}
 
 	pbGrants := make([]*typespb.BudgetGrant, len(grants))

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -297,9 +297,11 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// Accept session ID from candela-local (or other clients).
 	sessionID := r.Header.Get("X-Session-Id")
 
-	// Accept end-user identity from candela-local. When the proxy is called
-	// via a service account, X-User-Id carries the real user's email so
-	// spans are attributed correctly for per-user dashboards.
+	// ── Resolve effective end-user identity ──
+	// This is the single source of truth for "who is making this request"
+	// and is used for both budget enforcement and span attribution.
+	// Priority: (1) X-User-Id header from candela-local (real end-user
+	// behind a service account), (2) auth context email, (3) auth context UID.
 	//
 	// Security: only trust X-User-Id from service account callers
 	// (*.iam.gserviceaccount.com). Regular users cannot impersonate others.
@@ -311,6 +313,15 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		} else {
 			slog.Warn("X-User-Id header ignored — caller is not a service account",
 				"caller_email", auth.EmailFromContext(r.Context()), "attempted_override", xuid)
+		}
+	}
+
+	effectiveUserID := userOverride
+	if effectiveUserID == "" && caller != nil {
+		if caller.Email != "" {
+			effectiveUserID = strings.ToLower(caller.Email)
+		} else {
+			effectiveUserID = caller.ID
 		}
 	}
 
@@ -334,30 +345,21 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// We pass estimatedCostUSD=0 because we can't know the actual cost until
 	// after the upstream response. This blocks only fully-exhausted users;
 	// actual cost deduction happens post-response via DeductSpend.
-	if p.users != nil {
-		// Use userOverride (from X-User-Id) when present, so candela-local
-		// users get budget-checked against *their* identity, not the SA's.
-		budgetUserID := userOverride
-		if budgetUserID == "" && caller != nil {
-			budgetUserID = caller.Email
-			if budgetUserID == "" {
-				budgetUserID = caller.ID
-			}
-		}
-		if budgetUserID != "" {
-			check, err := p.users.CheckBudget(r.Context(), budgetUserID, 0)
-			if err != nil {
-				slog.Warn("budget check failed, allowing request",
-					"user_id", budgetUserID, "error", err)
-			} else if !check.Allowed {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusPaymentRequired)
-				_, _ = w.Write([]byte(`{"error":{"message":"budget exhausted — contact your admin for a grant or budget increase","type":"insufficient_budget","code":402}}`))
-				slog.Info("blocked request: budget exhausted",
-					"user_id", budgetUserID,
-					"remaining_usd", check.RemainingUSD)
-				return
-			}
+	// Uses effectiveUserID so budget is checked against the real end-user,
+	// not the service account in team mode.
+	if p.users != nil && effectiveUserID != "" {
+		check, err := p.users.CheckBudget(r.Context(), effectiveUserID, 0)
+		if err != nil {
+			slog.Warn("budget check failed, allowing request",
+				"user_id", effectiveUserID, "error", err)
+		} else if !check.Allowed {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusPaymentRequired)
+			_, _ = w.Write([]byte(`{"error":{"message":"budget exhausted — contact your admin for a grant or budget increase","type":"insufficient_budget","code":402}}`))
+			slog.Info("blocked request: budget exhausted",
+				"user_id", effectiveUserID,
+				"remaining_usd", check.RemainingUSD)
+			return
 		}
 	}
 
@@ -458,9 +460,9 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	cbAllow := p.breakers[providerName].AllowRequest()
 
 	if isStreaming && resp.StatusCode == http.StatusOK {
-		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, userOverride, cbAllow)
+		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, cbAllow)
 	} else {
-		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, userOverride, cbAllow)
+		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, cbAllow)
 	}
 }
 
@@ -621,21 +623,21 @@ func (p *Proxy) handleStreamingResponse(
 // Both standard and streaming responses produce the same struct; the only
 // difference is how they parse the upstream response.
 type spanParams struct {
-	provider      Provider
-	model         string
-	sessionID     string
-	userOverride  string // end-user email from X-User-Id header (candela-local)
-	inputContent  string
-	outputContent string
-	inputTokens   int64
-	outputTokens  int64
-	startTime     time.Time
-	endTime       time.Time
-	status        storage.SpanStatus
-	ttfb          time.Duration
-	requestID     string
-	extraAttrs    map[string]string // streaming-specific, status code, etc.
-	namePrefix    string            // e.g. "openai.chat" or "openai.chat.stream"
+	provider        Provider
+	model           string
+	sessionID       string
+	effectiveUserID string // resolved end-user identity (X-User-Id > auth email > auth UID)
+	inputContent    string
+	outputContent   string
+	inputTokens     int64
+	outputTokens    int64
+	startTime       time.Time
+	endTime         time.Time
+	status          storage.SpanStatus
+	ttfb            time.Duration
+	requestID       string
+	extraAttrs      map[string]string // streaming-specific, status code, etc.
+	namePrefix      string            // e.g. "openai.chat" or "openai.chat.stream"
 }
 
 // buildSpan constructs a storage.Span from parsed parameters and submits it.
@@ -675,18 +677,8 @@ func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 		Attributes: attrs,
 	}
 
-	// Set user ID for per-user attribution.
-	// Priority: (1) X-User-Id header from candela-local (end-user email),
-	// (2) auth context email, (3) auth context UID.
-	if params.userOverride != "" {
-		span.UserID = params.userOverride
-	} else if caller := auth.FromContext(ctx); caller != nil {
-		if caller.Email != "" {
-			span.UserID = strings.ToLower(caller.Email)
-		} else {
-			span.UserID = caller.ID
-		}
-	}
+	// Set user ID for per-user attribution (resolved once in handleProxy).
+	span.UserID = params.effectiveUserID
 
 	// Set session ID for conversation grouping.
 	span.SessionID = params.sessionID
@@ -756,20 +748,20 @@ func (p *Proxy) createSpan(
 	}
 
 	p.buildSpan(ctx, spanParams{
-		provider:      provider,
-		model:         model,
-		userOverride:  userOverride,
-		inputContent:  inputContent,
-		outputContent: outputContent,
-		inputTokens:   inputTokens,
-		outputTokens:  outputTokens,
-		startTime:     startTime,
-		endTime:       endTime,
-		status:        status,
-		ttfb:          ttfb,
-		requestID:     requestID,
-		sessionID:     sessionID,
-		namePrefix:    fmt.Sprintf("%s.chat", provider.Name),
+		provider:        provider,
+		model:           model,
+		effectiveUserID: userOverride,
+		inputContent:    inputContent,
+		outputContent:   outputContent,
+		inputTokens:     inputTokens,
+		outputTokens:    outputTokens,
+		startTime:       startTime,
+		endTime:         endTime,
+		status:          status,
+		ttfb:            ttfb,
+		requestID:       requestID,
+		sessionID:       sessionID,
+		namePrefix:      fmt.Sprintf("%s.chat", provider.Name),
 		extraAttrs: map[string]string{
 			"http.status": fmt.Sprintf("%d", statusCode),
 		},
@@ -790,20 +782,20 @@ func (p *Proxy) createStreamingSpan(
 	outputContent, inputTokens, outputTokens := extractStreamingUsage(provider.Name, streamData)
 
 	p.buildSpan(ctx, spanParams{
-		provider:      provider,
-		model:         model,
-		userOverride:  userOverride,
-		inputContent:  inputContent,
-		outputContent: outputContent,
-		inputTokens:   inputTokens,
-		outputTokens:  outputTokens,
-		startTime:     startTime,
-		endTime:       endTime,
-		status:        storage.SpanStatusOK,
-		ttfb:          ttfb,
-		requestID:     requestID,
-		sessionID:     sessionID,
-		namePrefix:    fmt.Sprintf("%s.chat.stream", provider.Name),
+		provider:        provider,
+		model:           model,
+		effectiveUserID: userOverride,
+		inputContent:    inputContent,
+		outputContent:   outputContent,
+		inputTokens:     inputTokens,
+		outputTokens:    outputTokens,
+		startTime:       startTime,
+		endTime:         endTime,
+		status:          storage.SpanStatusOK,
+		ttfb:            ttfb,
+		requestID:       requestID,
+		sessionID:       sessionID,
+		namePrefix:      fmt.Sprintf("%s.chat.stream", provider.Name),
 		extraAttrs: map[string]string{
 			"proxy.streaming": "true",
 			"llm.ttft_ms":     fmt.Sprintf("%d", ttft.Milliseconds()),

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -374,6 +374,7 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		WHERE project_id = @projectID
 		  AND start_time >= @startTime
 		  AND start_time <= @endTime
+		  AND (@userID = '' OR user_id = @userID)
 		GROUP BY trace_id
 		ORDER BY earliest DESC
 		LIMIT @pageSize
@@ -384,6 +385,7 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		{Name: "projectID", Value: tq.ProjectID},
 		{Name: "startTime", Value: tq.StartTime},
 		{Name: "endTime", Value: tq.EndTime},
+		{Name: "userID", Value: tq.UserID},
 		{Name: "pageSize", Value: tq.PageSize},
 	}
 
@@ -475,6 +477,7 @@ func (s *Store) SearchSpans(ctx context.Context, sq storage.SpanQuery) (*storage
 		  AND (@kind = 0 OR kind = @kind)
 		  AND (@model = '' OR gen_ai_model = @model)
 		  AND (@nameContains = '' OR name LIKE CONCAT('%%', @escapedName, '%%'))
+		  AND (@userID = '' OR user_id = @userID)
 		ORDER BY start_time DESC
 		LIMIT @pageSize
 	`, quoteTable(s.tableID))
@@ -488,6 +491,7 @@ func (s *Store) SearchSpans(ctx context.Context, sq storage.SpanQuery) (*storage
 		{Name: "model", Value: sq.Model},
 		{Name: "nameContains", Value: sq.NameContains},
 		{Name: "escapedName", Value: storage.EscapeLike(sq.NameContains)},
+		{Name: "userID", Value: sq.UserID},
 		{Name: "pageSize", Value: sq.PageSize},
 	}
 

--- a/pkg/storage/duckdb/duckdb.go
+++ b/pkg/storage/duckdb/duckdb.go
@@ -164,7 +164,7 @@ func (s *Store) GetTrace(ctx context.Context, traceID string) (*storage.Trace, e
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes, session_id
+			gen_ai_input_content, gen_ai_output_content, attributes, user_id, session_id
 		FROM spans WHERE trace_id = ? ORDER BY start_time ASC
 	`, traceID)
 	if err != nil {
@@ -250,18 +250,20 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes, session_id
+			gen_ai_input_content, gen_ai_output_content, attributes, user_id, session_id
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = 0 OR kind = ?)
 			AND (? = '' OR gen_ai_model = ?)
 			AND (? = '' OR name LIKE '%' || ? || '%' ESCAPE '\')
+			AND (? = '' OR user_id = ?)
 		ORDER BY start_time DESC
 		LIMIT ?
 	`, q.ProjectID, q.StartTime, q.EndTime,
 		int(q.Kind), int(q.Kind),
 		q.Model, q.Model,
 		q.NameContains, storage.EscapeLike(q.NameContains),
+		q.UserID, q.UserID,
 		q.PageSize,
 	)
 	if err != nil {
@@ -410,6 +412,7 @@ func scanSpans(rows *sql.Rows) ([]storage.Span, error) {
 			&genAI.CostUSD, &genAI.Temperature, &genAI.MaxTokens,
 			&genAI.InputContent, &genAI.OutputContent,
 			&attrsAny,
+			&span.UserID,
 			&span.SessionID,
 		)
 		if err != nil {

--- a/pkg/storage/duckdb/user_scoping_test.go
+++ b/pkg/storage/duckdb/user_scoping_test.go
@@ -1,0 +1,332 @@
+package duckdb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// testSpanWithUser creates a test span with a specific user_id.
+func testSpanWithUser(id, traceID, userID string, kind storage.SpanKind, model string) storage.Span {
+	sp := testSpan(id, traceID, kind, model)
+	sp.UserID = userID
+	return sp
+}
+
+// TestGetTrace_UserID_RoundTrip verifies that GetTrace returns spans with
+// UserID populated. This is critical: the handler's authorization gate in
+// traceUserID() relies on this field being set in the returned spans.
+func TestGetTrace_UserID_RoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	span := testSpanWithUser("s1", "t1", "alice@example.com", storage.SpanKindLLM, "gpt-4o")
+	if err := store.IngestSpans(ctx, []storage.Span{span}); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	trace, err := store.GetTrace(ctx, "t1")
+	if err != nil {
+		t.Fatalf("get trace: %v", err)
+	}
+	if len(trace.Spans) != 1 {
+		t.Fatalf("span count = %d, want 1", len(trace.Spans))
+	}
+	if trace.Spans[0].UserID != "alice@example.com" {
+		t.Errorf("UserID = %q, want %q (auth gate depends on this!)",
+			trace.Spans[0].UserID, "alice@example.com")
+	}
+}
+
+func TestQueryTraces_UserScoping(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().Truncate(time.Microsecond)
+
+	spans := []storage.Span{
+		testSpanWithUser("s1", "trace-alice", "alice@example.com", storage.SpanKindLLM, "gpt-4o"),
+		testSpanWithUser("s2", "trace-bob", "bob@example.com", storage.SpanKindLLM, "gpt-4o"),
+		testSpanWithUser("s3", "trace-alice2", "alice@example.com", storage.SpanKindLLM, "gemini-2.0"),
+	}
+	// Spread in time for deterministic ordering.
+	spans[0].StartTime = now.Add(-3 * time.Second)
+	spans[0].EndTime = now.Add(-2 * time.Second)
+	spans[1].StartTime = now.Add(-2 * time.Second)
+	spans[1].EndTime = now.Add(-1 * time.Second)
+	spans[2].StartTime = now.Add(-1 * time.Second)
+	spans[2].EndTime = now
+
+	if err := store.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	timeRange := storage.TraceQuery{
+		ProjectID: "proj-test",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  50,
+	}
+
+	t.Run("admin sees all traces", func(t *testing.T) {
+		q := timeRange
+		q.UserID = "" // empty = admin
+		result, err := store.QueryTraces(ctx, q)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(result.Traces) != 3 {
+			t.Errorf("trace count = %d, want 3 (admin sees all)", len(result.Traces))
+		}
+	})
+
+	t.Run("alice sees only her traces", func(t *testing.T) {
+		q := timeRange
+		q.UserID = "alice@example.com"
+		result, err := store.QueryTraces(ctx, q)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(result.Traces) != 2 {
+			t.Fatalf("trace count = %d, want 2 (alice's traces)", len(result.Traces))
+		}
+		for _, tr := range result.Traces {
+			if tr.TraceID != "trace-alice" && tr.TraceID != "trace-alice2" {
+				t.Errorf("unexpected trace %q in alice's results", tr.TraceID)
+			}
+		}
+	})
+
+	t.Run("bob sees only his trace", func(t *testing.T) {
+		q := timeRange
+		q.UserID = "bob@example.com"
+		result, err := store.QueryTraces(ctx, q)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(result.Traces) != 1 {
+			t.Fatalf("trace count = %d, want 1 (bob's trace)", len(result.Traces))
+		}
+		if result.Traces[0].TraceID != "trace-bob" {
+			t.Errorf("trace = %q, want trace-bob", result.Traces[0].TraceID)
+		}
+	})
+
+	t.Run("unknown user sees nothing", func(t *testing.T) {
+		q := timeRange
+		q.UserID = "nobody@example.com"
+		result, err := store.QueryTraces(ctx, q)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(result.Traces) != 0 {
+			t.Errorf("trace count = %d, want 0 (unknown user)", len(result.Traces))
+		}
+	})
+}
+
+func TestSearchSpans_UserScoping(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().Truncate(time.Microsecond)
+
+	spans := []storage.Span{
+		testSpanWithUser("s1", "t1", "alice@example.com", storage.SpanKindLLM, "gpt-4o"),
+		testSpanWithUser("s2", "t2", "bob@example.com", storage.SpanKindLLM, "gpt-4o"),
+		testSpanWithUser("s3", "t3", "alice@example.com", storage.SpanKindTool, ""),
+	}
+	for i := range spans {
+		spans[i].StartTime = now
+		spans[i].EndTime = now.Add(100 * time.Millisecond)
+	}
+
+	if err := store.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	baseQ := storage.SpanQuery{
+		ProjectID: "proj-test",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+	}
+
+	t.Run("admin sees all spans", func(t *testing.T) {
+		q := baseQ
+		q.UserID = ""
+		result, err := store.SearchSpans(ctx, q)
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(result.Spans) != 3 {
+			t.Errorf("span count = %d, want 3", len(result.Spans))
+		}
+	})
+
+	t.Run("alice sees only her spans", func(t *testing.T) {
+		q := baseQ
+		q.UserID = "alice@example.com"
+		result, err := store.SearchSpans(ctx, q)
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(result.Spans) != 2 {
+			t.Errorf("span count = %d, want 2 (alice's spans)", len(result.Spans))
+		}
+	})
+
+	t.Run("bob sees only his span", func(t *testing.T) {
+		q := baseQ
+		q.UserID = "bob@example.com"
+		result, err := store.SearchSpans(ctx, q)
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(result.Spans) != 1 {
+			t.Errorf("span count = %d, want 1 (bob's span)", len(result.Spans))
+		}
+	})
+
+	t.Run("user scoping combines with kind filter", func(t *testing.T) {
+		q := baseQ
+		q.UserID = "alice@example.com"
+		q.Kind = storage.SpanKindLLM
+		result, err := store.SearchSpans(ctx, q)
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(result.Spans) != 1 {
+			t.Errorf("span count = %d, want 1 (alice's LLM span only)", len(result.Spans))
+		}
+	})
+}
+
+func TestGetUsageSummary_UserScoping(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().Truncate(time.Microsecond)
+
+	spans := []storage.Span{
+		testSpanWithUser("s1", "t1", "alice@example.com", storage.SpanKindLLM, "gpt-4o"),
+		testSpanWithUser("s2", "t2", "bob@example.com", storage.SpanKindLLM, "gpt-4o"),
+	}
+	// Give bob a different cost.
+	spans[1].GenAI.CostUSD = 0.005
+	for i := range spans {
+		spans[i].StartTime = now
+		spans[i].EndTime = now.Add(100 * time.Millisecond)
+	}
+
+	if err := store.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	baseQ := storage.UsageQuery{
+		ProjectID: "proj-test",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+	}
+
+	t.Run("admin sees total cost", func(t *testing.T) {
+		q := baseQ
+		q.UserID = ""
+		summary, err := store.GetUsageSummary(ctx, q)
+		if err != nil {
+			t.Fatalf("usage: %v", err)
+		}
+		if summary.TotalSpans != 2 {
+			t.Errorf("TotalSpans = %d, want 2", summary.TotalSpans)
+		}
+	})
+
+	t.Run("alice sees only her usage", func(t *testing.T) {
+		q := baseQ
+		q.UserID = "alice@example.com"
+		summary, err := store.GetUsageSummary(ctx, q)
+		if err != nil {
+			t.Fatalf("usage: %v", err)
+		}
+		if summary.TotalSpans != 1 {
+			t.Errorf("TotalSpans = %d, want 1", summary.TotalSpans)
+		}
+		if summary.TotalCostUSD < 0.0009 || summary.TotalCostUSD > 0.0011 {
+			t.Errorf("TotalCostUSD = %f, want ~0.001 (alice only)", summary.TotalCostUSD)
+		}
+	})
+}
+
+func TestGetModelBreakdown_UserScoping(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().Truncate(time.Microsecond)
+
+	spans := []storage.Span{
+		testSpanWithUser("s1", "t1", "alice@example.com", storage.SpanKindLLM, "gpt-4o"),
+		testSpanWithUser("s2", "t2", "bob@example.com", storage.SpanKindLLM, "gemini-2.0"),
+		testSpanWithUser("s3", "t3", "alice@example.com", storage.SpanKindLLM, "gemini-2.0"),
+	}
+	for i := range spans {
+		spans[i].StartTime = now
+		spans[i].EndTime = now.Add(100 * time.Millisecond)
+	}
+
+	if err := store.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	baseQ := storage.UsageQuery{
+		ProjectID: "proj-test",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+	}
+
+	t.Run("admin sees all models", func(t *testing.T) {
+		q := baseQ
+		q.UserID = ""
+		models, err := store.GetModelBreakdown(ctx, q)
+		if err != nil {
+			t.Fatalf("model breakdown: %v", err)
+		}
+		if len(models) != 2 {
+			t.Errorf("model count = %d, want 2 (gpt-4o + gemini-2.0)", len(models))
+		}
+	})
+
+	t.Run("alice sees her models", func(t *testing.T) {
+		q := baseQ
+		q.UserID = "alice@example.com"
+		models, err := store.GetModelBreakdown(ctx, q)
+		if err != nil {
+			t.Fatalf("model breakdown: %v", err)
+		}
+		if len(models) != 2 {
+			t.Errorf("model count = %d, want 2 (alice uses both models)", len(models))
+		}
+		byModel := make(map[string]storage.ModelUsage)
+		for _, m := range models {
+			byModel[m.Model] = m
+		}
+		if byModel["gpt-4o"].CallCount != 1 {
+			t.Errorf("alice gpt-4o calls = %d, want 1", byModel["gpt-4o"].CallCount)
+		}
+	})
+
+	t.Run("bob sees only gemini", func(t *testing.T) {
+		q := baseQ
+		q.UserID = "bob@example.com"
+		models, err := store.GetModelBreakdown(ctx, q)
+		if err != nil {
+			t.Fatalf("model breakdown: %v", err)
+		}
+		if len(models) != 1 {
+			t.Fatalf("model count = %d, want 1 (bob only uses gemini)", len(models))
+		}
+		if models[0].Model != "gemini-2.0" {
+			t.Errorf("model = %q, want gemini-2.0", models[0].Model)
+		}
+	})
+}

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -126,8 +126,8 @@ func (s *Store) IngestSpans(ctx context.Context, spans []storage.Span) error {
 		start_time, end_time, duration_ns, project_id, environment, service_name,
 		gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 		gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-		gen_ai_input_content, gen_ai_output_content, attributes_json, session_id
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("preparing stmt: %w", err)
 	}
@@ -156,6 +156,7 @@ func (s *Store) IngestSpans(ctx context.Context, spans []storage.Span) error {
 			genAI.CostUSD, genAI.Temperature, genAI.MaxTokens,
 			genAI.InputContent, genAI.OutputContent,
 			string(attrsJSON),
+			span.UserID,
 			span.SessionID,
 		)
 		if err != nil {
@@ -172,7 +173,7 @@ func (s *Store) GetTrace(ctx context.Context, traceID string) (*storage.Trace, e
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes_json, session_id
+			gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id
 		FROM spans WHERE trace_id = ? ORDER BY start_time ASC
 	`, traceID)
 	if err != nil {
@@ -211,10 +212,11 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 			MAX(status) as status
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+			AND (? = '' OR user_id = ?)
 		GROUP BY trace_id
 		ORDER BY MIN(start_time) DESC
 		LIMIT ?
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.PageSize)
+	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID, q.PageSize)
 	if err != nil {
 		return nil, fmt.Errorf("querying traces: %w", err)
 	}
@@ -259,12 +261,13 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes_json, session_id
+			gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = 0 OR kind = ?)
 			AND (? = '' OR gen_ai_model = ?)
 			AND (? = '' OR name LIKE '%' || ? || '%' ESCAPE '\')
+			AND (? = '' OR user_id = ?)
 		ORDER BY start_time DESC
 		LIMIT ?
 	`, q.ProjectID,
@@ -272,6 +275,7 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 		int(q.Kind), int(q.Kind),
 		q.Model, q.Model,
 		q.NameContains, storage.EscapeLike(q.NameContains),
+		q.UserID, q.UserID,
 		q.PageSize,
 	)
 	if err != nil {
@@ -303,7 +307,8 @@ func (s *Store) GetUsageSummary(ctx context.Context, q storage.UsageQuery) (*sto
 				ELSE 0 END
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano)).Scan(
+			AND (? = '' OR user_id = ?)
+	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID).Scan(
 		&summary.TotalTraces, &summary.TotalSpans, &summary.TotalLLMCalls,
 		&summary.TotalInputTokens, &summary.TotalOutputTokens, &summary.TotalCostUSD,
 		&summary.AvgLatencyMs, &summary.ErrorRate,
@@ -322,9 +327,10 @@ func (s *Store) GetModelBreakdown(ctx context.Context, q storage.UsageQuery) ([]
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND gen_ai_model != ''
+			AND (? = '' OR user_id = ?)
 		GROUP BY gen_ai_model, gen_ai_provider
 		ORDER BY SUM(gen_ai_cost_usd) DESC
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano))
+	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID)
 	if err != nil {
 		return nil, fmt.Errorf("querying model breakdown: %w", err)
 	}
@@ -416,6 +422,7 @@ func scanSpans(rows *sql.Rows) ([]storage.Span, error) {
 			&genAI.CostUSD, &genAI.Temperature, &genAI.MaxTokens,
 			&genAI.InputContent, &genAI.OutputContent,
 			&attrsJSON,
+			&span.UserID,
 			&span.SessionID,
 		)
 		if err != nil {

--- a/pkg/storage/sqlite/user_scoping_test.go
+++ b/pkg/storage/sqlite/user_scoping_test.go
@@ -1,0 +1,265 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// testSpanWithUser creates a test span with a specific user_id.
+func testSpanWithUser(id, traceID, userID string) storage.Span {
+	now := time.Now().Truncate(time.Millisecond)
+	return storage.Span{
+		SpanID:      id,
+		TraceID:     traceID,
+		Name:        "test." + id,
+		Kind:        storage.SpanKindLLM,
+		Status:      storage.SpanStatusOK,
+		StartTime:   now,
+		EndTime:     now.Add(100 * time.Millisecond),
+		Duration:    100 * time.Millisecond,
+		ProjectID:   "proj-test",
+		Environment: "test",
+		UserID:      userID,
+		GenAI: &storage.GenAIAttributes{
+			Model:        "gpt-4o",
+			Provider:     "openai",
+			InputTokens:  100,
+			OutputTokens: 50,
+			TotalTokens:  150,
+			CostUSD:      0.001,
+		},
+	}
+}
+
+func newTestSQLiteStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := New(Config{Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestQueryTraces_UserScoping(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	now := time.Now().Truncate(time.Millisecond)
+
+	spans := []storage.Span{
+		testSpanWithUser("s1", "trace-alice", "alice@example.com"),
+		testSpanWithUser("s2", "trace-bob", "bob@example.com"),
+		testSpanWithUser("s3", "trace-alice2", "alice@example.com"),
+	}
+	spans[0].StartTime = now.Add(-3 * time.Second)
+	spans[0].EndTime = now.Add(-2 * time.Second)
+	spans[1].StartTime = now.Add(-2 * time.Second)
+	spans[1].EndTime = now.Add(-1 * time.Second)
+	spans[2].StartTime = now.Add(-1 * time.Second)
+	spans[2].EndTime = now
+
+	if err := store.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	timeRange := storage.TraceQuery{
+		ProjectID: "proj-test",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  50,
+	}
+
+	t.Run("admin sees all", func(t *testing.T) {
+		q := timeRange
+		q.UserID = ""
+		result, err := store.QueryTraces(ctx, q)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(result.Traces) != 3 {
+			t.Errorf("trace count = %d, want 3", len(result.Traces))
+		}
+	})
+
+	t.Run("alice sees 2", func(t *testing.T) {
+		q := timeRange
+		q.UserID = "alice@example.com"
+		result, err := store.QueryTraces(ctx, q)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(result.Traces) != 2 {
+			t.Errorf("trace count = %d, want 2", len(result.Traces))
+		}
+	})
+
+	t.Run("bob sees 1", func(t *testing.T) {
+		q := timeRange
+		q.UserID = "bob@example.com"
+		result, err := store.QueryTraces(ctx, q)
+		if err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		if len(result.Traces) != 1 {
+			t.Errorf("trace count = %d, want 1", len(result.Traces))
+		}
+	})
+}
+
+func TestSearchSpans_UserScoping(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	now := time.Now().Truncate(time.Millisecond)
+
+	spans := []storage.Span{
+		testSpanWithUser("s1", "t1", "alice@example.com"),
+		testSpanWithUser("s2", "t2", "bob@example.com"),
+	}
+	for i := range spans {
+		spans[i].StartTime = now
+		spans[i].EndTime = now.Add(100 * time.Millisecond)
+	}
+
+	if err := store.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	t.Run("alice sees only her spans", func(t *testing.T) {
+		result, err := store.SearchSpans(ctx, storage.SpanQuery{
+			ProjectID: "proj-test",
+			StartTime: now.Add(-10 * time.Second),
+			EndTime:   now.Add(10 * time.Second),
+			UserID:    "alice@example.com",
+		})
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(result.Spans) != 1 {
+			t.Errorf("span count = %d, want 1", len(result.Spans))
+		}
+	})
+
+	t.Run("admin sees all spans", func(t *testing.T) {
+		result, err := store.SearchSpans(ctx, storage.SpanQuery{
+			ProjectID: "proj-test",
+			StartTime: now.Add(-10 * time.Second),
+			EndTime:   now.Add(10 * time.Second),
+			UserID:    "",
+		})
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(result.Spans) != 2 {
+			t.Errorf("span count = %d, want 2", len(result.Spans))
+		}
+	})
+}
+
+func TestGetUsageSummary_UserScoping(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	now := time.Now().Truncate(time.Millisecond)
+
+	spans := []storage.Span{
+		testSpanWithUser("s1", "t1", "alice@example.com"),
+		testSpanWithUser("s2", "t2", "bob@example.com"),
+	}
+	for i := range spans {
+		spans[i].StartTime = now
+		spans[i].EndTime = now.Add(100 * time.Millisecond)
+	}
+
+	if err := store.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	t.Run("admin sees all", func(t *testing.T) {
+		summary, err := store.GetUsageSummary(ctx, storage.UsageQuery{
+			ProjectID: "proj-test",
+			StartTime: now.Add(-10 * time.Second),
+			EndTime:   now.Add(10 * time.Second),
+			UserID:    "",
+		})
+		if err != nil {
+			t.Fatalf("usage: %v", err)
+		}
+		if summary.TotalSpans != 2 {
+			t.Errorf("TotalSpans = %d, want 2", summary.TotalSpans)
+		}
+	})
+
+	t.Run("alice sees only hers", func(t *testing.T) {
+		summary, err := store.GetUsageSummary(ctx, storage.UsageQuery{
+			ProjectID: "proj-test",
+			StartTime: now.Add(-10 * time.Second),
+			EndTime:   now.Add(10 * time.Second),
+			UserID:    "alice@example.com",
+		})
+		if err != nil {
+			t.Fatalf("usage: %v", err)
+		}
+		if summary.TotalSpans != 1 {
+			t.Errorf("TotalSpans = %d, want 1", summary.TotalSpans)
+		}
+	})
+}
+
+func TestGetModelBreakdown_UserScoping(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	now := time.Now().Truncate(time.Millisecond)
+
+	spans := []storage.Span{
+		testSpanWithUser("s1", "t1", "alice@example.com"),
+		testSpanWithUser("s2", "t2", "bob@example.com"),
+	}
+	spans[1].GenAI.Model = "gemini-2.0"
+	for i := range spans {
+		spans[i].StartTime = now
+		spans[i].EndTime = now.Add(100 * time.Millisecond)
+	}
+
+	if err := store.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	t.Run("alice sees only gpt-4o", func(t *testing.T) {
+		models, err := store.GetModelBreakdown(ctx, storage.UsageQuery{
+			ProjectID: "proj-test",
+			StartTime: now.Add(-10 * time.Second),
+			EndTime:   now.Add(10 * time.Second),
+			UserID:    "alice@example.com",
+		})
+		if err != nil {
+			t.Fatalf("model breakdown: %v", err)
+		}
+		if len(models) != 1 {
+			t.Fatalf("model count = %d, want 1", len(models))
+		}
+		if models[0].Model != "gpt-4o" {
+			t.Errorf("model = %q, want gpt-4o", models[0].Model)
+		}
+	})
+
+	t.Run("admin sees both models", func(t *testing.T) {
+		models, err := store.GetModelBreakdown(ctx, storage.UsageQuery{
+			ProjectID: "proj-test",
+			StartTime: now.Add(-10 * time.Second),
+			EndTime:   now.Add(10 * time.Second),
+			UserID:    "",
+		})
+		if err != nil {
+			t.Fatalf("model breakdown: %v", err)
+		}
+		if len(models) != 2 {
+			t.Errorf("model count = %d, want 2", len(models))
+		}
+	})
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -167,6 +167,7 @@ type SpanQuery struct {
 	NameContains string
 	PageSize     int
 	PageToken    string
+	UserID       string // Filter by user (empty = all, for admins)
 }
 
 // SpanResult is the paginated result of a span query.


### PR DESCRIPTION
## Closes #89

### Problem

Non-admin developers could view **any** trace if they had the trace ID, see **all** users' spans via SearchSpans, and see aggregate usage/model data for the entire org on the dashboard. This was a cross-tenant data leakage issue.

### Root Cause

The `GetTrace` and `SearchSpans` handlers had **zero user-scoping**. At the storage layer, the `user_id` field was inconsistently filtered (or not filtered at all) across the three backends. SQLite was the worst — it was not even **writing** `user_id` to disk.

### What This PR Does

**14 bugs fixed** across 3 layers:

#### Handler Layer
- **`GetTrace`**: Authorization gate — non-admin users can only view their own traces. Returns `PermissionDenied` for others' traces. Legacy traces (no `user_id`) allowed through.
- **`SearchSpans`**: Now passes `scopeUserID()` into the new `SpanQuery.UserID` field.

#### Storage Interface
- Added `UserID string` to `SpanQuery` struct (was missing entirely).

#### BigQuery
- `QueryTraces`: Added `AND (@userID = '' OR user_id = @userID)` filter.
- `SearchSpans`: Added `AND (@userID = '' OR user_id = @userID)` filter.

#### DuckDB
- `SearchSpans`: Added user_id filter.
- `GetTrace` + `SearchSpans` SELECT: **Added `user_id` to column list** (was missing — auth gate was a no-op without this).
- `scanSpans`: Added `user_id` to scan targets.

#### SQLite (worst affected — 6 bugs)
- `IngestSpans`: **Was silently dropping `user_id`** — added to INSERT column list.
- `QueryTraces`, `SearchSpans`, `GetUsageSummary`, `GetModelBreakdown`: Added user_id filter.
- `GetTrace` + `SearchSpans` SELECT + `scanSpans`: Added `user_id` to SELECT and scan.

### New Helper
- `traceUserID()` — extracts owner from a trace's root span (or first span with `user_id`). Used by `GetTrace`'s authorization gate.

### Tests Added (30 new test cases)

| File | Tests |
|------|-------|
| `trace_handler_test.go` | 5 cases: `traceUserID` helper — root priority, child fallback, legacy, empty, conflicts |
| `duckdb/user_scoping_test.go` | 14 cases: `GetTrace_UserID_RoundTrip` (critical invariant), `QueryTraces`, `SearchSpans`, `GetUsageSummary`, `GetModelBreakdown` |
| `sqlite/user_scoping_test.go` | 11 cases: same coverage as DuckDB — verifying backend parity |

### Security Model

```
scopeUserID(ctx) → admin=""(see all) | developer="email@..."(filtered)
                                              ↓
                   Storage: WHERE (? = '' OR user_id = ?)
```

`GetTrace` uses a different pattern (fetch-then-check) because it queries by trace_id, not project+time range. The `traceUserID()` helper extracts ownership from the fetched spans.
