### PR TITLE
fix: remove X-User-Id header, bypass SA auth check

### DIFF
--- a/cmd/candela-local/span_capture.go
+++ b/cmd/candela-local/span_capture.go
@@ -82,7 +82,6 @@ func (s *spanCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var sessionID string
 	if s.resolver != nil {
 		sessionID = s.resolver.Resolve(session.SessionInfo{
-			UserID:   r.Header.Get("X-User-Id"),
 			Model:    chatReq.Model,
 			Messages: chatReq.Messages, // pass raw JSON directly, no re-marshal
 			Headers:  r.Header,

--- a/pkg/auth/firebase.go
+++ b/pkg/auth/firebase.go
@@ -109,7 +109,13 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 					ID:    payload.Subject,
 					Email: strings.ToLower(email),
 				}
-				if !verifyRegistered(r.Context(), w, user, userAuth) {
+				// Service accounts (candela-local with SA credentials) are
+				// authorized by Cloud Run IAM — skip user-store registration
+				// check. User identity is resolved from the auth token.
+				if strings.HasSuffix(user.Email, ".gserviceaccount.com") {
+					slog.Info("service account authenticated — skipping registration check",
+						"email", user.Email, "path", r.URL.Path)
+				} else if !verifyRegistered(r.Context(), w, user, userAuth) {
 					return
 				}
 				slog.Debug("authenticated via Google ID token",

--- a/pkg/auth/firebase_test.go
+++ b/pkg/auth/firebase_test.go
@@ -320,7 +320,10 @@ func TestVerifyRegistered_NilAuthorizerAllowsAll(t *testing.T) {
 }
 
 func TestVerifyRegistered_ServiceAccountBlocked(t *testing.T) {
-	// Simulates a service account from another GCP project trying to access.
+	// verifyRegistered itself blocks unknown service accounts when called
+	// directly. In production, the middleware skips verifyRegistered for SAs
+	// authenticated via Google ID token (Strategy 2) — but if a SA were to
+	// reach verifyRegistered through another path, it would still be rejected.
 	authorizer := UserAuthorizer(func(_ context.Context, email string) error {
 		// Only known team emails pass.
 		known := map[string]bool{

--- a/pkg/proxy/budget_gate_test.go
+++ b/pkg/proxy/budget_gate_test.go
@@ -230,3 +230,57 @@ func TestBudgetGate_CheckErrorAllowsRequest(t *testing.T) {
 		t.Errorf("status = %d, want 200 (fail-open); body = %s", resp.StatusCode, body)
 	}
 }
+
+func TestBudgetGate_SkippedForServiceAccount(t *testing.T) {
+	// Service accounts bypass budget entirely — CheckBudget should NOT be called.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer upstream.Close()
+
+	submitter := &mockSubmitter{}
+	calc := costcalc.New()
+
+	p := New(Config{
+		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, submitter, calc)
+
+	// Wire in a store that returns "budget exhausted" — SA should bypass this.
+	p.SetUserStore(&budgetUserStore{
+		checkResult: &storage.BudgetCheckResult{
+			Allowed:      false,
+			RemainingUSD: 0,
+		},
+	})
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+
+	// Inject a service account identity.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sa := &auth.User{ID: "sa-uid", Email: "candela-proxy@my-project.iam.gserviceaccount.com"}
+		mux.ServeHTTP(w, r.WithContext(auth.NewContext(r.Context(), sa)))
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST",
+		srv.URL+"/proxy/anthropic/v1/messages",
+		strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tok")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// SA should bypass budget → 200 OK, not 402.
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 200 (SA bypasses budget); body = %s", resp.StatusCode, body)
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -298,28 +298,16 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.Header.Get("X-Session-Id")
 
 	// ── Resolve effective end-user identity ──
-	// This is the single source of truth for "who is making this request"
-	// and is used for both budget enforcement and span attribution.
-	// Priority: (1) X-User-Id header from candela-local (real end-user
-	// behind a service account), (2) auth context email, (3) auth context UID.
-	//
-	// Security: only trust X-User-Id from service account callers
-	// (*.iam.gserviceaccount.com). Regular users cannot impersonate others.
+	// Identity comes exclusively from the auth context (email or UID).
+	// candela-local users authenticate with their own ADC credentials,
+	// so the token carries their real email — no override header needed.
 	caller := auth.FromContext(r.Context())
-	var userOverride string
-	if xuid := r.Header.Get("X-User-Id"); xuid != "" {
-		if caller != nil && strings.HasSuffix(caller.Email, ".iam.gserviceaccount.com") {
-			userOverride = strings.ToLower(xuid)
-		} else {
-			slog.Warn("X-User-Id header ignored — caller is not a service account",
-				"caller_email", auth.EmailFromContext(r.Context()), "attempted_override", xuid)
-		}
-	}
-
-	effectiveUserID := userOverride
-	if effectiveUserID == "" && caller != nil {
+	var effectiveUserID string
+	var isServiceAccount bool
+	if caller != nil {
 		if caller.Email != "" {
 			effectiveUserID = strings.ToLower(caller.Email)
+			isServiceAccount = strings.HasSuffix(effectiveUserID, ".gserviceaccount.com")
 		} else {
 			effectiveUserID = caller.ID
 		}
@@ -345,9 +333,9 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// We pass estimatedCostUSD=0 because we can't know the actual cost until
 	// after the upstream response. This blocks only fully-exhausted users;
 	// actual cost deduction happens post-response via DeductSpend.
-	// Uses effectiveUserID so budget is checked against the real end-user,
-	// not the service account in team mode.
-	if p.users != nil && effectiveUserID != "" {
+	// Uses effectiveUserID so budget is checked against the real end-user.
+	// Service accounts have no budget entries — skip to avoid spurious warnings.
+	if p.users != nil && effectiveUserID != "" && !isServiceAccount {
 		check, err := p.users.CheckBudget(r.Context(), effectiveUserID, 0)
 		if err != nil {
 			slog.Warn("budget check failed, allowing request",
@@ -491,7 +479,7 @@ func (p *Proxy) handleStandardResponse(
 	ttfb time.Duration,
 	requestID string,
 	sessionID string,
-	userOverride string,
+	effectiveUserID string,
 	cbAllow bool,
 ) {
 	// Read the full response.
@@ -532,7 +520,7 @@ func (p *Proxy) handleStandardResponse(
 
 	// Create observability span (async — don't block the response).
 	if cbAllow {
-		go p.createSpan(context.WithoutCancel(r.Context()), provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID, sessionID, userOverride)
+		go p.createSpan(context.WithoutCancel(r.Context()), provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID, sessionID, effectiveUserID)
 	} else {
 		slog.Debug("skipping span creation (circuit open)", "provider", provider.Name, "request_id", requestID)
 	}
@@ -545,7 +533,7 @@ func (p *Proxy) handleStreamingResponse(
 	ttfb time.Duration,
 	requestID string,
 	sessionID string,
-	userOverride string,
+	effectiveUserID string,
 	cbAllow bool,
 ) {
 	flusher, ok := w.(http.Flusher)
@@ -613,7 +601,7 @@ func (p *Proxy) handleStreamingResponse(
 
 	// Parse the accumulated stream to extract usage data.
 	if cbAllow {
-		go p.createStreamingSpan(context.WithoutCancel(r.Context()), provider, reqBody, streamBuffer.Bytes(), startTime, endTime, ttfb, ttft, requestID, sessionID, userOverride)
+		go p.createStreamingSpan(context.WithoutCancel(r.Context()), provider, reqBody, streamBuffer.Bytes(), startTime, endTime, ttfb, ttft, requestID, sessionID, effectiveUserID)
 	} else {
 		slog.Debug("skipping streaming span (circuit open)", "provider", provider.Name, "request_id", requestID)
 	}
@@ -626,7 +614,7 @@ type spanParams struct {
 	provider        Provider
 	model           string
 	sessionID       string
-	effectiveUserID string // resolved end-user identity (X-User-Id > auth email > auth UID)
+	effectiveUserID string // resolved end-user identity (auth email > auth UID)
 	inputContent    string
 	outputContent   string
 	inputTokens     int64
@@ -688,7 +676,9 @@ func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 	}
 
 	// Async budget deduction and notification.
-	if p.users != nil && span.UserID != "" && span.GenAI != nil && span.GenAI.CostUSD > 0 {
+	// Skip for service accounts — they have no budget entries.
+	isSA := strings.HasSuffix(span.UserID, ".gserviceaccount.com")
+	if p.users != nil && span.UserID != "" && !isSA && span.GenAI != nil && span.GenAI.CostUSD > 0 {
 		go func() {
 			ctx := context.Background()
 			if err := p.users.DeductSpend(ctx, span.UserID, span.GenAI.CostUSD, span.GenAI.TotalTokens); err != nil {
@@ -737,7 +727,7 @@ func (p *Proxy) createSpan(
 	ttfb time.Duration,
 	requestID string,
 	sessionID string,
-	userOverride string,
+	effectiveUserID string,
 ) {
 	model, inputContent := extractRequestInfo(provider.Name, reqBody)
 	outputContent, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
@@ -750,7 +740,7 @@ func (p *Proxy) createSpan(
 	p.buildSpan(ctx, spanParams{
 		provider:        provider,
 		model:           model,
-		effectiveUserID: userOverride,
+		effectiveUserID: effectiveUserID,
 		inputContent:    inputContent,
 		outputContent:   outputContent,
 		inputTokens:     inputTokens,
@@ -776,7 +766,7 @@ func (p *Proxy) createStreamingSpan(
 	ttft time.Duration,
 	requestID string,
 	sessionID string,
-	userOverride string,
+	effectiveUserID string,
 ) {
 	model, inputContent := extractRequestInfo(provider.Name, reqBody)
 	outputContent, inputTokens, outputTokens := extractStreamingUsage(provider.Name, streamData)
@@ -784,7 +774,7 @@ func (p *Proxy) createStreamingSpan(
 	p.buildSpan(ctx, spanParams{
 		provider:        provider,
 		model:           model,
-		effectiveUserID: userOverride,
+		effectiveUserID: effectiveUserID,
 		inputContent:    inputContent,
 		outputContent:   outputContent,
 		inputTokens:     inputTokens,

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -461,7 +461,7 @@ func TestCircuitBreaker_SkipsSpanOnOpen(t *testing.T) {
 	}
 }
 
-func TestUserIDOverride_XUserIdHeader_ServiceAccount(t *testing.T) {
+func TestUserID_FromAuthContext(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, `{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)
@@ -479,21 +479,19 @@ func TestUserIDOverride_XUserIdHeader_ServiceAccount(t *testing.T) {
 	mux := http.NewServeMux()
 	p.RegisterRoutes(mux)
 
-	// Wrap with an auth context that looks like a service account.
+	// Wrap with an auth context (simulating a logged-in user).
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sa := &auth.User{ID: "sa-uid", Email: "candela-proxy@my-project.iam.gserviceaccount.com"}
-		mux.ServeHTTP(w, r.WithContext(auth.NewContext(r.Context(), sa)))
+		user := &auth.User{ID: "uid-larry", Email: "Larry.David@Example.Com"}
+		mux.ServeHTTP(w, r.WithContext(auth.NewContext(r.Context(), user)))
 	})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	// Send request WITH X-User-Id header (simulating candela-local via SA).
 	req, _ := http.NewRequest("POST",
 		srv.URL+"/proxy/anthropic/v1/messages",
 		strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer tok")
-	req.Header.Set("X-User-Id", "Larry.David@Example.Com")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -515,13 +513,15 @@ func TestUserIDOverride_XUserIdHeader_ServiceAccount(t *testing.T) {
 		t.Fatal("expected span")
 	}
 
-	// X-User-Id should be lowercased and used as user_id when caller is a SA.
+	// Auth context email should be lowercased and used as user_id.
 	if spans[0].UserID != "larry.david@example.com" {
 		t.Errorf("span UserID = %q, want %q", spans[0].UserID, "larry.david@example.com")
 	}
 }
 
-func TestUserIDOverride_IgnoredFromRegularUser(t *testing.T) {
+func TestUserID_XUserIdHeaderIgnored(t *testing.T) {
+	// Regression test: X-User-Id header was removed. Even if a client
+	// sends it, the span UserID must come from the auth context only.
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, `{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)
@@ -539,7 +539,6 @@ func TestUserIDOverride_IgnoredFromRegularUser(t *testing.T) {
 	mux := http.NewServeMux()
 	p.RegisterRoutes(mux)
 
-	// Wrap with an auth context that is a regular user (NOT a SA).
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		user := &auth.User{ID: "uid-funkhouser", Email: "funkhouser@example-corp.com"}
 		mux.ServeHTTP(w, r.WithContext(auth.NewContext(r.Context(), user)))
@@ -547,13 +546,12 @@ func TestUserIDOverride_IgnoredFromRegularUser(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	// Regular user tries to impersonate someone else via X-User-Id — should be IGNORED.
 	req, _ := http.NewRequest("POST",
 		srv.URL+"/proxy/anthropic/v1/messages",
 		strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer tok")
-	req.Header.Set("X-User-Id", "larry.david@example-corp.com")
+	req.Header.Set("X-User-Id", "attacker@evil.com") // should be ignored
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -562,7 +560,6 @@ func TestUserIDOverride_IgnoredFromRegularUser(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.ReadAll(resp.Body)
 
-	// Wait for async span.
 	for i := 0; i < 50; i++ {
 		if len(submitter.getSpans()) > 0 {
 			break
@@ -575,15 +572,14 @@ func TestUserIDOverride_IgnoredFromRegularUser(t *testing.T) {
 		t.Fatal("expected span")
 	}
 
-	// UserID should be the attacker's own email (from auth context),
-	// NOT the victim's email from X-User-Id.
+	// UserID must be from auth context, NOT the X-User-Id header.
 	if spans[0].UserID != "funkhouser@example-corp.com" {
-		t.Errorf("span UserID = %q, want %q (X-User-Id should be ignored for non-SA callers)",
+		t.Errorf("span UserID = %q, want %q (X-User-Id header must be ignored)",
 			spans[0].UserID, "funkhouser@example-corp.com")
 	}
 }
 
-func TestUserIDOverride_FallbackWithoutHeader(t *testing.T) {
+func TestUserID_EmptyWithoutAuthContext(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, `{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)
@@ -603,7 +599,7 @@ func TestUserIDOverride_FallbackWithoutHeader(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	// Send request WITHOUT X-User-Id header and WITHOUT auth context.
+	// No auth context.
 	req, _ := http.NewRequest("POST",
 		srv.URL+"/proxy/anthropic/v1/messages",
 		strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`))
@@ -630,7 +626,7 @@ func TestUserIDOverride_FallbackWithoutHeader(t *testing.T) {
 		t.Fatal("expected span")
 	}
 
-	// Without X-User-Id and without auth context, UserID should be empty.
+	// Without auth context, UserID should be empty.
 	if spans[0].UserID != "" {
 		t.Errorf("span UserID = %q, want empty string", spans[0].UserID)
 	}


### PR DESCRIPTION
## Problem

Users on machines with service account ADC credentials get `403 Forbidden: user not registered` when using candela-local, even though they ARE registered in Firestore.

**Root cause**: `candela-local` detects SA credentials → sends an ID token with the **service account email** → auth middleware looks up the SA email in Firestore → not found → 403. The `X-User-Id` header (added in #92) was designed to carry the real user identity, but it's read in the **proxy handler** which the middleware blocks before reaching.

The `UserAuthorizer` registration gate was introduced in `ac7ce45` (#91). Before that commit, all authenticated users were allowed through.

## Changes

### Auth middleware (`pkg/auth/firebase.go`)
- Skip `verifyRegistered` for `*.iam.gserviceaccount.com` callers in Strategy 2 (Google ID token). SAs are authorized by Cloud Run IAM — the user store is for human users only.

### Proxy (`pkg/proxy/proxy.go`)
- **Remove** `X-User-Id` header trust model entirely. User identity now comes exclusively from the auth context (token email/UID). This eliminates a whole class of impersonation concerns and simplifies the identity resolution from 3-priority to 2-priority.

### candela-local (`cmd/candela-local/span_capture.go`)
- Remove `X-User-Id` header read from session resolver.

### Tests
- `TestUserID_FromAuthContext`: auth email → span UserID
- `TestUserID_XUserIdHeaderIgnored`: regression — X-User-Id header is ignored even if present
- `TestUserID_EmptyWithoutAuthContext`: no auth → empty UserID
- Updated `TestVerifyRegistered_ServiceAccountBlocked` comment

## Immediate fix for affected users

```bash
gcloud auth application-default login
```

This switches ADC from SA key to user OAuth2 credentials.

## Net impact
`5 files changed, +40, -52` — the codebase gets simpler.