### PR TITLE
fix(ci): use BSR for proto generation in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,11 +58,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate proto stubs
+      - name: Generate proto stubs (from BSR)
         env:
           BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
-        run: |
-          nix develop -c bash -c "cd proto && buf generate"
+        run: nix develop -c buf generate
 
       - name: Compute image tag
         id: meta


### PR DESCRIPTION
## Problem

The deploy workflow fails at step **Generate proto stubs** with:

```
bash: line 1: cd: proto: No such file or directory
```

**Failed run:** https://github.com/candelahq/candela/actions/runs/25294045680

The workflow runs `cd proto && buf generate`, but there is no local `proto/` directory. Protos are sourced from the BSR (`buf.build/candelahq/protos:v0.2.1`) via `buf.gen.yaml` at the repo root.

## Why buf generate is needed

The `/gen/` directory is gitignored — generated Go and TypeScript stubs are not committed. Cloud Build runs a plain `docker build`, and the Dockerfile relies on `COPY . .` to pick up the pre-generated stubs. So `buf generate` must run before `gcloud builds submit` to populate `gen/go/` and `ui/src/gen/`.

## Fix

Align `deploy.yml` with `ci.yml`, which already does this correctly:

```diff
-        run: |
-          nix develop -c bash -c "cd proto && buf generate"
+        run: nix develop -c buf generate
```

Runs `buf generate` from the repo root where `buf.gen.yaml` lives, pulling protos from the BSR.

## Notes

- The `deploy` job was also skipped because it depends on `build`
- FlakeHub cache auth warnings (401) are unrelated but worth investigating separately