### PR TITLE
fix: harden 12 critical security & reliability issues

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -146,8 +146,9 @@ func main() {
 	// Health check.
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		if err := reader.Ping(r.Context()); err != nil {
+			slog.Error("healthz: storage ping failed", "error", err)
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = fmt.Fprintf(w, `{"status": "error", "detail": %q}`, err.Error())
+			_, _ = fmt.Fprintln(w, `{"status": "unhealthy"}`)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -317,8 +318,10 @@ func main() {
 
 	// Wrap the mux with Firebase Auth middleware.
 	devMode := cfg.Auth.DevMode
-	if os.Getenv("CANDELA_DEV_MODE") == "true" {
-		devMode = true
+	// Guard: never allow dev mode on Cloud Run (K_SERVICE is always set by Cloud Run).
+	if devMode && os.Getenv("K_SERVICE") != "" {
+		slog.Error("auth.dev_mode=true is not allowed on Cloud Run — disabling")
+		devMode = false
 	}
 
 	// Initialize Firebase Admin SDK for token verification.
@@ -373,6 +376,8 @@ func main() {
 		Addr:              addr,
 		Handler:           h2c.NewHandler(authedMux, &http2.Server{}),
 		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      10 * time.Minute, // generous for streaming LLM responses
+		IdleTimeout:       120 * time.Second,
 	}
 
 	// Graceful shutdown.
@@ -408,8 +413,25 @@ func main() {
 			_, _ = fmt.Fprintln(w, `{"status":"ok","mode":"lmstudio"}`)
 		})
 
+		// Wrap LM Studio mux with the same auth + CORS middleware as the main
+		// server. Without this, port 1234 would be completely unauthenticated,
+		// allowing anyone on the network to make unlimited LLM API calls.
+		authedLmMux := auth.FirebaseAuthMiddleware(
+			corsMiddleware(lmMux, cfg.CORS.AllowedOrigins),
+			fbAuthClient,
+			cloudRunURL,
+			userAuth,
+			devMode,
+		)
+
 		lmAddr := fmt.Sprintf("%s:%d", cfg.Server.Host, lmPort)
-		lmSrv = &http.Server{Addr: lmAddr, Handler: lmMux, ReadHeaderTimeout: 10 * time.Second}
+		lmSrv = &http.Server{
+			Addr:              lmAddr,
+			Handler:           authedLmMux,
+			ReadHeaderTimeout: 10 * time.Second,
+			WriteTimeout:      10 * time.Minute,
+			IdleTimeout:       120 * time.Second,
+		}
 
 		go func() {
 			slog.Info("🖥️  LM Studio compat listener starting", "addr", lmAddr)

--- a/pkg/auth/firebase.go
+++ b/pkg/auth/firebase.go
@@ -38,6 +38,15 @@ type UserAuthorizer func(ctx context.Context, email string) error
 //
 // In dev mode (devMode=true), no validation is performed; a synthetic admin
 // user is injected instead.
+// selfServicePaths are ConnectRPC procedures that bypass the registration
+// gate. These allow auto-provisioning on first login (GetCurrentUser) and
+// self-service budget queries (GetMyBudget) without requiring admin
+// pre-provisioning. The handler itself is responsible for auth checks.
+var selfServicePaths = map[string]bool{
+	"/candela.v1.UserService/GetCurrentUser": true,
+	"/candela.v1.UserService/GetMyBudget":    true,
+}
+
 func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAudience string, userAuth UserAuthorizer, devMode bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip auth for health checks.
@@ -45,6 +54,11 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 			next.ServeHTTP(w, r)
 			return
 		}
+
+		// Self-service RPCs bypass the registration gate so that
+		// auto-provisioning (GetCurrentUser) works for first-time users.
+		// Auth token is still validated — only the user-store lookup is skipped.
+		isSelfService := selfServicePaths[r.URL.Path]
 
 		if devMode {
 			// Dev mode: inject a synthetic admin user.
@@ -78,7 +92,7 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 					ID:    decoded.UID,
 					Email: strings.ToLower(email),
 				}
-				if !verifyRegistered(r.Context(), w, user, userAuth) {
+				if !isSelfService && !verifyRegistered(r.Context(), w, user, userAuth) {
 					return
 				}
 				slog.Debug("authenticated via Firebase",
@@ -115,7 +129,7 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 				if strings.HasSuffix(user.Email, ".gserviceaccount.com") {
 					slog.Info("service account authenticated — skipping registration check",
 						"email", user.Email, "path", r.URL.Path)
-				} else if !verifyRegistered(r.Context(), w, user, userAuth) {
+				} else if !isSelfService && !verifyRegistered(r.Context(), w, user, userAuth) {
 					return
 				}
 				slog.Debug("authenticated via Google ID token",
@@ -131,7 +145,7 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 		// Validates via Google's userinfo endpoint.
 		user, err := validateAccessToken(r.Context(), token)
 		if err == nil {
-			if !verifyRegistered(r.Context(), w, user, userAuth) {
+			if !isSelfService && !verifyRegistered(r.Context(), w, user, userAuth) {
 				return
 			}
 			slog.Debug("authenticated via OAuth2 access token",

--- a/pkg/connecthandlers/trace_handler.go
+++ b/pkg/connecthandlers/trace_handler.go
@@ -103,6 +103,9 @@ func (h *TraceHandler) ListTraces(
 	if q.PageSize == 0 {
 		q.PageSize = 50
 	}
+	if q.PageSize > 500 {
+		q.PageSize = 500
+	}
 
 	result, err := h.store.QueryTraces(ctx, q)
 	if err != nil {
@@ -149,6 +152,12 @@ func (h *TraceHandler) SearchSpans(
 	if msg.Pagination != nil {
 		q.PageSize = int(msg.Pagination.PageSize)
 		q.PageToken = msg.Pagination.PageToken
+	}
+	if q.PageSize == 0 {
+		q.PageSize = 50
+	}
+	if q.PageSize > 500 {
+		q.PageSize = 500
 	}
 
 	result, err := h.store.SearchSpans(ctx, q)

--- a/pkg/proxy/ids.go
+++ b/pkg/proxy/ids.go
@@ -17,7 +17,8 @@ func generateTraceID() string {
 	if _, err := rand.Read(b); err != nil {
 		// Fallback: time-based ID is not cryptographically random but
 		// keeps the server alive instead of panicking.
-		return fmt.Sprintf("%016x%016x", time.Now().UnixNano(), time.Now().UnixNano()^0xdeadbeef)
+		now := time.Now().UnixNano()
+		return fmt.Sprintf("%016x%016x", now, now^0xdeadbeef)
 	}
 	return hex.EncodeToString(b)
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"log/slog"
 
@@ -360,6 +361,24 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// Uses effectiveUserID so budget is checked against the real end-user.
 	// Service accounts have no budget entries — skip to avoid spurious warnings.
 	if p.users != nil && effectiveUserID != "" && !isServiceAccount {
+		// ── Rate limiting ──
+		// Enforce per-user request velocity limits before budget check.
+		allowed, count, limit, rlErr := p.users.CheckRateLimit(r.Context(), effectiveUserID)
+		if rlErr != nil {
+			slog.Warn("rate limit check failed, allowing request",
+				"user_id", effectiveUserID, "error", rlErr)
+		} else if !allowed {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Retry-After", "60")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = fmt.Fprintf(w, `{"error":{"message":"rate limit exceeded (%d/%d requests/min)","type":"rate_limit_exceeded","code":429}}`, count, limit)
+			slog.Info("blocked request: rate limit exceeded",
+				"user_id", effectiveUserID,
+				"count", count, "limit", limit)
+			return
+		}
+
+		// ── Pre-flight budget check ──
 		check, err := p.users.CheckBudget(r.Context(), effectiveUserID, 0)
 		if err != nil {
 			slog.Warn("budget check failed, allowing request",
@@ -569,8 +588,14 @@ func (p *Proxy) handleStandardResponse(
 	_, _ = w.Write(clientBody)
 
 	// Create observability span (async — don't block the response).
+	// Use a bounded timeout (not WithoutCancel) to prevent goroutine leaks
+	// if downstream services (Firestore, storage) hang.
 	if cbAllow {
-		go p.createSpan(context.WithoutCancel(r.Context()), provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID, sessionID, effectiveUserID, traceCtx, proxySpanID)
+		spanCtx, spanCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		go func() {
+			defer spanCancel()
+			p.createSpan(spanCtx, provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID, sessionID, effectiveUserID, traceCtx, proxySpanID)
+		}()
 	} else {
 		slog.Debug("skipping span creation (circuit open)", "provider", provider.Name, "request_id", requestID)
 	}
@@ -616,6 +641,7 @@ func (p *Proxy) handleStreamingResponse(
 	buf := make([]byte, 4096)
 	var ttft time.Duration
 	isFirstChunk := true
+	streamCompleted := false // tracks whether stream ended normally
 
 	for {
 		n, err := resp.Body.Read(buf)
@@ -656,6 +682,9 @@ func (p *Proxy) handleStreamingResponse(
 			flusher.Flush()
 		}
 		if err != nil {
+			if err == io.EOF {
+				streamCompleted = true
+			}
 			break
 		}
 	}
@@ -663,8 +692,17 @@ func (p *Proxy) handleStreamingResponse(
 	endTime := time.Now()
 
 	// Parse the accumulated stream to extract usage data.
+	// Use bounded timeout to prevent goroutine leaks.
+	streamStatus := storage.SpanStatusOK
+	if !streamCompleted {
+		streamStatus = storage.SpanStatusError
+	}
 	if cbAllow {
-		go p.createStreamingSpan(context.WithoutCancel(r.Context()), provider, reqBody, streamBuffer.Bytes(), startTime, endTime, ttfb, ttft, requestID, sessionID, effectiveUserID, traceCtx, proxySpanID)
+		spanCtx, spanCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		go func() {
+			defer spanCancel()
+			p.createStreamingSpan(spanCtx, provider, reqBody, streamBuffer.Bytes(), startTime, endTime, ttfb, ttft, requestID, sessionID, effectiveUserID, streamStatus, traceCtx, proxySpanID)
+		}()
 	} else {
 		slog.Debug("skipping streaming span (circuit open)", "provider", provider.Name, "request_id", requestID)
 	}
@@ -844,6 +882,7 @@ func (p *Proxy) createStreamingSpan(
 	requestID string,
 	sessionID string,
 	effectiveUserID string,
+	streamStatus storage.SpanStatus,
 	traceCtx *traceContext,
 	proxySpanID string,
 ) {
@@ -860,7 +899,7 @@ func (p *Proxy) createStreamingSpan(
 		outputTokens:    outputTokens,
 		startTime:       startTime,
 		endTime:         endTime,
-		status:          storage.SpanStatusOK,
+		status:          streamStatus,
 		ttfb:            ttfb,
 		requestID:       requestID,
 		sessionID:       sessionID,
@@ -947,5 +986,11 @@ func truncate(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
-	return s[:maxLen] + "...[truncated]"
+	// Operate on runes to avoid cutting multi-byte UTF-8 characters mid-sequence,
+	// which would produce invalid strings rejected by BigQuery and protobuf.
+	if utf8.RuneCountInString(s) <= maxLen {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxLen]) + "...[truncated]"
 }

--- a/pkg/storage/duckdb/duckdb.go
+++ b/pkg/storage/duckdb/duckdb.go
@@ -177,7 +177,7 @@ func (s *Store) GetTrace(ctx context.Context, traceID string) (*storage.Trace, e
 		return nil, err
 	}
 	if len(spans) == 0 {
-		return nil, fmt.Errorf("trace %s not found", traceID)
+		return nil, fmt.Errorf("trace %s: %w", traceID, storage.ErrNotFound)
 	}
 
 	return buildTrace(traceID, spans), nil
@@ -354,14 +354,23 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, q storage.UsageQuery, li
 			COALESCE(SUM(gen_ai_total_tokens), 0)::BIGINT,
 			COALESCE(SUM(gen_ai_cost_usd), 0)::DOUBLE,
 			COALESCE(AVG(duration_ns), 0)::DOUBLE / 1000000.0,
-			COALESCE(MODE(gen_ai_model), '') AS top_model
+			COALESCE((
+				SELECT s2.gen_ai_model FROM spans s2
+				WHERE s2.user_id = spans.user_id
+					AND s2.project_id = ? AND s2.start_time >= ? AND s2.start_time <= ?
+					AND s2.gen_ai_model != ''
+				GROUP BY s2.gen_ai_model
+				ORDER BY SUM(s2.gen_ai_cost_usd) DESC
+				LIMIT 1
+			), '') AS top_model
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND user_id != ''
 		GROUP BY user_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
-	`, q.ProjectID, q.StartTime, q.EndTime, limit)
+	`, q.ProjectID, q.StartTime, q.EndTime,
+		q.ProjectID, q.StartTime, q.EndTime, limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying user leaderboard: %w", err)
 	}

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -186,7 +186,7 @@ func (s *Store) GetTrace(ctx context.Context, traceID string) (*storage.Trace, e
 		return nil, err
 	}
 	if len(spans) == 0 {
-		return nil, fmt.Errorf("trace %s not found", traceID)
+		return nil, fmt.Errorf("trace %s: %w", traceID, storage.ErrNotFound)
 	}
 
 	return buildTrace(traceID, spans), nil
@@ -363,14 +363,23 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, q storage.UsageQuery, li
 			COALESCE(SUM(gen_ai_total_tokens), 0),
 			COALESCE(SUM(gen_ai_cost_usd), 0),
 			COALESCE(AVG(duration_ns), 0) / 1000000.0,
-			COALESCE(MAX(gen_ai_model), '') AS top_model
+			COALESCE((
+				SELECT s2.gen_ai_model FROM spans s2
+				WHERE s2.user_id = spans.user_id
+					AND s2.project_id = ? AND s2.start_time >= ? AND s2.start_time <= ?
+					AND s2.gen_ai_model != ''
+				GROUP BY s2.gen_ai_model
+				ORDER BY SUM(s2.gen_ai_cost_usd) DESC
+				LIMIT 1
+			), '') AS top_model
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND user_id != ''
 		GROUP BY user_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)
+	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+		q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying user leaderboard: %w", err)
 	}

--- a/rust/bins/candela-sidecar/src/main.rs
+++ b/rust/bins/candela-sidecar/src/main.rs
@@ -145,10 +145,11 @@ mod tests {
 
     #[test]
     fn env_or_returns_env_when_set() {
-        // SAFETY: This test runs single-threaded; no other threads read this var.
-        unsafe { env::set_var("CANDELA_TEST_ENV_OR", "custom_value") };
-        let result = env_or("CANDELA_TEST_ENV_OR", "fallback");
-        assert_eq!(result, "custom_value");
-        unsafe { env::remove_var("CANDELA_TEST_ENV_OR") };
+        // Test env_or logic without mutating global state:
+        // env::var succeeds → env_or returns its value (not the default).
+        // We rely on PATH always being set on all platforms.
+        let result = env_or("PATH", "fallback");
+        assert_ne!(result, "fallback");
+        assert!(!result.is_empty());
     }
 }

--- a/rust/crates/candela-processor/src/lib.rs
+++ b/rust/crates/candela-processor/src/lib.rs
@@ -136,10 +136,14 @@ async fn flush(batch: &mut Vec<Span>, writers: &[Arc<dyn SpanWriter>], calc: &Co
     }
 
     // Fan-out to all sinks in parallel.
+    // Use Arc<[Span]> to share the batch across tasks without cloning —
+    // avoids expensive allocations when spans contain large content strings.
+    let count = batch.len();
+    let shared_spans: Arc<[Span]> = Arc::from(std::mem::take(batch).into_boxed_slice());
     let mut handles = Vec::with_capacity(writers.len());
     for writer in writers {
-        let spans = batch.clone();
-        let writer = writer.clone();
+        let spans = Arc::clone(&shared_spans);
+        let writer = Arc::clone(writer);
         handles.push(tokio::spawn(async move {
             if let Err(e) = writer.ingest_spans(&spans).await {
                 error!(error = %e, count = spans.len(), "failed to flush spans");
@@ -151,9 +155,8 @@ async fn flush(batch: &mut Vec<Span>, writers: &[Arc<dyn SpanWriter>], calc: &Co
     }
 
     debug!(
-        count = batch.len(),
+        count = count,
         sinks = writers.len(),
         "flushed spans to storage"
     );
-    batch.clear();
 }


### PR DESCRIPTION
## Summary

Addresses 12 critical issues identified during a comprehensive security audit of the Candela codebase.

## Changes

### 🔴 Security (4 fixes)
- **#1 — LM Studio listener auth**: Port 1234 was completely unauthenticated. Now wrapped with same `FirebaseAuthMiddleware` + CORS as main server.
- **#2 — Rate limiting enforced**: `CheckRateLimit()` was implemented in Firestore but never called. Now enforced before budget check, returning HTTP 429 with `Retry-After`.
- **#9 — Dev mode guard**: Removed `CANDELA_DEV_MODE` env var override. Added Cloud Run guard (`K_SERVICE` check) to prevent dev mode in production.
- **#18 — Auto-provisioning fix**: `GetCurrentUser` and `GetMyBudget` exempted from registration gate so first-time user auto-provisioning actually works.

### ⚡ Reliability (4 fixes)
- **#4 — Bounded goroutine lifetime**: Replaced `context.WithoutCancel` with `context.WithTimeout(30s)` in span creation goroutines. Prevents goroutine leaks when Firestore hangs.
- **#10 — Streaming status accuracy**: Streaming spans now correctly report `SpanStatusError` on mid-stream failures (connection drops) instead of always `SpanStatusOK`.
- **#11 — PageSize cap**: `ListTraces` and `SearchSpans` now cap `PageSize` at 500 to prevent unbounded queries.
- **#19 — Server timeouts**: Added `WriteTimeout: 10min` and `IdleTimeout: 2min` to both main and LM Studio servers.

### 🛡️ Data Integrity (3 fixes)
- **#6 — ErrNotFound contract**: Both SQLite and DuckDB `GetTrace()` now wrap `storage.ErrNotFound`.
- **#17 — TopModel consistency**: SQLite `MAX()` (lexicographic) and DuckDB `MODE()` (statistical) replaced with cost-based correlated subquery across both backends.
- **#20 — UTF-8 safe truncation**: `truncate()` now operates on runes to avoid corrupting multi-byte characters (breaks BigQuery/protobuf).

### 🔒 Information Disclosure (1 fix)
- **#7 — Health check sanitized**: `/healthz` returns generic `{"status":"unhealthy"}` instead of leaking internal error details.

## Testing
- ✅ `go build ./cmd/candela-server/...` — clean
- ✅ `go build ./cmd/candela-local/...` — clean
- ✅ `go test ./pkg/...` — all 22 packages pass
- ✅ `golangci-lint run ./...` — 0 issues
- ✅ Pre-commit hooks all pass