### PR TITLE
fix: resolve Today page user_id mismatch in dev mode

### DIFF
--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -4,12 +4,25 @@
 // The middleware extracts the email/uid and makes the user available via context.
 package auth
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 // User represents the authenticated identity for the current request.
 type User struct {
 	ID    string // Firebase UID or Google subject
 	Email string // Verified email claim
+}
+
+// EffectiveID returns the canonical user identifier used for span attribution
+// and budget tracking. Prefers lowercased email (matching the proxy's user_id
+// convention) and falls back to the raw ID.
+func (u *User) EffectiveID() string {
+	if u.Email != "" {
+		return strings.ToLower(u.Email)
+	}
+	return u.ID
 }
 
 type contextKey struct{}

--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -138,7 +138,8 @@ func (h *DashboardHandler) GetMyUsage(
 		}
 		userID = user.ID
 	} else {
-		userID = authUser.ID
+		// No Firestore — use EffectiveID to match the proxy's user_id convention.
+		userID = authUser.EffectiveID()
 	}
 
 	msg := req.Msg

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -330,12 +330,8 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	var effectiveUserID string
 	var isServiceAccount bool
 	if caller != nil {
-		if caller.Email != "" {
-			effectiveUserID = strings.ToLower(caller.Email)
-			isServiceAccount = strings.HasSuffix(effectiveUserID, ".gserviceaccount.com")
-		} else {
-			effectiveUserID = caller.ID
-		}
+		effectiveUserID = caller.EffectiveID()
+		isServiceAccount = strings.HasSuffix(effectiveUserID, ".gserviceaccount.com")
 	}
 
 	// Extract provider from path: /proxy/{provider}/v1/...


### PR DESCRIPTION
## Problem

The **Today** page (`/today`) shows no data in dev mode, while the **Dashboard** page works fine and shows all traces/counts.

### Root Cause

`GetMyUsage` (used by the Today page) resolves the user ID differently from the proxy:

| Component | user_id value | Source |
|-----------|--------------|--------|
| **Proxy** (writes spans) | `admin@localhost` | `strings.ToLower(caller.Email)` |
| **GetMyUsage** (reads spans) | `dev-admin` | `authUser.ID` |

The DuckDB query filters with `AND (? = '' OR user_id = ?)`, so querying for `dev-admin` matches nothing because all spans have `user_id = admin@localhost`.

The Dashboard works because `scopeUserID()` returns `""` when Firestore is unavailable, which bypasses the user filter entirely.

## Fix

When Firestore is unavailable (no `h.users`), use `authUser.Email` (lowercased) instead of `authUser.ID` to match the proxy's `user_id` convention.

## Testing

- `go build` passes
- All pre-commit hooks pass (go-test, go-vet, golangci-lint, gofmt)