### PR TITLE
fix: stamp user_id on ingested spans from candela-local

### DIFF
--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -4,12 +4,25 @@
 // The middleware extracts the email/uid and makes the user available via context.
 package auth
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 // User represents the authenticated identity for the current request.
 type User struct {
 	ID    string // Firebase UID or Google subject
 	Email string // Verified email claim
+}
+
+// EffectiveID returns the canonical user identifier used for span attribution
+// and budget tracking. Prefers lowercased email (matching the proxy's user_id
+// convention) and falls back to the raw ID.
+func (u *User) EffectiveID() string {
+	if u.Email != "" {
+		return strings.ToLower(u.Email)
+	}
+	return u.ID
 }
 
 type contextKey struct{}

--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -138,7 +138,8 @@ func (h *DashboardHandler) GetMyUsage(
 		}
 		userID = user.ID
 	} else {
-		userID = authUser.ID
+		// No Firestore — use EffectiveID to match the proxy's user_id convention.
+		userID = authUser.EffectiveID()
 	}
 
 	msg := req.Msg

--- a/pkg/connecthandlers/ingestion_handler.go
+++ b/pkg/connecthandlers/ingestion_handler.go
@@ -5,6 +5,7 @@ import (
 
 	connect "connectrpc.com/connect"
 	v1 "github.com/candelahq/candela/gen/go/candela/v1"
+	"github.com/candelahq/candela/pkg/auth"
 	"github.com/candelahq/candela/pkg/storage"
 )
 
@@ -28,6 +29,13 @@ func (h *IngestionHandler) IngestSpans(
 	ctx context.Context,
 	req *connect.Request[v1.IngestSpansRequest],
 ) (*connect.Response[v1.IngestSpansResponse], error) {
+	// Resolve the caller's identity so we can attribute spans that arrive
+	// without a user_id (e.g. from candela-local).
+	var callerID string
+	if caller := auth.FromContext(ctx); caller != nil {
+		callerID = caller.EffectiveID()
+	}
+
 	var spans []storage.Span
 	var errors []string
 
@@ -36,6 +44,12 @@ func (h *IngestionHandler) IngestSpans(
 		if err != nil {
 			errors = append(errors, err.Error())
 			continue
+		}
+		// Stamp the caller's identity on spans with no user_id.
+		// This ensures candela-local spans are attributed to the
+		// authenticated user for per-user views (Today page).
+		if span.UserID == "" && callerID != "" {
+			span.UserID = callerID
 		}
 		spans = append(spans, *span)
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -330,12 +330,8 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	var effectiveUserID string
 	var isServiceAccount bool
 	if caller != nil {
-		if caller.Email != "" {
-			effectiveUserID = strings.ToLower(caller.Email)
-			isServiceAccount = strings.HasSuffix(effectiveUserID, ".gserviceaccount.com")
-		} else {
-			effectiveUserID = caller.ID
-		}
+		effectiveUserID = caller.EffectiveID()
+		isServiceAccount = strings.HasSuffix(effectiveUserID, ".gserviceaccount.com")
 	}
 
 	// Extract provider from path: /proxy/{provider}/v1/...


### PR DESCRIPTION
## Problem

The Today page shows no data for candela-local users on the deployed server, even though the Dashboard shows their traces.

### Root Cause

candela-local sends spans with `user_id=""` because it doesn't resolve the caller's identity locally. The ingestion handler on candela-server stores these spans as-is.

The Today page's `GetMyUsage` filters by `user_id = <caller's email>`, which matches nothing since all candela-local spans have `user_id = ""`.

The Dashboard works because `scopeUserID()` returns `""` for admins, bypassing the user filter.

## Fix

The `IngestSpans` handler now stamps the authenticated caller's `EffectiveID()` on any span that arrives with an empty `user_id`. This ensures candela-local spans are properly attributed to the user who sent them.

## Testing

- All pre-commit hooks pass (go-test, go-vet, golangci-lint, gofmt)