### PR TITLE
fix(flake): add jdk21 for Firestore emulator

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
             cloudflared
             grpcurl
             google-cloud-sdk  # Includes Firestore emulator (gcloud emulators firestore start)
-            jdk21             # Required by the Firestore emulator (Java 8+ JRE)
+            jdk21_headless            # Required by the Firestore emulator (Java 8+ JRE)
             jq
             yq-go
 

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,7 @@
             cloudflared
             grpcurl
             google-cloud-sdk  # Includes Firestore emulator (gcloud emulators firestore start)
+            jdk21             # Required by the Firestore emulator (Java 8+ JRE)
             jq
             yq-go
 


### PR DESCRIPTION
## Problem

The Firestore emulator (bundled in `google-cloud-sdk`) requires Java 8+ on PATH. CI fails with:

```
ERROR: (gcloud.emulators.firestore.start) To use the Google Cloud Firestore emulator,
a Java 8+ JRE must be installed and on your system PATH
```

## Fix

Add `jdk21` to the Nix dev shell `buildInputs`. This makes `java` available both locally and inside the CI container (which is rebuilt from `flake.nix` via `dev-container.yml`).

## Note

After this merges, the CI container image needs to be rebuilt (trigger `dev-container.yml`) to pick up the new dependency. Until then, the go-test jobs on #141 will continue to fail on the emulator step.