### PR TITLE
feat: multitenant LLM cost attribution via Baggage + header

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -193,7 +193,7 @@ func main() {
 		connecthandlers.NewIngestionHandlerDirect(proc))
 	mux.Handle(ingestionPath, ingestionH)
 
-	dashboardPath, dashboardH := candelav1connect.NewDashboardServiceHandler(
+	dashboardPath, dashboardH := candelav1connect.NewDashboardServiceHandlerWithTenant(
 		connecthandlers.NewDashboardHandler(reader, userStore))
 	mux.Handle(dashboardPath, dashboardH)
 

--- a/docs/adk/candela_adk.py
+++ b/docs/adk/candela_adk.py
@@ -6,14 +6,14 @@ made by an agent — including sub-agents and tool calls — are attributed to
 the correct tenant and job for cost tracking in Candela.
 
 Usage:
-    from candela.adk import CandleaContextPlugin, CandelaContext
+    from candela.adk import CandelaContextPlugin, CandelaContext
 
     context = CandelaContext(
         tenant_id="acme-corp",
         job_id="trial-NCT01750580",   # optional: maps to trial_id, campaign_id, etc.
         session_id="session-42",       # optional: groups related calls
     )
-    plugin = CandleaContextPlugin(context)
+    plugin = CandelaContextPlugin(context)
 
     result = await agent.run_async(message, plugins=[plugin])
 
@@ -178,16 +178,16 @@ class CandelaContext:
 # ── ADK Plugin ────────────────────────────────────────────────────────────────
 
 
-class CandleaContextPlugin:
+class CandelaContextPlugin:
     """ADK plugin that injects Candela tenant context into every LLM call.
 
     Usage with Google ADK:
 
         from google.adk.agents import LlmAgent
-        from candela.adk import CandleaContextPlugin, CandelaContext
+        from candela.adk import CandelaContextPlugin, CandelaContext
 
         ctx = CandelaContext(tenant_id="acme-corp", job_id="trial-NCT01750580")
-        plugin = CandleaContextPlugin(ctx)
+        plugin = CandelaContextPlugin(ctx)
 
         result = await agent.run_async(
             "Match this patient for NCT01750580",
@@ -210,7 +210,7 @@ class CandleaContextPlugin:
 
     @property
     def name(self) -> str:
-        return "CandleaContextPlugin"
+        return "CandelaContextPlugin"
 
     def before_model_call(self, request: Any) -> Any:
         """Inject Candela baggage headers before each LLM HTTP request.
@@ -262,7 +262,7 @@ def _inject_headers(request: Any, headers: dict[str, str]) -> None:
     import warnings
 
     warnings.warn(
-        f"CandleaContextPlugin: could not inject headers into {type(request).__name__}. "
+        f"CandelaContextPlugin: could not inject headers into {type(request).__name__}. "
         "Tenant attribution may be missing for this call.",
         stacklevel=2,
     )
@@ -275,14 +275,14 @@ def make_candela_plugin(
     tenant_id: str | None = None,
     job_id: str | None = None,
     session_id: str | None = None,
-) -> CandleaContextPlugin:
-    """Convenience factory for creating a CandleaContextPlugin.
+) -> CandelaContextPlugin:
+    """Convenience factory for creating a CandelaContextPlugin.
 
     Example:
         plugin = make_candela_plugin(tenant_id="acme-corp", job_id="NCT01750580")
         result = await agent.run_async(message, plugins=[plugin])
     """
-    return CandleaContextPlugin(
+    return CandelaContextPlugin(
         CandelaContext(tenant_id=tenant_id, job_id=job_id, session_id=session_id)
     )
 
@@ -304,7 +304,7 @@ class CTMSCandelaContext(CandelaContext):
             trial_id=funnel_request.trial_id,
             run_id=funnel_request.run_id,
         )
-        plugin = CandleaContextPlugin(ctx)
+        plugin = CandelaContextPlugin(ctx)
     """
 
     trial_id: str | None = field(default=None)

--- a/docs/adk/candela_adk.py
+++ b/docs/adk/candela_adk.py
@@ -1,0 +1,339 @@
+"""Candela ADK Integration — Tenant-Aware Observability Plugin.
+
+Provides automatic propagation of tenant context (and optional job context)
+through Google ADK agent traces via W3C Baggage. This ensures all LLM calls
+made by an agent — including sub-agents and tool calls — are attributed to
+the correct tenant and job for cost tracking in Candela.
+
+Usage:
+    from candela.adk import CandleaContextPlugin, CandelaContext
+
+    context = CandelaContext(
+        tenant_id="acme-corp",
+        job_id="trial-NCT01750580",   # optional: maps to trial_id, campaign_id, etc.
+        session_id="session-42",       # optional: groups related calls
+    )
+    plugin = CandleaContextPlugin(context)
+
+    result = await agent.run_async(message, plugins=[plugin])
+
+Installation:
+    uv add opentelemetry-api opentelemetry-sdk
+
+The plugin uses the standard OTel propagation mechanism — no Candela-specific
+SDK is required. Any OTel-compatible propagator (W3C TraceContext + Baggage)
+will correctly forward these headers.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+# OTel imports — required for Baggage propagation.
+try:
+    from opentelemetry import baggage, context
+    from opentelemetry.propagate import inject
+
+    _OTEL_AVAILABLE = True
+except ImportError:
+    _OTEL_AVAILABLE = False
+
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+# Must match the proxy-side tenantIDPattern in pkg/proxy/proxy.go
+_TENANT_ID_PATTERN = re.compile(r"^[a-zA-Z0-9\-._]{1,128}$")
+
+# job_id follows the same rules (will be added to the proxy in a future PR)
+_JOB_ID_PATTERN = re.compile(r"^[a-zA-Z0-9\-._]{1,128}$")
+
+
+def _validate_tenant_id(value: str | None, field_name: str = "tenant_id") -> str | None:
+    """Validate a tenant/job ID against the allowed pattern.
+
+    Returns the value unchanged if valid, or None (with a warning) if invalid.
+    Never raises — invalid IDs are silently discarded, matching proxy behavior.
+    """
+    if value is None:
+        return None
+    if not _TENANT_ID_PATTERN.match(value):
+        import warnings
+
+        warnings.warn(
+            f"candela: invalid {field_name}={value!r} — must match "
+            f"[a-zA-Z0-9\\-._]{{1,128}}. Value will be ignored.",
+            stacklevel=3,
+        )
+        return None
+    return value
+
+
+# ── Context Dataclass ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CandelaContext:
+    """Immutable attribution context for Candela observability.
+
+    All fields are optional except that at least one should be set for
+    cost attribution to be meaningful.
+
+    Attributes:
+        tenant_id: The downstream customer/tenant to attribute costs to.
+            Maps to W3C Baggage key ``candela.tenant_id`` and the
+            ``X-Candela-Tenant-Id`` header. Validated against
+            ``[a-zA-Z0-9\\-._]{1,128}``.
+
+        job_id: An optional job/trial/campaign identifier for second-dimension
+            attribution. Useful when a single tenant runs many distinct jobs
+            (e.g., clinical trial NCT IDs, campaign IDs, batch run IDs).
+            Maps to W3C Baggage key ``candela.job_id``.
+            **Note:** ``job_id`` storage support is planned — it is forwarded
+            in Baggage today but not yet persisted as a first-class column.
+
+        session_id: Optional session identifier for grouping related calls
+            within a single user session or conversation. Maps to
+            ``X-Session-Id``.
+
+    Example:
+        >>> ctx = CandelaContext(
+        ...     tenant_id="acme-corp",
+        ...     job_id="trial-NCT01750580",
+        ...     session_id="conversation-abc123",
+        ... )
+        >>> ctx.to_baggage_headers()
+        {'Baggage': 'candela.tenant_id=acme-corp,candela.job_id=trial-NCT01750580'}
+    """
+
+    tenant_id: str | None = None
+    job_id: str | None = None
+    session_id: str | None = None
+
+    def __post_init__(self) -> None:
+        # Validate at construction time so errors surface early.
+        object.__setattr__(self, "tenant_id", _validate_tenant_id(self.tenant_id, "tenant_id"))
+        object.__setattr__(self, "job_id", _validate_tenant_id(self.job_id, "job_id"))
+
+    def to_baggage_dict(self) -> dict[str, str]:
+        """Return the Candela-specific baggage entries as a plain dict.
+
+        Keys are the W3C Baggage key names; values are the IDs.
+        Only non-None, valid entries are included.
+        """
+        result: dict[str, str] = {}
+        if self.tenant_id:
+            result["candela.tenant_id"] = self.tenant_id
+        if self.job_id:
+            result["candela.job_id"] = self.job_id
+        return result
+
+    def to_baggage_headers(self) -> dict[str, str]:
+        """Build HTTP headers dict with W3C Baggage for manual injection.
+
+        Use this when you cannot use the OTel propagator directly (e.g., raw
+        httpx/requests calls):
+
+            headers = ctx.to_baggage_headers()
+            resp = httpx.post(url, headers={**base_headers, **headers}, json=body)
+        """
+        if not _OTEL_AVAILABLE:
+            # Fallback: build the Baggage header manually.
+            entries = self.to_baggage_dict()
+            if not entries:
+                return {}
+            header_value = ",".join(f"{k}={v}" for k, v in entries.items())
+            return {"Baggage": header_value}
+
+        entries = self.to_baggage_dict()
+        if not entries:
+            return {}
+
+        ctx = context.get_current()
+        for key, value in entries.items():
+            ctx = baggage.set_baggage(key, value, context=ctx)
+
+        headers: dict[str, str] = {}
+        inject(headers, context=ctx)
+        return headers
+
+    def to_explicit_headers(self) -> dict[str, str]:
+        """Build explicit Candela headers (non-OTel fallback).
+
+        Use this for simple HTTP clients or test scripts that don't need
+        OTel trace propagation but want tenant attribution:
+
+            headers = ctx.to_explicit_headers()
+            # {"X-Candela-Tenant-Id": "acme-corp"}
+        """
+        result: dict[str, str] = {}
+        if self.tenant_id:
+            result["X-Candela-Tenant-Id"] = self.tenant_id
+        if self.session_id:
+            result["X-Session-Id"] = self.session_id
+        return result
+
+
+# ── ADK Plugin ────────────────────────────────────────────────────────────────
+
+
+class CandleaContextPlugin:
+    """ADK plugin that injects Candela tenant context into every LLM call.
+
+    Usage with Google ADK:
+
+        from google.adk.agents import LlmAgent
+        from candela.adk import CandleaContextPlugin, CandelaContext
+
+        ctx = CandelaContext(tenant_id="acme-corp", job_id="trial-NCT01750580")
+        plugin = CandleaContextPlugin(ctx)
+
+        result = await agent.run_async(
+            "Match this patient for NCT01750580",
+            plugins=[plugin],
+        )
+
+    The plugin hooks into ADK's ``before_model_call`` lifecycle to inject
+    W3C Baggage headers before each LLM HTTP request. This ensures:
+
+    1. The Candela proxy captures tenant_id on every call.
+    2. Baggage propagates through multi-hop agent traces (sub-agents, tool calls).
+    3. No code changes are needed in agent tools or sub-agents.
+
+    If ``opentelemetry-api`` is not installed, the plugin falls back to
+    injecting the ``X-Candela-Tenant-Id`` explicit header instead.
+    """
+
+    def __init__(self, candela_context: CandelaContext) -> None:
+        self._ctx = candela_context
+
+    @property
+    def name(self) -> str:
+        return "CandleaContextPlugin"
+
+    def before_model_call(self, request: Any) -> Any:
+        """Inject Candela baggage headers before each LLM HTTP request.
+
+        ADK calls this hook with the model request object. We inject headers
+        into the request so the proxy can capture tenant attribution.
+
+        Args:
+            request: The ADK model request object (provider-specific).
+
+        Returns:
+            The modified request with injected headers.
+        """
+        headers_to_inject = self._ctx.to_baggage_headers()
+        if not headers_to_inject and self._ctx.tenant_id:
+            # OTel not available — fall back to explicit header.
+            headers_to_inject = self._ctx.to_explicit_headers()
+
+        if headers_to_inject:
+            _inject_headers(request, headers_to_inject)
+
+        return request
+
+
+def _inject_headers(request: Any, headers: dict[str, str]) -> None:
+    """Best-effort header injection into an ADK model request.
+
+    ADK request objects vary by provider. We try the most common patterns.
+    """
+    # Pattern 1: request.headers is a dict-like object.
+    if hasattr(request, "headers") and isinstance(request.headers, dict):
+        request.headers.update(headers)
+        return
+
+    # Pattern 2: request has a config with extra_headers (Gemini SDK pattern).
+    if hasattr(request, "config") and hasattr(request.config, "extra_headers"):
+        existing = request.config.extra_headers or {}
+        request.config.extra_headers = {**existing, **headers}
+        return
+
+    # Pattern 3: request.kwargs (httpx-style).
+    if hasattr(request, "kwargs"):
+        existing = request.kwargs.get("headers", {})
+        request.kwargs["headers"] = {**existing, **headers}
+        return
+
+    # No-op: we couldn't find a headers attachment point.
+    # The request proceeds without tenant context; this is non-fatal.
+    import warnings
+
+    warnings.warn(
+        f"CandleaContextPlugin: could not inject headers into {type(request).__name__}. "
+        "Tenant attribution may be missing for this call.",
+        stacklevel=2,
+    )
+
+
+# ── Convenience Factory ───────────────────────────────────────────────────────
+
+
+def make_candela_plugin(
+    tenant_id: str | None = None,
+    job_id: str | None = None,
+    session_id: str | None = None,
+) -> CandleaContextPlugin:
+    """Convenience factory for creating a CandleaContextPlugin.
+
+    Example:
+        plugin = make_candela_plugin(tenant_id="acme-corp", job_id="NCT01750580")
+        result = await agent.run_async(message, plugins=[plugin])
+    """
+    return CandleaContextPlugin(
+        CandelaContext(tenant_id=tenant_id, job_id=job_id, session_id=session_id)
+    )
+
+
+# ── CTMS Adapter ─────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CTMSCandelaContext(CandelaContext):
+    """Candela context specialized for CTMS / clinical trial workloads.
+
+    Maps CTMS domain concepts to Candela attribution fields:
+    - tenant_id → the CTMS tenant (healthcare organization)
+    - job_id    → the trial NCT ID or campaign ID being processed
+
+    Example (matching the FunnelRequest pattern in intelligence-service):
+        ctx = CTMSCandelaContext.from_funnel_request(
+            tenant_id=funnel_request.tenant_id,
+            trial_id=funnel_request.trial_id,
+            run_id=funnel_request.run_id,
+        )
+        plugin = CandleaContextPlugin(ctx)
+    """
+
+    trial_id: str | None = field(default=None)
+    run_id: str | None = field(default=None)
+
+    @classmethod
+    def from_funnel_request(
+        cls,
+        tenant_id: str,
+        trial_id: str | None = None,
+        run_id: str | None = None,
+        session_id: str | None = None,
+    ) -> "CTMSCandelaContext":
+        """Build a CTMSCandelaContext from FunnelRequest fields.
+
+        The trial_id is used as the job_id for Candela cost attribution, so you
+        can query "how much did this trial run cost?" via GetTenantLeaderboard
+        once job_id is fully supported.
+
+        Args:
+            tenant_id: CTMS tenant identifier (e.g. "azra-health").
+            trial_id: NCT ID or internal trial identifier (e.g. "NCT01750580").
+            run_id: Optional run/campaign identifier for sub-attribution.
+            session_id: Optional session ID for grouping calls.
+        """
+        return cls(
+            tenant_id=tenant_id,
+            job_id=trial_id,        # trial_id → job_id for Candela
+            session_id=session_id,
+            trial_id=trial_id,
+            run_id=run_id,
+        )

--- a/docs/multitenancy.md
+++ b/docs/multitenancy.md
@@ -1,0 +1,279 @@
+# Multitenancy: Per-Tenant LLM Cost Attribution
+
+Candela supports **first-class multitenant observability**: every LLM API call can
+be attributed to a downstream customer (tenant), enabling you to answer:
+
+> *"How much did we spend on LLM calls for Acme Corp this month?"*
+
+This is accomplished by propagating a `tenant_id` through the proxy — either via
+[W3C Baggage](https://www.w3.org/TR/baggage/) (preferred for ADK/OTel) or via an
+explicit HTTP header.
+
+---
+
+## How It Works
+
+```
+  Your App (ADK agent / FastAPI / etc.)
+       │
+       │  Baggage: candela.tenant_id=acme-corp          ← preferred (propagates through hops)
+       │  X-Candela-Tenant-Id: acme-corp                ← fallback (single-hop only)
+       ▼
+  Candela Proxy  ──────────────────────────────────────────────────────────
+       │  Extracts tenant_id → validates → attaches to Span
+       ▼
+  Storage (DuckDB / SQLite / BigQuery)
+       │  tenant_id column indexed for efficient GROUP BY queries
+       ▼
+  GetTenantLeaderboard RPC  →  Dashboard / Billing system
+```
+
+---
+
+## Propagation Methods
+
+### Option 1: W3C Baggage (Recommended for ADK)
+
+The W3C Baggage header carries key-value pairs through distributed traces. ADK's
+built-in OpenTelemetry propagator injects this header automatically — so if you
+set `candela.tenant_id` in the baggage context at the *start* of an agent run,
+it flows through every downstream LLM call automatically, even in multi-hop traces.
+
+**Baggage takes precedence over the explicit header** (see precedence rules below).
+
+```
+Baggage: candela.tenant_id=acme-corp,svc.version=1.2.0
+```
+
+The proxy extracts **only** `candela.tenant_id` from baggage. All other baggage
+entries are forwarded unchanged.
+
+### Option 2: Explicit Header
+
+For non-OTel callers (cURL, direct API clients, service-to-service without OTel):
+
+```
+X-Candela-Tenant-Id: acme-corp
+```
+
+If both Baggage and header are present, **Baggage wins**.
+
+---
+
+## Tenant ID Format
+
+Tenant IDs must match the pattern `[a-zA-Z0-9\-._]{1,128}`. Examples:
+
+| ✅ Valid             | ❌ Invalid                  |
+|---------------------|-----------------------------|
+| `acme-corp`         | `acme corp` (space)         |
+| `acme.corp`         | `acme@corp` (@ sign)        |
+| `tenant_42`         | `` (empty string)           |
+| `trial-NCT01750580` | 129+ characters             |
+| `customer.a.b.c`   | `../escape` (path traversal)|
+
+Invalid values are **silently discarded** (not rejected with 4xx) to avoid
+breaking clients that send malformed headers. The span is written without a
+`tenant_id` in this case.
+
+---
+
+## ADK Integration
+
+### Python: Setting Tenant Context
+
+```python
+from opentelemetry import baggage, context
+from opentelemetry.propagate import inject
+import httpx
+
+def make_llm_request_with_tenant(tenant_id: str, payload: dict) -> dict:
+    """Make an LLM request through Candela with tenant attribution."""
+    # Set tenant_id in OTel baggage context.
+    ctx = baggage.set_baggage("candela.tenant_id", tenant_id)
+
+    # Inject baggage into outgoing headers.
+    headers = {}
+    inject(headers, context=ctx)
+    # headers now contains: {"Baggage": "candela.tenant_id=acme-corp"}
+
+    with httpx.Client() as client:
+        resp = client.post(
+            "http://candela-proxy/proxy/openai/v1/chat/completions",
+            headers=headers,
+            json=payload,
+        )
+        resp.raise_for_status()
+        return resp.json()
+```
+
+### ADK Agent: Automatic Context Propagation
+
+With the `CandlaContextPlugin` (see `docs/adk-integration.md`), tenant context
+is injected automatically into every LLM call made by an ADK agent:
+
+```python
+from google.adk.agents import LlmAgent
+from candela.adk import CandleaContextPlugin, CandelaContext
+
+agent = LlmAgent(
+    name="my-agent",
+    model="gemini-2.0-flash",
+    # ... tools, system_prompt, etc.
+)
+
+ctx = CandelaContext(tenant_id="acme-corp", session_id="session-42")
+plugin = CandleaContextPlugin(ctx)
+
+# The plugin injects Baggage headers on every underlying HTTP call.
+# No code changes needed in the agent itself.
+result = await agent.run_async(message, plugins=[plugin])
+```
+
+### Multi-Hop Traces: Why Baggage Matters
+
+Consider a CTMS pipeline:
+
+```
+FastAPI handler
+  └─ Orchestrator agent (Gemini call ①)  ← tenant_id set here
+       └─ Tool: query_clinical_data
+            └─ Sub-agent (Gemini call ②)  ← tenant_id auto-propagated via Baggage
+                 └─ Tool: find_evidence
+                      └─ Sub-agent (Gemini call ③)  ← tenant_id still here
+```
+
+With **Baggage**, `tenant_id=acme-corp` is set once and propagates through all
+three Gemini calls automatically. With just the header, you'd have to manually
+re-attach it at every hop.
+
+### FunnelRequest Pattern (CTMS)
+
+For the `intelligence-service`, you likely want to propagate **both** `tenant_id`
+and `trial_id` to attribute costs to specific trials:
+
+```python
+from opentelemetry import baggage, context
+from opentelemetry.propagate import inject
+
+def make_funnel_baggage(tenant_id: str, trial_id: str) -> dict:
+    """Build baggage headers for a funnel run."""
+    ctx = context.get_current()
+    ctx = baggage.set_baggage("candela.tenant_id", tenant_id, context=ctx)
+    ctx = baggage.set_baggage("candela.job_id", trial_id, context=ctx)
+    headers = {}
+    inject(headers, context=ctx)
+    return headers
+
+# Example output:
+# {"Baggage": "candela.tenant_id=azra-health,candela.job_id=NCT01750580"}
+```
+
+> **Note:** `candela.job_id` support is planned — see the roadmap section below.
+
+---
+
+## Querying Tenant Data
+
+### Connect RPC: GetTenantLeaderboard
+
+```python
+import httpx
+
+resp = httpx.post(
+    "http://candela-server/candela.v1.DashboardService/GetTenantLeaderboard",
+    headers={"Authorization": f"Bearer {admin_token}"},
+    json={
+        "project_id": "my-project",
+        "limit": 10,
+        "time_range": {
+            "start": "2025-01-01T00:00:00Z",
+            "end": "2025-02-01T00:00:00Z",
+        }
+    }
+)
+
+for tenant in resp.json()["tenants"]:
+    print(f"{tenant['tenant_id']}: ${tenant['cost_usd']:.4f} ({tenant['call_count']} calls)")
+```
+
+Example output:
+```
+acme-corp:        $12.45 (342 calls)
+trial-NCT01234:   $7.23  (198 calls)
+azra-health-demo: $3.11  (89 calls)
+```
+
+This endpoint is **admin-only** (requires admin Firebase token).
+
+### Direct SQL (DuckDB / BigQuery)
+
+```sql
+-- Per-tenant cost breakdown for the last 30 days
+SELECT
+    COALESCE(tenant_id, '(unattributed)') AS tenant,
+    COUNT(*)                               AS calls,
+    SUM(gen_ai_input_tokens)               AS input_tokens,
+    SUM(gen_ai_output_tokens)              AS output_tokens,
+    SUM(gen_ai_cost_usd)                   AS cost_usd
+FROM spans
+WHERE
+    project_id = 'my-project'
+    AND start_time >= NOW() - INTERVAL 30 DAY
+GROUP BY 1
+ORDER BY cost_usd DESC;
+```
+
+---
+
+## OTLP Export
+
+When the OTLP sink is enabled, `tenant_id` is exported as the `candela.tenant_id`
+OTLP attribute on every span. This surfaces automatically in:
+
+- **Datadog**: filterable via `@candela.tenant_id` in Log Explorer
+- **Honeycomb**: group-by `candela.tenant_id` in query builder
+- **Grafana / Tempo**: filter traces by `candela.tenant_id` attribute
+
+---
+
+## Schema Details
+
+The `tenant_id` column is added via idempotent `ALTER TABLE` migration:
+
+| Backend  | Migration strategy            | Index          |
+|----------|-------------------------------|----------------|
+| DuckDB   | `ALTER TABLE ... ADD COLUMN`  | Composite with `project_id, start_time` |
+| SQLite   | `ALTER TABLE ... ADD COLUMN`  | Separate `idx_spans_tenant_id` |
+| BigQuery | Schema update via Go client   | Clustering field |
+
+The migration runs automatically on startup and is safe to run multiple times.
+
+---
+
+## Roadmap
+
+| Feature | Status |
+|---------|--------|
+| `tenant_id` via Baggage + header | ✅ Implemented |
+| `tenant_id` in DuckDB / SQLite / BigQuery | ✅ Implemented |
+| `GetTenantLeaderboard` RPC | ✅ Implemented |
+| OTLP export of `candela.tenant_id` | ✅ Implemented |
+| ADK `CandleaContextPlugin` | ✅ Implemented |
+| `job_id` / `trial_id` second attribution dimension | 🔜 Planned |
+| Rust sidecar parity for tenant extraction | 🔜 Planned (after HTTP handler is wired) |
+| UI: Tenant leaderboard dashboard widget | 🔜 Planned (see GitHub issues) |
+| Per-tenant budget enforcement | 💡 Future |
+
+---
+
+## Security Considerations
+
+- `tenant_id` is **set by the calling application**, not by Candela's auth system.
+  It is an attribution label, not an access control boundary.
+- Candela validates format but cannot verify that the caller is authorized to
+  bill costs to that tenant. Enforce tenant authorization in your application layer.
+- The `GetTenantLeaderboard` API is admin-only and requires a verified Firebase
+  admin token.
+- Tenant IDs are validated against `[a-zA-Z0-9\-._]{1,128}` to prevent log
+  injection and other attacks.

--- a/docs/multitenancy.md
+++ b/docs/multitenancy.md
@@ -109,12 +109,12 @@ def make_llm_request_with_tenant(tenant_id: str, payload: dict) -> dict:
 
 ### ADK Agent: Automatic Context Propagation
 
-With the `CandlaContextPlugin` (see `docs/adk-integration.md`), tenant context
+With the `CandelaContextPlugin` (see `docs/adk-integration.md`), tenant context
 is injected automatically into every LLM call made by an ADK agent:
 
 ```python
 from google.adk.agents import LlmAgent
-from candela.adk import CandleaContextPlugin, CandelaContext
+from candela.adk import CandelaContextPlugin, CandelaContext
 
 agent = LlmAgent(
     name="my-agent",
@@ -123,7 +123,7 @@ agent = LlmAgent(
 )
 
 ctx = CandelaContext(tenant_id="acme-corp", session_id="session-42")
-plugin = CandleaContextPlugin(ctx)
+plugin = CandelaContextPlugin(ctx)
 
 # The plugin injects Baggage headers on every underlying HTTP call.
 # No code changes needed in the agent itself.
@@ -259,7 +259,7 @@ The migration runs automatically on startup and is safe to run multiple times.
 | `tenant_id` in DuckDB / SQLite / BigQuery | ✅ Implemented |
 | `GetTenantLeaderboard` RPC | ✅ Implemented |
 | OTLP export of `candela.tenant_id` | ✅ Implemented |
-| ADK `CandleaContextPlugin` | ✅ Implemented |
+| ADK `CandelaContextPlugin` | ✅ Implemented |
 | `job_id` / `trial_id` second attribution dimension | 🔜 Planned |
 | Rust sidecar parity for tenant extraction | 🔜 Planned (after HTTP handler is wired) |
 | UI: Tenant leaderboard dashboard widget | 🔜 Planned (see GitHub issues) |

--- a/gen/go/candela/v1/candelav1connect/tenant_leaderboard_connect.go
+++ b/gen/go/candela/v1/candelav1connect/tenant_leaderboard_connect.go
@@ -1,0 +1,53 @@
+// Hand-authored Connect RPC extension for the tenant cost leaderboard.
+//
+// This extends the generated DashboardService with GetTenantLeaderboard without
+// modifying the BSR-managed proto. The new RPC will be upstreamed to the BSR
+// proto definition in a follow-up PR; at that point this file can be removed
+// and replaced with the regenerated output.
+
+package candelav1connect
+
+import (
+	connect "connectrpc.com/connect"
+	context "context"
+	v1 "github.com/candelahq/candela/gen/go/candela/v1"
+	http "net/http"
+)
+
+const (
+	// DashboardServiceGetTenantLeaderboardProcedure is the fully-qualified name of the
+	// GetTenantLeaderboard RPC (admin-only, multitenant cost attribution).
+	DashboardServiceGetTenantLeaderboardProcedure = "/candela.v1.DashboardService/GetTenantLeaderboard"
+)
+
+// DashboardServiceWithTenantHandler extends DashboardServiceHandler with tenant leaderboard support.
+// Embed this interface instead of DashboardServiceHandler to opt into the new RPC.
+type DashboardServiceWithTenantHandler interface {
+	DashboardServiceHandler
+	// GetTenantLeaderboard returns per-tenant LLM cost aggregations ranked by spend (admin only).
+	GetTenantLeaderboard(context.Context, *connect.Request[v1.GetTenantLeaderboardRequest]) (*connect.Response[v1.GetTenantLeaderboardResponse], error)
+}
+
+// NewDashboardServiceHandlerWithTenant builds the full HTTP handler including the
+// GetTenantLeaderboard RPC. Use this instead of NewDashboardServiceHandler when
+// the service implementation embeds DashboardServiceWithTenantHandler.
+func NewDashboardServiceHandlerWithTenant(svc DashboardServiceWithTenantHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	// Build the base handler (all existing RPCs).
+	basePath, baseHandler := NewDashboardServiceHandler(svc, opts...)
+
+	// Build the tenant leaderboard handler separately.
+	tenantHandler := connect.NewUnaryHandler(
+		DashboardServiceGetTenantLeaderboardProcedure,
+		svc.GetTenantLeaderboard,
+		connect.WithHandlerOptions(opts...),
+	)
+
+	// Wrap: route the new procedure, fall through to the base handler for all others.
+	return basePath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == DashboardServiceGetTenantLeaderboardProcedure {
+			tenantHandler.ServeHTTP(w, r)
+			return
+		}
+		baseHandler.ServeHTTP(w, r)
+	})
+}

--- a/gen/go/candela/v1/tenant_leaderboard.go
+++ b/gen/go/candela/v1/tenant_leaderboard.go
@@ -1,0 +1,127 @@
+// Package candelav1 — hand-authored extension for multitenant leaderboard types.
+//
+// These types extend the generated proto types without modifying the BSR-managed
+// proto files. They will be upstreamed to the proto definition in a follow-up PR.
+//
+// NOTE: Do NOT add protoimpl machinery here — these are plain Go structs used
+// directly with the Connect handler extension below.
+
+package candelav1
+
+import (
+	"github.com/candelahq/candela/gen/go/candela/types"
+)
+
+// GetTenantLeaderboardRequest is the request type for the tenant cost leaderboard.
+// Admin-only: returns all tenants ranked by LLM cost for the given project/period.
+type GetTenantLeaderboardRequest struct {
+	// project_id scopes the query to a specific Candela project.
+	ProjectId string `json:"project_id,omitempty"`
+
+	// time_range filters to spans within the given window.
+	// Defaults to the last 30 days if unset.
+	TimeRange *types.TimeRange `json:"time_range,omitempty"`
+
+	// limit caps the number of tenants returned. Default: 20, max: 100.
+	Limit int32 `json:"limit,omitempty"`
+}
+
+func (r *GetTenantLeaderboardRequest) GetProjectId() string {
+	if r != nil {
+		return r.ProjectId
+	}
+	return ""
+}
+
+func (r *GetTenantLeaderboardRequest) GetTimeRange() *types.TimeRange {
+	if r != nil {
+		return r.TimeRange
+	}
+	return nil
+}
+
+func (r *GetTenantLeaderboardRequest) GetLimit() int32 {
+	if r != nil {
+		return r.Limit
+	}
+	return 0
+}
+
+// GetTenantLeaderboardResponse is the response for the tenant cost leaderboard.
+type GetTenantLeaderboardResponse struct {
+	// tenants is the ranked list of tenants, ordered by total cost descending.
+	Tenants []*TenantUsage `json:"tenants,omitempty"`
+}
+
+func (r *GetTenantLeaderboardResponse) GetTenants() []*TenantUsage {
+	if r != nil {
+		return r.Tenants
+	}
+	return nil
+}
+
+// TenantUsage holds aggregated LLM usage metrics for a single tenant.
+// Tenant identity comes from the X-Candela-Tenant-Id header or W3C Baggage
+// (candela.tenant_id), set by the calling application.
+type TenantUsage struct {
+	// tenant_id is the opaque tenant identifier set by the application
+	// (e.g. "acme-corp", "trial-NCT01750580", "customer-42").
+	TenantId string `json:"tenant_id,omitempty"`
+
+	// call_count is total LLM API calls attributed to this tenant.
+	CallCount int64 `json:"call_count,omitempty"`
+
+	// total_tokens is sum of input + output tokens for all calls.
+	TotalTokens int64 `json:"total_tokens,omitempty"`
+
+	// cost_usd is total cost in USD for all LLM calls.
+	CostUsd float64 `json:"cost_usd,omitempty"`
+
+	// avg_latency_ms is mean end-to-end LLM call latency in milliseconds.
+	AvgLatencyMs float64 `json:"avg_latency_ms,omitempty"`
+
+	// top_model is the most-used model (by cost) for this tenant.
+	TopModel string `json:"top_model,omitempty"`
+}
+
+func (u *TenantUsage) GetTenantId() string {
+	if u != nil {
+		return u.TenantId
+	}
+	return ""
+}
+
+func (u *TenantUsage) GetCallCount() int64 {
+	if u != nil {
+		return u.CallCount
+	}
+	return 0
+}
+
+func (u *TenantUsage) GetTotalTokens() int64 {
+	if u != nil {
+		return u.TotalTokens
+	}
+	return 0
+}
+
+func (u *TenantUsage) GetCostUsd() float64 {
+	if u != nil {
+		return u.CostUsd
+	}
+	return 0
+}
+
+func (u *TenantUsage) GetAvgLatencyMs() float64 {
+	if u != nil {
+		return u.AvgLatencyMs
+	}
+	return 0
+}
+
+func (u *TenantUsage) GetTopModel() string {
+	if u != nil {
+		return u.TopModel
+	}
+	return ""
+}

--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -308,3 +308,68 @@ func (h *DashboardHandler) GetTeamLeaderboard(
 		Users: pbUsers,
 	}), nil
 }
+
+// GetTenantLeaderboard returns per-tenant LLM cost aggregations ranked by spend (admin only).
+// Tenant identity is captured from X-Candela-Tenant-Id header or W3C Baggage (candela.tenant_id).
+func (h *DashboardHandler) GetTenantLeaderboard(
+	ctx context.Context,
+	req *connect.Request[v1.GetTenantLeaderboardRequest],
+) (*connect.Response[v1.GetTenantLeaderboardResponse], error) {
+	// Admin-only: non-admin users (non-empty scopeUserID) are denied.
+	if uid := scopeUserID(ctx, h.users); uid != "" {
+		return nil, connect.NewError(connect.CodePermissionDenied,
+			fmt.Errorf("tenant leaderboard is admin-only"))
+	}
+
+	msg := req.Msg
+	q := storage.UsageQuery{ProjectID: msg.GetProjectId()}
+	if msg.GetTimeRange() != nil {
+		if msg.GetTimeRange().Start != nil {
+			q.StartTime = msg.GetTimeRange().Start.AsTime()
+		}
+		if msg.GetTimeRange().End != nil {
+			q.EndTime = msg.GetTimeRange().End.AsTime()
+		}
+	}
+	if q.StartTime.IsZero() {
+		q.StartTime = time.Now().Add(-30 * 24 * time.Hour) // default: last 30 days
+	}
+	if q.EndTime.IsZero() {
+		q.EndTime = time.Now()
+	}
+
+	limit := int(msg.GetLimit())
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	tenants, err := h.store.GetTenantLeaderboard(ctx, q, limit)
+	if err != nil {
+		return nil, internalError("failed to get tenant leaderboard", err)
+	}
+
+	var pbTenants []*v1.TenantUsage
+	for _, t := range tenants {
+		pbTenants = append(pbTenants, &v1.TenantUsage{
+			TenantId:     t.TenantID,
+			CallCount:    t.CallCount,
+			TotalTokens:  t.TotalTokens,
+			CostUsd:      t.CostUSD,
+			AvgLatencyMs: t.AvgLatencyMs,
+			TopModel:     t.TopModel,
+		})
+	}
+
+	slog.Info("tenant leaderboard fetched",
+		"project_id", q.ProjectID,
+		"tenant_count", len(tenants),
+		"limit", limit,
+	)
+
+	return connect.NewResponse(&v1.GetTenantLeaderboardResponse{
+		Tenants: pbTenants,
+	}), nil
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -362,8 +362,10 @@ var requestIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-]{1,128}$`)
 // underscores for domain-style tenant IDs (e.g. "acme.corp", "tenant_42").
 var tenantIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-._]{1,128}$`)
 
-// parseBaggage extracts candela.tenant_id from a W3C Baggage header value.
+// parseBaggage extracts candela.tenant_id from W3C Baggage header value(s).
 // W3C Baggage format: "key1=val1;prop, key2=val2" (RFC 8941 list).
+// A single request may carry multiple Baggage headers; we join them all.
+// Baggage keys are case-insensitive per RFC 8941 — EqualFold is used.
 // ADK's OTel propagator injects Baggage automatically when context has baggage
 // set, making this the preferred propagation path for multitenant applications.
 //
@@ -377,7 +379,8 @@ func parseBaggage(header string) string {
 		// Each member may have properties after a semicolon: "key=value;prop".
 		kv := strings.SplitN(strings.TrimSpace(member), ";", 2)[0]
 		parts := strings.SplitN(kv, "=", 2)
-		if len(parts) == 2 && strings.TrimSpace(parts[0]) == "candela.tenant_id" {
+		// RFC 8941: Baggage keys are case-insensitive.
+		if len(parts) == 2 && strings.EqualFold(strings.TrimSpace(parts[0]), "candela.tenant_id") {
 			val := strings.TrimSpace(parts[1])
 			if tenantIDPattern.MatchString(val) {
 				return val
@@ -388,6 +391,12 @@ func parseBaggage(header string) string {
 		}
 	}
 	return ""
+}
+
+// parseBaggageHeaders joins multiple Baggage header values (W3C allows multiple
+// header instances) and delegates to parseBaggage for extraction.
+func parseBaggageHeaders(values []string) string {
+	return parseBaggage(strings.Join(values, ","))
 }
 
 func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
@@ -410,12 +419,9 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// ── Tenant ID extraction (for multitenant cost attribution) ──
 	// Precedence: W3C Baggage (candela.tenant_id) wins over X-Candela-Tenant-Id header.
 	//
-	// Baggage wins because it is set at the application boundary and propagated
-	// automatically by ADK/OTel through every LLM call in the agent trace tree,
-	// correctly representing the tenant for the ENTIRE trace — not just one hop.
-	//
-	// The header is the fallback for non-OTel callers (scripts, direct API use).
-	tenantID := parseBaggage(r.Header.Get("Baggage"))
+	// Use r.Header.Values (not .Get) to handle multiple Baggage header instances —
+	// W3C spec and some HTTP/1.1 proxies send separate Baggage lines per entry.
+	tenantID := parseBaggageHeaders(r.Header.Values("Baggage"))
 	if tenantID == "" {
 		// Fallback: explicit header (non-OTel callers, tests, simple scripts).
 		hdr := r.Header.Get("X-Candela-Tenant-Id")

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -355,8 +355,40 @@ func rewriteModelField(body []byte, newModel string) []byte {
 // requestIDPattern validates that a request ID contains only safe characters
 // (alphanumeric, hyphens) and is between 1-128 chars.
 // This prevents log injection and trace poisoning via crafted X-Request-ID headers.
-// Also used to validate X-Session-Id.
+// Also used to validate X-Session-Id and X-Candela-Tenant-Id.
 var requestIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-]{1,128}$`)
+
+// tenantIDPattern is slightly looser than requestIDPattern — allows dots and
+// underscores for domain-style tenant IDs (e.g. "acme.corp", "tenant_42").
+var tenantIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-._]{1,128}$`)
+
+// parseBaggage extracts candela.tenant_id from a W3C Baggage header value.
+// W3C Baggage format: "key1=val1;prop, key2=val2" (RFC 8941 list).
+// ADK's OTel propagator injects Baggage automatically when context has baggage
+// set, making this the preferred propagation path for multitenant applications.
+//
+// If multiple candela.tenant_id entries are present (RFC 8941 allows duplicates),
+// the first valid one wins. Invalid values are warned and skipped.
+func parseBaggage(header string) string {
+	if header == "" {
+		return ""
+	}
+	for _, member := range strings.Split(header, ",") {
+		// Each member may have properties after a semicolon: "key=value;prop".
+		kv := strings.SplitN(strings.TrimSpace(member), ";", 2)[0]
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) == 2 && strings.TrimSpace(parts[0]) == "candela.tenant_id" {
+			val := strings.TrimSpace(parts[1])
+			if tenantIDPattern.MatchString(val) {
+				return val
+			}
+			slog.Warn("skipping invalid candela.tenant_id in Baggage header",
+				"value", val)
+			// Continue scanning — there may be a valid duplicate entry later.
+		}
+	}
+	return ""
+}
 
 func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
@@ -373,6 +405,25 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.Header.Get("X-Session-Id")
 	if sessionID != "" && !requestIDPattern.MatchString(sessionID) {
 		sessionID = "" // invalid → discard
+	}
+
+	// ── Tenant ID extraction (for multitenant cost attribution) ──
+	// Precedence: W3C Baggage (candela.tenant_id) wins over X-Candela-Tenant-Id header.
+	//
+	// Baggage wins because it is set at the application boundary and propagated
+	// automatically by ADK/OTel through every LLM call in the agent trace tree,
+	// correctly representing the tenant for the ENTIRE trace — not just one hop.
+	//
+	// The header is the fallback for non-OTel callers (scripts, direct API use).
+	tenantID := parseBaggage(r.Header.Get("Baggage"))
+	if tenantID == "" {
+		// Fallback: explicit header (non-OTel callers, tests, simple scripts).
+		hdr := r.Header.Get("X-Candela-Tenant-Id")
+		if tenantIDPattern.MatchString(hdr) {
+			tenantID = hdr
+		} else if hdr != "" {
+			slog.Warn("discarding invalid X-Candela-Tenant-Id header", "value", hdr)
+		}
 	}
 
 	// Extract W3C Trace Context for trace correlation with OTel-instrumented
@@ -592,9 +643,9 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	cbAllow := p.breakers[providerName].AllowRequest()
 
 	if isStreaming && resp.StatusCode == http.StatusOK {
-		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, cbAllow, traceCtx, proxySpanID)
+		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, cbAllow, traceCtx, proxySpanID)
 	} else {
-		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, cbAllow, traceCtx, proxySpanID)
+		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, cbAllow, traceCtx, proxySpanID)
 	}
 }
 
@@ -624,6 +675,7 @@ func (p *Proxy) handleStandardResponse(
 	requestID string,
 	sessionID string,
 	effectiveUserID string,
+	tenantID string,
 	cbAllow bool,
 	traceCtx *traceContext,
 	proxySpanID string,
@@ -679,7 +731,7 @@ func (p *Proxy) handleStandardResponse(
 		spanCtx, spanCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
 		go func() {
 			defer spanCancel()
-			p.createSpan(spanCtx, provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID, sessionID, effectiveUserID, traceCtx, proxySpanID)
+			p.createSpan(spanCtx, provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID, sessionID, effectiveUserID, tenantID, traceCtx, proxySpanID)
 		}()
 	} else {
 		slog.Debug("skipping span creation (circuit open)", "provider", provider.Name, "request_id", requestID)
@@ -694,6 +746,7 @@ func (p *Proxy) handleStreamingResponse(
 	requestID string,
 	sessionID string,
 	effectiveUserID string,
+	tenantID string,
 	cbAllow bool,
 	traceCtx *traceContext,
 	proxySpanID string,
@@ -825,7 +878,7 @@ func (p *Proxy) handleStreamingResponse(
 		spanCtx, spanCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
 		go func() {
 			defer spanCancel()
-			p.createStreamingSpan(spanCtx, provider, reqBody, parseData, startTime, endTime, ttfb, ttft, requestID, sessionID, effectiveUserID, streamStatus, traceCtx, proxySpanID)
+			p.createStreamingSpan(spanCtx, provider, reqBody, parseData, startTime, endTime, ttfb, ttft, requestID, sessionID, effectiveUserID, tenantID, streamStatus, traceCtx, proxySpanID)
 		}()
 	} else {
 		slog.Debug("skipping streaming span (circuit open)", "provider", provider.Name, "request_id", requestID)
@@ -840,6 +893,7 @@ type spanParams struct {
 	model           string
 	sessionID       string
 	effectiveUserID string // resolved end-user identity (auth email > auth UID)
+	tenantID        string // downstream customer/tenant (from Baggage or header)
 	inputContent    string
 	outputContent   string
 	inputTokens     int64
@@ -907,6 +961,9 @@ func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 
 	// Set session ID for conversation grouping.
 	span.SessionID = params.sessionID
+
+	// Set tenant ID for multitenant cost attribution.
+	span.TenantID = params.tenantID
 
 	if p.submitter != nil {
 		p.submitter.SubmitBatch([]storage.Span{span})
@@ -999,6 +1056,7 @@ func (p *Proxy) createSpan(
 	requestID string,
 	sessionID string,
 	effectiveUserID string,
+	tenantID string,
 	traceCtx *traceContext,
 	proxySpanID string,
 ) {
@@ -1014,6 +1072,7 @@ func (p *Proxy) createSpan(
 		provider:        provider,
 		model:           model,
 		effectiveUserID: effectiveUserID,
+		tenantID:        tenantID,
 		inputContent:    inputContent,
 		outputContent:   outputContent,
 		inputTokens:     inputTokens,
@@ -1042,6 +1101,7 @@ func (p *Proxy) createStreamingSpan(
 	requestID string,
 	sessionID string,
 	effectiveUserID string,
+	tenantID string,
 	streamStatus storage.SpanStatus,
 	traceCtx *traceContext,
 	proxySpanID string,
@@ -1053,6 +1113,7 @@ func (p *Proxy) createStreamingSpan(
 		provider:        provider,
 		model:           model,
 		effectiveUserID: effectiveUserID,
+		tenantID:        tenantID,
 		inputContent:    inputContent,
 		outputContent:   outputContent,
 		inputTokens:     inputTokens,

--- a/pkg/proxy/tenant_test.go
+++ b/pkg/proxy/tenant_test.go
@@ -1,0 +1,304 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/costcalc"
+)
+
+// ── Unit Tests: parseBaggage ───────────────────────────────────────────────
+
+// UNIT-1: Valid candela.tenant_id values are correctly extracted from Baggage.
+func TestParseBaggage_ValidTenantID(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"simple", "candela.tenant_id=acme-corp", "acme-corp"},
+		{"with other keys", "svc.version=1.0,candela.tenant_id=tenant-42,foo=bar", "tenant-42"},
+		{"with property", "candela.tenant_id=dot.tenant;ttl=100", "dot.tenant"},
+		{"underscore", "candela.tenant_id=tenant_42", "tenant_42"},
+		{"dot domain style", "candela.tenant_id=acme.corp", "acme.corp"},
+		{"spaces around", "  candela.tenant_id = acme-corp ", "acme-corp"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseBaggage(tc.header)
+			if got != tc.want {
+				t.Errorf("parseBaggage(%q) = %q, want %q", tc.header, got, tc.want)
+			}
+		})
+	}
+}
+
+// UNIT-2: Invalid candela.tenant_id values are silently discarded.
+func TestParseBaggage_InvalidTenantID_Discarded(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+	}{
+		{"space in value", "candela.tenant_id=acme corp"},
+		{"at sign", "candela.tenant_id=acme@corp"},
+		{"too long", "candela.tenant_id=" + strings.Repeat("a", 129)},
+		{"slash injection", "candela.tenant_id=../../etc"},
+		{"empty value", "candela.tenant_id="},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseBaggage(tc.header)
+			if got != "" {
+				t.Errorf("parseBaggage(%q) = %q, want empty (invalid value should be discarded)", tc.header, got)
+			}
+		})
+	}
+}
+
+// UNIT-3: Empty and no-match baggage headers return empty string without panicking.
+func TestParseBaggage_EmptyAndMissing(t *testing.T) {
+	if got := parseBaggage(""); got != "" {
+		t.Errorf(`parseBaggage("") = %q, want ""`, got)
+	}
+	if got := parseBaggage("svc.version=1.0,other=stuff"); got != "" {
+		t.Errorf("parseBaggage(no tenant key) = %q, want \"\"", got)
+	}
+}
+
+// UNIT-4: CRIT-4 fix — invalid first duplicate entry is skipped; valid second entry wins.
+func TestParseBaggage_InvalidFirstValidSecond(t *testing.T) {
+	// First value has a space (invalid), second is valid — should return second.
+	header := "candela.tenant_id=bad value,candela.tenant_id=good-tenant"
+	got := parseBaggage(header)
+	if got != "good-tenant" {
+		t.Errorf("parseBaggage(%q) = %q, want good-tenant (invalid first entry should be skipped)", header, got)
+	}
+}
+
+// UNIT-5: tenantIDPattern enforces the allowed character set and length limits.
+func TestTenantIDPattern(t *testing.T) {
+	valid := []string{
+		"acme-corp", "tenant_42", "dot.tenant", "A1b2C3",
+		strings.Repeat("a", 128), // exactly max length
+	}
+	invalid := []string{
+		"", "acme corp", "acme@corp", "../../etc",
+		strings.Repeat("a", 129), // one over max
+		"acme/corp", "acme:corp",
+	}
+	for _, v := range valid {
+		if !tenantIDPattern.MatchString(v) {
+			t.Errorf("tenantIDPattern should match %q", v)
+		}
+	}
+	for _, v := range invalid {
+		if tenantIDPattern.MatchString(v) {
+			t.Errorf("tenantIDPattern should NOT match %q", v)
+		}
+	}
+}
+
+// ── Integration Tests: tenant_id propagated through proxy span ────────────
+// These reuse the mockSubmitter and helpers defined in proxy_test.go (same package).
+
+// waitForSpan polls the mock submitter until at least one span is available or timeout.
+func waitForSpan(sub *mockSubmitter) bool {
+	for i := 0; i < 50; i++ {
+		if len(sub.getSpans()) > 0 {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// INTEG-1: tenant_id from X-Candela-Tenant-Id header is persisted in the emitted span.
+func TestProxy_TenantID_HeaderPropagatedToSpan(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-t","object":"chat.completion","model":"gpt-4o",
+			"choices":[{"message":{"role":"assistant","content":"hi"},"finish_reason":"stop","index":0}],
+			"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+		}`))
+	}))
+	defer upstream.Close()
+
+	sub := &mockSubmitter{}
+	p := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "proj-test",
+	}, sub, costcalc.New())
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/proxy/openai/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer sk-test")
+	req.Header.Set("X-Candela-Tenant-Id", "acme-corp")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	if !waitForSpan(sub) {
+		t.Fatal("no spans submitted within timeout")
+	}
+	spans := sub.getSpans()
+	if spans[0].TenantID != "acme-corp" {
+		t.Errorf("span.TenantID = %q, want acme-corp", spans[0].TenantID)
+	}
+}
+
+// INTEG-2: candela.tenant_id in W3C Baggage takes precedence over the explicit header.
+func TestProxy_TenantID_BaggageWinsOverHeader(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-b","object":"chat.completion","model":"gpt-4o",
+			"choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop","index":0}],
+			"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}
+		}`))
+	}))
+	defer upstream.Close()
+
+	sub := &mockSubmitter{}
+	p := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "proj-test",
+	}, sub, costcalc.New())
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/proxy/openai/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer sk-test")
+	req.Header.Set("Baggage", "candela.tenant_id=baggage-tenant,svc=myapp")
+	req.Header.Set("X-Candela-Tenant-Id", "header-tenant") // must be overridden
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	if !waitForSpan(sub) {
+		t.Fatal("no spans submitted within timeout")
+	}
+	if got := sub.getSpans()[0].TenantID; got != "baggage-tenant" {
+		t.Errorf("TenantID = %q, want baggage-tenant (Baggage must win over header)", got)
+	}
+}
+
+// INTEG-3: No tenant headers → span.TenantID is empty string (not an error).
+func TestProxy_TenantID_AbsentHeaderLeavesEmpty(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-n","object":"chat.completion","model":"gpt-4o",
+			"choices":[{"message":{"role":"assistant","content":"pong"},"finish_reason":"stop","index":0}],
+			"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}
+		}`))
+	}))
+	defer upstream.Close()
+
+	sub := &mockSubmitter{}
+	p := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "proj-test",
+	}, sub, costcalc.New())
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"ping"}]}`
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/proxy/openai/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer sk-test")
+	// No tenant headers.
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	if !waitForSpan(sub) {
+		t.Fatal("no spans submitted within timeout")
+	}
+	if got := sub.getSpans()[0].TenantID; got != "" {
+		t.Errorf("TenantID = %q, want empty when no tenant headers provided", got)
+	}
+}
+
+// INTEG-4: Invalid X-Candela-Tenant-Id is silently rejected; request still succeeds.
+func TestProxy_TenantID_InvalidHeaderRejected(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-i","object":"chat.completion","model":"gpt-4o",
+			"choices":[{"message":{"role":"assistant","content":"safe"},"finish_reason":"stop","index":0}],
+			"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}
+		}`))
+	}))
+	defer upstream.Close()
+
+	sub := &mockSubmitter{}
+	p := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "proj-test",
+	}, sub, costcalc.New())
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}]}`
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/proxy/openai/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer sk-test")
+	req.Header.Set("X-Candela-Tenant-Id", "../../etc/passwd") // path injection attempt
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Must not return an error to the client — invalid tenant IDs are silently discarded.
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (invalid tenant must not break the request)", resp.StatusCode)
+	}
+
+	if !waitForSpan(sub) {
+		t.Fatal("no spans submitted within timeout")
+	}
+	if got := sub.getSpans()[0].TenantID; got != "" {
+		t.Errorf("TenantID = %q, want empty (injection attempt must be rejected)", got)
+	}
+}

--- a/pkg/proxy/tenant_test.go
+++ b/pkg/proxy/tenant_test.go
@@ -78,6 +78,31 @@ func TestParseBaggage_InvalidFirstValidSecond(t *testing.T) {
 	}
 }
 
+// UNIT-4b: parseBaggageHeaders joins multiple header values (W3C allows multiple
+// Baggage: header instances in a single HTTP request).
+func TestParseBaggageHeaders_MultipleHeaders(t *testing.T) {
+	// Simulate two separate Baggage header lines — r.Header.Values returns both.
+	values := []string{"svc.version=1.0", "candela.tenant_id=multi-tenant,other=val"}
+	got := parseBaggageHeaders(values)
+	if got != "multi-tenant" {
+		t.Errorf("parseBaggageHeaders(%v) = %q, want multi-tenant", values, got)
+	}
+}
+
+// UNIT-4c: Baggage key matching is case-insensitive per RFC 8941.
+func TestParseBaggage_CaseInsensitiveKey(t *testing.T) {
+	cases := []string{
+		"Candela.Tenant_Id=acme-corp",
+		"CANDELA.TENANT_ID=acme-corp",
+		"candela.TENANT_ID=acme-corp",
+	}
+	for _, h := range cases {
+		if got := parseBaggage(h); got != "acme-corp" {
+			t.Errorf("parseBaggage(%q) = %q, want acme-corp (key should be case-insensitive)", h, got)
+		}
+	}
+}
+
 // UNIT-5: tenantIDPattern enforces the allowed character set and length limits.
 func TestTenantIDPattern(t *testing.T) {
 	valid := []string{

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -106,6 +106,9 @@ type spanRow struct {
 	Attributes    []AttributeKV `bigquery:"attributes"`
 	UserID        string        `bigquery:"user_id"`
 	SessionID     string        `bigquery:"session_id"`
+	// TenantID identifies the downstream customer on whose behalf this LLM call
+	// was made. Populated from X-Candela-Tenant-Id header or W3C Baggage.
+	TenantID string `bigquery:"tenant_id"`
 }
 
 func spanToRow(span storage.Span) spanRow {
@@ -125,6 +128,7 @@ func spanToRow(span storage.Span) spanRow {
 		ServiceName:   span.ServiceName,
 		UserID:        span.UserID,
 		SessionID:     span.SessionID,
+		TenantID:      span.TenantID,
 	}
 
 	if span.GenAI != nil {
@@ -164,6 +168,7 @@ func rowToSpan(row spanRow) storage.Span {
 		ServiceName:   row.ServiceName,
 		UserID:        row.UserID,
 		SessionID:     row.SessionID,
+		TenantID:      row.TenantID,
 	}
 
 	if row.GenAIModel != "" {
@@ -218,7 +223,7 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 			Type:  bigquery.DayPartitioningType,
 		},
 		Clustering: &bigquery.Clustering{
-			Fields: []string{"project_id", "user_id", "trace_id"},
+			Fields: []string{"project_id", "tenant_id", "user_id", "trace_id"},
 		},
 	}
 	if err := table.Create(ctx, tableMeta); err != nil {
@@ -493,6 +498,7 @@ func (s *Store) SearchSpans(ctx context.Context, sq storage.SpanQuery) (*storage
 		  AND (@model = '' OR gen_ai_model = @model)
 		  AND (@nameContains = '' OR name LIKE CONCAT('%%', @escapedName, '%%'))
 		  AND (@userID = '' OR user_id = @userID)
+		  AND (@tenantID = '' OR tenant_id = @tenantID)
 		ORDER BY start_time DESC
 		LIMIT @pageSize
 	`, quoteTable(s.tableID))
@@ -507,6 +513,7 @@ func (s *Store) SearchSpans(ctx context.Context, sq storage.SpanQuery) (*storage
 		{Name: "nameContains", Value: sq.NameContains},
 		{Name: "escapedName", Value: storage.EscapeLike(sq.NameContains)},
 		{Name: "userID", Value: sq.UserID},
+		{Name: "tenantID", Value: sq.TenantID},
 		{Name: "pageSize", Value: sq.PageSize},
 	}
 
@@ -535,6 +542,7 @@ func (s *Store) GetUsageSummary(ctx context.Context, uq storage.UsageQuery) (*st
 		  AND start_time >= @startTime
 		  AND start_time <= @endTime
 		  AND (@userID = '' OR user_id = @userID)
+		  AND (@tenantID = '' OR tenant_id = @tenantID)
 	`, quoteTable(s.tableID))
 
 	q := s.client.Query(query)
@@ -544,6 +552,7 @@ func (s *Store) GetUsageSummary(ctx context.Context, uq storage.UsageQuery) (*st
 		{Name: "endTime", Value: uq.EndTime},
 		{Name: "llmKind", Value: int(storage.SpanKindLLM)},
 		{Name: "userID", Value: uq.UserID},
+		{Name: "tenantID", Value: uq.TenantID},
 	}
 
 	it, err := q.Read(ctx)
@@ -599,6 +608,7 @@ func (s *Store) GetModelBreakdown(ctx context.Context, uq storage.UsageQuery) ([
 		  AND start_time <= @endTime
 		  AND gen_ai_model != ''
 		  AND (@userID = '' OR user_id = @userID)
+		  AND (@tenantID = '' OR tenant_id = @tenantID)
 		GROUP BY gen_ai_model, gen_ai_provider
 		ORDER BY total_cost_usd DESC
 	`, quoteTable(s.tableID))
@@ -609,6 +619,7 @@ func (s *Store) GetModelBreakdown(ctx context.Context, uq storage.UsageQuery) ([
 		{Name: "startTime", Value: uq.StartTime},
 		{Name: "endTime", Value: uq.EndTime},
 		{Name: "userID", Value: uq.UserID},
+		{Name: "tenantID", Value: uq.TenantID},
 	}
 
 	it, err := q.Read(ctx)
@@ -711,6 +722,70 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, uq storage.UsageQuery, l
 	}
 
 	return users, nil
+}
+
+// GetTenantLeaderboard returns per-tenant cost aggregations ranked by cost.
+func (s *Store) GetTenantLeaderboard(ctx context.Context, uq storage.UsageQuery, limit int) ([]storage.TenantUsageSummary, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+
+	query := fmt.Sprintf(`
+		SELECT
+			tenant_id,
+			COUNT(*) AS call_count,
+			COALESCE(SUM(gen_ai_total_tokens), 0) AS total_tokens,
+			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
+			COALESCE(AVG(duration_ns), 0) AS avg_duration_ns
+		FROM %s
+		WHERE project_id = @projectID
+		  AND start_time >= @startTime
+		  AND start_time <= @endTime
+		  AND tenant_id != ''
+		GROUP BY tenant_id
+		ORDER BY total_cost_usd DESC
+		LIMIT @limit
+	`, quoteTable(s.tableID))
+
+	q := s.client.Query(query)
+	q.Parameters = []bigquery.QueryParameter{
+		{Name: "projectID", Value: uq.ProjectID},
+		{Name: "startTime", Value: uq.StartTime},
+		{Name: "endTime", Value: uq.EndTime},
+		{Name: "limit", Value: limit},
+	}
+
+	it, err := q.Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("querying tenant leaderboard: %w", err)
+	}
+
+	var tenants []storage.TenantUsageSummary
+	for {
+		var row struct {
+			TenantID      string  `bigquery:"tenant_id"`
+			CallCount     int64   `bigquery:"call_count"`
+			TotalTokens   int64   `bigquery:"total_tokens"`
+			TotalCostUSD  float64 `bigquery:"total_cost_usd"`
+			AvgDurationNs float64 `bigquery:"avg_duration_ns"`
+		}
+		err := it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("iterating tenant leaderboard: %w", err)
+		}
+		tenants = append(tenants, storage.TenantUsageSummary{
+			TenantID:     row.TenantID,
+			CallCount:    row.CallCount,
+			TotalTokens:  row.TotalTokens,
+			CostUSD:      row.TotalCostUSD,
+			AvgLatencyMs: float64(row.AvgDurationNs) / 1e6,
+		})
+	}
+
+	return tenants, nil
 }
 
 // querySpans executes a query and scans results into storage.Span.

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -736,12 +736,22 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, uq storage.UsageQuery,
 			COUNT(*) AS call_count,
 			COALESCE(SUM(gen_ai_total_tokens), 0) AS total_tokens,
 			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
-			COALESCE(AVG(duration_ns), 0) AS avg_duration_ns
-		FROM %s
-		WHERE project_id = @projectID
-		  AND start_time >= @startTime
-		  AND start_time <= @endTime
-		  AND tenant_id != ''
+			COALESCE(AVG(duration_ns), 0) AS avg_duration_ns,
+			COALESCE(
+				(SELECT m FROM UNNEST(ARRAY_AGG(gen_ai_model ORDER BY cnt DESC LIMIT 1)) AS m),
+				''
+			) AS top_model
+		FROM (
+			SELECT
+				tenant_id, gen_ai_model, gen_ai_total_tokens, gen_ai_cost_usd,
+				duration_ns,
+				COUNT(*) OVER (PARTITION BY tenant_id, gen_ai_model) AS cnt
+			FROM %s
+			WHERE project_id = @projectID
+			  AND start_time >= @startTime
+			  AND start_time <= @endTime
+			  AND tenant_id IS NOT NULL AND tenant_id != ''
+		)
 		GROUP BY tenant_id
 		ORDER BY total_cost_usd DESC
 		LIMIT @limit
@@ -768,6 +778,7 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, uq storage.UsageQuery,
 			TotalTokens   int64   `bigquery:"total_tokens"`
 			TotalCostUSD  float64 `bigquery:"total_cost_usd"`
 			AvgDurationNs float64 `bigquery:"avg_duration_ns"`
+			TopModel      string  `bigquery:"top_model"`
 		}
 		err := it.Next(&row)
 		if err == iterator.Done {
@@ -782,6 +793,7 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, uq storage.UsageQuery,
 			TotalTokens:  row.TotalTokens,
 			CostUSD:      row.TotalCostUSD,
 			AvgLatencyMs: float64(row.AvgDurationNs) / 1e6,
+			TopModel:     row.TopModel,
 		})
 	}
 

--- a/pkg/storage/duckdb/duckdb.go
+++ b/pkg/storage/duckdb/duckdb.go
@@ -91,6 +91,9 @@ func (s *Store) migrate() error {
 		`ALTER TABLE spans ADD COLUMN IF NOT EXISTS user_id VARCHAR DEFAULT ''`,
 		// Migration: add session_id column for conversation tracking.
 		`ALTER TABLE spans ADD COLUMN IF NOT EXISTS session_id VARCHAR DEFAULT ''`,
+		// Migration: add tenant_id for multitenant cost attribution.
+		`ALTER TABLE spans ADD COLUMN IF NOT EXISTS tenant_id VARCHAR DEFAULT ''`,
+		`CREATE INDEX IF NOT EXISTS idx_spans_tenant ON spans(tenant_id)`,
 	}
 
 	for _, q := range queries {
@@ -146,6 +149,7 @@ func (s *Store) IngestSpans(ctx context.Context, spans []storage.Span) error {
 				genAI.InputContent, genAI.OutputContent,
 				attrs,
 				span.SessionID,
+				span.TenantID,
 			); err != nil {
 				return fmt.Errorf("appending span %s: %w", span.SpanID, err)
 			}
@@ -164,7 +168,7 @@ func (s *Store) GetTrace(ctx context.Context, traceID string) (*storage.Trace, e
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes, user_id, session_id
+			gen_ai_input_content, gen_ai_output_content, attributes, user_id, session_id, tenant_id
 		FROM spans WHERE trace_id = ? ORDER BY start_time ASC
 	`, traceID)
 	if err != nil {
@@ -225,10 +229,11 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = '' OR user_id = ?)
 			AND (? = '' OR environment = ?)
+			AND (? = '' OR tenant_id = ?)
 		GROUP BY trace_id
 		ORDER BY `+orderExpr+` `+dir+`
 		LIMIT ?
-	`, q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID, q.Environment, q.Environment, q.PageSize)
+	`, q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID, q.Environment, q.Environment, q.TenantID, q.TenantID, q.PageSize)
 	if err != nil {
 		return nil, fmt.Errorf("querying traces: %w", err)
 	}
@@ -271,13 +276,14 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes, user_id, session_id
+			gen_ai_input_content, gen_ai_output_content, attributes, user_id, session_id, tenant_id
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = 0 OR kind = ?)
 			AND (? = '' OR gen_ai_model = ?)
 			AND (? = '' OR name LIKE '%' || ? || '%' ESCAPE '\')
 			AND (? = '' OR user_id = ?)
+			AND (? = '' OR tenant_id = ?)
 		ORDER BY start_time DESC
 		LIMIT ?
 	`, q.ProjectID, q.StartTime, q.EndTime,
@@ -285,6 +291,7 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 		q.Model, q.Model,
 		q.NameContains, storage.EscapeLike(q.NameContains),
 		q.UserID, q.UserID,
+		q.TenantID, q.TenantID,
 		q.PageSize,
 	)
 	if err != nil {
@@ -413,6 +420,54 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, q storage.UsageQuery, li
 	return users, nil
 }
 
+// GetTenantLeaderboard returns per-tenant cost aggregations ranked by cost.
+func (s *Store) GetTenantLeaderboard(ctx context.Context, q storage.UsageQuery, limit int) ([]storage.TenantUsageSummary, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT tenant_id,
+			COUNT(*)::BIGINT,
+			COALESCE(SUM(gen_ai_total_tokens), 0)::BIGINT,
+			COALESCE(SUM(gen_ai_cost_usd), 0)::DOUBLE,
+			COALESCE(AVG(duration_ns), 0)::DOUBLE / 1000000.0,
+			COALESCE((
+				SELECT s2.gen_ai_model FROM spans s2
+				WHERE s2.tenant_id = spans.tenant_id
+					AND s2.project_id = ? AND s2.start_time >= ? AND s2.start_time <= ?
+					AND s2.gen_ai_model != ''
+				GROUP BY s2.gen_ai_model
+				ORDER BY SUM(s2.gen_ai_cost_usd) DESC
+				LIMIT 1
+			), '') AS top_model
+		FROM spans
+		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+			AND tenant_id IS NOT NULL AND tenant_id != ''
+		GROUP BY tenant_id
+		ORDER BY SUM(gen_ai_cost_usd) DESC
+		LIMIT ?
+	`, q.ProjectID, q.StartTime, q.EndTime, q.ProjectID, q.StartTime, q.EndTime, limit)
+	if err != nil {
+		return nil, fmt.Errorf("querying tenant leaderboard: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tenants []storage.TenantUsageSummary
+	for rows.Next() {
+		var t storage.TenantUsageSummary
+		if err := rows.Scan(&t.TenantID, &t.CallCount, &t.TotalTokens,
+			&t.CostUSD, &t.AvgLatencyMs, &t.TopModel); err != nil {
+			return nil, fmt.Errorf("scanning tenant: %w", err)
+		}
+		tenants = append(tenants, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating tenants: %w", err)
+	}
+	return tenants, nil
+}
+
 func (s *Store) Ping(ctx context.Context) error {
 	return s.db.PingContext(ctx)
 }
@@ -444,6 +499,7 @@ func scanSpans(rows *sql.Rows) ([]storage.Span, error) {
 			&attrsAny,
 			&span.UserID,
 			&span.SessionID,
+			&span.TenantID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scanning span: %w", err)

--- a/pkg/storage/duckdb/tenant_leaderboard_test.go
+++ b/pkg/storage/duckdb/tenant_leaderboard_test.go
@@ -1,0 +1,173 @@
+package duckdb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// ── Integration Tests: GetTenantLeaderboard ───────────────────────────────
+// These use a real in-memory DuckDB store (same as other duckdb tests).
+
+// INTEG-5: GetTenantLeaderboard returns tenants ranked by cost, highest first.
+func TestGetTenantLeaderboard_RanksByCost(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	spans := []storage.Span{
+		tenantSpan("span-1", "trace-A", "acme-corp", 0.05),
+		tenantSpan("span-2", "trace-B", "acme-corp", 0.10), // acme total = 0.15
+		tenantSpan("span-3", "trace-C", "beta-inc", 0.20),  // beta total = 0.20
+		tenantSpan("span-4", "trace-D", "gamma-co", 0.01),  // gamma total = 0.01
+	}
+	for i := range spans {
+		spans[i].ProjectID = "proj-rank"
+		spans[i].StartTime = now.Add(-time.Duration(i) * time.Minute)
+		spans[i].EndTime = spans[i].StartTime.Add(100 * time.Millisecond)
+	}
+	if err := s.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("AppendSpans: %v", err)
+	}
+
+	q := storage.UsageQuery{
+		ProjectID: "proj-rank",
+		StartTime: now.Add(-1 * time.Hour),
+		EndTime:   now.Add(1 * time.Hour),
+	}
+	results, err := s.GetTenantLeaderboard(ctx, q, 10)
+	if err != nil {
+		t.Fatalf("GetTenantLeaderboard: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(results))
+	}
+
+	// Ranked by cost descending: beta (0.20) > acme (0.15) > gamma (0.01).
+	wantOrder := []string{"beta-inc", "acme-corp", "gamma-co"}
+	for i, want := range wantOrder {
+		if results[i].TenantID != want {
+			t.Errorf("results[%d].TenantID = %q, want %q", i, results[i].TenantID, want)
+		}
+	}
+}
+
+// INTEG-6: Spans with empty tenant_id are excluded from the leaderboard (CRIT-3 fix).
+func TestGetTenantLeaderboard_ExcludesEmptyAndNullTenants(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	spans := []storage.Span{
+		tenantSpan("span-a", "trace-A", "real-tenant", 0.50),
+		tenantSpan("span-b", "trace-B", "", 99.99), // no tenant — must be excluded
+	}
+	for i := range spans {
+		spans[i].ProjectID = "proj-empty"
+		spans[i].StartTime = now.Add(-time.Duration(i) * time.Minute)
+		spans[i].EndTime = spans[i].StartTime.Add(100 * time.Millisecond)
+	}
+	if err := s.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("AppendSpans: %v", err)
+	}
+
+	q := storage.UsageQuery{
+		ProjectID: "proj-empty",
+		StartTime: now.Add(-1 * time.Hour),
+		EndTime:   now.Add(1 * time.Hour),
+	}
+	results, err := s.GetTenantLeaderboard(ctx, q, 10)
+	if err != nil {
+		t.Fatalf("GetTenantLeaderboard: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1 (empty-tenant spans must be excluded)", len(results))
+	}
+	if results[0].TenantID != "real-tenant" {
+		t.Errorf("TenantID = %q, want real-tenant", results[0].TenantID)
+	}
+}
+
+// INTEG-7: limit parameter is respected.
+func TestGetTenantLeaderboard_LimitRespected(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Insert 5 distinct tenants.
+	for i := 0; i < 5; i++ {
+		sp := tenantSpan(
+			"span-limit-"+string(rune('a'+i)),
+			"trace-limit-"+string(rune('a'+i)),
+			"tenant-"+string(rune('a'+i)),
+			float64(i+1)*0.10,
+		)
+		sp.ProjectID = "proj-limit"
+		sp.StartTime = now.Add(-time.Duration(i) * time.Minute)
+		sp.EndTime = sp.StartTime.Add(100 * time.Millisecond)
+		if err := s.IngestSpans(ctx, []storage.Span{sp}); err != nil {
+			t.Fatalf("IngestSpans: %v", err)
+		}
+	}
+
+	q := storage.UsageQuery{
+		ProjectID: "proj-limit",
+		StartTime: now.Add(-1 * time.Hour),
+		EndTime:   now.Add(1 * time.Hour),
+	}
+	results, err := s.GetTenantLeaderboard(ctx, q, 3)
+	if err != nil {
+		t.Fatalf("GetTenantLeaderboard: %v", err)
+	}
+	if len(results) != 3 {
+		t.Errorf("len(results) = %d, want 3 (limit must be enforced)", len(results))
+	}
+}
+
+// INTEG-8: Empty store returns empty slice, not an error.
+func TestGetTenantLeaderboard_EmptyStore(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	q := storage.UsageQuery{
+		ProjectID: "proj-empty-store",
+		StartTime: now.Add(-1 * time.Hour),
+		EndTime:   now.Add(1 * time.Hour),
+	}
+	results, err := s.GetTenantLeaderboard(ctx, q, 10)
+	if err != nil {
+		t.Fatalf("GetTenantLeaderboard on empty store returned error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("len(results) = %d, want 0", len(results))
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+// tenantSpan builds a minimal span with the given tenant_id and cost.
+func tenantSpan(spanID, traceID, tenantID string, costUSD float64) storage.Span {
+	now := time.Now().Truncate(time.Microsecond)
+	const totalTokens = int64(100)
+	return storage.Span{
+		SpanID:    spanID,
+		TraceID:   traceID,
+		Name:      "test.llm.call",
+		Kind:      storage.SpanKindLLM,
+		Status:    storage.SpanStatusOK,
+		StartTime: now,
+		EndTime:   now.Add(100 * time.Millisecond),
+		TenantID:  tenantID,
+		GenAI: &storage.GenAIAttributes{
+			Model:        "gpt-4o",
+			Provider:     "openai",
+			InputTokens:  60,
+			OutputTokens: 40,
+			TotalTokens:  totalTokens,
+			CostUSD:      costUSD,
+		},
+	}
+}

--- a/pkg/storage/otlpexporter/convert.go
+++ b/pkg/storage/otlpexporter/convert.go
@@ -151,6 +151,12 @@ func buildAttributes(s storage.Span) []*commonpb.KeyValue {
 		add(stringAttr("enduser.id", s.UserID))
 	}
 
+	// Tenant identity — enables per-customer cost attribution in multitenant apps.
+	// Set via X-Candela-Tenant-Id header or W3C Baggage (candela.tenant_id).
+	if s.TenantID != "" {
+		add(stringAttr("candela.tenant_id", s.TenantID))
+	}
+
 	// Pass-through custom attributes — skip keys already set above to avoid duplicates.
 	for k, v := range s.Attributes {
 		if !setKeys[k] {

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -101,6 +101,8 @@ func (s *Store) migrate() error {
 		`ALTER TABLE spans ADD COLUMN user_id TEXT DEFAULT ''`,
 		// Migration: add session_id column to existing tables.
 		`ALTER TABLE spans ADD COLUMN session_id TEXT DEFAULT ''`,
+		// Migration: add tenant_id for multitenant cost attribution.
+		`ALTER TABLE spans ADD COLUMN tenant_id TEXT DEFAULT ''`,
 	}
 
 	for _, q := range queries {
@@ -126,8 +128,8 @@ func (s *Store) IngestSpans(ctx context.Context, spans []storage.Span) error {
 		start_time, end_time, duration_ns, project_id, environment, service_name,
 		gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 		gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-		gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id, tenant_id
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("preparing stmt: %w", err)
 	}
@@ -158,6 +160,7 @@ func (s *Store) IngestSpans(ctx context.Context, spans []storage.Span) error {
 			string(attrsJSON),
 			span.UserID,
 			span.SessionID,
+			span.TenantID,
 		)
 		if err != nil {
 			return fmt.Errorf("inserting span: %w", err)
@@ -173,7 +176,7 @@ func (s *Store) GetTrace(ctx context.Context, traceID string) (*storage.Trace, e
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id
+			gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id, tenant_id
 		FROM spans WHERE trace_id = ? ORDER BY start_time ASC
 	`, traceID)
 	if err != nil {
@@ -232,12 +235,13 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = '' OR user_id = ?)
+			AND (? = '' OR tenant_id = ?)
 			AND (? = '' OR environment = ?)
 		GROUP BY trace_id
 		ORDER BY `+orderExpr+` `+dir+`
 		LIMIT ?
 	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
-		q.UserID, q.UserID, q.Environment, q.Environment, q.PageSize)
+		q.UserID, q.UserID, q.TenantID, q.TenantID, q.Environment, q.Environment, q.PageSize)
 	if err != nil {
 		return nil, fmt.Errorf("querying traces: %w", err)
 	}
@@ -282,13 +286,14 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id
+			gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id, tenant_id
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = 0 OR kind = ?)
 			AND (? = '' OR gen_ai_model = ?)
 			AND (? = '' OR name LIKE '%' || ? || '%' ESCAPE '\')
 			AND (? = '' OR user_id = ?)
+			AND (? = '' OR tenant_id = ?)
 		ORDER BY start_time DESC
 		LIMIT ?
 	`, q.ProjectID,
@@ -297,6 +302,7 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 		q.Model, q.Model,
 		q.NameContains, storage.EscapeLike(q.NameContains),
 		q.UserID, q.UserID,
+		q.TenantID, q.TenantID,
 		q.PageSize,
 	)
 	if err != nil {
@@ -329,7 +335,8 @@ func (s *Store) GetUsageSummary(ctx context.Context, q storage.UsageQuery) (*sto
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = '' OR user_id = ?)
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID).Scan(
+			AND (? = '' OR tenant_id = ?)
+	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID, q.TenantID, q.TenantID).Scan(
 		&summary.TotalTraces, &summary.TotalSpans, &summary.TotalLLMCalls,
 		&summary.TotalInputTokens, &summary.TotalOutputTokens, &summary.TotalCostUSD,
 		&summary.AvgLatencyMs, &summary.ErrorRate,
@@ -349,9 +356,10 @@ func (s *Store) GetModelBreakdown(ctx context.Context, q storage.UsageQuery) ([]
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND gen_ai_model != ''
 			AND (? = '' OR user_id = ?)
+			AND (? = '' OR tenant_id = ?)
 		GROUP BY gen_ai_model, gen_ai_provider
 		ORDER BY SUM(gen_ai_cost_usd) DESC
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID)
+	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID, q.TenantID, q.TenantID)
 	if err != nil {
 		return nil, fmt.Errorf("querying model breakdown: %w", err)
 	}
@@ -422,6 +430,55 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, q storage.UsageQuery, li
 	return users, nil
 }
 
+// GetTenantLeaderboard returns per-tenant cost aggregations ranked by cost.
+func (s *Store) GetTenantLeaderboard(ctx context.Context, q storage.UsageQuery, limit int) ([]storage.TenantUsageSummary, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT tenant_id,
+			COUNT(*),
+			COALESCE(SUM(gen_ai_total_tokens), 0),
+			COALESCE(SUM(gen_ai_cost_usd), 0),
+			COALESCE(AVG(duration_ns), 0) / 1000000.0,
+			COALESCE((
+				SELECT s2.gen_ai_model FROM spans s2
+				WHERE s2.tenant_id = spans.tenant_id
+					AND s2.project_id = ? AND s2.start_time >= ? AND s2.start_time <= ?
+					AND s2.gen_ai_model != ''
+				GROUP BY s2.gen_ai_model
+				ORDER BY SUM(s2.gen_ai_cost_usd) DESC
+				LIMIT 1
+			), '') AS top_model
+		FROM spans
+		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+			AND tenant_id IS NOT NULL AND tenant_id != ''
+		GROUP BY tenant_id
+		ORDER BY SUM(gen_ai_cost_usd) DESC
+		LIMIT ?
+	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+		q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)
+	if err != nil {
+		return nil, fmt.Errorf("querying tenant leaderboard: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tenants []storage.TenantUsageSummary
+	for rows.Next() {
+		var t storage.TenantUsageSummary
+		if err := rows.Scan(&t.TenantID, &t.CallCount, &t.TotalTokens,
+			&t.CostUSD, &t.AvgLatencyMs, &t.TopModel); err != nil {
+			return nil, fmt.Errorf("scanning tenant: %w", err)
+		}
+		tenants = append(tenants, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating tenants: %w", err)
+	}
+	return tenants, nil
+}
+
 func (s *Store) Ping(ctx context.Context) error {
 	return s.db.PingContext(ctx)
 }
@@ -454,6 +511,7 @@ func scanSpans(rows *sql.Rows) ([]storage.Span, error) {
 			&attrsJSON,
 			&span.UserID,
 			&span.SessionID,
+			&span.TenantID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scanning span: %w", err)

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -103,6 +103,7 @@ func (s *Store) migrate() error {
 		`ALTER TABLE spans ADD COLUMN session_id TEXT DEFAULT ''`,
 		// Migration: add tenant_id for multitenant cost attribution.
 		`ALTER TABLE spans ADD COLUMN tenant_id TEXT DEFAULT ''`,
+		`CREATE INDEX IF NOT EXISTS idx_spans_tenant ON spans(tenant_id)`,
 	}
 
 	for _, q := range queries {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -112,6 +112,10 @@ type Span struct {
 	ServiceName   string            `json:"service_name,omitempty"`
 	UserID        string            `json:"user_id,omitempty"`
 	SessionID     string            `json:"session_id,omitempty"`
+	// TenantID identifies the downstream customer/tenant on whose behalf this LLM
+	// call was made. Set via X-Candela-Tenant-Id header or W3C Baggage
+	// (candela.tenant_id) for automatic propagation through ADK/OTel traces.
+	TenantID string `json:"tenant_id,omitempty"`
 }
 
 // TraceSummary is a lightweight summary for list views.
@@ -131,6 +135,7 @@ type TraceSummary struct {
 	PrimaryProvider string        `json:"primary_provider"`
 	UserID          string        `json:"user_id,omitempty"`
 	SessionID       string        `json:"session_id,omitempty"`
+	TenantID        string        `json:"tenant_id,omitempty"`
 }
 
 // Trace is a complete trace with all spans.
@@ -148,6 +153,7 @@ type Trace struct {
 	Spans        []Span        `json:"spans"`
 	UserID       string        `json:"user_id,omitempty"`
 	SessionID    string        `json:"session_id,omitempty"`
+	TenantID     string        `json:"tenant_id,omitempty"`
 }
 
 // TraceQuery defines filters for listing traces.
@@ -166,6 +172,7 @@ type TraceQuery struct {
 	PageToken   string
 	UserID      string // Filter by user (empty = all, for admins)
 	SessionID   string // Filter by session (empty = all)
+	TenantID    string // Filter by tenant (empty = all)
 }
 
 // TraceResult is the paginated result of a trace query.
@@ -186,6 +193,7 @@ type SpanQuery struct {
 	PageSize     int
 	PageToken    string
 	UserID       string // Filter by user (empty = all, for admins)
+	TenantID     string // Filter by tenant (empty = all)
 }
 
 // SpanResult is the paginated result of a span query.
@@ -214,11 +222,24 @@ type UsageQuery struct {
 	StartTime   time.Time
 	EndTime     time.Time
 	UserID      string // Filter by user (empty = all, for admins)
+	TenantID    string // Filter by tenant (empty = all)
 }
 
 // UserUsageSummary is a per-user aggregation for the team leaderboard.
 type UserUsageSummary struct {
 	UserID       string  `json:"user_id"`
+	CallCount    int64   `json:"call_count"`
+	TotalTokens  int64   `json:"total_tokens"`
+	CostUSD      float64 `json:"cost_usd"`
+	AvgLatencyMs float64 `json:"avg_latency_ms"`
+	TopModel     string  `json:"top_model"`
+}
+
+// TenantUsageSummary is a per-tenant aggregation for the tenant cost leaderboard.
+// TenantID values come from X-Candela-Tenant-Id headers or W3C Baggage
+// (candela.tenant_id) set by multitenant applications.
+type TenantUsageSummary struct {
+	TenantID     string  `json:"tenant_id"`
 	CallCount    int64   `json:"call_count"`
 	TotalTokens  int64   `json:"total_tokens"`
 	CostUSD      float64 `json:"cost_usd"`
@@ -268,6 +289,11 @@ type SpanReader interface {
 
 	// GetUserLeaderboard returns per-user usage ranked by cost (admin only).
 	GetUserLeaderboard(ctx context.Context, q UsageQuery, limit int) ([]UserUsageSummary, error)
+
+	// GetTenantLeaderboard returns per-tenant LLM cost aggregations ranked by
+	// cost (admin only). TenantIDs are set by multitenant applications via
+	// X-Candela-Tenant-Id header or W3C Baggage (candela.tenant_id).
+	GetTenantLeaderboard(ctx context.Context, q UsageQuery, limit int) ([]TenantUsageSummary, error)
 
 	// Ping verifies that the storage backend is reachable.
 	Ping(ctx context.Context) error

--- a/rust/crates/candela-core/src/lib.rs
+++ b/rust/crates/candela-core/src/lib.rs
@@ -118,6 +118,11 @@ pub struct Span {
     pub user_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
+    /// Downstream customer/tenant on whose behalf this LLM call was made.
+    /// Populated from W3C Baggage (`candela.tenant_id`) or the
+    /// `X-Candela-Tenant-Id` header. Used for per-tenant cost attribution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
 }
 
 // ── SpanWriter Trait ──
@@ -211,6 +216,7 @@ mod tests {
             service_name: None,
             user_id: None,
             session_id: None,
+            tenant_id: None,
         };
 
         let json = serde_json::to_string(&span).expect("serialize");
@@ -254,6 +260,7 @@ mod tests {
             service_name: Some("svc".into()),
             user_id: Some("u1".into()),
             session_id: Some("sess1".into()),
+            tenant_id: Some("acme-corp".into()),
         };
         let json = serde_json::to_string(&span).unwrap();
         let restored: Span = serde_json::from_str(&json).unwrap();
@@ -262,6 +269,7 @@ mod tests {
         assert_eq!(restored.status_message, Some("timeout".into()));
         assert_eq!(restored.attributes.get("key").unwrap(), "val");
         assert_eq!(restored.user_id, Some("u1".into()));
+        assert_eq!(restored.tenant_id, Some("acme-corp".into()));
     }
 
     #[test]

--- a/rust/crates/candela-processor/tests/processor_integration.rs
+++ b/rust/crates/candela-processor/tests/processor_integration.rs
@@ -74,6 +74,7 @@ fn make_test_span(name: &str) -> Span {
         service_name: None,
         user_id: None,
         session_id: None,
+        tenant_id: None,
     }
 }
 

--- a/test/functional/proxy/proxy_tenant.hurl
+++ b/test/functional/proxy/proxy_tenant.hurl
@@ -1,0 +1,106 @@
+# TENANT-01..05: Tenant cost attribution — header and baggage propagation
+#
+# These tests verify that X-Candela-Tenant-Id header and W3C Baggage
+# (candela.tenant_id) are accepted, validated, and propagated correctly.
+# Spans with tenant_id enable per-customer cost attribution in multitenant apps.
+#
+# Run:
+#   hurl --variable CANDELA_URL=http://localhost:8080 \
+#        test/functional/proxy/proxy_tenant.hurl
+
+# ── TENANT-01: Valid X-Candela-Tenant-Id header is accepted ──────────────────
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+X-Candela-Tenant-Id: acme-corp
+{"model":"gpt-4o","messages":[{"role":"user","content":"tenant header test"}]}
+
+HTTP 200
+[Asserts]
+# Proxy must accept the request — tenant ID is captured in the span.
+status == 200
+
+
+# ── TENANT-02: Baggage with candela.tenant_id is accepted ────────────────────
+# W3C Baggage format: "key=value, key2=value2"
+# ADK's OTel propagator injects this header automatically.
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+Baggage: candela.tenant_id=acme-corp,svc.version=1.2.0
+Traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
+{"model":"gpt-4o","messages":[{"role":"user","content":"baggage tenant test"}]}
+
+HTTP 200
+[Asserts]
+# Must not crash. Baggage is parsed, tenant_id captured, other baggage ignored.
+status == 200
+
+
+# ── TENANT-03: Baggage takes precedence over header when both present ─────────
+# If an ADK agent sets baggage AND a client also sends the header,
+# baggage wins (it represents the distributed trace context, not just one hop).
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+X-Candela-Tenant-Id: header-tenant
+Baggage: candela.tenant_id=baggage-tenant
+{"model":"gpt-4o","messages":[{"role":"user","content":"precedence test"}]}
+
+HTTP 200
+[Asserts]
+# Request must succeed. Span tenant_id = "baggage-tenant".
+# (Deep value verified in unit tests, this confirms no crash on conflict.)
+status == 200
+
+
+# ── TENANT-04: Invalid X-Candela-Tenant-Id is silently discarded ─────────────
+# Tenant IDs must match [a-zA-Z0-9\-._]{1,128}.
+# Invalid values are dropped (not rejected with 4xx) to avoid breaking clients.
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+X-Candela-Tenant-Id: evil\ninjection@attack!!
+{"model":"gpt-4o","messages":[{"role":"user","content":"invalid tenant header"}]}
+
+HTTP 200
+[Asserts]
+# Must not 400/500 — invalid tenant ID is silently dropped, span has no tenant_id.
+status == 200
+
+
+# ── TENANT-05: Domain-style tenant IDs with dots/underscores are valid ────────
+# tenantIDPattern allows [a-zA-Z0-9\-._]{1,128} — broader than session IDs.
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+X-Candela-Tenant-Id: acme.corp_42
+{"model":"gpt-4o","messages":[{"role":"user","content":"domain-style tenant"}]}
+
+HTTP 200
+[Asserts]
+status == 200
+
+
+# ── TENANT-06: Empty Baggage header doesn't crash ────────────────────────────
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+Baggage:
+{"model":"gpt-4o","messages":[{"role":"user","content":"empty baggage"}]}
+
+HTTP 200
+[Asserts]
+status == 200
+
+
+# ── TENANT-07: Baggage with no candela key is a no-op ────────────────────────
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+Baggage: other.service=foo,another.key=bar
+{"model":"gpt-4o","messages":[{"role":"user","content":"unrelated baggage"}]}
+
+HTTP 200
+[Asserts]
+status == 200


### PR DESCRIPTION
## Summary

Enables granular per-customer observability and cost attribution across the Candela stack.

## What's in this PR

### Core feature
- **Tenant extraction**: `candela.tenant_id` from W3C Baggage (preferred, ADK/OTel-compatible) or `X-Candela-Tenant-Id` header fallback — Baggage always wins
- **Full call chain**: threaded through `handleProxy` → `handleStandardResponse`/`handleStreamingResponse` → `createSpan`/`createStreamingSpan` → `buildSpan` → `span.TenantID`
- **Storage**: `tenant_id` column + migration (DuckDB, SQLite, BigQuery), `SearchSpans` filter
- **`GetTenantLeaderboard` RPC**: admin-only, ranked by spend, limit capped at 100
- **OTLP export**: `candela.tenant_id` attribute on every exported span
- **Rust `candela-core`**: `tenant_id: Option<String>` added to `Span` struct

### Critical bug fixes
- **CRIT-3**: `AND tenant_id IS NOT NULL AND tenant_id != ''` — SQL `NULL != ''` is `NULL` not `TRUE`, so NULLs would silently appear in leaderboard
- **CRIT-4**: `parseBaggage` now skips-and-continues on invalid values instead of early-returning `""`, correctly handling RFC 8941 duplicate keys

### Tests (13 new)
| Type | Count | What |
|---|---|---|
| Unit | 5 | `parseBaggage` valid/invalid/empty/CRIT-4/pattern |
| Proxy integration | 4 | Header propagation, Baggage precedence, no-tenant, injection rejection |
| DuckDB integration | 4 | Rank by cost, NULL exclusion, limit, empty store |
| Hurl | 7 | `proxy_tenant.hurl` TENANT-01..07 |

### Docs
- `docs/multitenancy.md` — comprehensive guide: Baggage vs header, ADK integration, SQL queries, OTLP, CTMS `trial_id` pattern, security notes
- `docs/adk/candela_adk.py` — `CandleaContextPlugin`, `CandelaContext`, `CTMSCandelaContext` (maps `FunnelRequest.trial_id` → `job_id`)

## Not in this PR (deferred)
- `job_id` / `trial_id` as a second attribution dimension (column + leaderboard grouping)
- Rust sidecar HTTP handler (blocked on TODOs #123-125)
- UI: tenant leaderboard dashboard widget

## Testing
```bash
# Go tests
nix develop -c go test ./pkg/proxy/... ./pkg/storage/duckdb/...

# Hurl (requires server + mock upstream)
./test/functional/run.sh --go
```