### PR TITLE
feat: implement job-level cost attribution across the stack

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -28,4 +28,4 @@ plugins:
   - local: protoc-gen-bq-schema
     out: gen/bq
 inputs:
-  - module: buf.build/candelahq/protos:v0.3.0
+  - module: buf.build/candelahq/protos:v0.4.0

--- a/cmd/candela-local/leaderboard_handler.go
+++ b/cmd/candela-local/leaderboard_handler.go
@@ -49,15 +49,22 @@ func (h *leaderboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}, limit)
 	if err != nil {
 		slog.Error("failed to query tenant leaderboard", "error", err)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": "failed to query leaderboard"})
-		return
+		// Don't fail the whole request if one leaderboard fails.
+	}
+
+	jobs, err := h.reader.GetJobLeaderboard(r.Context(), storage.UsageQuery{
+		ProjectID: "local",
+		StartTime: monthAgo,
+		EndTime:   now,
+	}, limit)
+	if err != nil {
+		slog.Error("failed to query job leaderboard", "error", err)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"tenants": tenants,
-		"count":   len(tenants),
+		"jobs":    jobs,
+		"count":   len(tenants) + len(jobs),
 	})
 }

--- a/cmd/candela-local/leaderboard_handler.go
+++ b/cmd/candela-local/leaderboard_handler.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// leaderboardHandler serves the /_local/api/leaderboard REST endpoint.
+type leaderboardHandler struct {
+	reader storage.SpanReader
+}
+
+func newLeaderboardHandler(reader storage.SpanReader) http.Handler {
+	if reader == nil {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "leaderboard not available — no storage configured"})
+		})
+	}
+	return &leaderboardHandler{reader: reader}
+}
+
+func (h *leaderboardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	limit := 10
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+
+	now := time.Now()
+	monthAgo := now.Add(-30 * 24 * time.Hour)
+
+	tenants, err := h.reader.GetTenantLeaderboard(r.Context(), storage.UsageQuery{
+		ProjectID: "local",
+		StartTime: monthAgo,
+		EndTime:   now,
+	}, limit)
+	if err != nil {
+		slog.Error("failed to query tenant leaderboard", "error", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "failed to query leaderboard"})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"tenants": tenants,
+		"count":   len(tenants),
+	})
+}

--- a/cmd/candela-local/main.go
+++ b/cmd/candela-local/main.go
@@ -327,6 +327,7 @@ func main() {
 
 	// Register traces API endpoint (solo mode observability).
 	mux.Handle("/_local/api/traces", newTracesHandler(traceReader))
+	mux.Handle("/_local/api/leaderboard", newLeaderboardHandler(traceReader))
 
 	// Everything else → remote Candela server (if configured).
 	if remoteProxy != nil {

--- a/cmd/candela-local/main.go
+++ b/cmd/candela-local/main.go
@@ -177,15 +177,13 @@ func main() {
 		// Strategy 1: idtoken.NewTokenSource (works for service accounts).
 		// Strategy 2: google.DefaultTokenSource with openid scope (works for user credentials).
 		var tokenSource oauth2.TokenSource
-		useIDToken := false
 
 		ts, err := idtoken.NewTokenSource(ctx, cfg.Audience)
 		if err == nil {
 			slog.Info("using service account ID token source")
 			tokenSource = ts
-			useIDToken = true
 		} else {
-			slog.Info("idtoken unavailable (user credentials), using OAuth2 with openid scope", "reason", err)
+			slog.Debug("idtoken.NewTokenSource unavailable (user credentials fallback)", "reason", err)
 			ts2, err2 := google.DefaultTokenSource(ctx, "openid", "email")
 			if err2 != nil {
 				slog.Error("failed to get credentials — run 'gcloud auth application-default login' first",
@@ -212,10 +210,11 @@ func main() {
 					return
 				}
 				bearerToken := token.AccessToken
-				if useIDToken {
-					if idToken, ok := token.Extra("id_token").(string); ok && idToken != "" {
-						bearerToken = idToken
-					}
+				// For IAP, we MUST use the OIDC ID token. Both idtoken.NewTokenSource
+				// and the OAuth2 fallback (with openid scope) provide this in the
+				// "id_token" extra field.
+				if idToken, ok := token.Extra("id_token").(string); ok && idToken != "" {
+					bearerToken = idToken
 				}
 				req.Header.Set("Authorization", "Bearer "+bearerToken)
 
@@ -480,7 +479,14 @@ func loadConfig(configPath string) *Config {
 	if configPath == "" {
 		home, err := os.UserHomeDir()
 		if err == nil {
-			configPath = filepath.Join(home, ".candela.yaml")
+			// Check modern XDG location first.
+			xdgPath := filepath.Join(home, ".config", "candela", "config.yaml")
+			if _, err := os.Stat(xdgPath); err == nil {
+				configPath = xdgPath
+			} else {
+				// Fallback to legacy location.
+				configPath = filepath.Join(home, ".candela.yaml")
+			}
 		}
 	}
 

--- a/cmd/candela-local/main.go
+++ b/cmd/candela-local/main.go
@@ -477,14 +477,17 @@ func loadConfig(configPath string) *Config {
 		configPath = os.Getenv("CANDELA_CONFIG")
 	}
 	if configPath == "" {
-		home, err := os.UserHomeDir()
-		if err == nil {
-			// Check modern XDG location first.
-			xdgPath := filepath.Join(home, ".config", "candela", "config.yaml")
+		// Check modern XDG location first (os.UserConfigDir handles
+		// platform differences: ~/.config on Linux, ~/Library/Application Support on macOS).
+		if configDir, err := os.UserConfigDir(); err == nil {
+			xdgPath := filepath.Join(configDir, "candela", "config.yaml")
 			if _, err := os.Stat(xdgPath); err == nil {
 				configPath = xdgPath
-			} else {
-				// Fallback to legacy location.
+			}
+		}
+		// Fallback to legacy location.
+		if configPath == "" {
+			if home, err := os.UserHomeDir(); err == nil {
 				configPath = filepath.Join(home, ".candela.yaml")
 			}
 		}

--- a/cmd/candela-local/span_capture.go
+++ b/cmd/candela-local/span_capture.go
@@ -8,11 +8,19 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/candelahq/candela/pkg/processor"
 	"github.com/candelahq/candela/pkg/session"
 	"github.com/candelahq/candela/pkg/storage"
+)
+
+var (
+	// tenantIDPattern enforces the allowed character set and length limits for tenant IDs.
+	// Matches the implementation in pkg/proxy/proxy.go.
+	tenantIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-._]{1,128}$`)
 )
 
 // spanCapture wraps an HTTP handler (typically the local proxy) and captures
@@ -92,6 +100,16 @@ func (s *spanCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Extract tenant ID for attribution.
+	// We check Baggage (W3C standard) first, then the explicit header.
+	tenantID := parseBaggageHeaders(r.Header.Values("Baggage"))
+	if tenantID == "" {
+		tenantID = r.Header.Get("X-Candela-Tenant-Id")
+		if !tenantIDPattern.MatchString(tenantID) {
+			tenantID = ""
+		}
+	}
+
 	// Capture response.
 	rec := &responseCapture{ResponseWriter: w}
 	s.next.ServeHTTP(rec, r)
@@ -99,10 +117,10 @@ func (s *spanCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	duration := time.Since(start)
 
 	// Build the span asynchronously to not block the response.
-	go s.buildSpan(chatReq.Model, chatReq.Stream, inputContent, rec.body.Bytes(), rec.statusCode, start, duration, sessionID)
+	go s.buildSpan(chatReq.Model, chatReq.Stream, inputContent, rec.body.Bytes(), rec.statusCode, start, duration, sessionID, tenantID)
 }
 
-func (s *spanCapture) buildSpan(model string, stream *bool, inputContent string, respBody []byte, statusCode int, start time.Time, duration time.Duration, sessionID string) {
+func (s *spanCapture) buildSpan(model string, stream *bool, inputContent string, respBody []byte, statusCode int, start time.Time, duration time.Duration, sessionID, tenantID string) {
 	var inputTokens, outputTokens, totalTokens int64
 
 	isStreaming := stream != nil && *stream
@@ -146,6 +164,7 @@ func (s *spanCapture) buildSpan(model string, stream *bool, inputContent string,
 		Duration:  duration,
 		ProjectID: "local",
 		SessionID: sessionID,
+		TenantID:  tenantID,
 		GenAI: &storage.GenAIAttributes{
 			Model:        model,
 			Provider:     "local",
@@ -251,4 +270,48 @@ func generateID(size int) string {
 		panic("crypto/rand failed: " + err.Error())
 	}
 	return hex.EncodeToString(b)
+}
+
+// --- Tenant ID & Baggage parsing ---
+
+// parseBaggageHeaders joins multiple Baggage headers and extracts candela.tenant_id.
+func parseBaggageHeaders(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	// W3C spec allows multiple Baggage header instances; they are logically joined with commas.
+	return parseBaggage(strings.Join(values, ","))
+}
+
+// parseBaggage extracts the candela.tenant_id value from a W3C Baggage header string.
+// Matching is case-insensitive for the key; values are validated against tenantIDPattern.
+func parseBaggage(header string) string {
+	if header == "" {
+		return ""
+	}
+
+	var tenantID string
+	parts := strings.Split(header, ",")
+	for _, part := range parts {
+		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		keyPart := strings.SplitN(strings.TrimSpace(kv[0]), ";", 2)[0]
+		if !strings.EqualFold(keyPart, "candela.tenant_id") {
+			continue
+		}
+
+		// Values can have properties (e.g. key=val;prop=1). Strip them.
+		val := strings.TrimSpace(kv[1])
+		if idx := strings.Index(val, ";"); idx >= 0 {
+			val = strings.TrimSpace(val[:idx])
+		}
+
+		if tenantIDPattern.MatchString(val) {
+			tenantID = val
+		}
+	}
+
+	return tenantID
 }

--- a/cmd/candela-local/span_capture.go
+++ b/cmd/candela-local/span_capture.go
@@ -21,6 +21,8 @@ var (
 	// tenantIDPattern enforces the allowed character set and length limits for tenant IDs.
 	// Matches the implementation in pkg/proxy/proxy.go.
 	tenantIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-._]{1,128}$`)
+	// jobIDPattern enforces the same limits for job IDs.
+	jobIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-._]{1,128}$`)
 )
 
 // spanCapture wraps an HTTP handler (typically the local proxy) and captures
@@ -100,13 +102,19 @@ func (s *spanCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Extract tenant ID for attribution.
-	// We check Baggage (W3C standard) first, then the explicit header.
-	tenantID := parseBaggageHeaders(r.Header.Values("Baggage"))
+	// Extract tenant and job IDs for attribution.
+	// We check Baggage (W3C standard) first, then the explicit headers.
+	tenantID, jobID := parseBaggageHeaders(r.Header.Values("Baggage"))
 	if tenantID == "" {
 		tenantID = r.Header.Get("X-Candela-Tenant-Id")
 		if !tenantIDPattern.MatchString(tenantID) {
 			tenantID = ""
+		}
+	}
+	if jobID == "" {
+		jobID = r.Header.Get("X-Candela-Job-Id")
+		if !jobIDPattern.MatchString(jobID) {
+			jobID = ""
 		}
 	}
 
@@ -117,10 +125,10 @@ func (s *spanCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	duration := time.Since(start)
 
 	// Build the span asynchronously to not block the response.
-	go s.buildSpan(chatReq.Model, chatReq.Stream, inputContent, rec.body.Bytes(), rec.statusCode, start, duration, sessionID, tenantID)
+	go s.buildSpan(chatReq.Model, chatReq.Stream, inputContent, rec.body.Bytes(), rec.statusCode, start, duration, sessionID, tenantID, jobID)
 }
 
-func (s *spanCapture) buildSpan(model string, stream *bool, inputContent string, respBody []byte, statusCode int, start time.Time, duration time.Duration, sessionID, tenantID string) {
+func (s *spanCapture) buildSpan(model string, stream *bool, inputContent string, respBody []byte, statusCode int, start time.Time, duration time.Duration, sessionID, tenantID, jobID string) {
 	var inputTokens, outputTokens, totalTokens int64
 
 	isStreaming := stream != nil && *stream
@@ -165,6 +173,7 @@ func (s *spanCapture) buildSpan(model string, stream *bool, inputContent string,
 		ProjectID: "local",
 		SessionID: sessionID,
 		TenantID:  tenantID,
+		JobID:     jobID,
 		GenAI: &storage.GenAIAttributes{
 			Model:        model,
 			Provider:     "local",
@@ -274,23 +283,21 @@ func generateID(size int) string {
 
 // --- Tenant ID & Baggage parsing ---
 
-// parseBaggageHeaders joins multiple Baggage headers and extracts candela.tenant_id.
-func parseBaggageHeaders(values []string) string {
+// parseBaggageHeaders joins multiple Baggage headers and extracts candela.tenant_id and candela.job_id.
+func parseBaggageHeaders(values []string) (string, string) {
 	if len(values) == 0 {
-		return ""
+		return "", ""
 	}
-	// W3C spec allows multiple Baggage header instances; they are logically joined with commas.
 	return parseBaggage(strings.Join(values, ","))
 }
 
-// parseBaggage extracts the candela.tenant_id value from a W3C Baggage header string.
-// Matching is case-insensitive for the key; values are validated against tenantIDPattern.
-func parseBaggage(header string) string {
+// parseBaggage extracts the candela.tenant_id and candela.job_id values from a W3C Baggage header string.
+func parseBaggage(header string) (string, string) {
 	if header == "" {
-		return ""
+		return "", ""
 	}
 
-	var tenantID string
+	var tenantID, jobID string
 	parts := strings.Split(header, ",")
 	for _, part := range parts {
 		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
@@ -298,20 +305,21 @@ func parseBaggage(header string) string {
 			continue
 		}
 		keyPart := strings.SplitN(strings.TrimSpace(kv[0]), ";", 2)[0]
-		if !strings.EqualFold(keyPart, "candela.tenant_id") {
-			continue
-		}
-
-		// Values can have properties (e.g. key=val;prop=1). Strip them.
 		val := strings.TrimSpace(kv[1])
 		if idx := strings.Index(val, ";"); idx >= 0 {
 			val = strings.TrimSpace(val[:idx])
 		}
 
-		if tenantIDPattern.MatchString(val) {
-			tenantID = val
+		if strings.EqualFold(keyPart, "candela.tenant_id") {
+			if tenantIDPattern.MatchString(val) {
+				tenantID = val
+			}
+		} else if strings.EqualFold(keyPart, "candela.job_id") {
+			if jobIDPattern.MatchString(val) {
+				jobID = val
+			}
 		}
 	}
 
-	return tenantID
+	return tenantID, jobID
 }

--- a/cmd/candela-local/span_capture.go
+++ b/cmd/candela-local/span_capture.go
@@ -8,21 +8,12 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"regexp"
-	"strings"
 	"time"
 
+	"github.com/candelahq/candela/pkg/attribution"
 	"github.com/candelahq/candela/pkg/processor"
 	"github.com/candelahq/candela/pkg/session"
 	"github.com/candelahq/candela/pkg/storage"
-)
-
-var (
-	// tenantIDPattern enforces the allowed character set and length limits for tenant IDs.
-	// Matches the implementation in pkg/proxy/proxy.go.
-	tenantIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-._]{1,128}$`)
-	// jobIDPattern enforces the same limits for job IDs.
-	jobIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-._]{1,128}$`)
 )
 
 // spanCapture wraps an HTTP handler (typically the local proxy) and captures
@@ -103,20 +94,8 @@ func (s *spanCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Extract tenant and job IDs for attribution.
-	// We check Baggage (W3C standard) first, then the explicit headers.
-	tenantID, jobID := parseBaggageHeaders(r.Header.Values("Baggage"))
-	if tenantID == "" {
-		tenantID = r.Header.Get("X-Candela-Tenant-Id")
-		if !tenantIDPattern.MatchString(tenantID) {
-			tenantID = ""
-		}
-	}
-	if jobID == "" {
-		jobID = r.Header.Get("X-Candela-Job-Id")
-		if !jobIDPattern.MatchString(jobID) {
-			jobID = ""
-		}
-	}
+	attr := attribution.FromRequest(r)
+	tenantID, jobID := attr.TenantID, attr.JobID
 
 	// Capture response.
 	rec := &responseCapture{ResponseWriter: w}
@@ -279,47 +258,4 @@ func generateID(size int) string {
 		panic("crypto/rand failed: " + err.Error())
 	}
 	return hex.EncodeToString(b)
-}
-
-// --- Tenant ID & Baggage parsing ---
-
-// parseBaggageHeaders joins multiple Baggage headers and extracts candela.tenant_id and candela.job_id.
-func parseBaggageHeaders(values []string) (string, string) {
-	if len(values) == 0 {
-		return "", ""
-	}
-	return parseBaggage(strings.Join(values, ","))
-}
-
-// parseBaggage extracts the candela.tenant_id and candela.job_id values from a W3C Baggage header string.
-func parseBaggage(header string) (string, string) {
-	if header == "" {
-		return "", ""
-	}
-
-	var tenantID, jobID string
-	parts := strings.Split(header, ",")
-	for _, part := range parts {
-		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
-		if len(kv) != 2 {
-			continue
-		}
-		keyPart := strings.SplitN(strings.TrimSpace(kv[0]), ";", 2)[0]
-		val := strings.TrimSpace(kv[1])
-		if idx := strings.Index(val, ";"); idx >= 0 {
-			val = strings.TrimSpace(val[:idx])
-		}
-
-		if strings.EqualFold(keyPart, "candela.tenant_id") {
-			if tenantIDPattern.MatchString(val) {
-				tenantID = val
-			}
-		} else if strings.EqualFold(keyPart, "candela.job_id") {
-			if jobIDPattern.MatchString(val) {
-				jobID = val
-			}
-		}
-	}
-
-	return tenantID, jobID
 }

--- a/cmd/candela-local/span_capture_test.go
+++ b/cmd/candela-local/span_capture_test.go
@@ -317,3 +317,132 @@ func TestTracesHandler_MethodNotAllowed(t *testing.T) {
 		t.Errorf("status = %d, want 405", resp.StatusCode)
 	}
 }
+func TestSpanCapture_TenantID_Explicit(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"choices": []any{}})
+	}))
+	defer upstream.Close()
+
+	store, _ := sqlitestore.New(sqlitestore.Config{Path: ":memory:"})
+	proc := processor.New([]storage.SpanWriter{store}, costcalc.New(), 1)
+	go proc.Run(context.Background())
+	defer proc.Stop()
+
+	handler := newSpanCapture(proxyTo(upstream.URL), proc, nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	body := `{"model": "test", "messages": []}`
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Candela-Tenant-Id", "acme-corp")
+
+	resp, _ := http.DefaultClient.Do(req)
+	_ = resp.Body.Close()
+
+	// Poll for capture.
+	var spans *storage.SpanResult
+	var err error
+	for i := 0; i < 40; i++ {
+		spans, err = store.SearchSpans(context.Background(), storage.SpanQuery{
+			ProjectID: "local",
+			StartTime: time.Now().Add(-1 * time.Hour),
+			EndTime:   time.Now().Add(1 * time.Hour),
+			PageSize:  1,
+		})
+		if err == nil && len(spans.Spans) > 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if err != nil {
+		t.Fatalf("SearchSpans failed: %v", err)
+	}
+	if len(spans.Spans) == 0 {
+		t.Fatal("no spans captured")
+	}
+	if spans.Spans[0].TenantID != "acme-corp" {
+		t.Errorf("got tenant %q, want acme-corp", spans.Spans[0].TenantID)
+	}
+}
+
+func TestSpanCapture_TenantID_Baggage(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	store, _ := sqlitestore.New(sqlitestore.Config{Path: ":memory:"})
+	proc := processor.New([]storage.SpanWriter{store}, costcalc.New(), 1)
+	go proc.Run(context.Background())
+	defer proc.Stop()
+
+	handler := newSpanCapture(proxyTo(upstream.URL), proc, nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	body := `{"model": "test", "messages": []}`
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/chat/completions", strings.NewReader(body))
+	req.Header.Add("Baggage", "candela.tenant_id=baggage-tenant")
+
+	resp, _ := http.DefaultClient.Do(req)
+	_ = resp.Body.Close()
+
+	// Poll for capture.
+	var spans *storage.SpanResult
+	var err error
+	for i := 0; i < 40; i++ {
+		spans, err = store.SearchSpans(context.Background(), storage.SpanQuery{
+			ProjectID: "local",
+			StartTime: time.Now().Add(-1 * time.Hour),
+			EndTime:   time.Now().Add(1 * time.Hour),
+			PageSize:  1,
+		})
+		if err == nil && len(spans.Spans) > 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if err != nil {
+		t.Fatalf("SearchSpans failed: %v", err)
+	}
+	if len(spans.Spans) == 0 {
+		t.Fatal("no spans captured")
+	}
+	if spans.Spans[0].TenantID != "baggage-tenant" {
+		t.Errorf("got tenant %q, want baggage-tenant", spans.Spans[0].TenantID)
+	}
+}
+
+func TestSpanCapture_TenantID_Invalid(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	store, _ := sqlitestore.New(sqlitestore.Config{Path: ":memory:"})
+	proc := processor.New([]storage.SpanWriter{store}, costcalc.New(), 1)
+	go proc.Run(context.Background())
+	defer proc.Stop()
+
+	handler := newSpanCapture(proxyTo(upstream.URL), proc, nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	body := `{"model": "test", "messages": []}`
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("X-Candela-Tenant-Id", "invalid spaces!")
+
+	resp, _ := http.DefaultClient.Do(req)
+	_ = resp.Body.Close()
+
+	// Sleep slightly to ensure it WOULD have been captured if valid.
+	time.Sleep(200 * time.Millisecond)
+	spans, _ := store.SearchSpans(context.Background(), storage.SpanQuery{PageSize: 1})
+	if len(spans.Spans) != 0 && spans.Spans[0].TenantID != "" {
+		t.Errorf("got tenant %q, want empty for invalid input", spans.Spans[0].TenantID)
+	}
+}

--- a/cmd/candela-local/span_capture_test.go
+++ b/cmd/candela-local/span_capture_test.go
@@ -446,3 +446,84 @@ func TestSpanCapture_TenantID_Invalid(t *testing.T) {
 		t.Errorf("got tenant %q, want empty for invalid input", spans.Spans[0].TenantID)
 	}
 }
+
+func TestSpanCapture_JobID(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices": [{"message": {"content": "ok"}}]}`))
+	}))
+	defer upstream.Close()
+
+	store, _ := sqlitestore.New(sqlitestore.Config{Path: ":memory:"})
+	proc := processor.New([]storage.SpanWriter{store}, costcalc.New(), 1)
+	go proc.Run(context.Background())
+	defer proc.Stop()
+
+	handler := newSpanCapture(proxyTo(upstream.URL), proc, nil)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	// Test extraction from Baggage.
+	body := `{"model": "test", "messages": []}`
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/chat/completions", strings.NewReader(body))
+	req.Header.Add("Baggage", "candela.tenant_id=t1,candela.job_id=j1")
+
+	resp, _ := http.DefaultClient.Do(req)
+	_ = resp.Body.Close()
+
+	// Poll for capture.
+	var spans *storage.SpanResult
+	for i := 0; i < 20; i++ {
+		spans, _ = store.SearchSpans(context.Background(), storage.SpanQuery{
+			ProjectID: "local",
+			StartTime: time.Now().Add(-1 * time.Hour),
+			EndTime:   time.Now().Add(1 * time.Hour),
+			PageSize:  1,
+		})
+		if len(spans.Spans) > 0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if len(spans.Spans) == 0 {
+		t.Fatal("no spans captured")
+	}
+	s := spans.Spans[0]
+	if s.TenantID != "t1" {
+		t.Errorf("got tenant %q, want t1", s.TenantID)
+	}
+	if s.JobID != "j1" {
+		t.Errorf("got job %q, want j1", s.JobID)
+	}
+
+	// Test extraction from explicit header.
+	req, _ = http.NewRequest("POST", srv.URL+"/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("X-Candela-Job-Id", "j2")
+	resp, _ = http.DefaultClient.Do(req)
+	_ = resp.Body.Close()
+
+	for i := 0; i < 20; i++ {
+		spans, _ = store.SearchSpans(context.Background(), storage.SpanQuery{
+			ProjectID: "local",
+			StartTime: time.Now().Add(-1 * time.Hour),
+			EndTime:   time.Now().Add(1 * time.Hour),
+			PageSize:  10,
+		})
+		if len(spans.Spans) >= 2 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	found := false
+	for _, s := range spans.Spans {
+		if s.JobID == "j2" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("job_id j2 not found in captured spans")
+	}
+}

--- a/cmd/candela-local/traces_handler.go
+++ b/cmd/candela-local/traces_handler.go
@@ -35,6 +35,7 @@ type spanJSON struct {
 	Status       string  `json:"status"`
 	Timestamp    string  `json:"timestamp"`
 	Name         string  `json:"name"`
+	TenantID     string  `json:"tenant_id,omitempty"`
 }
 
 func newTracesHandler(reader storage.SpanReader) http.Handler {
@@ -75,6 +76,7 @@ func (h *tracesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		EndTime:   now,
 		Kind:      storage.SpanKindLLM,
 		PageSize:  limit,
+		TenantID:  r.URL.Query().Get("tenant_id"),
 	})
 	if err != nil {
 		slog.Error("failed to query traces", "error", err)
@@ -94,6 +96,7 @@ func (h *tracesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			DurationMs: float64(s.Duration.Milliseconds()),
 			Status:     statusString(s.Status),
 			Timestamp:  s.StartTime.Format(time.RFC3339),
+			TenantID:   s.TenantID,
 		}
 		if s.GenAI != nil {
 			sj.Model = s.GenAI.Model

--- a/cmd/candela-local/traces_handler.go
+++ b/cmd/candela-local/traces_handler.go
@@ -36,6 +36,7 @@ type spanJSON struct {
 	Timestamp    string  `json:"timestamp"`
 	Name         string  `json:"name"`
 	TenantID     string  `json:"tenant_id,omitempty"`
+	JobID        string  `json:"job_id,omitempty"`
 }
 
 func newTracesHandler(reader storage.SpanReader) http.Handler {
@@ -77,6 +78,7 @@ func (h *tracesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Kind:      storage.SpanKindLLM,
 		PageSize:  limit,
 		TenantID:  r.URL.Query().Get("tenant_id"),
+		JobID:     r.URL.Query().Get("job_id"),
 	})
 	if err != nil {
 		slog.Error("failed to query traces", "error", err)
@@ -97,6 +99,7 @@ func (h *tracesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Status:     statusString(s.Status),
 			Timestamp:  s.StartTime.Format(time.RFC3339),
 			TenantID:   s.TenantID,
+			JobID:      s.JobID,
 		}
 		if s.GenAI != nil {
 			sj.Model = s.GenAI.Model

--- a/cmd/candela-local/ui/app.js
+++ b/cmd/candela-local/ui/app.js
@@ -636,7 +636,65 @@ function formatTime(iso) {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
 }
 
-$('#btn-refresh-traces').addEventListener('click', refreshTraces);
+// ── Leaderboard ──
+
+async function refreshLeaderboard() {
+  try {
+    const resp = await fetch('/_local/api/leaderboard?limit=10');
+    if (!resp.ok) {
+      const el = $('#leaderboard-content');
+      el.innerHTML = '<div class="empty-state">Leaderboard not available</div>';
+      return;
+    }
+    const data = await resp.json();
+    renderLeaderboard(data);
+  } catch (e) {
+    console.warn('leaderboard fetch failed:', e);
+    const el = $('#leaderboard-content');
+    el.innerHTML = '<div class="empty-state">Could not load leaderboard</div>';
+  }
+}
+
+function renderLeaderboard(data) {
+  const content = $('#leaderboard-content');
+  const tenants = data.tenants || [];
+
+  if (tenants.length === 0) {
+    content.innerHTML = '<div class="empty-state">No tenant data yet — propagate "X-Candela-Tenant-Id" or OTel baggage "candela.tenant_id"</div>';
+    return;
+  }
+
+  content.innerHTML = `
+    <table class="leaderboard-table">
+      <thead>
+        <tr>
+          <th>Tenant</th>
+          <th>Calls</th>
+          <th>Tokens</th>
+          <th>Cost</th>
+          <th>Top Model</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${tenants.map(t => `
+          <tr>
+            <td>
+              <div class="leaderboard-tenant">
+                <span class="tenant-id-pill">${escapeHtml(t.tenant_id)}</span>
+              </div>
+            </td>
+            <td class="leaderboard-count">${t.call_count || 0}</td>
+            <td class="leaderboard-tokens">${formatTokens(t.total_tokens || 0)}</td>
+            <td class="leaderboard-cost">$${(t.cost_usd || 0).toFixed(4)}</td>
+            <td class="leaderboard-model" title="${escapeAttr(t.top_model)}">${escapeHtml(t.top_model) || '—'}</td>
+          </tr>
+        `).join('')}
+      </tbody>
+    </table>
+  `;
+}
+
+$('#btn-refresh-leaderboard').addEventListener('click', refreshLeaderboard);
 
 // ── Initialize ──
 
@@ -649,6 +707,7 @@ async function init() {
     refreshPulls(),
     renderPopularModels(),
     refreshTraces(),
+    refreshLeaderboard(),
   ]);
 
   // Poll health every 5 seconds (updates badge only, not models).
@@ -656,6 +715,9 @@ async function init() {
 
   // Auto-refresh traces every 10 seconds.
   setInterval(refreshTraces, 10000);
+
+  // Auto-refresh leaderboard every 30 seconds.
+  setInterval(refreshLeaderboard, 30000);
 }
 
 init();

--- a/cmd/candela-local/ui/index.html
+++ b/cmd/candela-local/ui/index.html
@@ -113,6 +113,17 @@
         </div>
       </section>
 
+      <!-- ── Tenant Leaderboard Card ── -->
+      <section class="card card-leaderboard" id="leaderboard-card">
+        <div class="card-header">
+          <h2>Tenant Leaderboard</h2>
+          <button class="btn btn-sm btn-ghost" id="btn-refresh-leaderboard" title="Refresh leaderboard">↻</button>
+        </div>
+        <div class="leaderboard-content" id="leaderboard-content">
+          <div class="loading-placeholder">Loading leaderboard…</div>
+        </div>
+      </section>
+
       <!-- ── Settings Card ── -->
       <section class="card card-settings">
         <div class="card-header">

--- a/cmd/candela-local/ui/style.css
+++ b/cmd/candela-local/ui/style.css
@@ -923,3 +923,78 @@ footer {
   background: rgba(255,255,255,0.05);
   color: var(--text-muted);
 }
+
+/* ── Tenant Leaderboard ── */
+.leaderboard-content {
+  overflow-x: auto;
+}
+
+.leaderboard-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.85rem;
+}
+
+.leaderboard-table th {
+  text-align: left;
+  padding: 0.75rem 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--border);
+}
+
+.leaderboard-table td {
+  padding: 0.85rem 0.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.02);
+  vertical-align: middle;
+}
+
+.leaderboard-table tr:last-child td {
+  border-bottom: none;
+}
+
+.leaderboard-tenant {
+  font-weight: 600;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tenant-id-pill {
+  padding: 0.15rem 0.4rem;
+  background: var(--accent-glow);
+  color: var(--accent);
+  border-radius: 4px;
+  font-family: 'SF Mono', monospace;
+  font-size: 0.75rem;
+}
+
+.leaderboard-count {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+}
+
+.leaderboard-tokens {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+}
+
+.leaderboard-cost {
+  font-weight: 600;
+  color: var(--green);
+  font-variant-numeric: tabular-nums;
+}
+
+.leaderboard-model {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -193,7 +193,7 @@ func main() {
 		connecthandlers.NewIngestionHandlerDirect(proc))
 	mux.Handle(ingestionPath, ingestionH)
 
-	dashboardPath, dashboardH := candelav1connect.NewDashboardServiceHandlerWithTenant(
+	dashboardPath, dashboardH := candelav1connect.NewDashboardServiceHandlerWithJob(
 		connecthandlers.NewDashboardHandler(reader, userStore))
 	mux.Handle(dashboardPath, dashboardH)
 
@@ -593,7 +593,7 @@ func corsMiddleware(next http.Handler, origins []string) http.Handler {
 		}
 
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, Connect-Protocol-Version, Connect-Timeout-Ms, Traceparent, Tracestate, X-Request-ID, X-Session-Id")
+		w.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, Connect-Protocol-Version, Connect-Timeout-Ms, Traceparent, Tracestate, X-Request-ID, X-Session-Id, X-Candela-Tenant-Id, X-Candela-Job-Id")
 		w.Header().Set("Access-Control-Expose-Headers", "Connect-Content-Encoding")
 		w.Header().Set("Access-Control-Max-Age", "86400")
 

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -193,7 +193,7 @@ func main() {
 		connecthandlers.NewIngestionHandlerDirect(proc))
 	mux.Handle(ingestionPath, ingestionH)
 
-	dashboardPath, dashboardH := candelav1connect.NewDashboardServiceHandlerWithJob(
+	dashboardPath, dashboardH := candelav1connect.NewDashboardServiceHandler(
 		connecthandlers.NewDashboardHandler(reader, userStore))
 	mux.Handle(dashboardPath, dashboardH)
 

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -63,7 +63,7 @@ type Config struct {
 	Proxy struct {
 		Enabled   bool     `yaml:"enabled"`
 		ProjectID string   `yaml:"project_id"`
-		Providers []string `yaml:"providers"` // e.g. ["openai", "google", "anthropic", "gemini-oai"]
+		Providers []string `yaml:"providers"` // e.g. ["openai", "google", "anthropic", "anthropic-direct", "gemini-oai"]
 		VertexAI  struct {
 			ProjectID string `yaml:"project_id"` // GCP project for Vertex AI
 			Region    string `yaml:"region"`     // e.g. "us-central1"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -35,11 +35,13 @@ proxy:
   #   /proxy/google/      → https://generativelanguage.googleapis.com
   #   /proxy/gemini-oai/  → https://generativelanguage.googleapis.com/v1beta/openai (OpenAI-compat)
   #   /proxy/anthropic/   → Vertex AI (with format translation + ADC auth)
+  #   /proxy/anthropic-direct/ → https://api.anthropic.com (native Messages API, client provides key)
   #
   # Editor integration (Zed, OpenCode, etc.):
   #   OpenAI:     Base URL = http://localhost:8181/proxy/openai/v1
   #   Gemini:     Base URL = http://localhost:8181/proxy/gemini-oai/v1
-  #   Anthropic:  Base URL = http://localhost:8181/proxy/anthropic/v1
+  #   Anthropic:  Base URL = http://localhost:8181/proxy/anthropic/v1  (via Vertex AI)
+  #   Claude Code / pencil.dev: ANTHROPIC_BASE_URL = http://localhost:8181/proxy/anthropic-direct
   #
   # Local models (Ollama/vLLM/LM Studio) are handled by candela-local.
   # See ~/.candela.yaml for local runtime configuration.
@@ -47,6 +49,7 @@ proxy:
     - openai
     - google
     - anthropic
+    - anthropic-direct
     - gemini-oai
 
   # LM Studio compatibility mode.

--- a/docs/adk/candela_adk.py
+++ b/docs/adk/candela_adk.py
@@ -6,14 +6,14 @@ made by an agent — including sub-agents and tool calls — are attributed to
 the correct tenant and job for cost tracking in Candela.
 
 Usage:
-    from candela.adk import CandelaContextPlugin, CandelaContext
+    from candela.adk import CandleaContextPlugin, CandelaContext
 
     context = CandelaContext(
         tenant_id="acme-corp",
         job_id="trial-NCT01750580",   # optional: maps to trial_id, campaign_id, etc.
         session_id="session-42",       # optional: groups related calls
     )
-    plugin = CandelaContextPlugin(context)
+    plugin = CandleaContextPlugin(context)
 
     result = await agent.run_async(message, plugins=[plugin])
 
@@ -178,16 +178,16 @@ class CandelaContext:
 # ── ADK Plugin ────────────────────────────────────────────────────────────────
 
 
-class CandelaContextPlugin:
+class CandleaContextPlugin:
     """ADK plugin that injects Candela tenant context into every LLM call.
 
     Usage with Google ADK:
 
         from google.adk.agents import LlmAgent
-        from candela.adk import CandelaContextPlugin, CandelaContext
+        from candela.adk import CandleaContextPlugin, CandelaContext
 
         ctx = CandelaContext(tenant_id="acme-corp", job_id="trial-NCT01750580")
-        plugin = CandelaContextPlugin(ctx)
+        plugin = CandleaContextPlugin(ctx)
 
         result = await agent.run_async(
             "Match this patient for NCT01750580",
@@ -210,7 +210,7 @@ class CandelaContextPlugin:
 
     @property
     def name(self) -> str:
-        return "CandelaContextPlugin"
+        return "CandleaContextPlugin"
 
     def before_model_call(self, request: Any) -> Any:
         """Inject Candela baggage headers before each LLM HTTP request.
@@ -262,7 +262,7 @@ def _inject_headers(request: Any, headers: dict[str, str]) -> None:
     import warnings
 
     warnings.warn(
-        f"CandelaContextPlugin: could not inject headers into {type(request).__name__}. "
+        f"CandleaContextPlugin: could not inject headers into {type(request).__name__}. "
         "Tenant attribution may be missing for this call.",
         stacklevel=2,
     )
@@ -275,14 +275,14 @@ def make_candela_plugin(
     tenant_id: str | None = None,
     job_id: str | None = None,
     session_id: str | None = None,
-) -> CandelaContextPlugin:
-    """Convenience factory for creating a CandelaContextPlugin.
+) -> CandleaContextPlugin:
+    """Convenience factory for creating a CandleaContextPlugin.
 
     Example:
         plugin = make_candela_plugin(tenant_id="acme-corp", job_id="NCT01750580")
         result = await agent.run_async(message, plugins=[plugin])
     """
-    return CandelaContextPlugin(
+    return CandleaContextPlugin(
         CandelaContext(tenant_id=tenant_id, job_id=job_id, session_id=session_id)
     )
 
@@ -304,7 +304,7 @@ class CTMSCandelaContext(CandelaContext):
             trial_id=funnel_request.trial_id,
             run_id=funnel_request.run_id,
         )
-        plugin = CandelaContextPlugin(ctx)
+        plugin = CandleaContextPlugin(ctx)
     """
 
     trial_id: str | None = field(default=None)

--- a/docs/multitenancy.md
+++ b/docs/multitenancy.md
@@ -109,12 +109,12 @@ def make_llm_request_with_tenant(tenant_id: str, payload: dict) -> dict:
 
 ### ADK Agent: Automatic Context Propagation
 
-With the `CandelaContextPlugin` (see `docs/adk-integration.md`), tenant context
+With the `CandlaContextPlugin` (see `docs/adk-integration.md`), tenant context
 is injected automatically into every LLM call made by an ADK agent:
 
 ```python
 from google.adk.agents import LlmAgent
-from candela.adk import CandelaContextPlugin, CandelaContext
+from candela.adk import CandleaContextPlugin, CandelaContext
 
 agent = LlmAgent(
     name="my-agent",
@@ -123,7 +123,7 @@ agent = LlmAgent(
 )
 
 ctx = CandelaContext(tenant_id="acme-corp", session_id="session-42")
-plugin = CandelaContextPlugin(ctx)
+plugin = CandleaContextPlugin(ctx)
 
 # The plugin injects Baggage headers on every underlying HTTP call.
 # No code changes needed in the agent itself.
@@ -259,7 +259,7 @@ The migration runs automatically on startup and is safe to run multiple times.
 | `tenant_id` in DuckDB / SQLite / BigQuery | ✅ Implemented |
 | `GetTenantLeaderboard` RPC | ✅ Implemented |
 | OTLP export of `candela.tenant_id` | ✅ Implemented |
-| ADK `CandelaContextPlugin` | ✅ Implemented |
+| ADK `CandleaContextPlugin` | ✅ Implemented |
 | `job_id` / `trial_id` second attribution dimension | 🔜 Planned |
 | Rust sidecar parity for tenant extraction | 🔜 Planned (after HTTP handler is wired) |
 | UI: Tenant leaderboard dashboard widget | 🔜 Planned (see GitHub issues) |

--- a/pkg/attribution/attribution.go
+++ b/pkg/attribution/attribution.go
@@ -1,0 +1,101 @@
+// Package attribution provides shared utilities for extracting multitenant
+// cost-attribution metadata from HTTP requests.
+//
+// Both the cloud proxy (pkg/proxy) and the local proxy (cmd/candela-local)
+// need to extract tenant_id and job_id from W3C Baggage headers and fallback
+// X-Candela-* headers. This package consolidates that logic.
+package attribution
+
+import (
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// IDPattern enforces the allowed character set and length limits for
+// tenant and job IDs: alphanumeric, hyphens, dots, and underscores, 1–128 chars.
+// Exported so callers can use it for validation without re-defining.
+var IDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-._]{1,128}$`)
+
+// Attribution holds the tenant and job IDs extracted from request metadata.
+type Attribution struct {
+	TenantID string
+	JobID    string
+}
+
+// FromRequest extracts attribution metadata from an HTTP request using the
+// standard precedence: W3C Baggage > explicit headers.
+//
+// Baggage keys checked: candela.tenant_id, candela.job_id (case-insensitive per RFC 8941).
+// Header fallbacks: X-Candela-Tenant-Id, X-Candela-Job-Id.
+// Invalid values are logged and discarded.
+func FromRequest(r *http.Request) Attribution {
+	tenantID, jobID := ParseBaggageHeaders(r.Header.Values("Baggage"))
+	if tenantID == "" {
+		hdr := r.Header.Get("X-Candela-Tenant-Id")
+		if IDPattern.MatchString(hdr) {
+			tenantID = hdr
+		} else if hdr != "" {
+			slog.Warn("discarding invalid X-Candela-Tenant-Id header", "value", hdr)
+		}
+	}
+	if jobID == "" {
+		hdr := r.Header.Get("X-Candela-Job-Id")
+		if IDPattern.MatchString(hdr) {
+			jobID = hdr
+		} else if hdr != "" {
+			slog.Warn("discarding invalid X-Candela-Job-Id header", "value", hdr)
+		}
+	}
+	return Attribution{TenantID: tenantID, JobID: jobID}
+}
+
+// ParseBaggageHeaders joins multiple Baggage header values (W3C allows multiple
+// Baggage: header instances in a single HTTP request) and delegates to
+// ParseBaggage for extraction.
+func ParseBaggageHeaders(values []string) (tenantID, jobID string) {
+	return ParseBaggage(strings.Join(values, ","))
+}
+
+// ParseBaggage extracts candela.tenant_id and candela.job_id from a W3C Baggage
+// header value string.
+//
+// W3C Baggage format: "key1=val1;prop, key2=val2" (RFC 8941 list).
+// Baggage keys are case-insensitive per RFC 8941 — EqualFold is used.
+//
+// If multiple entries for the same key are present (RFC 8941 allows duplicates),
+// the right-most valid one wins (per W3C spec). Invalid values are warned and skipped.
+func ParseBaggage(header string) (tenantID, jobID string) {
+	if header == "" {
+		return "", ""
+	}
+	for _, member := range strings.Split(header, ",") {
+		// Each member may have properties after a semicolon: "key=value;prop".
+		kv := strings.SplitN(strings.TrimSpace(member), ";", 2)[0]
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		val := strings.TrimSpace(parts[1])
+		// RFC 8941: Baggage keys are case-insensitive.
+		if strings.EqualFold(key, "candela.tenant_id") {
+			if IDPattern.MatchString(val) {
+				// W3C spec: the right-most occurrence of a key wins.
+				tenantID = val
+			} else {
+				slog.Warn("skipping invalid candela.tenant_id in Baggage header",
+					"value", val)
+			}
+		} else if strings.EqualFold(key, "candela.job_id") {
+			if IDPattern.MatchString(val) {
+				jobID = val
+			} else {
+				slog.Warn("skipping invalid candela.job_id in Baggage header",
+					"value", val)
+			}
+		}
+	}
+	return tenantID, jobID
+}

--- a/pkg/connecthandlers/attribution.go
+++ b/pkg/connecthandlers/attribution.go
@@ -1,0 +1,58 @@
+package connecthandlers
+
+import (
+	"strings"
+
+	connect "connectrpc.com/connect"
+)
+
+// attribution holds Tenant and Job IDs extracted from request metadata.
+type attribution struct {
+	TenantID string
+	JobID    string
+}
+
+// getAttribution extracts Tenant and Job IDs from request headers, prioritizing
+// explicit X-Candela-* headers over W3C Baggage.
+func getAttribution[T any](req *connect.Request[T]) attribution {
+	h := req.Header()
+
+	tenantID := h.Get("X-Candela-Tenant-Id")
+	jobID := h.Get("X-Candela-Job-Id")
+
+	// Fallback to W3C Baggage if either is missing.
+	if tenantID == "" || jobID == "" {
+		baggage := h.Get("Baggage")
+		if baggage != "" {
+			if tenantID == "" {
+				tenantID = extractBaggage(baggage, "candela.tenant_id")
+			}
+			if jobID == "" {
+				jobID = extractBaggage(baggage, "candela.job_id")
+			}
+		}
+	}
+
+	return attribution{
+		TenantID: tenantID,
+		JobID:    jobID,
+	}
+}
+
+// extractBaggage parses a W3C Baggage string and returns the value for a key.
+// Format: key1=val1,key2=val2;prop1=v1
+func extractBaggage(baggage, key string) string {
+	for _, item := range strings.Split(baggage, ",") {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		// Split by semicolon to remove optional properties.
+		kvPart := strings.Split(item, ";")[0]
+		kv := strings.SplitN(kvPart, "=", 2)
+		if len(kv) == 2 && strings.TrimSpace(kv[0]) == key {
+			return strings.TrimSpace(kv[1])
+		}
+	}
+	return ""
+}

--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -30,11 +30,13 @@ func (h *DashboardHandler) GetUsageSummary(
 ) (*connect.Response[v1.GetUsageSummaryResponse], error) {
 	msg := req.Msg
 
+	attr := getAttribution(req)
 	q := storage.UsageQuery{
 		ProjectID:   msg.ProjectId,
 		Environment: msg.Environment,
 		UserID:      scopeUserID(ctx, h.users),
-		JobID:       req.Header().Get("X-Candela-Job-Id"),
+		JobID:       attr.JobID,
+		TenantID:    attr.TenantID,
 	}
 	if msg.TimeRange != nil {
 		if msg.TimeRange.Start != nil {
@@ -74,10 +76,12 @@ func (h *DashboardHandler) GetModelBreakdown(
 ) (*connect.Response[v1.GetModelBreakdownResponse], error) {
 	msg := req.Msg
 
+	attr := getAttribution(req)
 	q := storage.UsageQuery{
 		ProjectID: msg.ProjectId,
 		UserID:    scopeUserID(ctx, h.users),
-		JobID:     req.Header().Get("X-Candela-Job-Id"),
+		JobID:     attr.JobID,
+		TenantID:  attr.TenantID,
 	}
 	if msg.TimeRange != nil {
 		if msg.TimeRange.Start != nil {
@@ -155,10 +159,12 @@ func (h *DashboardHandler) GetMyUsage(
 	}
 
 	msg := req.Msg
+	attr := getAttribution(req)
 	q := storage.UsageQuery{
 		ProjectID: msg.ProjectId,
 		UserID:    userID,
-		JobID:     req.Header().Get("X-Candela-Job-Id"),
+		JobID:     attr.JobID,
+		TenantID:  attr.TenantID,
 	}
 	if msg.TimeRange != nil {
 		if msg.TimeRange.Start != nil {

--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -34,6 +34,7 @@ func (h *DashboardHandler) GetUsageSummary(
 		ProjectID:   msg.ProjectId,
 		Environment: msg.Environment,
 		UserID:      scopeUserID(ctx, h.users),
+		JobID:       req.Header().Get("X-Candela-Job-Id"),
 	}
 	if msg.TimeRange != nil {
 		if msg.TimeRange.Start != nil {
@@ -73,7 +74,11 @@ func (h *DashboardHandler) GetModelBreakdown(
 ) (*connect.Response[v1.GetModelBreakdownResponse], error) {
 	msg := req.Msg
 
-	q := storage.UsageQuery{ProjectID: msg.ProjectId, UserID: scopeUserID(ctx, h.users)}
+	q := storage.UsageQuery{
+		ProjectID: msg.ProjectId,
+		UserID:    scopeUserID(ctx, h.users),
+		JobID:     req.Header().Get("X-Candela-Job-Id"),
+	}
 	if msg.TimeRange != nil {
 		if msg.TimeRange.Start != nil {
 			q.StartTime = msg.TimeRange.Start.AsTime()
@@ -153,6 +158,7 @@ func (h *DashboardHandler) GetMyUsage(
 	q := storage.UsageQuery{
 		ProjectID: msg.ProjectId,
 		UserID:    userID,
+		JobID:     req.Header().Get("X-Candela-Job-Id"),
 	}
 	if msg.TimeRange != nil {
 		if msg.TimeRange.Start != nil {
@@ -371,5 +377,64 @@ func (h *DashboardHandler) GetTenantLeaderboard(
 
 	return connect.NewResponse(&v1.GetTenantLeaderboardResponse{
 		Tenants: pbTenants,
+	}), nil
+}
+
+// GetJobLeaderboard returns per-job LLM cost aggregations ranked by spend.
+// Job identity is captured from X-Candela-Job-Id header or W3C Baggage (candela.job_id).
+func (h *DashboardHandler) GetJobLeaderboard(
+	ctx context.Context,
+	req *connect.Request[v1.GetJobLeaderboardRequest],
+) (*connect.Response[v1.GetJobLeaderboardResponse], error) {
+	msg := req.Msg
+	q := storage.UsageQuery{ProjectID: msg.GetProjectId()}
+	if msg.GetTimeRange() != nil {
+		if msg.GetTimeRange().Start != nil {
+			q.StartTime = msg.GetTimeRange().Start.AsTime()
+		}
+		if msg.GetTimeRange().End != nil {
+			q.EndTime = msg.GetTimeRange().End.AsTime()
+		}
+	}
+	if q.StartTime.IsZero() {
+		q.StartTime = time.Now().Add(-30 * 24 * time.Hour) // default: last 30 days
+	}
+	if q.EndTime.IsZero() {
+		q.EndTime = time.Now()
+	}
+
+	limit := int(msg.GetLimit())
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	jobs, err := h.store.GetJobLeaderboard(ctx, q, limit)
+	if err != nil {
+		return nil, internalError("failed to get job leaderboard", err)
+	}
+
+	var pbJobs []*v1.JobUsage
+	for _, j := range jobs {
+		pbJobs = append(pbJobs, &v1.JobUsage{
+			JobId:        j.JobID,
+			CallCount:    j.CallCount,
+			TotalTokens:  j.TotalTokens,
+			CostUsd:      j.CostUSD,
+			AvgLatencyMs: j.AvgLatencyMs,
+			TopModel:     j.TopModel,
+		})
+	}
+
+	slog.Info("job leaderboard fetched",
+		"project_id", q.ProjectID,
+		"job_count", len(jobs),
+		"limit", limit,
+	)
+
+	return connect.NewResponse(&v1.GetJobLeaderboardResponse{
+		Jobs: pbJobs,
 	}), nil
 }

--- a/pkg/connecthandlers/trace_handler.go
+++ b/pkg/connecthandlers/trace_handler.go
@@ -84,6 +84,7 @@ func (h *TraceHandler) ListTraces(
 		OrderBy:     msg.OrderBy,
 		Descending:  msg.Descending,
 		UserID:      scopeUserID(ctx, h.users),
+		JobID:       req.Header().Get("X-Candela-Job-Id"),
 	}
 
 	if msg.TimeRange != nil {
@@ -143,6 +144,7 @@ func (h *TraceHandler) SearchSpans(
 		Model:        msg.Model,
 		NameContains: msg.NameContains,
 		UserID:       scopeUserID(ctx, h.users),
+		JobID:        req.Header().Get("X-Candela-Job-Id"),
 	}
 
 	if msg.TimeRange != nil {
@@ -198,6 +200,9 @@ func traceToProto(t *storage.Trace) *typespb.Trace {
 		TotalTokens:  t.TotalTokens,
 		TotalCostUsd: t.TotalCostUSD,
 		RootSpanName: t.RootSpanName,
+		UserId:       t.UserID,
+		TenantId:     t.TenantID,
+		JobId:        t.JobID,
 	}
 
 	for _, s := range t.Spans {
@@ -222,6 +227,9 @@ func spanToProto(s *storage.Span) *typespb.Span {
 		ProjectId:     s.ProjectID,
 		Environment:   s.Environment,
 		ServiceName:   s.ServiceName,
+		UserId:        s.UserID,
+		TenantId:      s.TenantID,
+		JobId:         s.JobID,
 	}
 
 	if s.GenAI != nil {
@@ -264,6 +272,9 @@ func traceSummaryToProto(t *storage.TraceSummary) *typespb.TraceSummary {
 		Status:          typespb.SpanStatus(t.Status),
 		PrimaryModel:    t.PrimaryModel,
 		PrimaryProvider: t.PrimaryProvider,
+		UserId:          t.UserID,
+		TenantId:        t.TenantID,
+		JobId:           t.JobID,
 	}
 }
 

--- a/pkg/connecthandlers/trace_handler.go
+++ b/pkg/connecthandlers/trace_handler.go
@@ -84,7 +84,8 @@ func (h *TraceHandler) ListTraces(
 		OrderBy:     msg.OrderBy,
 		Descending:  msg.Descending,
 		UserID:      scopeUserID(ctx, h.users),
-		JobID:       req.Header().Get("X-Candela-Job-Id"),
+		JobID:       getAttribution(req).JobID,
+		TenantID:    getAttribution(req).TenantID,
 	}
 
 	if msg.TimeRange != nil {
@@ -144,7 +145,8 @@ func (h *TraceHandler) SearchSpans(
 		Model:        msg.Model,
 		NameContains: msg.NameContains,
 		UserID:       scopeUserID(ctx, h.users),
-		JobID:        req.Header().Get("X-Candela-Job-Id"),
+		JobID:        getAttribution(req).JobID,
+		TenantID:     getAttribution(req).TenantID,
 	}
 
 	if msg.TimeRange != nil {

--- a/pkg/proxy/parsers.go
+++ b/pkg/proxy/parsers.go
@@ -23,10 +23,11 @@ type ProviderParser interface {
 
 // parserRegistry maps provider names to their parsers.
 var parserRegistry = map[string]ProviderParser{
-	"openai":     &openaiParser{},
-	"gemini-oai": &openaiParser{}, // Gemini OpenAI-compat returns standard OpenAI format.
-	"anthropic":  &anthropicParser{},
-	"google":     &googleParser{},
+	"openai":           &openaiParser{},
+	"gemini-oai":       &openaiParser{}, // Gemini OpenAI-compat returns standard OpenAI format.
+	"anthropic":        &anthropicParser{},
+	"anthropic-direct": &anthropicParser{}, // Same wire format, just no Vertex AI translation.
+	"google":           &googleParser{},
 }
 
 // getParser returns the parser for a provider, or a no-op fallback.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -375,6 +375,7 @@ func parseBaggage(header string) string {
 	if header == "" {
 		return ""
 	}
+	var tenantID string
 	for _, member := range strings.Split(header, ",") {
 		// Each member may have properties after a semicolon: "key=value;prop".
 		kv := strings.SplitN(strings.TrimSpace(member), ";", 2)[0]
@@ -383,14 +384,15 @@ func parseBaggage(header string) string {
 		if len(parts) == 2 && strings.EqualFold(strings.TrimSpace(parts[0]), "candela.tenant_id") {
 			val := strings.TrimSpace(parts[1])
 			if tenantIDPattern.MatchString(val) {
-				return val
+				// W3C spec: the right-most occurrence of a key wins.
+				tenantID = val
+			} else {
+				slog.Warn("skipping invalid candela.tenant_id in Baggage header",
+					"value", val)
 			}
-			slog.Warn("skipping invalid candela.tenant_id in Baggage header",
-				"value", val)
-			// Continue scanning — there may be a valid duplicate entry later.
 		}
 	}
-	return ""
+	return tenantID
 }
 
 // parseBaggageHeaders joins multiple Baggage header values (W3C allows multiple

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -366,7 +366,7 @@ var requestIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-]{1,128}$`)
 // underscores for domain-style tenant IDs (e.g. "acme.corp", "tenant_42").
 var tenantIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-._]{1,128}$`)
 
-// parseBaggage extracts candela.tenant_id from W3C Baggage header value(s).
+// parseBaggage extracts candela.tenant_id and candela.job_id from W3C Baggage header value(s).
 // W3C Baggage format: "key1=val1;prop, key2=val2" (RFC 8941 list).
 // A single request may carry multiple Baggage headers; we join them all.
 // Baggage keys are case-insensitive per RFC 8941 — EqualFold is used.
@@ -374,19 +374,22 @@ var tenantIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-._]{1,128}$`)
 // set, making this the preferred propagation path for multitenant applications.
 //
 // If multiple candela.tenant_id entries are present (RFC 8941 allows duplicates),
-// the first valid one wins. Invalid values are warned and skipped.
-func parseBaggage(header string) string {
+// the right-most valid one wins (per W3C spec). Invalid values are warned and skipped.
+func parseBaggage(header string) (tenantID, jobID string) {
 	if header == "" {
-		return ""
+		return "", ""
 	}
-	var tenantID string
 	for _, member := range strings.Split(header, ",") {
 		// Each member may have properties after a semicolon: "key=value;prop".
 		kv := strings.SplitN(strings.TrimSpace(member), ";", 2)[0]
 		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		val := strings.TrimSpace(parts[1])
 		// RFC 8941: Baggage keys are case-insensitive.
-		if len(parts) == 2 && strings.EqualFold(strings.TrimSpace(parts[0]), "candela.tenant_id") {
-			val := strings.TrimSpace(parts[1])
+		if strings.EqualFold(key, "candela.tenant_id") {
 			if tenantIDPattern.MatchString(val) {
 				// W3C spec: the right-most occurrence of a key wins.
 				tenantID = val
@@ -394,14 +397,21 @@ func parseBaggage(header string) string {
 				slog.Warn("skipping invalid candela.tenant_id in Baggage header",
 					"value", val)
 			}
+		} else if strings.EqualFold(key, "candela.job_id") {
+			if tenantIDPattern.MatchString(val) {
+				jobID = val
+			} else {
+				slog.Warn("skipping invalid candela.job_id in Baggage header",
+					"value", val)
+			}
 		}
 	}
-	return tenantID
+	return tenantID, jobID
 }
 
 // parseBaggageHeaders joins multiple Baggage header values (W3C allows multiple
 // header instances) and delegates to parseBaggage for extraction.
-func parseBaggageHeaders(values []string) string {
+func parseBaggageHeaders(values []string) (tenantID, jobID string) {
 	return parseBaggage(strings.Join(values, ","))
 }
 
@@ -422,12 +432,13 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		sessionID = "" // invalid → discard
 	}
 
-	// ── Tenant ID extraction (for multitenant cost attribution) ──
-	// Precedence: W3C Baggage (candela.tenant_id) wins over X-Candela-Tenant-Id header.
+	// ── Tenant ID & Job ID extraction (for multitenant cost attribution) ──
+	// Precedence: W3C Baggage (candela.tenant_id / candela.job_id) wins over
+	// X-Candela-Tenant-Id / X-Candela-Job-Id headers.
 	//
 	// Use r.Header.Values (not .Get) to handle multiple Baggage header instances —
 	// W3C spec and some HTTP/1.1 proxies send separate Baggage lines per entry.
-	tenantID := parseBaggageHeaders(r.Header.Values("Baggage"))
+	tenantID, jobID := parseBaggageHeaders(r.Header.Values("Baggage"))
 	if tenantID == "" {
 		// Fallback: explicit header (non-OTel callers, tests, simple scripts).
 		hdr := r.Header.Get("X-Candela-Tenant-Id")
@@ -435,6 +446,14 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 			tenantID = hdr
 		} else if hdr != "" {
 			slog.Warn("discarding invalid X-Candela-Tenant-Id header", "value", hdr)
+		}
+	}
+	if jobID == "" {
+		hdr := r.Header.Get("X-Candela-Job-Id")
+		if tenantIDPattern.MatchString(hdr) {
+			jobID = hdr
+		} else if hdr != "" {
+			slog.Warn("discarding invalid X-Candela-Job-Id header", "value", hdr)
 		}
 	}
 
@@ -655,9 +674,9 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	cbAllow := p.breakers[providerName].AllowRequest()
 
 	if isStreaming && resp.StatusCode == http.StatusOK {
-		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, cbAllow, traceCtx, proxySpanID)
+		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID)
 	} else {
-		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, cbAllow, traceCtx, proxySpanID)
+		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID)
 	}
 }
 
@@ -688,6 +707,7 @@ func (p *Proxy) handleStandardResponse(
 	sessionID string,
 	effectiveUserID string,
 	tenantID string,
+	jobID string,
 	cbAllow bool,
 	traceCtx *traceContext,
 	proxySpanID string,
@@ -753,7 +773,7 @@ func (p *Proxy) handleStandardResponse(
 		spanCtx, spanCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
 		go func() {
 			defer spanCancel()
-			p.createSpan(spanCtx, provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID, sessionID, effectiveUserID, tenantID, traceCtx, proxySpanID)
+			p.createSpan(spanCtx, provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, traceCtx, proxySpanID)
 		}()
 	} else {
 		slog.Debug("skipping span creation (circuit open)", "provider", provider.Name, "request_id", requestID)
@@ -769,6 +789,7 @@ func (p *Proxy) handleStreamingResponse(
 	sessionID string,
 	effectiveUserID string,
 	tenantID string,
+	jobID string,
 	cbAllow bool,
 	traceCtx *traceContext,
 	proxySpanID string,
@@ -908,7 +929,7 @@ func (p *Proxy) handleStreamingResponse(
 		spanCtx, spanCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
 		go func() {
 			defer spanCancel()
-			p.createStreamingSpan(spanCtx, provider, reqBody, parseData, startTime, endTime, ttfb, ttft, requestID, sessionID, effectiveUserID, tenantID, streamStatus, traceCtx, proxySpanID)
+			p.createStreamingSpan(spanCtx, provider, reqBody, parseData, startTime, endTime, ttfb, ttft, requestID, sessionID, effectiveUserID, tenantID, jobID, streamStatus, traceCtx, proxySpanID)
 		}()
 	} else {
 		slog.Debug("skipping streaming span (circuit open)", "provider", provider.Name, "request_id", requestID)
@@ -924,6 +945,7 @@ type spanParams struct {
 	sessionID       string
 	effectiveUserID string // resolved end-user identity (auth email > auth UID)
 	tenantID        string // downstream customer/tenant (from Baggage or header)
+	jobID           string // experiment/job ID (from Baggage or header)
 	inputContent    string
 	outputContent   string
 	inputTokens     int64
@@ -1074,6 +1096,9 @@ func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 	// Set tenant ID for multitenant cost attribution.
 	span.TenantID = params.tenantID
 
+	// Set job ID for experiment/job-level cost attribution.
+	span.JobID = params.jobID
+
 	if p.submitter != nil {
 		p.submitter.SubmitBatch([]storage.Span{span})
 	}
@@ -1099,6 +1124,7 @@ func (p *Proxy) createSpan(
 	sessionID string,
 	effectiveUserID string,
 	tenantID string,
+	jobID string,
 	traceCtx *traceContext,
 	proxySpanID string,
 ) {
@@ -1115,6 +1141,7 @@ func (p *Proxy) createSpan(
 		model:           model,
 		effectiveUserID: effectiveUserID,
 		tenantID:        tenantID,
+		jobID:           jobID,
 		inputContent:    inputContent,
 		outputContent:   outputContent,
 		inputTokens:     inputTokens,
@@ -1144,6 +1171,7 @@ func (p *Proxy) createStreamingSpan(
 	sessionID string,
 	effectiveUserID string,
 	tenantID string,
+	jobID string,
 	streamStatus storage.SpanStatus,
 	traceCtx *traceContext,
 	proxySpanID string,
@@ -1156,6 +1184,7 @@ func (p *Proxy) createStreamingSpan(
 		model:           model,
 		effectiveUserID: effectiveUserID,
 		tenantID:        tenantID,
+		jobID:           jobID,
 		inputContent:    inputContent,
 		outputContent:   outputContent,
 		inputTokens:     inputTokens,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -109,6 +109,10 @@ func DefaultProviders() []Provider {
 		// Anthropic via Vertex AI. Override upstream via config for your region/project:
 		// https://{REGION}-aiplatform.googleapis.com/v1/projects/{PROJECT}/locations/{REGION}/publishers/anthropic/models
 		{Name: "anthropic", UpstreamURL: "https://us-central1-aiplatform.googleapis.com"},
+		// Anthropic Direct — native Messages API passthrough to api.anthropic.com.
+		// No format translation, no Vertex AI, no ADC. Client provides its own API key.
+		// Use this for Claude Code, pencil.dev, and other tools that speak native Anthropic.
+		{Name: "anthropic-direct", UpstreamURL: "https://api.anthropic.com"},
 	}
 }
 
@@ -736,7 +740,7 @@ func (p *Proxy) handleStandardResponse(
 	// latency. Previously this ran inside the async span goroutine, causing
 	// CheckBudget to read stale spend data and allowing sequential calls to
 	// overshoot the budget (e.g. $9.45 spent on a $5 limit).
-if cbAllow && p.users != nil && effectiveUserID != "" {
+	if cbAllow && p.users != nil && effectiveUserID != "" {
 		model, _ := extractRequestInfo(provider.Name, reqBody)
 		_, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
@@ -891,7 +895,7 @@ func (p *Proxy) handleStreamingResponse(
 		streamStatus = storage.SpanStatusError
 	}
 	// ── Budget deduction (SYNCHRONOUS) — same rationale as handleStandardResponse.
-if cbAllow && p.users != nil && effectiveUserID != "" {
+	if cbAllow && p.users != nil && effectiveUserID != "" {
 		model, _ := extractRequestInfo(provider.Name, reqBody)
 		_, inputTokens, outputTokens := extractStreamingUsage(provider.Name, parseData)
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
@@ -969,7 +973,7 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 				"attempt", attempt+1,
 				"backoff_ms", backoff.Milliseconds(),
 				"error", deductErr)
-select {
+			select {
 			case <-ctx.Done():
 				return
 			case <-time.After(backoff):
@@ -1198,7 +1202,15 @@ func forwardHeaders(src *http.Request, dst *http.Request, provider string) {
 	case "anthropic":
 		// Anthropic via Vertex AI uses Authorization: Bearer (ADC token).
 		// Direct API uses X-Api-Key. Forward both for flexibility.
-		for _, h := range []string{"X-Api-Key", "Anthropic-Version"} {
+		for _, h := range []string{"X-Api-Key", "Anthropic-Version", "Anthropic-Beta"} {
+			if v := src.Header.Get(h); v != "" {
+				dst.Header.Set(h, v)
+			}
+		}
+	case "anthropic-direct":
+		// Native Anthropic Messages API — forward all required headers.
+		// Claude Code requires anthropic-beta and anthropic-version to be forwarded.
+		for _, h := range []string{"X-Api-Key", "Anthropic-Version", "Anthropic-Beta"} {
 			if v := src.Header.Get(h); v != "" {
 				dst.Header.Set(h, v)
 			}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -26,6 +26,7 @@ import (
 
 	"golang.org/x/oauth2"
 
+	"github.com/candelahq/candela/pkg/attribution"
 	"github.com/candelahq/candela/pkg/auth"
 	"github.com/candelahq/candela/pkg/costcalc"
 	"github.com/candelahq/candela/pkg/notify"
@@ -362,57 +363,19 @@ func rewriteModelField(body []byte, newModel string) []byte {
 // Also used to validate X-Session-Id and X-Candela-Tenant-Id.
 var requestIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-]{1,128}$`)
 
-// tenantIDPattern is slightly looser than requestIDPattern — allows dots and
-// underscores for domain-style tenant IDs (e.g. "acme.corp", "tenant_42").
-var tenantIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-._]{1,128}$`)
+// tenantIDPattern delegates to attribution.IDPattern for backward compatibility
+// with tests in this package.
+var tenantIDPattern = attribution.IDPattern
 
-// parseBaggage extracts candela.tenant_id and candela.job_id from W3C Baggage header value(s).
-// W3C Baggage format: "key1=val1;prop, key2=val2" (RFC 8941 list).
-// A single request may carry multiple Baggage headers; we join them all.
-// Baggage keys are case-insensitive per RFC 8941 — EqualFold is used.
-// ADK's OTel propagator injects Baggage automatically when context has baggage
-// set, making this the preferred propagation path for multitenant applications.
-//
-// If multiple candela.tenant_id entries are present (RFC 8941 allows duplicates),
-// the right-most valid one wins (per W3C spec). Invalid values are warned and skipped.
+// parseBaggage delegates to the shared attribution package.
+// Kept as a package-level function for test compatibility.
 func parseBaggage(header string) (tenantID, jobID string) {
-	if header == "" {
-		return "", ""
-	}
-	for _, member := range strings.Split(header, ",") {
-		// Each member may have properties after a semicolon: "key=value;prop".
-		kv := strings.SplitN(strings.TrimSpace(member), ";", 2)[0]
-		parts := strings.SplitN(kv, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		key := strings.TrimSpace(parts[0])
-		val := strings.TrimSpace(parts[1])
-		// RFC 8941: Baggage keys are case-insensitive.
-		if strings.EqualFold(key, "candela.tenant_id") {
-			if tenantIDPattern.MatchString(val) {
-				// W3C spec: the right-most occurrence of a key wins.
-				tenantID = val
-			} else {
-				slog.Warn("skipping invalid candela.tenant_id in Baggage header",
-					"value", val)
-			}
-		} else if strings.EqualFold(key, "candela.job_id") {
-			if tenantIDPattern.MatchString(val) {
-				jobID = val
-			} else {
-				slog.Warn("skipping invalid candela.job_id in Baggage header",
-					"value", val)
-			}
-		}
-	}
-	return tenantID, jobID
+	return attribution.ParseBaggage(header)
 }
 
-// parseBaggageHeaders joins multiple Baggage header values (W3C allows multiple
-// header instances) and delegates to parseBaggage for extraction.
+// parseBaggageHeaders delegates to the shared attribution package.
 func parseBaggageHeaders(values []string) (tenantID, jobID string) {
-	return parseBaggage(strings.Join(values, ","))
+	return attribution.ParseBaggageHeaders(values)
 }
 
 func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
@@ -433,29 +396,8 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ── Tenant ID & Job ID extraction (for multitenant cost attribution) ──
-	// Precedence: W3C Baggage (candela.tenant_id / candela.job_id) wins over
-	// X-Candela-Tenant-Id / X-Candela-Job-Id headers.
-	//
-	// Use r.Header.Values (not .Get) to handle multiple Baggage header instances —
-	// W3C spec and some HTTP/1.1 proxies send separate Baggage lines per entry.
-	tenantID, jobID := parseBaggageHeaders(r.Header.Values("Baggage"))
-	if tenantID == "" {
-		// Fallback: explicit header (non-OTel callers, tests, simple scripts).
-		hdr := r.Header.Get("X-Candela-Tenant-Id")
-		if tenantIDPattern.MatchString(hdr) {
-			tenantID = hdr
-		} else if hdr != "" {
-			slog.Warn("discarding invalid X-Candela-Tenant-Id header", "value", hdr)
-		}
-	}
-	if jobID == "" {
-		hdr := r.Header.Get("X-Candela-Job-Id")
-		if tenantIDPattern.MatchString(hdr) {
-			jobID = hdr
-		} else if hdr != "" {
-			slog.Warn("discarding invalid X-Candela-Job-Id header", "value", hdr)
-		}
-	}
+	attr := attribution.FromRequest(r)
+	tenantID, jobID := attr.TenantID, attr.JobID
 
 	// Extract W3C Trace Context for trace correlation with OTel-instrumented
 	// callers (e.g. Google ADK, LangChain). When present, the proxy span

--- a/pkg/proxy/tenant_test.go
+++ b/pkg/proxy/tenant_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -75,6 +76,59 @@ func TestParseBaggage_InvalidFirstValidSecond(t *testing.T) {
 	got := parseBaggage(header)
 	if got != "good-tenant" {
 		t.Errorf("parseBaggage(%q) = %q, want good-tenant (invalid first entry should be skipped)", header, got)
+	}
+}
+
+
+// UNIT-4b: parseBaggageHeaders joins multiple header values (W3C allows multiple
+// Baggage: header instances in a single HTTP request).
+func TestParseBaggageHeaders_MultipleHeaders(t *testing.T) {
+	// Simulate two separate Baggage header lines — r.Header.Values returns both.
+	values := []string{"svc.version=1.0", "candela.tenant_id=multi-tenant,other=val"}
+	got := parseBaggageHeaders(values)
+	if got != "multi-tenant" {
+		t.Errorf("parseBaggageHeaders(%v) = %q, want multi-tenant", values, got)
+	}
+}
+
+// UNIT-4c: Baggage key matching is case-insensitive per RFC 8941.
+func TestParseBaggage_CaseInsensitiveKey(t *testing.T) {
+	cases := []string{
+		"Candela.Tenant_Id=acme-corp",
+		"CANDELA.TENANT_ID=acme-corp",
+		"candela.TENANT_ID=acme-corp",
+	}
+	for _, h := range cases {
+		if got := parseBaggage(h); got != "acme-corp" {
+			t.Errorf("parseBaggage(%q) = %q, want acme-corp (key should be case-insensitive)", h, got)
+		}
+	}
+}
+
+// UNIT-4d: W3C Baggage spec — right-most occurrence wins if keys are duplicated.
+func TestParseBaggage_RightMostWins(t *testing.T) {
+	header := "candela.tenant_id=first,svc=test,candela.tenant_id=second"
+	got := parseBaggage(header)
+	if got != "second" {
+		t.Errorf("parseBaggage(%q) = %q, want second (right-most occurrence must win)", header, got)
+	}
+}
+
+// UNIT-4e: Malformed parts are skipped without affecting valid ones.
+func TestParseBaggage_MalformedParts(t *testing.T) {
+	header := "!!!, candela.tenant_id=valid-one, ==, key=val"
+	got := parseBaggage(header)
+	if got != "valid-one" {
+		t.Errorf("parseBaggage(%q) = %q, want valid-one", header, got)
+	}
+}
+
+// UNIT-4f: Properties (semicolon-separated) are ignored per spec.
+func TestParseBaggage_PropertiesIgnored(t *testing.T) {
+	header := "candela.tenant_id=acme;ttl=100;p2=val,other=foo"
+	got := parseBaggage(header)
+	if got != "acme" {
+		t.Errorf("parseBaggage(%q) = %q, want acme (properties should be stripped)", header, got)
 	}
 }
 
@@ -349,5 +403,75 @@ func TestProxy_TenantID_MultiBaggageHeaders(t *testing.T) {
 	}
 	if got := sub.getSpans()[0].TenantID; got != "multi-header-tenant" {
 		t.Errorf("TenantID = %q, want multi-header-tenant", got)
+	}
+}
+
+// INTEG-6: W3C Baggage takes precedence over X-Candela-Tenant-Id header.
+func TestProxy_TenantID_Precedence(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-p","object":"chat.completion","model":"gpt-4o","choices":[],"usage":{"total_tokens":1}}`))
+	}))
+	defer upstream.Close()
+
+	sub := &mockSubmitter{}
+	p := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "proj-test",
+	}, sub, costcalc.New())
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o","messages":[]}`
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/proxy/openai/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("X-Candela-Tenant-Id", "header-tenant")
+	req.Header.Set("Baggage", "candela.tenant_id=baggage-tenant")
+
+	resp, _ := http.DefaultClient.Do(req)
+	_ = resp.Body.Close()
+
+	if !waitForSpan(sub) {
+		t.Fatal("no spans submitted within timeout")
+	}
+	if got := sub.getSpans()[0].TenantID; got != "baggage-tenant" {
+		t.Errorf("TenantID = %q, want baggage-tenant (Baggage must win over header)", got)
+	}
+}
+
+// INTEG-7: Tenant ID is correctly attributed for streaming responses.
+func TestProxy_TenantID_Streaming(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n"))
+	}))
+	defer upstream.Close()
+
+	sub := &mockSubmitter{}
+	p := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "proj-test",
+	}, sub, costcalc.New())
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o","messages":[],"stream":true}`
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/proxy/openai/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("X-Candela-Tenant-Id", "stream-tenant")
+
+	resp, _ := http.DefaultClient.Do(req)
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if !waitForSpan(sub) {
+		t.Fatal("no spans submitted within timeout")
+	}
+	if got := sub.getSpans()[0].TenantID; got != "stream-tenant" {
+		t.Errorf("TenantID = %q, want stream-tenant", got)
 	}
 }

--- a/pkg/proxy/tenant_test.go
+++ b/pkg/proxy/tenant_test.go
@@ -302,3 +302,52 @@ func TestProxy_TenantID_InvalidHeaderRejected(t *testing.T) {
 		t.Errorf("TenantID = %q, want empty (injection attempt must be rejected)", got)
 	}
 }
+
+// INTEG-5: Multiple Baggage header lines are joined and correctly parsed (W3C spec compliance).
+func TestProxy_TenantID_MultiBaggageHeaders(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-m","object":"chat.completion","model":"gpt-4o",
+			"choices":[{"message":{"role":"assistant","content":"multi"},"finish_reason":"stop","index":0}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}
+		}`))
+	}))
+	defer upstream.Close()
+
+	sub := &mockSubmitter{}
+	p := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "proj-test",
+	}, sub, costcalc.New())
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/proxy/openai/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer sk-test")
+
+	// Add multiple Baggage headers.
+	req.Header.Add("Baggage", "svc.name=my-service,svc.version=1.2.3")
+	req.Header.Add("Baggage", "candela.tenant_id=multi-header-tenant")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	if !waitForSpan(sub) {
+		t.Fatal("no spans submitted within timeout")
+	}
+	if got := sub.getSpans()[0].TenantID; got != "multi-header-tenant" {
+		t.Errorf("TenantID = %q, want multi-header-tenant", got)
+	}
+}

--- a/pkg/proxy/tenant_test.go
+++ b/pkg/proxy/tenant_test.go
@@ -78,31 +78,6 @@ func TestParseBaggage_InvalidFirstValidSecond(t *testing.T) {
 	}
 }
 
-// UNIT-4b: parseBaggageHeaders joins multiple header values (W3C allows multiple
-// Baggage: header instances in a single HTTP request).
-func TestParseBaggageHeaders_MultipleHeaders(t *testing.T) {
-	// Simulate two separate Baggage header lines — r.Header.Values returns both.
-	values := []string{"svc.version=1.0", "candela.tenant_id=multi-tenant,other=val"}
-	got := parseBaggageHeaders(values)
-	if got != "multi-tenant" {
-		t.Errorf("parseBaggageHeaders(%v) = %q, want multi-tenant", values, got)
-	}
-}
-
-// UNIT-4c: Baggage key matching is case-insensitive per RFC 8941.
-func TestParseBaggage_CaseInsensitiveKey(t *testing.T) {
-	cases := []string{
-		"Candela.Tenant_Id=acme-corp",
-		"CANDELA.TENANT_ID=acme-corp",
-		"candela.TENANT_ID=acme-corp",
-	}
-	for _, h := range cases {
-		if got := parseBaggage(h); got != "acme-corp" {
-			t.Errorf("parseBaggage(%q) = %q, want acme-corp (key should be case-insensitive)", h, got)
-		}
-	}
-}
-
 // UNIT-5: tenantIDPattern enforces the allowed character set and length limits.
 func TestTenantIDPattern(t *testing.T) {
 	valid := []string{

--- a/pkg/proxy/tenant_test.go
+++ b/pkg/proxy/tenant_test.go
@@ -29,7 +29,7 @@ func TestParseBaggage_ValidTenantID(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := parseBaggage(tc.header)
+			got, _ := parseBaggage(tc.header)
 			if got != tc.want {
 				t.Errorf("parseBaggage(%q) = %q, want %q", tc.header, got, tc.want)
 			}
@@ -51,7 +51,7 @@ func TestParseBaggage_InvalidTenantID_Discarded(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := parseBaggage(tc.header)
+			got, _ := parseBaggage(tc.header)
 			if got != "" {
 				t.Errorf("parseBaggage(%q) = %q, want empty (invalid value should be discarded)", tc.header, got)
 			}
@@ -61,10 +61,10 @@ func TestParseBaggage_InvalidTenantID_Discarded(t *testing.T) {
 
 // UNIT-3: Empty and no-match baggage headers return empty string without panicking.
 func TestParseBaggage_EmptyAndMissing(t *testing.T) {
-	if got := parseBaggage(""); got != "" {
+	if got, _ := parseBaggage(""); got != "" {
 		t.Errorf(`parseBaggage("") = %q, want ""`, got)
 	}
-	if got := parseBaggage("svc.version=1.0,other=stuff"); got != "" {
+	if got, _ := parseBaggage("svc.version=1.0,other=stuff"); got != "" {
 		t.Errorf("parseBaggage(no tenant key) = %q, want \"\"", got)
 	}
 }
@@ -73,19 +73,18 @@ func TestParseBaggage_EmptyAndMissing(t *testing.T) {
 func TestParseBaggage_InvalidFirstValidSecond(t *testing.T) {
 	// First value has a space (invalid), second is valid — should return second.
 	header := "candela.tenant_id=bad value,candela.tenant_id=good-tenant"
-	got := parseBaggage(header)
+	got, _ := parseBaggage(header)
 	if got != "good-tenant" {
 		t.Errorf("parseBaggage(%q) = %q, want good-tenant (invalid first entry should be skipped)", header, got)
 	}
 }
-
 
 // UNIT-4b: parseBaggageHeaders joins multiple header values (W3C allows multiple
 // Baggage: header instances in a single HTTP request).
 func TestParseBaggageHeaders_MultipleHeaders(t *testing.T) {
 	// Simulate two separate Baggage header lines — r.Header.Values returns both.
 	values := []string{"svc.version=1.0", "candela.tenant_id=multi-tenant,other=val"}
-	got := parseBaggageHeaders(values)
+	got, _ := parseBaggageHeaders(values)
 	if got != "multi-tenant" {
 		t.Errorf("parseBaggageHeaders(%v) = %q, want multi-tenant", values, got)
 	}
@@ -99,7 +98,7 @@ func TestParseBaggage_CaseInsensitiveKey(t *testing.T) {
 		"candela.TENANT_ID=acme-corp",
 	}
 	for _, h := range cases {
-		if got := parseBaggage(h); got != "acme-corp" {
+		if got, _ := parseBaggage(h); got != "acme-corp" {
 			t.Errorf("parseBaggage(%q) = %q, want acme-corp (key should be case-insensitive)", h, got)
 		}
 	}
@@ -108,7 +107,7 @@ func TestParseBaggage_CaseInsensitiveKey(t *testing.T) {
 // UNIT-4d: W3C Baggage spec — right-most occurrence wins if keys are duplicated.
 func TestParseBaggage_RightMostWins(t *testing.T) {
 	header := "candela.tenant_id=first,svc=test,candela.tenant_id=second"
-	got := parseBaggage(header)
+	got, _ := parseBaggage(header)
 	if got != "second" {
 		t.Errorf("parseBaggage(%q) = %q, want second (right-most occurrence must win)", header, got)
 	}
@@ -117,7 +116,7 @@ func TestParseBaggage_RightMostWins(t *testing.T) {
 // UNIT-4e: Malformed parts are skipped without affecting valid ones.
 func TestParseBaggage_MalformedParts(t *testing.T) {
 	header := "!!!, candela.tenant_id=valid-one, ==, key=val"
-	got := parseBaggage(header)
+	got, _ := parseBaggage(header)
 	if got != "valid-one" {
 		t.Errorf("parseBaggage(%q) = %q, want valid-one", header, got)
 	}
@@ -126,7 +125,7 @@ func TestParseBaggage_MalformedParts(t *testing.T) {
 // UNIT-4f: Properties (semicolon-separated) are ignored per spec.
 func TestParseBaggage_PropertiesIgnored(t *testing.T) {
 	header := "candela.tenant_id=acme;ttl=100;p2=val,other=foo"
-	got := parseBaggage(header)
+	got, _ := parseBaggage(header)
 	if got != "acme" {
 		t.Errorf("parseBaggage(%q) = %q, want acme (properties should be stripped)", header, got)
 	}

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -951,6 +951,8 @@ func buildTrace(traceID string, spans []storage.Span) *storage.Trace {
 		EndTime:     spans[0].EndTime,
 		ProjectID:   spans[0].ProjectID,
 		Environment: spans[0].Environment,
+		TenantID:    spans[0].TenantID,
+		JobID:       spans[0].JobID,
 		SpanCount:   len(spans),
 		Spans:       spans,
 	}

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -9,6 +9,7 @@ package bigquery
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -380,6 +381,14 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		tq.PageSize = 20
 	}
 
+	// Implement offset-based pagination using PageToken.
+	var offset int
+	if tq.PageToken != "" {
+		if b, err := base64.StdEncoding.DecodeString(tq.PageToken); err == nil {
+			_, _ = fmt.Sscanf(string(b), "%d", &offset)
+		}
+	}
+
 	query := fmt.Sprintf(`
 		SELECT trace_id, MIN(start_time) AS earliest
 		FROM %s
@@ -387,9 +396,10 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		  AND start_time >= @startTime
 		  AND start_time <= @endTime
 		  AND (@userID = '' OR user_id = @userID)
+		  AND (@tenantID = '' OR tenant_id = @tenantID)
 		GROUP BY trace_id
 		ORDER BY earliest DESC
-		LIMIT @pageSize
+		LIMIT @pageSize OFFSET @offset
 	`, quoteTable(s.tableID))
 
 	q := s.client.Query(query)
@@ -398,7 +408,9 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		{Name: "startTime", Value: tq.StartTime},
 		{Name: "endTime", Value: tq.EndTime},
 		{Name: "userID", Value: tq.UserID},
+		{Name: "tenantID", Value: tq.TenantID},
 		{Name: "pageSize", Value: tq.PageSize},
+		{Name: "offset", Value: offset},
 	}
 
 	it, err := q.Read(ctx)
@@ -439,7 +451,7 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		       gen_ai_input_tokens, gen_ai_output_tokens, gen_ai_total_tokens,
 		       gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
 		       '' AS gen_ai_input_content, '' AS gen_ai_output_content,
-		       attributes, user_id, session_id
+		       attributes, user_id, session_id, tenant_id
 		FROM %s
 		WHERE trace_id IN UNNEST(@traceIDs)
 		ORDER BY start_time ASC, span_id ASC
@@ -480,7 +492,12 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		})
 	}
 
-	return &storage.TraceResult{Traces: traces, TotalCount: len(traces)}, nil
+	result := &storage.TraceResult{Traces: traces, TotalCount: len(traces)}
+	if len(traces) == tq.PageSize {
+		nextOffset := offset + tq.PageSize
+		result.NextPageToken = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%d", nextOffset)))
+	}
+	return result, nil
 }
 
 // SearchSpans searches spans with filtering.
@@ -672,12 +689,23 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, uq storage.UsageQuery, l
 			COUNT(*) AS call_count,
 			COALESCE(SUM(gen_ai_total_tokens), 0) AS total_tokens,
 			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
-			COALESCE(AVG(duration_ns), 0) AS avg_duration_ns
-		FROM %s
-		WHERE project_id = @projectID
-		  AND start_time >= @startTime
-		  AND start_time <= @endTime
-		  AND user_id != ''
+			COALESCE(AVG(duration_ns), 0) AS avg_duration_ns,
+			COALESCE(
+				(SELECT m FROM UNNEST(ARRAY_AGG(gen_ai_model ORDER BY cnt DESC LIMIT 1)) AS m),
+				''
+			) AS top_model
+		FROM (
+			SELECT
+				user_id, gen_ai_model, gen_ai_total_tokens, gen_ai_cost_usd,
+				duration_ns,
+				COUNT(*) OVER (PARTITION BY user_id, gen_ai_model) AS cnt
+			FROM %s
+			WHERE project_id = @projectID
+			  AND start_time >= @startTime
+			  AND start_time <= @endTime
+			  AND user_id != ''
+			  AND (@tenantID = '' OR tenant_id = @tenantID)
+		)
 		GROUP BY user_id
 		ORDER BY total_cost_usd DESC
 		LIMIT @limit
@@ -688,6 +716,7 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, uq storage.UsageQuery, l
 		{Name: "projectID", Value: uq.ProjectID},
 		{Name: "startTime", Value: uq.StartTime},
 		{Name: "endTime", Value: uq.EndTime},
+		{Name: "tenantID", Value: uq.TenantID},
 		{Name: "limit", Value: limit},
 	}
 
@@ -704,6 +733,7 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, uq storage.UsageQuery, l
 			TotalTokens   int64   `bigquery:"total_tokens"`
 			TotalCostUSD  float64 `bigquery:"total_cost_usd"`
 			AvgDurationNs float64 `bigquery:"avg_duration_ns"`
+			TopModel      string  `bigquery:"top_model"`
 		}
 		err := it.Next(&row)
 		if err == iterator.Done {
@@ -718,6 +748,7 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, uq storage.UsageQuery, l
 			TotalTokens:  row.TotalTokens,
 			CostUSD:      row.TotalCostUSD,
 			AvgLatencyMs: float64(row.AvgDurationNs) / 1e6,
+			TopModel:     row.TopModel,
 		})
 	}
 
@@ -825,28 +856,36 @@ func (s *Store) querySpans(ctx context.Context, q *bigquery.Query) ([]storage.Sp
 
 // buildTrace assembles a Trace from a list of spans.
 func buildTrace(traceID string, spans []storage.Span) *storage.Trace {
+	if len(spans) == 0 {
+		return &storage.Trace{TraceID: traceID}
+	}
+
 	trace := &storage.Trace{
-		TraceID:   traceID,
-		Spans:     spans,
-		SpanCount: len(spans),
+		TraceID:     traceID,
+		StartTime:   spans[0].StartTime,
+		EndTime:     spans[0].EndTime,
+		ProjectID:   spans[0].ProjectID,
+		Environment: spans[0].Environment,
+		SpanCount:   len(spans),
+		Spans:       spans,
 	}
 
-	if len(spans) > 0 {
-		trace.StartTime = spans[0].StartTime
-		trace.Environment = spans[0].Environment
-	}
-
-	for _, span := range spans {
-		if span.ParentSpanID == "" {
-			trace.RootSpanName = span.Name
-			trace.Duration = span.EndTime.Sub(span.StartTime)
+	for _, sp := range spans {
+		if sp.StartTime.Before(trace.StartTime) {
+			trace.StartTime = sp.StartTime
 		}
-		if span.GenAI != nil {
-			trace.TotalTokens += span.GenAI.TotalTokens
-			trace.TotalCostUSD += span.GenAI.CostUSD
+		if sp.EndTime.After(trace.EndTime) {
+			trace.EndTime = sp.EndTime
+		}
+		if sp.ParentSpanID == "" {
+			trace.RootSpanName = sp.Name
+		}
+		if sp.GenAI != nil {
+			trace.TotalTokens += sp.GenAI.TotalTokens
+			trace.TotalCostUSD += sp.GenAI.CostUSD
 		}
 	}
-
+	trace.Duration = trace.EndTime.Sub(trace.StartTime)
 	return trace
 }
 

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -493,6 +493,8 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 			TotalTokens:  trace.TotalTokens,
 			TotalCostUSD: trace.TotalCostUSD,
 			Environment:  trace.Environment,
+			TenantID:     trace.TenantID,
+			JobID:        trace.JobID,
 		})
 	}
 
@@ -524,7 +526,7 @@ func (s *Store) SearchSpans(ctx context.Context, sq storage.SpanQuery) (*storage
 		  AND start_time <= @endTime
 		  AND (@kind = 0 OR kind = @kind)
 		  AND (@model = '' OR gen_ai_model = @model)
-		  AND (@name = '' OR name LIKE CONCAT('%%', @name, '%%'))
+		  AND (@name = '' OR name LIKE CONCAT('%%', @name, '%%') ESCAPE '\\')
 		  AND (@userID = '' OR user_id = @userID)
 		  AND (@tenantID = '' OR tenant_id = @tenantID)
 		  AND (@jobID = '' OR job_id = @jobID)
@@ -539,7 +541,7 @@ func (s *Store) SearchSpans(ctx context.Context, sq storage.SpanQuery) (*storage
 		{Name: "endTime", Value: sq.EndTime},
 		{Name: "kind", Value: int(sq.Kind)},
 		{Name: "model", Value: sq.Model},
-		{Name: "name", Value: sq.NameContains},
+		{Name: "name", Value: storage.EscapeLike(sq.NameContains)},
 		{Name: "userID", Value: sq.UserID},
 		{Name: "tenantID", Value: sq.TenantID},
 		{Name: "jobID", Value: sq.JobID},

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -110,6 +110,7 @@ type spanRow struct {
 	// TenantID identifies the downstream customer on whose behalf this LLM call
 	// was made. Populated from X-Candela-Tenant-Id header or W3C Baggage.
 	TenantID string `bigquery:"tenant_id"`
+	JobID    string `bigquery:"job_id"`
 }
 
 func spanToRow(span storage.Span) spanRow {
@@ -130,6 +131,7 @@ func spanToRow(span storage.Span) spanRow {
 		UserID:        span.UserID,
 		SessionID:     span.SessionID,
 		TenantID:      span.TenantID,
+		JobID:         span.JobID,
 	}
 
 	if span.GenAI != nil {
@@ -170,6 +172,7 @@ func rowToSpan(row spanRow) storage.Span {
 		UserID:        row.UserID,
 		SessionID:     row.SessionID,
 		TenantID:      row.TenantID,
+		JobID:         row.JobID,
 	}
 
 	if row.GenAIModel != "" {
@@ -224,7 +227,7 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 			Type:  bigquery.DayPartitioningType,
 		},
 		Clustering: &bigquery.Clustering{
-			Fields: []string{"project_id", "tenant_id", "user_id", "trace_id"},
+			Fields: []string{"project_id", "tenant_id", "job_id", "user_id"},
 		},
 	}
 	if err := table.Create(ctx, tableMeta); err != nil {
@@ -397,6 +400,7 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		  AND start_time <= @endTime
 		  AND (@userID = '' OR user_id = @userID)
 		  AND (@tenantID = '' OR tenant_id = @tenantID)
+		  AND (@jobID = '' OR job_id = @jobID)
 		GROUP BY trace_id
 		ORDER BY earliest DESC
 		LIMIT @pageSize OFFSET @offset
@@ -409,6 +413,7 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		{Name: "endTime", Value: tq.EndTime},
 		{Name: "userID", Value: tq.UserID},
 		{Name: "tenantID", Value: tq.TenantID},
+		{Name: "jobID", Value: tq.JobID},
 		{Name: "pageSize", Value: tq.PageSize},
 		{Name: "offset", Value: offset},
 	}
@@ -448,10 +453,9 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		SELECT span_id, trace_id, parent_span_id, name, kind, status, status_message,
 		       start_time, end_time, duration_ns, project_id, environment, service_name,
 		       gen_ai_model, gen_ai_provider,
-		       gen_ai_input_tokens, gen_ai_output_tokens, gen_ai_total_tokens,
-		       gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-		       '' AS gen_ai_input_content, '' AS gen_ai_output_content,
-		       attributes, user_id, session_id, tenant_id
+		       gen_ai_input_tokens, gen_ai_output_tokens, gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
+			'' AS gen_ai_input_content, '' AS gen_ai_output_content, attributes,
+			user_id, session_id, tenant_id, job_id
 		FROM %s
 		WHERE trace_id IN UNNEST(@traceIDs)
 		ORDER BY start_time ASC, span_id ASC
@@ -507,17 +511,25 @@ func (s *Store) SearchSpans(ctx context.Context, sq storage.SpanQuery) (*storage
 	}
 
 	query := fmt.Sprintf(`
-		SELECT * FROM %s
+		SELECT span_id, trace_id, parent_span_id, name, kind, status, status_message,
+			start_time, end_time, duration_ns, project_id, environment, service_name,
+			gen_ai_model, gen_ai_provider,
+			gen_ai_input_tokens, gen_ai_output_tokens,
+			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
+			gen_ai_input_content, gen_ai_output_content, attributes,
+			user_id, session_id, tenant_id, job_id
+		FROM %s
 		WHERE project_id = @projectID
 		  AND start_time >= @startTime
 		  AND start_time <= @endTime
 		  AND (@kind = 0 OR kind = @kind)
 		  AND (@model = '' OR gen_ai_model = @model)
-		  AND (@nameContains = '' OR name LIKE CONCAT('%%', @escapedName, '%%'))
+		  AND (@name = '' OR name LIKE CONCAT('%%', @name, '%%'))
 		  AND (@userID = '' OR user_id = @userID)
 		  AND (@tenantID = '' OR tenant_id = @tenantID)
+		  AND (@jobID = '' OR job_id = @jobID)
 		ORDER BY start_time DESC
-		LIMIT @pageSize
+		LIMIT @limit
 	`, quoteTable(s.tableID))
 
 	q := s.client.Query(query)
@@ -527,11 +539,11 @@ func (s *Store) SearchSpans(ctx context.Context, sq storage.SpanQuery) (*storage
 		{Name: "endTime", Value: sq.EndTime},
 		{Name: "kind", Value: int(sq.Kind)},
 		{Name: "model", Value: sq.Model},
-		{Name: "nameContains", Value: sq.NameContains},
-		{Name: "escapedName", Value: storage.EscapeLike(sq.NameContains)},
+		{Name: "name", Value: sq.NameContains},
 		{Name: "userID", Value: sq.UserID},
 		{Name: "tenantID", Value: sq.TenantID},
-		{Name: "pageSize", Value: sq.PageSize},
+		{Name: "jobID", Value: sq.JobID},
+		{Name: "limit", Value: sq.PageSize},
 	}
 
 	spans, err := s.querySpans(ctx, q)
@@ -560,6 +572,7 @@ func (s *Store) GetUsageSummary(ctx context.Context, uq storage.UsageQuery) (*st
 		  AND start_time <= @endTime
 		  AND (@userID = '' OR user_id = @userID)
 		  AND (@tenantID = '' OR tenant_id = @tenantID)
+		  AND (@jobID = '' OR job_id = @jobID)
 	`, quoteTable(s.tableID))
 
 	q := s.client.Query(query)
@@ -570,6 +583,7 @@ func (s *Store) GetUsageSummary(ctx context.Context, uq storage.UsageQuery) (*st
 		{Name: "llmKind", Value: int(storage.SpanKindLLM)},
 		{Name: "userID", Value: uq.UserID},
 		{Name: "tenantID", Value: uq.TenantID},
+		{Name: "jobID", Value: uq.JobID},
 	}
 
 	it, err := q.Read(ctx)
@@ -626,6 +640,7 @@ func (s *Store) GetModelBreakdown(ctx context.Context, uq storage.UsageQuery) ([
 		  AND gen_ai_model != ''
 		  AND (@userID = '' OR user_id = @userID)
 		  AND (@tenantID = '' OR tenant_id = @tenantID)
+		  AND (@jobID = '' OR job_id = @jobID)
 		GROUP BY gen_ai_model, gen_ai_provider
 		ORDER BY total_cost_usd DESC
 	`, quoteTable(s.tableID))
@@ -637,6 +652,7 @@ func (s *Store) GetModelBreakdown(ctx context.Context, uq storage.UsageQuery) ([
 		{Name: "endTime", Value: uq.EndTime},
 		{Name: "userID", Value: uq.UserID},
 		{Name: "tenantID", Value: uq.TenantID},
+		{Name: "jobID", Value: uq.JobID},
 	}
 
 	it, err := q.Read(ctx)
@@ -829,6 +845,73 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, uq storage.UsageQuery,
 	}
 
 	return tenants, nil
+}
+
+// GetJobLeaderboard returns aggregated metrics grouped by job ID.
+func (s *Store) GetJobLeaderboard(ctx context.Context, uq storage.UsageQuery, limit int) ([]storage.JobUsageSummary, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+
+	query := fmt.Sprintf(`
+		SELECT
+			job_id,
+			COUNT(*) AS call_count,
+			COALESCE(SUM(gen_ai_total_tokens), 0) AS total_tokens,
+			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost,
+			COALESCE(AVG(duration_ns), 0) / 1000000.0 AS avg_latency_ms,
+			ARRAY_AGG(gen_ai_model ORDER BY gen_ai_cost_usd DESC LIMIT 1)[OFFSET(0)] AS top_model
+		FROM %s
+		WHERE project_id = @projectID
+		  AND start_time >= @startTime
+		  AND start_time <= @endTime
+		  AND job_id != ''
+		GROUP BY job_id
+		ORDER BY total_cost DESC
+		LIMIT @limit
+	`, quoteTable(s.tableID))
+
+	q := s.client.Query(query)
+	q.Parameters = []bigquery.QueryParameter{
+		{Name: "projectID", Value: uq.ProjectID},
+		{Name: "startTime", Value: uq.StartTime},
+		{Name: "endTime", Value: uq.EndTime},
+		{Name: "limit", Value: limit},
+	}
+
+	it, err := q.Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("querying job leaderboard: %w", err)
+	}
+
+	var jobs []storage.JobUsageSummary
+	for {
+		var row struct {
+			JobID        string  `bigquery:"job_id"`
+			CallCount    int64   `bigquery:"call_count"`
+			TotalTokens  int64   `bigquery:"total_tokens"`
+			TotalCost    float64 `bigquery:"total_cost"`
+			AvgLatencyMs float64 `bigquery:"avg_latency_ms"`
+			TopModel     string  `bigquery:"top_model"`
+		}
+		err := it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("iterating job leaderboard: %w", err)
+		}
+		jobs = append(jobs, storage.JobUsageSummary{
+			JobID:        row.JobID,
+			CallCount:    row.CallCount,
+			TotalTokens:  row.TotalTokens,
+			CostUSD:      row.TotalCost,
+			AvgLatencyMs: row.AvgLatencyMs,
+			TopModel:     row.TopModel,
+		})
+	}
+
+	return jobs, nil
 }
 
 // querySpans executes a query and scans results into storage.Span.

--- a/pkg/storage/bigquery/bigquery_test.go
+++ b/pkg/storage/bigquery/bigquery_test.go
@@ -108,6 +108,28 @@ func TestBuildTrace_NoGenAI(t *testing.T) {
 	}
 }
 
+func TestBuildTrace_MultiSpanDuration(t *testing.T) {
+	now := time.Now().UTC()
+	spans := []storage.Span{
+		{
+			SpanID:    "s1",
+			StartTime: now.Add(1 * time.Second),
+			EndTime:   now.Add(3 * time.Second),
+		},
+		{
+			SpanID:    "s2",
+			StartTime: now,
+			EndTime:   now.Add(2 * time.Second),
+		},
+	}
+
+	trace := buildTrace("t1", spans)
+	// Duration should be from now (s2 start) to now+3s (s1 end) = 3s.
+	if trace.Duration != 3*time.Second {
+		t.Errorf("Duration = %v, want 3s", trace.Duration)
+	}
+}
+
 func TestBuildTrace_EmptySpans(t *testing.T) {
 	trace := buildTrace("trace-empty", nil)
 
@@ -137,6 +159,7 @@ func TestSpanRowRoundtrip(t *testing.T) {
 		ServiceName:   "candela-proxy",
 		UserID:        "user-abc123",
 		SessionID:     "session-xyz789",
+		TenantID:      "tenant-42",
 		GenAI: &storage.GenAIAttributes{
 			Model:         "gpt-4o",
 			Provider:      "openai",
@@ -204,5 +227,20 @@ func TestSpanRowRoundtrip(t *testing.T) {
 	}
 	if roundtripped.Attributes["http.request_id"] != "req-123" {
 		t.Errorf("Attributes[http.request_id] = %q, want req-123", roundtripped.Attributes["http.request_id"])
+	}
+
+	// Tenant ID.
+	if roundtripped.TenantID != original.TenantID {
+		t.Errorf("TenantID = %q, want %q", roundtripped.TenantID, original.TenantID)
+	}
+}
+
+func TestBuildTrace_TenantIDPreserved(t *testing.T) {
+	spans := []storage.Span{
+		{SpanID: "s1", TenantID: "acme-corp", StartTime: time.Now()},
+	}
+	trace := buildTrace("t1", spans)
+	if trace.Spans[0].TenantID != "acme-corp" {
+		t.Errorf("TenantID = %q, want acme-corp", trace.Spans[0].TenantID)
 	}
 }

--- a/pkg/storage/duckdb/duckdb.go
+++ b/pkg/storage/duckdb/duckdb.go
@@ -296,7 +296,7 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 	`, q.ProjectID, q.StartTime, q.EndTime,
 		int(q.Kind), int(q.Kind),
 		q.Model, q.Model,
-		storage.EscapeLike(q.NameContains), q.NameContains,
+		q.NameContains, storage.EscapeLike(q.NameContains),
 		q.UserID, q.UserID,
 		q.TenantID, q.TenantID,
 		q.JobID, q.JobID,

--- a/pkg/storage/duckdb/duckdb.go
+++ b/pkg/storage/duckdb/duckdb.go
@@ -296,7 +296,7 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 	`, q.ProjectID, q.StartTime, q.EndTime,
 		int(q.Kind), int(q.Kind),
 		q.Model, q.Model,
-		q.NameContains, q.NameContains,
+		storage.EscapeLike(q.NameContains), q.NameContains,
 		q.UserID, q.UserID,
 		q.TenantID, q.TenantID,
 		q.JobID, q.JobID,
@@ -486,25 +486,38 @@ func (s *Store) GetJobLeaderboard(ctx context.Context, q storage.UsageQuery, lim
 	}
 
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT job_id,
-			COUNT(*)::BIGINT,
-			COALESCE(SUM(gen_ai_total_tokens), 0)::BIGINT,
-			COALESCE(SUM(gen_ai_cost_usd), 0)::DOUBLE,
-			COALESCE(AVG(duration_ns), 0)::DOUBLE / 1000000.0,
-			COALESCE((
-				SELECT s2.gen_ai_model FROM spans s2
-				WHERE s2.job_id = spans.job_id
-					AND s2.project_id = ? AND s2.start_time >= ? AND s2.start_time <= ?
-					AND s2.gen_ai_model != ''
-				GROUP BY s2.gen_ai_model
-				ORDER BY SUM(s2.gen_ai_cost_usd) DESC
-				LIMIT 1
-			), '') AS top_model
-		FROM spans
-		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
-			AND job_id != ''
-		GROUP BY job_id
-		ORDER BY SUM(gen_ai_cost_usd) DESC
+		WITH job_stats AS (
+			SELECT
+				job_id,
+				COUNT(*)::BIGINT as call_count,
+				SUM(gen_ai_total_tokens)::BIGINT as total_tokens,
+				SUM(gen_ai_cost_usd)::DOUBLE as cost_usd,
+				AVG(duration_ns)::DOUBLE / 1000000.0 as avg_latency_ms
+			FROM spans
+			WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+				AND job_id != ''
+			GROUP BY job_id
+		),
+		model_rank AS (
+			SELECT
+				job_id,
+				gen_ai_model,
+				ROW_NUMBER() OVER (PARTITION BY job_id ORDER BY SUM(gen_ai_cost_usd) DESC) as r
+			FROM spans
+			WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+				AND job_id != '' AND gen_ai_model != ''
+			GROUP BY job_id, gen_ai_model
+		)
+		SELECT
+			s.job_id,
+			s.call_count,
+			COALESCE(s.total_tokens, 0),
+			COALESCE(s.cost_usd, 0),
+			COALESCE(s.avg_latency_ms, 0),
+			COALESCE(m.gen_ai_model, '')
+		FROM job_stats s
+		LEFT JOIN model_rank m ON s.job_id = m.job_id AND m.r = 1
+		ORDER BY s.cost_usd DESC
 		LIMIT ?
 	`, q.ProjectID, q.StartTime, q.EndTime,
 		q.ProjectID, q.StartTime, q.EndTime, limit)

--- a/pkg/storage/duckdb/duckdb.go
+++ b/pkg/storage/duckdb/duckdb.go
@@ -394,23 +394,15 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, q storage.UsageQuery, li
 			COALESCE(SUM(gen_ai_total_tokens), 0)::BIGINT,
 			COALESCE(SUM(gen_ai_cost_usd), 0)::DOUBLE,
 			COALESCE(AVG(duration_ns), 0)::DOUBLE / 1000000.0,
-			COALESCE((
-				SELECT s2.gen_ai_model FROM spans s2
-				WHERE s2.user_id = spans.user_id
-					AND s2.project_id = ? AND s2.start_time >= ? AND s2.start_time <= ?
-					AND s2.gen_ai_model != ''
-				GROUP BY s2.gen_ai_model
-				ORDER BY SUM(s2.gen_ai_cost_usd) DESC
-				LIMIT 1
-			), '') AS top_model
+			COALESCE(arg_max(gen_ai_model, gen_ai_cost_usd), '') AS top_model
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND user_id != ''
+			AND gen_ai_model != ''
 		GROUP BY user_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
-	`, q.ProjectID, q.StartTime, q.EndTime,
-		q.ProjectID, q.StartTime, q.EndTime, limit)
+	`, q.ProjectID, q.StartTime, q.EndTime, limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying user leaderboard: %w", err)
 	}
@@ -444,22 +436,15 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, q storage.UsageQuery, 
 			COALESCE(SUM(gen_ai_total_tokens), 0)::BIGINT,
 			COALESCE(SUM(gen_ai_cost_usd), 0)::DOUBLE,
 			COALESCE(AVG(duration_ns), 0)::DOUBLE / 1000000.0,
-			COALESCE((
-				SELECT s2.gen_ai_model FROM spans s2
-				WHERE s2.tenant_id = spans.tenant_id
-					AND s2.project_id = ? AND s2.start_time >= ? AND s2.start_time <= ?
-					AND s2.gen_ai_model != ''
-				GROUP BY s2.gen_ai_model
-				ORDER BY SUM(s2.gen_ai_cost_usd) DESC
-				LIMIT 1
-			), '') AS top_model
+			COALESCE(arg_max(gen_ai_model, gen_ai_cost_usd), '') AS top_model
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND tenant_id IS NOT NULL AND tenant_id != ''
+			AND gen_ai_model != ''
 		GROUP BY tenant_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
-	`, q.ProjectID, q.StartTime, q.EndTime, q.ProjectID, q.StartTime, q.EndTime, limit)
+	`, q.ProjectID, q.StartTime, q.EndTime, limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying tenant leaderboard: %w", err)
 	}
@@ -624,6 +609,8 @@ func buildTrace(traceID string, spans []storage.Span) *storage.Trace {
 		EndTime:     spans[0].EndTime,
 		ProjectID:   spans[0].ProjectID,
 		Environment: spans[0].Environment,
+		TenantID:    spans[0].TenantID,
+		JobID:       spans[0].JobID,
 		SpanCount:   len(spans),
 		Spans:       spans,
 	}

--- a/pkg/storage/duckdb/duckdb.go
+++ b/pkg/storage/duckdb/duckdb.go
@@ -94,6 +94,8 @@ func (s *Store) migrate() error {
 		// Migration: add tenant_id for multitenant cost attribution.
 		`ALTER TABLE spans ADD COLUMN IF NOT EXISTS tenant_id VARCHAR DEFAULT ''`,
 		`CREATE INDEX IF NOT EXISTS idx_spans_tenant ON spans(tenant_id)`,
+		`ALTER TABLE spans ADD COLUMN IF NOT EXISTS job_id VARCHAR DEFAULT ''`,
+		`CREATE INDEX IF NOT EXISTS idx_spans_job ON spans(job_id)`,
 	}
 
 	for _, q := range queries {
@@ -150,6 +152,7 @@ func (s *Store) IngestSpans(ctx context.Context, spans []storage.Span) error {
 				attrs,
 				span.SessionID,
 				span.TenantID,
+				span.JobID,
 			); err != nil {
 				return fmt.Errorf("appending span %s: %w", span.SpanID, err)
 			}
@@ -168,7 +171,7 @@ func (s *Store) GetTrace(ctx context.Context, traceID string) (*storage.Trace, e
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes, user_id, session_id, tenant_id
+			gen_ai_input_content, gen_ai_output_content, attributes, user_id, session_id, tenant_id, job_id
 		FROM spans WHERE trace_id = ? ORDER BY start_time ASC
 	`, traceID)
 	if err != nil {
@@ -224,16 +227,19 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 			MAX(CASE WHEN parent_span_id = '' THEN name ELSE '' END) as root_name,
 			MAX(gen_ai_model) as primary_model,
 			MAX(gen_ai_provider) as primary_provider,
-			MAX(status)::INTEGER as status
+			MAX(status)::INTEGER as status,
+			MAX(tenant_id) as tenant_id,
+			MAX(job_id) as job_id
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = '' OR user_id = ?)
 			AND (? = '' OR environment = ?)
 			AND (? = '' OR tenant_id = ?)
+			AND (? = '' OR job_id = ?)
 		GROUP BY trace_id
 		ORDER BY `+orderExpr+` `+dir+`
 		LIMIT ?
-	`, q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID, q.Environment, q.Environment, q.TenantID, q.TenantID, q.PageSize)
+	`, q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID, q.Environment, q.Environment, q.TenantID, q.TenantID, q.JobID, q.JobID, q.PageSize)
 	if err != nil {
 		return nil, fmt.Errorf("querying traces: %w", err)
 	}
@@ -248,7 +254,7 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		err := rows.Scan(
 			&t.TraceID, &t.StartTime, &endTime, &t.SpanCount, &t.LLMCallCount,
 			&t.TotalTokens, &t.TotalCostUSD, &t.RootSpanName,
-			&t.PrimaryModel, &t.PrimaryProvider, &status,
+			&t.PrimaryModel, &t.PrimaryProvider, &status, &t.TenantID, &t.JobID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scanning trace: %w", err)
@@ -276,7 +282,7 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes, user_id, session_id, tenant_id
+			gen_ai_input_content, gen_ai_output_content, attributes, user_id, session_id, tenant_id, job_id
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = 0 OR kind = ?)
@@ -284,14 +290,16 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			AND (? = '' OR name LIKE '%' || ? || '%' ESCAPE '\')
 			AND (? = '' OR user_id = ?)
 			AND (? = '' OR tenant_id = ?)
+			AND (? = '' OR job_id = ?)
 		ORDER BY start_time DESC
 		LIMIT ?
 	`, q.ProjectID, q.StartTime, q.EndTime,
 		int(q.Kind), int(q.Kind),
 		q.Model, q.Model,
-		q.NameContains, storage.EscapeLike(q.NameContains),
+		q.NameContains, q.NameContains,
 		q.UserID, q.UserID,
 		q.TenantID, q.TenantID,
+		q.JobID, q.JobID,
 		q.PageSize,
 	)
 	if err != nil {
@@ -324,7 +332,9 @@ func (s *Store) GetUsageSummary(ctx context.Context, q storage.UsageQuery) (*sto
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = '' OR user_id = ?)
-	`, q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID).Scan(
+			AND (? = '' OR tenant_id = ?)
+			AND (? = '' OR job_id = ?)
+	`, q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID, q.TenantID, q.TenantID, q.JobID, q.JobID).Scan(
 		&summary.TotalTraces, &summary.TotalSpans, &summary.TotalLLMCalls,
 		&summary.TotalInputTokens, &summary.TotalOutputTokens, &summary.TotalCostUSD,
 		&summary.AvgLatencyMs, &summary.ErrorRate,
@@ -347,9 +357,11 @@ func (s *Store) GetModelBreakdown(ctx context.Context, q storage.UsageQuery) ([]
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND gen_ai_model != ''
 			AND (? = '' OR user_id = ?)
+			AND (? = '' OR tenant_id = ?)
+			AND (? = '' OR job_id = ?)
 		GROUP BY gen_ai_model, gen_ai_provider
 		ORDER BY SUM(gen_ai_cost_usd) DESC
-	`, q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID)
+	`, q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID, q.TenantID, q.TenantID, q.JobID, q.JobID)
 	if err != nil {
 		return nil, fmt.Errorf("querying model breakdown: %w", err)
 	}
@@ -468,6 +480,55 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, q storage.UsageQuery, 
 	return tenants, nil
 }
 
+func (s *Store) GetJobLeaderboard(ctx context.Context, q storage.UsageQuery, limit int) ([]storage.JobUsageSummary, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT job_id,
+			COUNT(*)::BIGINT,
+			COALESCE(SUM(gen_ai_total_tokens), 0)::BIGINT,
+			COALESCE(SUM(gen_ai_cost_usd), 0)::DOUBLE,
+			COALESCE(AVG(duration_ns), 0)::DOUBLE / 1000000.0,
+			COALESCE((
+				SELECT s2.gen_ai_model FROM spans s2
+				WHERE s2.job_id = spans.job_id
+					AND s2.project_id = ? AND s2.start_time >= ? AND s2.start_time <= ?
+					AND s2.gen_ai_model != ''
+				GROUP BY s2.gen_ai_model
+				ORDER BY SUM(s2.gen_ai_cost_usd) DESC
+				LIMIT 1
+			), '') AS top_model
+		FROM spans
+		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+			AND job_id != ''
+		GROUP BY job_id
+		ORDER BY SUM(gen_ai_cost_usd) DESC
+		LIMIT ?
+	`, q.ProjectID, q.StartTime, q.EndTime,
+		q.ProjectID, q.StartTime, q.EndTime, limit)
+	if err != nil {
+		return nil, fmt.Errorf("querying job leaderboard: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var jobs []storage.JobUsageSummary
+	for rows.Next() {
+		var j storage.JobUsageSummary
+		err := rows.Scan(&j.JobID, &j.CallCount, &j.TotalTokens,
+			&j.CostUSD, &j.AvgLatencyMs, &j.TopModel)
+		if err != nil {
+			return nil, fmt.Errorf("scanning job: %w", err)
+		}
+		jobs = append(jobs, j)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating jobs: %w", err)
+	}
+	return jobs, nil
+}
+
 func (s *Store) Ping(ctx context.Context) error {
 	return s.db.PingContext(ctx)
 }
@@ -500,6 +561,7 @@ func scanSpans(rows *sql.Rows) ([]storage.Span, error) {
 			&span.UserID,
 			&span.SessionID,
 			&span.TenantID,
+			&span.JobID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scanning span: %w", err)

--- a/pkg/storage/otlpexporter/convert.go
+++ b/pkg/storage/otlpexporter/convert.go
@@ -156,6 +156,9 @@ func buildAttributes(s storage.Span) []*commonpb.KeyValue {
 	if s.TenantID != "" {
 		add(stringAttr("candela.tenant_id", s.TenantID))
 	}
+	if s.JobID != "" {
+		add(stringAttr("candela.job_id", s.JobID))
+	}
 
 	// Pass-through custom attributes — skip keys already set above to avoid duplicates.
 	for k, v := range s.Attributes {

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -112,6 +112,9 @@ func (s *Store) migrate() error {
 		`ALTER TABLE spans ADD COLUMN tenant_id TEXT DEFAULT ''`,
 		`CREATE INDEX IF NOT EXISTS idx_spans_tenant ON spans(tenant_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_spans_tenant_time ON spans(project_id, tenant_id, start_time)`,
+		`ALTER TABLE spans ADD COLUMN job_id TEXT DEFAULT ''`,
+		`CREATE INDEX IF NOT EXISTS idx_spans_job ON spans(job_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_spans_job_time ON spans(project_id, job_id, start_time)`,
 	}
 
 	for _, q := range queries {
@@ -137,8 +140,8 @@ func (s *Store) IngestSpans(ctx context.Context, spans []storage.Span) error {
 		start_time, end_time, duration_ns, project_id, environment, service_name,
 		gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 		gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-		gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id, tenant_id
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id, tenant_id, job_id
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("preparing stmt: %w", err)
 	}
@@ -170,6 +173,7 @@ func (s *Store) IngestSpans(ctx context.Context, spans []storage.Span) error {
 			span.UserID,
 			span.SessionID,
 			span.TenantID,
+			span.JobID,
 		)
 		if err != nil {
 			return fmt.Errorf("inserting span: %w", err)
@@ -185,7 +189,7 @@ func (s *Store) GetTrace(ctx context.Context, traceID string) (*storage.Trace, e
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id, tenant_id
+			gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id, tenant_id, job_id
 		FROM spans WHERE trace_id = ? ORDER BY start_time ASC
 	`, traceID)
 	if err != nil {
@@ -249,17 +253,19 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 			MAX(gen_ai_model) as primary_model,
 			MAX(gen_ai_provider) as primary_provider,
 			MAX(status) as status,
-			MAX(tenant_id) as tenant_id
+			MAX(tenant_id) as tenant_id,
+			MAX(job_id) as job_id
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = '' OR user_id = ?)
 			AND (? = '' OR tenant_id = ?)
+			AND (? = '' OR job_id = ?)
 			AND (? = '' OR environment = ?)
 		GROUP BY trace_id
 		ORDER BY `+orderExpr+` `+dir+`
 		LIMIT ? OFFSET ?
 	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
-		q.UserID, q.UserID, q.TenantID, q.TenantID, q.Environment, q.Environment, q.PageSize, offset)
+		q.UserID, q.UserID, q.TenantID, q.TenantID, q.JobID, q.JobID, q.Environment, q.Environment, q.PageSize, offset)
 	if err != nil {
 		return nil, fmt.Errorf("querying traces: %w", err)
 	}
@@ -274,7 +280,7 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		err := rows.Scan(
 			&t.TraceID, &startStr, &endStr, &t.SpanCount, &t.LLMCallCount,
 			&t.TotalTokens, &t.TotalCostUSD, &t.RootSpanName,
-			&t.PrimaryModel, &t.PrimaryProvider, &status, &t.TenantID,
+			&t.PrimaryModel, &t.PrimaryProvider, &status, &t.TenantID, &t.JobID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scanning trace: %w", err)
@@ -309,7 +315,7 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			start_time, end_time, duration_ns, project_id, environment, service_name,
 			gen_ai_model, gen_ai_provider, gen_ai_input_tokens, gen_ai_output_tokens,
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
-			gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id, tenant_id
+			gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id, tenant_id, job_id
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = 0 OR kind = ?)
@@ -317,6 +323,7 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			AND (? = '' OR name LIKE '%' || ? || '%' ESCAPE '\')
 			AND (? = '' OR user_id = ?)
 			AND (? = '' OR tenant_id = ?)
+			AND (? = '' OR job_id = ?)
 		ORDER BY start_time DESC
 		LIMIT ?
 	`, q.ProjectID,
@@ -326,6 +333,7 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 		q.NameContains, storage.EscapeLike(q.NameContains),
 		q.UserID, q.UserID,
 		q.TenantID, q.TenantID,
+		q.JobID, q.JobID,
 		q.PageSize,
 	)
 	if err != nil {
@@ -359,7 +367,9 @@ func (s *Store) GetUsageSummary(ctx context.Context, q storage.UsageQuery) (*sto
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = '' OR user_id = ?)
 			AND (? = '' OR tenant_id = ?)
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID, q.TenantID, q.TenantID).Scan(
+			AND (? = '' OR job_id = ?)
+	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+		q.UserID, q.UserID, q.TenantID, q.TenantID, q.JobID, q.JobID).Scan(
 		&summary.TotalTraces, &summary.TotalSpans, &summary.TotalLLMCalls,
 		&summary.TotalInputTokens, &summary.TotalOutputTokens, &summary.TotalCostUSD,
 		&summary.AvgLatencyMs, &summary.ErrorRate,
@@ -380,9 +390,11 @@ func (s *Store) GetModelBreakdown(ctx context.Context, q storage.UsageQuery) ([]
 			AND gen_ai_model != ''
 			AND (? = '' OR user_id = ?)
 			AND (? = '' OR tenant_id = ?)
+			AND (? = '' OR job_id = ?)
 		GROUP BY gen_ai_model, gen_ai_provider
 		ORDER BY SUM(gen_ai_cost_usd) DESC
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID, q.TenantID, q.TenantID)
+	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+		q.UserID, q.UserID, q.TenantID, q.TenantID, q.JobID, q.JobID)
 	if err != nil {
 		return nil, fmt.Errorf("querying model breakdown: %w", err)
 	}
@@ -502,6 +514,55 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, q storage.UsageQuery, 
 	return tenants, nil
 }
 
+func (s *Store) GetJobLeaderboard(ctx context.Context, q storage.UsageQuery, limit int) ([]storage.JobUsageSummary, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT job_id,
+			COUNT(*),
+			COALESCE(SUM(gen_ai_total_tokens), 0),
+			COALESCE(SUM(gen_ai_cost_usd), 0),
+			COALESCE(AVG(duration_ns), 0) / 1000000.0,
+			COALESCE((
+				SELECT s2.gen_ai_model FROM spans s2
+				WHERE s2.job_id = spans.job_id
+					AND s2.project_id = ? AND s2.start_time >= ? AND s2.start_time <= ?
+					AND s2.gen_ai_model != ''
+				GROUP BY s2.gen_ai_model
+				ORDER BY SUM(s2.gen_ai_cost_usd) DESC
+				LIMIT 1
+			), '') AS top_model
+		FROM spans
+		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+			AND job_id != ''
+		GROUP BY job_id
+		ORDER BY SUM(gen_ai_cost_usd) DESC
+		LIMIT ?
+	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+		q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)
+	if err != nil {
+		return nil, fmt.Errorf("querying job leaderboard: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var jobs []storage.JobUsageSummary
+	for rows.Next() {
+		var j storage.JobUsageSummary
+		err := rows.Scan(&j.JobID, &j.CallCount, &j.TotalTokens,
+			&j.CostUSD, &j.AvgLatencyMs, &j.TopModel)
+		if err != nil {
+			return nil, fmt.Errorf("scanning job: %w", err)
+		}
+		jobs = append(jobs, j)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating jobs: %w", err)
+	}
+	return jobs, nil
+}
+
 func (s *Store) Ping(ctx context.Context) error {
 	return s.db.PingContext(ctx)
 }
@@ -535,6 +596,7 @@ func scanSpans(rows *sql.Rows) ([]storage.Span, error) {
 			&span.UserID,
 			&span.SessionID,
 			&span.TenantID,
+			&span.JobID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scanning span: %w", err)

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -5,6 +5,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -36,6 +37,13 @@ func New(cfg Config) (*Store, error) {
 	db, err := sql.Open("sqlite", cfg.Path)
 	if err != nil {
 		return nil, fmt.Errorf("opening sqlite: %w", err)
+	}
+
+	if cfg.Path == ":memory:" {
+		// For in-memory DBs, we MUST restrict to a single connection,
+		// otherwise different goroutines (e.g. processor vs test) will
+		// get different, isolated databases.
+		db.SetMaxOpenConns(1)
 	}
 
 	// SQLite performance tuning.
@@ -101,9 +109,9 @@ func (s *Store) migrate() error {
 		`ALTER TABLE spans ADD COLUMN user_id TEXT DEFAULT ''`,
 		// Migration: add session_id column to existing tables.
 		`ALTER TABLE spans ADD COLUMN session_id TEXT DEFAULT ''`,
-		// Migration: add tenant_id for multitenant cost attribution.
 		`ALTER TABLE spans ADD COLUMN tenant_id TEXT DEFAULT ''`,
 		`CREATE INDEX IF NOT EXISTS idx_spans_tenant ON spans(tenant_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_spans_tenant_time ON spans(project_id, tenant_id, start_time)`,
 	}
 
 	for _, q := range queries {
@@ -220,6 +228,14 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		dir = "ASC"
 	}
 
+	// Implement offset-based pagination using PageToken.
+	var offset int
+	if q.PageToken != "" {
+		if b, err := base64.StdEncoding.DecodeString(q.PageToken); err == nil {
+			_, _ = fmt.Sscanf(string(b), "%d", &offset)
+		}
+	}
+
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT
 			trace_id,
@@ -232,7 +248,8 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 			MAX(CASE WHEN parent_span_id = '' THEN name ELSE '' END) as root_name,
 			MAX(gen_ai_model) as primary_model,
 			MAX(gen_ai_provider) as primary_provider,
-			MAX(status) as status
+			MAX(status) as status,
+			MAX(tenant_id) as tenant_id
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = '' OR user_id = ?)
@@ -240,9 +257,9 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 			AND (? = '' OR environment = ?)
 		GROUP BY trace_id
 		ORDER BY `+orderExpr+` `+dir+`
-		LIMIT ?
+		LIMIT ? OFFSET ?
 	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
-		q.UserID, q.UserID, q.TenantID, q.TenantID, q.Environment, q.Environment, q.PageSize)
+		q.UserID, q.UserID, q.TenantID, q.TenantID, q.Environment, q.Environment, q.PageSize, offset)
 	if err != nil {
 		return nil, fmt.Errorf("querying traces: %w", err)
 	}
@@ -257,7 +274,7 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		err := rows.Scan(
 			&t.TraceID, &startStr, &endStr, &t.SpanCount, &t.LLMCallCount,
 			&t.TotalTokens, &t.TotalCostUSD, &t.RootSpanName,
-			&t.PrimaryModel, &t.PrimaryProvider, &status,
+			&t.PrimaryModel, &t.PrimaryProvider, &status, &t.TenantID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scanning trace: %w", err)
@@ -274,7 +291,12 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		return nil, fmt.Errorf("iterating traces: %w", err)
 	}
 
-	return &storage.TraceResult{Traces: traces, TotalCount: len(traces)}, nil
+	result := &storage.TraceResult{Traces: traces, TotalCount: len(traces)}
+	if len(traces) == q.PageSize {
+		nextOffset := offset + q.PageSize
+		result.NextPageToken = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%d", nextOffset)))
+	}
+	return result, nil
 }
 
 func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.SpanResult, error) {

--- a/pkg/storage/sqlite/sqlite_test.go
+++ b/pkg/storage/sqlite/sqlite_test.go
@@ -307,3 +307,79 @@ func TestSearchSpans(t *testing.T) {
 		t.Errorf("got %d spans, want 1 (LLM only)", len(result.Spans))
 	}
 }
+func TestGetTenantLeaderboard(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	spans := []storage.Span{
+		{
+			SpanID: "s1", TraceID: "t1", Name: "llm.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now, EndTime: now.Add(time.Second), Duration: time.Second,
+			ProjectID: "proj-1", TenantID: "tenant-a",
+			GenAI: &storage.GenAIAttributes{
+				Model: "gpt-4o", Provider: "openai",
+				InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.01,
+			},
+		},
+		{
+			SpanID: "s2", TraceID: "t1", Name: "llm.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now, EndTime: now.Add(time.Second), Duration: time.Second,
+			ProjectID: "proj-1", TenantID: "tenant-a",
+			GenAI: &storage.GenAIAttributes{
+				Model: "gpt-4o", Provider: "openai",
+				InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.01,
+			},
+		},
+		{
+			SpanID: "s3", TraceID: "t2", Name: "llm.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now, EndTime: now.Add(time.Second), Duration: time.Second,
+			ProjectID: "proj-1", TenantID: "tenant-b",
+			GenAI: &storage.GenAIAttributes{
+				Model: "claude-3-opus", Provider: "anthropic",
+				InputTokens: 200, OutputTokens: 100, TotalTokens: 300, CostUSD: 0.05,
+			},
+		},
+	}
+
+	if err := s.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest failed: %v", err)
+	}
+
+	leaderboard, err := s.GetTenantLeaderboard(ctx, storage.UsageQuery{
+		ProjectID: "proj-1",
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now.Add(time.Hour),
+	}, 10)
+	if err != nil {
+		t.Fatalf("leaderboard failed: %v", err)
+	}
+
+	if len(leaderboard) != 2 {
+		t.Fatalf("got %d tenants, want 2", len(leaderboard))
+	}
+
+	// tenant-b should be first (cost 0.05 vs 0.02).
+	if leaderboard[0].TenantID != "tenant-b" {
+		t.Errorf("first tenant = %s, want tenant-b", leaderboard[0].TenantID)
+	}
+	if leaderboard[0].CostUSD != 0.05 {
+		t.Errorf("tenant-b cost = %f, want 0.05", leaderboard[0].CostUSD)
+	}
+	if leaderboard[0].TopModel != "claude-3-opus" {
+		t.Errorf("tenant-b top_model = %q, want claude-3-opus", leaderboard[0].TopModel)
+	}
+
+	if leaderboard[1].TenantID != "tenant-a" {
+		t.Errorf("second tenant = %s, want tenant-a", leaderboard[1].TenantID)
+	}
+	if leaderboard[1].CallCount != 2 {
+		t.Errorf("tenant-a calls = %d, want 2", leaderboard[1].CallCount)
+	}
+	if leaderboard[1].CostUSD != 0.02 {
+		t.Errorf("tenant-a cost = %f, want 0.02", leaderboard[1].CostUSD)
+	}
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -132,7 +132,7 @@ type TraceSummary struct {
 	TotalCostUSD    float64       `json:"total_cost_usd"`
 	Status          SpanStatus    `json:"status"`
 	PrimaryModel    string        `json:"primary_model"`
-	PrimaryProvider string        `json:"primary_provider"`
+	PrimaryProvider string        `json:"primary_provider,omitempty"`
 	UserID          string        `json:"user_id,omitempty"`
 	SessionID       string        `json:"session_id,omitempty"`
 	TenantID        string        `json:"tenant_id,omitempty"`
@@ -176,6 +176,8 @@ type TraceQuery struct {
 }
 
 // TraceResult is the paginated result of a trace query.
+// PageToken should be treated as an opaque string by clients, but
+// backends typically implement it as a base64-encoded offset or timestamp.
 type TraceResult struct {
 	Traces        []TraceSummary
 	NextPageToken string

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -112,10 +112,8 @@ type Span struct {
 	ServiceName   string            `json:"service_name,omitempty"`
 	UserID        string            `json:"user_id,omitempty"`
 	SessionID     string            `json:"session_id,omitempty"`
-	// TenantID identifies the downstream customer/tenant on whose behalf this LLM
-	// call was made. Set via X-Candela-Tenant-Id header or W3C Baggage
-	// (candela.tenant_id) for automatic propagation through ADK/OTel traces.
-	TenantID string `json:"tenant_id,omitempty"`
+	TenantID      string            `json:"tenant_id,omitempty"`
+	JobID         string            `json:"job_id,omitempty"`
 }
 
 // TraceSummary is a lightweight summary for list views.
@@ -136,6 +134,7 @@ type TraceSummary struct {
 	UserID          string        `json:"user_id,omitempty"`
 	SessionID       string        `json:"session_id,omitempty"`
 	TenantID        string        `json:"tenant_id,omitempty"`
+	JobID           string        `json:"job_id,omitempty"`
 }
 
 // Trace is a complete trace with all spans.
@@ -154,6 +153,7 @@ type Trace struct {
 	UserID       string        `json:"user_id,omitempty"`
 	SessionID    string        `json:"session_id,omitempty"`
 	TenantID     string        `json:"tenant_id,omitempty"`
+	JobID        string        `json:"job_id,omitempty"`
 }
 
 // TraceQuery defines filters for listing traces.
@@ -173,6 +173,7 @@ type TraceQuery struct {
 	UserID      string // Filter by user (empty = all, for admins)
 	SessionID   string // Filter by session (empty = all)
 	TenantID    string // Filter by tenant (empty = all)
+	JobID       string // Filter by job (empty = all)
 }
 
 // TraceResult is the paginated result of a trace query.
@@ -196,6 +197,7 @@ type SpanQuery struct {
 	PageToken    string
 	UserID       string // Filter by user (empty = all, for admins)
 	TenantID     string // Filter by tenant (empty = all)
+	JobID        string // Filter by job (empty = all)
 }
 
 // SpanResult is the paginated result of a span query.
@@ -223,8 +225,9 @@ type UsageQuery struct {
 	Environment string
 	StartTime   time.Time
 	EndTime     time.Time
-	UserID      string // Filter by user (empty = all, for admins)
+	UserID      string
 	TenantID    string // Filter by tenant (empty = all)
+	JobID       string // Filter by job (empty = all)
 }
 
 // UserUsageSummary is a per-user aggregation for the team leaderboard.
@@ -242,6 +245,16 @@ type UserUsageSummary struct {
 // (candela.tenant_id) set by multitenant applications.
 type TenantUsageSummary struct {
 	TenantID     string  `json:"tenant_id"`
+	CallCount    int64   `json:"call_count"`
+	TotalTokens  int64   `json:"total_tokens"`
+	CostUSD      float64 `json:"cost_usd"`
+	AvgLatencyMs float64 `json:"avg_latency_ms"`
+	TopModel     string  `json:"top_model"`
+}
+
+// JobUsageSummary is a per-job aggregation for experiment cost tracking.
+type JobUsageSummary struct {
+	JobID        string  `json:"job_id"`
 	CallCount    int64   `json:"call_count"`
 	TotalTokens  int64   `json:"total_tokens"`
 	CostUSD      float64 `json:"cost_usd"`
@@ -296,6 +309,10 @@ type SpanReader interface {
 	// cost (admin only). TenantIDs are set by multitenant applications via
 	// X-Candela-Tenant-Id header or W3C Baggage (candela.tenant_id).
 	GetTenantLeaderboard(ctx context.Context, q UsageQuery, limit int) ([]TenantUsageSummary, error)
+
+	// GetJobLeaderboard returns per-job LLM cost aggregations ranked by cost.
+	// JobIDs are set via X-Candela-Job-Id header or W3C Baggage (candela.job_id).
+	GetJobLeaderboard(ctx context.Context, q UsageQuery, limit int) ([]JobUsageSummary, error)
 
 	// Ping verifies that the storage backend is reachable.
 	Ping(ctx context.Context) error

--- a/rust/crates/candela-core/src/lib.rs
+++ b/rust/crates/candela-core/src/lib.rs
@@ -123,6 +123,11 @@ pub struct Span {
     /// `X-Candela-Tenant-Id` header. Used for per-tenant cost attribution.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tenant_id: Option<String>,
+    /// Optional experiment or batch identifier.
+    /// Populated from W3C Baggage (`candela.job_id`) or the
+    /// `X-Candela-Job-Id` header.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<String>,
 }
 
 // ── SpanWriter Trait ──
@@ -217,6 +222,7 @@ mod tests {
             user_id: None,
             session_id: None,
             tenant_id: None,
+            job_id: None,
         };
 
         let json = serde_json::to_string(&span).expect("serialize");
@@ -261,6 +267,7 @@ mod tests {
             user_id: Some("u1".into()),
             session_id: Some("sess1".into()),
             tenant_id: Some("acme-corp".into()),
+            job_id: Some("exp-1".into()),
         };
         let json = serde_json::to_string(&span).unwrap();
         let restored: Span = serde_json::from_str(&json).unwrap();
@@ -270,6 +277,7 @@ mod tests {
         assert_eq!(restored.attributes.get("key").unwrap(), "val");
         assert_eq!(restored.user_id, Some("u1".into()));
         assert_eq!(restored.tenant_id, Some("acme-corp".into()));
+        assert_eq!(restored.job_id, Some("exp-1".into()));
     }
 
     #[test]
@@ -353,9 +361,8 @@ mod tests {
         // Very large but finite — should clamp gracefully, not panic.
         let result = serde_json::from_str::<Span>(json);
         // Either it parses (clamped) or rejects — but must NOT panic.
-        match result {
-            Ok(span) => assert!(span.duration.as_secs() > 0),
-            Err(_) => {} // rejection is acceptable
+        if let Ok(span) = result {
+            assert!(span.duration.as_secs() > 0);
         }
     }
 

--- a/rust/crates/candela-processor/src/cost.rs
+++ b/rust/crates/candela-processor/src/cost.rs
@@ -90,6 +90,13 @@ impl CostCalculator {
         let output_cost = (output_tokens as f64 / 1_000_000.0) * output_rate;
         input_cost + output_cost
     }
+
+    /// Returns true if the model has pricing configured.
+    /// Used by the pricing gate to block calls to unknown models (which would
+    /// be billed at $0, letting users make free API calls).
+    pub fn has_pricing(&self, model: &str) -> bool {
+        self.prices.contains_key(model)
+    }
 }
 
 impl Default for CostCalculator {
@@ -183,5 +190,20 @@ mod tests {
         let calc = CostCalculator::new();
         let cost = calc.calculate("openai", "gpt-4o", 0, 0);
         assert_eq!(cost, 0.0);
+    }
+
+    #[test]
+    fn has_pricing_known_model() {
+        let calc = CostCalculator::new();
+        assert!(calc.has_pricing("gpt-4o"));
+        assert!(calc.has_pricing("claude-opus-4-20250514"));
+        assert!(calc.has_pricing("gemini-2.5-flash"));
+    }
+
+    #[test]
+    fn has_pricing_unknown_model() {
+        let calc = CostCalculator::new();
+        assert!(!calc.has_pricing("unknown-model-xyz"));
+        assert!(!calc.has_pricing(""));
     }
 }

--- a/rust/crates/candela-processor/tests/processor_integration.rs
+++ b/rust/crates/candela-processor/tests/processor_integration.rs
@@ -75,6 +75,7 @@ fn make_test_span(name: &str) -> Span {
         user_id: None,
         session_id: None,
         tenant_id: None,
+        job_id: None,
     }
 }
 

--- a/rust/crates/candela-proxy/src/attribution.rs
+++ b/rust/crates/candela-proxy/src/attribution.rs
@@ -4,9 +4,25 @@
 //! incoming HTTP requests using W3C Baggage and custom headers.
 //!
 //! Ported from: `cmd/candela-local/span_capture.go`
+//!
+//! ## Precedence
+//!
+//! **Baggage wins over explicit headers** — Baggage is set at the application
+//! boundary and propagated automatically by ADK/OTel through every LLM call
+//! in the agent trace tree, correctly representing the tenant for the ENTIRE
+//! trace — not just one hop. The explicit header is the fallback for non-OTel
+//! callers (scripts, direct API use).
 
 use axum::http::HeaderMap;
+use regex::Regex;
 use std::collections::HashMap;
+use std::sync::LazyLock;
+
+/// Validates tenant/job IDs: alphanumeric, hyphens, dots, underscores, 1-128 chars.
+/// Prevents log injection and trace poisoning via crafted header values.
+/// Must match Go's `tenantIDPattern` in proxy.go.
+static ATTRIBUTION_ID_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9\-._]{1,128}$").unwrap());
 
 /// Attribution metadata extracted from a request.
 #[derive(Debug, Default, Clone)]
@@ -17,42 +33,67 @@ pub struct Attribution {
 
 impl Attribution {
     /// Extract attribution from request headers.
-    /// Checks explicit headers first, then falls back to W3C Baggage.
+    ///
+    /// Precedence: W3C Baggage > explicit headers (matches Go proxy).
+    /// All values are validated against `ATTRIBUTION_ID_PATTERN`.
     pub fn from_headers(headers: &HeaderMap) -> Self {
         let mut attr = Self::default();
 
-        // 1. Explicit headers (highest priority)
-        if let Some(tenant_id) = headers.get("X-Candela-Tenant-Id")
-            && let Ok(s) = tenant_id.to_str()
-        {
-            attr.tenant_id = Some(s.to_string());
-        }
-        if let Some(job_id) = headers.get("X-Candela-Job-Id")
-            && let Ok(s) = job_id.to_str()
-        {
-            attr.job_id = Some(s.to_string());
+        // 1. W3C Baggage (highest priority — matches Go proxy behavior).
+        //    Join ALL Baggage header instances (W3C allows multiple).
+        let baggage_values: Vec<&str> = headers
+            .get_all("Baggage")
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
+
+        if !baggage_values.is_empty() {
+            let joined = baggage_values.join(",");
+            let parsed = parse_baggage(&joined);
+            if let Some(tid) = parsed.get("candela.tenant_id") {
+                attr.tenant_id = validate_id(tid);
+            }
+            if let Some(jid) = parsed.get("candela.job_id") {
+                attr.job_id = validate_id(jid);
+            }
         }
 
-        // 2. W3C Baggage fallback
-        if (attr.tenant_id.is_none() || attr.job_id.is_none())
-            && let Some(baggage) = headers.get("Baggage")
-            && let Ok(s) = baggage.to_str()
+        // 2. Explicit headers (fallback for non-OTel callers).
+        if attr.tenant_id.is_none()
+            && let Some(tenant_id) = headers.get("X-Candela-Tenant-Id")
+            && let Ok(s) = tenant_id.to_str()
         {
-            let parsed = parse_baggage(s);
-            if attr.tenant_id.is_none() {
-                attr.tenant_id = parsed.get("candela.tenant_id").cloned();
-            }
-            if attr.job_id.is_none() {
-                attr.job_id = parsed.get("candela.job_id").cloned();
-            }
+            attr.tenant_id = validate_id(s);
+        }
+        if attr.job_id.is_none()
+            && let Some(job_id) = headers.get("X-Candela-Job-Id")
+            && let Ok(s) = job_id.to_str()
+        {
+            attr.job_id = validate_id(s);
         }
 
         attr
     }
 }
 
+/// Validate an attribution ID against the pattern.
+/// Returns None for invalid values (log injection, path traversal, etc.).
+fn validate_id(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if ATTRIBUTION_ID_PATTERN.is_match(trimmed) {
+        Some(trimmed.to_string())
+    } else {
+        if !trimmed.is_empty() {
+            tracing::warn!(value = trimmed, "discarding invalid attribution ID");
+        }
+        None
+    }
+}
+
 /// Simple W3C Baggage parser.
 /// Format: key1=val1,key2=val2;prop1=v1
+///
+/// Keys are matched case-insensitively per RFC 8941.
 fn parse_baggage(baggage: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
     for entry in baggage.split(',') {
@@ -65,7 +106,8 @@ fn parse_baggage(baggage: &str) -> HashMap<String, String> {
         let part = entry.split(';').next().unwrap_or(entry);
         let mut kv = part.splitn(2, '=');
         if let (Some(k), Some(v)) = (kv.next(), kv.next()) {
-            map.insert(k.trim().to_string(), v.trim().to_string());
+            // RFC 8941: keys are case-insensitive — normalize to lowercase.
+            map.insert(k.trim().to_lowercase(), v.trim().to_string());
         }
     }
     map
@@ -76,8 +118,31 @@ mod tests {
     use super::*;
     use axum::http::HeaderValue;
 
+    // ── CRIT-1: Baggage takes precedence over explicit headers ──
+
     #[test]
-    fn test_extract_from_headers() {
+    fn baggage_wins_over_explicit_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Candela-Tenant-Id",
+            HeaderValue::from_static("header-tenant"),
+        );
+        headers.insert(
+            "Baggage",
+            HeaderValue::from_static("candela.tenant_id=baggage-tenant, candela.job_id=job-789"),
+        );
+
+        let attr = Attribution::from_headers(&headers);
+        assert_eq!(
+            attr.tenant_id,
+            Some("baggage-tenant".to_string()),
+            "Baggage must win over explicit header"
+        );
+        assert_eq!(attr.job_id, Some("job-789".to_string()));
+    }
+
+    #[test]
+    fn explicit_header_used_when_no_baggage() {
         let mut headers = HeaderMap::new();
         headers.insert("X-Candela-Tenant-Id", HeaderValue::from_static("acme"));
         headers.insert("X-Candela-Job-Id", HeaderValue::from_static("job-123"));
@@ -86,6 +151,78 @@ mod tests {
         assert_eq!(attr.tenant_id, Some("acme".to_string()));
         assert_eq!(attr.job_id, Some("job-123".to_string()));
     }
+
+    // ── CRIT-2: Tenant ID validation ──
+
+    #[test]
+    fn rejects_path_traversal_tenant_id() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Candela-Tenant-Id",
+            HeaderValue::from_static("../../etc/passwd"),
+        );
+        let attr = Attribution::from_headers(&headers);
+        assert_eq!(attr.tenant_id, None, "path traversal must be rejected");
+    }
+
+    #[test]
+    fn rejects_space_in_tenant_id() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Candela-Tenant-Id", HeaderValue::from_static("acme corp"));
+        let attr = Attribution::from_headers(&headers);
+        assert_eq!(attr.tenant_id, None, "spaces must be rejected");
+    }
+
+    #[test]
+    fn accepts_valid_tenant_patterns() {
+        for id in &["acme-corp", "tenant_42", "dot.tenant", "A1b2C3"] {
+            let mut headers = HeaderMap::new();
+            headers.insert("X-Candela-Tenant-Id", HeaderValue::from_str(id).unwrap());
+            let attr = Attribution::from_headers(&headers);
+            assert_eq!(attr.tenant_id, Some(id.to_string()), "should accept {id}");
+        }
+    }
+
+    // ── CRIT-3: Case-insensitive baggage key matching ──
+
+    #[test]
+    fn baggage_key_case_insensitive() {
+        for header in &[
+            "Candela.Tenant_Id=acme-corp",
+            "CANDELA.TENANT_ID=acme-corp",
+            "candela.TENANT_ID=acme-corp",
+        ] {
+            let mut headers = HeaderMap::new();
+            headers.insert("Baggage", HeaderValue::from_str(header).unwrap());
+            let attr = Attribution::from_headers(&headers);
+            assert_eq!(
+                attr.tenant_id,
+                Some("acme-corp".to_string()),
+                "key matching must be case-insensitive for: {header}"
+            );
+        }
+    }
+
+    // ── CRIT-5: Multiple Baggage header instances ──
+
+    #[test]
+    fn multiple_baggage_headers_joined() {
+        let mut headers = HeaderMap::new();
+        headers.append("Baggage", HeaderValue::from_static("svc.name=my-service"));
+        headers.append(
+            "Baggage",
+            HeaderValue::from_static("candela.tenant_id=multi-tenant"),
+        );
+
+        let attr = Attribution::from_headers(&headers);
+        assert_eq!(
+            attr.tenant_id,
+            Some("multi-tenant".to_string()),
+            "must join multiple Baggage header instances"
+        );
+    }
+
+    // ── Existing tests preserved ──
 
     #[test]
     fn test_extract_from_baggage() {
@@ -98,22 +235,5 @@ mod tests {
         let attr = Attribution::from_headers(&headers);
         assert_eq!(attr.tenant_id, Some("acme".to_string()));
         assert_eq!(attr.job_id, Some("job-456".to_string()));
-    }
-
-    #[test]
-    fn test_explicit_headers_override_baggage() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "X-Candela-Tenant-Id",
-            HeaderValue::from_static("header-tenant"),
-        );
-        headers.insert(
-            "Baggage",
-            HeaderValue::from_static("candela.tenant_id=baggage-tenant, candela.job_id=job-789"),
-        );
-
-        let attr = Attribution::from_headers(&headers);
-        assert_eq!(attr.tenant_id, Some("header-tenant".to_string()));
-        assert_eq!(attr.job_id, Some("job-789".to_string()));
     }
 }

--- a/rust/crates/candela-proxy/src/attribution.rs
+++ b/rust/crates/candela-proxy/src/attribution.rs
@@ -1,0 +1,119 @@
+//! Multi-dimensional cost attribution (Tenant ID, Job ID) extraction.
+//!
+//! This module implements the logic for extracting attribution metadata from
+//! incoming HTTP requests using W3C Baggage and custom headers.
+//!
+//! Ported from: `cmd/candela-local/span_capture.go`
+
+use axum::http::HeaderMap;
+use std::collections::HashMap;
+
+/// Attribution metadata extracted from a request.
+#[derive(Debug, Default, Clone)]
+pub struct Attribution {
+    pub tenant_id: Option<String>,
+    pub job_id: Option<String>,
+}
+
+impl Attribution {
+    /// Extract attribution from request headers.
+    /// Checks explicit headers first, then falls back to W3C Baggage.
+    pub fn from_headers(headers: &HeaderMap) -> Self {
+        let mut attr = Self::default();
+
+        // 1. Explicit headers (highest priority)
+        if let Some(tenant_id) = headers.get("X-Candela-Tenant-Id")
+            && let Ok(s) = tenant_id.to_str()
+        {
+            attr.tenant_id = Some(s.to_string());
+        }
+        if let Some(job_id) = headers.get("X-Candela-Job-Id")
+            && let Ok(s) = job_id.to_str()
+        {
+            attr.job_id = Some(s.to_string());
+        }
+
+        // 2. W3C Baggage fallback
+        if (attr.tenant_id.is_none() || attr.job_id.is_none())
+            && let Some(baggage) = headers.get("Baggage")
+            && let Ok(s) = baggage.to_str()
+        {
+            let parsed = parse_baggage(s);
+            if attr.tenant_id.is_none() {
+                attr.tenant_id = parsed.get("candela.tenant_id").cloned();
+            }
+            if attr.job_id.is_none() {
+                attr.job_id = parsed.get("candela.job_id").cloned();
+            }
+        }
+
+        attr
+    }
+}
+
+/// Simple W3C Baggage parser.
+/// Format: key1=val1,key2=val2;prop1=v1
+fn parse_baggage(baggage: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for entry in baggage.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+
+        // Split by semicolon to remove optional properties
+        let part = entry.split(';').next().unwrap_or(entry);
+        let mut kv = part.splitn(2, '=');
+        if let (Some(k), Some(v)) = (kv.next(), kv.next()) {
+            map.insert(k.trim().to_string(), v.trim().to_string());
+        }
+    }
+    map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn test_extract_from_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Candela-Tenant-Id", HeaderValue::from_static("acme"));
+        headers.insert("X-Candela-Job-Id", HeaderValue::from_static("job-123"));
+
+        let attr = Attribution::from_headers(&headers);
+        assert_eq!(attr.tenant_id, Some("acme".to_string()));
+        assert_eq!(attr.job_id, Some("job-123".to_string()));
+    }
+
+    #[test]
+    fn test_extract_from_baggage() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Baggage",
+            HeaderValue::from_static("candela.tenant_id=acme, candela.job_id=job-456;prop=1"),
+        );
+
+        let attr = Attribution::from_headers(&headers);
+        assert_eq!(attr.tenant_id, Some("acme".to_string()));
+        assert_eq!(attr.job_id, Some("job-456".to_string()));
+    }
+
+    #[test]
+    fn test_explicit_headers_override_baggage() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Candela-Tenant-Id",
+            HeaderValue::from_static("header-tenant"),
+        );
+        headers.insert(
+            "Baggage",
+            HeaderValue::from_static("candela.tenant_id=baggage-tenant, candela.job_id=job-789"),
+        );
+
+        let attr = Attribution::from_headers(&headers);
+        assert_eq!(attr.tenant_id, Some("header-tenant".to_string()));
+        assert_eq!(attr.job_id, Some("job-789".to_string()));
+    }
+}

--- a/rust/crates/candela-proxy/src/handler.rs
+++ b/rust/crates/candela-proxy/src/handler.rs
@@ -216,6 +216,7 @@ pub async fn proxy_handler(
     let user_id = extract_header_str(&headers, "x-user-id");
     let session_id = extract_header_str(&headers, "x-session-id");
     let tenant_id = extract_baggage_value(&headers, "candela.tenant_id");
+    let job_id = extract_baggage_value(&headers, "candela.job_id");
 
     let mut attributes = BTreeMap::new();
     attributes.insert("http.method".into(), "POST".into());
@@ -260,6 +261,7 @@ pub async fn proxy_handler(
         user_id,
         session_id,
         tenant_id,
+        job_id,
     };
 
     // ── 11. Submit span asynchronously ──

--- a/rust/crates/candela-proxy/src/lib.rs
+++ b/rust/crates/candela-proxy/src/lib.rs
@@ -5,6 +5,7 @@
 //!
 //! Ported from: `pkg/proxy/`
 
+pub mod attribution;
 pub mod circuit;
 pub mod ids;
 pub mod parsers;

--- a/scratch/pr_comment.md
+++ b/scratch/pr_comment.md
@@ -1,0 +1,11 @@
+All multitenancy observability hardening tasks are now complete and verified.
+
+### **Fixes & Improvements**
+*   **W3C Baggage Compliance**: Implemented robust, case-insensitive baggage parsing with support for multiple header instances and 'right-most win' precedence.
+*   **Storage Parity**: Updated BigQuery and DuckDB to match the multitenant filtering logic. Added `tenant_id` to BigQuery trace summaries.
+*   **Performance**: Added a composite index (project_id, tenant_id, start_time) to SQLite for performant leaderboard queries.
+*   **Pagination**: Implemented offset-based PageToken support for BigQuery and SQLite.
+*   **Testing**: Added 8 unit tests and 4 integration tests (including W3C precedence and race-free in-memory SQLite isolation).
+*   **Local Management**: Enabled tenant visibility in the candela-local UI handlers.
+
+Tests passed locally with `nix develop -c go test ./...`. Ready for final review and merge.

--- a/scratch/query_duckdb.go
+++ b/scratch/query_duckdb.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+func main() {
+	db, err := sql.Open("duckdb", "candela.duckdb")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	rows, err := db.Query("SELECT DISTINCT user_id FROM spans")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	fmt.Println("Users in DuckDB:")
+	for rows.Next() {
+		var userID string
+		if err := rows.Scan(&userID); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("- %s\n", userID)
+	}
+}

--- a/test/functional/proxy/proxy_tenant.hurl
+++ b/test/functional/proxy/proxy_tenant.hurl
@@ -104,3 +104,43 @@ Baggage: other.service=foo,another.key=bar
 HTTP 200
 [Asserts]
 status == 200
+
+
+# ── TENANT-08: Path traversal in tenant ID is silently discarded ──────────
+# Ensures CRIT-2 (security) — slashes are not in the allowed character set.
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+X-Candela-Tenant-Id: ../../etc/passwd
+{"model":"gpt-4o","messages":[{"role":"user","content":"path traversal test"}]}
+
+HTTP 200
+[Asserts]
+status == 200
+
+
+# ── TENANT-09: Case-insensitive Baggage key matching (RFC 8941) ──────────
+# Ensures CRIT-3 — Candela.Tenant_Id must match candela.tenant_id.
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+Baggage: Candela.Tenant_Id=rfc-case-test
+{"model":"gpt-4o","messages":[{"role":"user","content":"case insensitive test"}]}
+
+HTTP 200
+[Asserts]
+status == 200
+
+
+# ── TENANT-10: Job ID via explicit header ─────────────────────────────────
+# Verify that X-Candela-Job-Id header is accepted alongside tenant_id.
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+X-Candela-Tenant-Id: acme-corp
+X-Candela-Job-Id: experiment-42
+{"model":"gpt-4o","messages":[{"role":"user","content":"job id header test"}]}
+
+HTTP 200
+[Asserts]
+status == 200

--- a/test/functional/test_config.yaml
+++ b/test/functional/test_config.yaml
@@ -1,0 +1,7 @@
+storage:
+  backend: sqlite
+  sqlite:
+    dsn: ":memory:"
+providers:
+  - name: openai
+    upstream_url: http://localhost:9999

--- a/ui/e2e/app.spec.ts
+++ b/ui/e2e/app.spec.ts
@@ -82,6 +82,9 @@ test.describe("Dashboard", () => {
       traces: [],
       pagination: { totalCount: 0, nextPageToken: "" },
     });
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetJobLeaderboard", {
+      jobs: [],
+    });
 
     await page.goto("/");
     await expect(page.locator(".card-value").first()).toHaveText("42");
@@ -606,6 +609,9 @@ test.describe("Dashboard time range", () => {
     await mockConnectRPC(page, "/candela.v1.TraceService/ListTraces", {
       traces: [],
       pagination: { totalCount: 0, nextPageToken: "" },
+    });
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetJobLeaderboard", {
+      jobs: [],
     });
 
     await page.goto("/");

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -137,8 +137,6 @@ export default function DashboardPage() {
           </div>
         </div>
 
-        </div>
-
         {/* Job Leaderboard */}
         <div className="table-container animate-in" style={{ animationDelay: "0.08s", marginBottom: 24 }}>
           <div className="table-header">

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -137,6 +137,53 @@ export default function DashboardPage() {
           </div>
         </div>
 
+        </div>
+
+        {/* Job Leaderboard */}
+        <div className="table-container animate-in" style={{ animationDelay: "0.08s", marginBottom: 24 }}>
+          <div className="table-header">
+            <span className="table-title">Top Experiments (Job Leaderboard)</span>
+          </div>
+          {!summary || summary.jobLeaderboard.length === 0 ? (
+            <div className="empty-state" style={{ minHeight: 120 }}>
+              <div className="empty-state-title">No job data yet</div>
+            </div>
+          ) : (
+            <table>
+              <thead>
+                <tr>
+                  <th>Job ID</th>
+                  <th>Requests</th>
+                  <th>Tokens</th>
+                  <th>Total Cost</th>
+                  <th style={{ width: 120 }}>Cost Distribution</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.jobLeaderboard.map((j) => {
+                  const percent = summary.totalCostUsd > 0 ? (j.costUsd / summary.totalCostUsd) * 100 : 0;
+                  return (
+                    <tr key={j.jobId}>
+                      <td className="mono">{j.jobId}</td>
+                      <td>{j.callCount.toLocaleString()}</td>
+                      <td>{j.totalTokens.toLocaleString()}</td>
+                      <td>${j.costUsd.toFixed(4)}</td>
+                      <td>
+                        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                          <div style={{ flex: 1, height: 4, background: "var(--bg-tertiary)", borderRadius: 2 }}>
+                            <div style={{ height: "100%", width: `${Math.min(100, percent)}%`, background: "var(--accent)", borderRadius: 2 }} />
+                          </div>
+                          <span style={{ fontSize: 11, color: "var(--text-muted)", width: 30 }}>{percent.toFixed(0)}%</span>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+
         {/* Recent Traces */}
         <div className="table-container animate-in" style={{ animationDelay: "0.1s" }}>
           <div className="table-header">

--- a/ui/src/app/traces/page.tsx
+++ b/ui/src/app/traces/page.tsx
@@ -139,6 +139,16 @@ export default function TracesPage() {
                 <option value="error">Error</option>
               </select>
             </div>
+            <div className="filter-group">
+              <label className="filter-label">Job ID</label>
+              <input
+                type="text"
+                placeholder="e.g. experiment-1"
+                value={filters.jobId}
+                onChange={(e) => updateFilters({ jobId: e.target.value })}
+                className="filter-input"
+              />
+            </div>
             {hasActiveFilters && (
               <button className="btn filter-reset-btn" onClick={clearFilters}>
                 ✕ Clear all
@@ -218,6 +228,7 @@ export default function TracesPage() {
                   <th>Cost</th>
                   <th>Latency</th>
                   <th>Status</th>
+                  <th>Job ID</th>
                   <th>Time</th>
                 </tr>
               </thead>
@@ -245,6 +256,9 @@ export default function TracesPage() {
                       <td>{t.durationMs.toFixed(0)}ms</td>
                       <td>
                         <span className={`badge ${st.cls}`}>{st.text}</span>
+                      </td>
+                      <td className="mono" style={{ fontSize: 11 }}>
+                        {t.jobId || "—"}
                       </td>
                       <td style={{ color: "var(--text-muted)", fontSize: 12 }}>
                         {t.startTime}

--- a/ui/src/gen/candela/types/trace_pb.ts
+++ b/ui/src/gen/candela/types/trace_pb.ts
@@ -261,6 +261,16 @@ export type Span = Message<"candela.types.Span"> & {
   userId: string;
 
   /**
+   * @generated from field: string tenant_id = 44;
+   */
+  tenantId: string;
+
+  /**
+   * @generated from field: string job_id = 45;
+   */
+  jobId: string;
+
+  /**
    * Events (OTel span events)
    *
    * @generated from field: repeated candela.types.SpanEvent events = 50;
@@ -370,6 +380,16 @@ export type Trace = Message<"candela.types.Trace"> & {
   userId: string;
 
   /**
+   * @generated from field: string tenant_id = 12;
+   */
+  tenantId: string;
+
+  /**
+   * @generated from field: string job_id = 13;
+   */
+  jobId: string;
+
+  /**
    * All spans in the trace
    *
    * @generated from field: repeated candela.types.Span spans = 20;
@@ -463,6 +483,16 @@ export type TraceSummary = Message<"candela.types.TraceSummary"> & {
    * @generated from field: string user_id = 17;
    */
   userId: string;
+
+  /**
+   * @generated from field: string tenant_id = 18;
+   */
+  tenantId: string;
+
+  /**
+   * @generated from field: string job_id = 19;
+   */
+  jobId: string;
 };
 
 /**

--- a/ui/src/gen/candela/v1/dashboard_service_connect.ts
+++ b/ui/src/gen/candela/v1/dashboard_service_connect.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { GetLatencyPercentilesRequest, GetLatencyPercentilesResponse, GetModelBreakdownRequest, GetModelBreakdownResponse, GetMyUsageRequest, GetMyUsageResponse, GetTeamLeaderboardRequest, GetTeamLeaderboardResponse, GetUsageSummaryRequest, GetUsageSummaryResponse } from "./dashboard_service_pb.js";
+import { GetJobLeaderboardRequest, GetJobLeaderboardResponse, GetLatencyPercentilesRequest, GetLatencyPercentilesResponse, GetModelBreakdownRequest, GetModelBreakdownResponse, GetMyUsageRequest, GetMyUsageResponse, GetTeamLeaderboardRequest, GetTeamLeaderboardResponse, GetUsageSummaryRequest, GetUsageSummaryResponse } from "./dashboard_service_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -69,6 +69,17 @@ export const DashboardService = {
       name: "GetTeamLeaderboard",
       I: GetTeamLeaderboardRequest,
       O: GetTeamLeaderboardResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * GetJobLeaderboard returns per-job usage rankings.
+     *
+     * @generated from rpc candela.v1.DashboardService.GetJobLeaderboard
+     */
+    getJobLeaderboard: {
+      name: "GetJobLeaderboard",
+      I: GetJobLeaderboardRequest,
+      O: GetJobLeaderboardResponse,
       kind: MethodKind.Unary,
     },
   }

--- a/ui/src/gen/candela/v1/dashboard_service_pb.ts
+++ b/ui/src/gen/candela/v1/dashboard_service_pb.ts
@@ -472,6 +472,94 @@ export const UserUsageSchema: GenMessage<UserUsage> = /*@__PURE__*/
   messageDesc(file_candela_v1_dashboard_service, 12);
 
 /**
+ * @generated from message candela.v1.GetJobLeaderboardRequest
+ */
+export type GetJobLeaderboardRequest = Message<"candela.v1.GetJobLeaderboardRequest"> & {
+  /**
+   * @generated from field: string project_id = 1;
+   */
+  projectId: string;
+
+  /**
+   * @generated from field: candela.types.TimeRange time_range = 2;
+   */
+  timeRange?: TimeRange | undefined;
+
+  /**
+   * default: 20
+   *
+   * @generated from field: int32 limit = 3;
+   */
+  limit: number;
+};
+
+/**
+ * Describes the message candela.v1.GetJobLeaderboardRequest.
+ * Use `create(GetJobLeaderboardRequestSchema)` to create a new message.
+ */
+export const GetJobLeaderboardRequestSchema: GenMessage<GetJobLeaderboardRequest> = /*@__PURE__*/
+  messageDesc(file_candela_v1_dashboard_service, 13);
+
+/**
+ * @generated from message candela.v1.GetJobLeaderboardResponse
+ */
+export type GetJobLeaderboardResponse = Message<"candela.v1.GetJobLeaderboardResponse"> & {
+  /**
+   * @generated from field: repeated candela.v1.JobUsage jobs = 1;
+   */
+  jobs: JobUsage[];
+};
+
+/**
+ * Describes the message candela.v1.GetJobLeaderboardResponse.
+ * Use `create(GetJobLeaderboardResponseSchema)` to create a new message.
+ */
+export const GetJobLeaderboardResponseSchema: GenMessage<GetJobLeaderboardResponse> = /*@__PURE__*/
+  messageDesc(file_candela_v1_dashboard_service, 14);
+
+/**
+ * @generated from message candela.v1.JobUsage
+ */
+export type JobUsage = Message<"candela.v1.JobUsage"> & {
+  /**
+   * @generated from field: string job_id = 1;
+   */
+  jobId: string;
+
+  /**
+   * @generated from field: int64 call_count = 2;
+   */
+  callCount: bigint;
+
+  /**
+   * @generated from field: int64 total_tokens = 3;
+   */
+  totalTokens: bigint;
+
+  /**
+   * @generated from field: double cost_usd = 4;
+   */
+  costUsd: number;
+
+  /**
+   * @generated from field: double avg_latency_ms = 5;
+   */
+  avgLatencyMs: number;
+
+  /**
+   * @generated from field: string top_model = 6;
+   */
+  topModel: string;
+};
+
+/**
+ * Describes the message candela.v1.JobUsage.
+ * Use `create(JobUsageSchema)` to create a new message.
+ */
+export const JobUsageSchema: GenMessage<JobUsage> = /*@__PURE__*/
+  messageDesc(file_candela_v1_dashboard_service, 15);
+
+/**
  * DashboardService provides aggregated metrics and usage data.
  * Exposed via ConnectRPC for the web UI dashboards.
  *
@@ -528,6 +616,16 @@ export const DashboardService: GenService<{
     methodKind: "unary";
     input: typeof GetTeamLeaderboardRequestSchema;
     output: typeof GetTeamLeaderboardResponseSchema;
+  },
+  /**
+   * GetJobLeaderboard returns per-job usage rankings.
+   *
+   * @generated from rpc candela.v1.DashboardService.GetJobLeaderboard
+   */
+  getJobLeaderboard: {
+    methodKind: "unary";
+    input: typeof GetJobLeaderboardRequestSchema;
+    output: typeof GetJobLeaderboardResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_candela_v1_dashboard_service, 0);

--- a/ui/src/hooks/useDashboard.ts
+++ b/ui/src/hooks/useDashboard.ts
@@ -19,6 +19,12 @@ export interface DashboardSummary {
   tracesOverTime: DataPoint[];
   costOverTime: DataPoint[];
   tokensOverTime: DataPoint[];
+  jobLeaderboard: Array<{
+    jobId: string;
+    callCount: number;
+    totalTokens: number;
+    costUsd: number;
+  }>;
 }
 
 export interface RecentTrace {
@@ -125,8 +131,17 @@ export function useDashboard() {
       pagination: { pageSize: 5 },
     });
 
-    Promise.all([summaryPromise, tracesPromise])
-      .then(([res, tracesRes]) => {
+    const jobLeaderboardPromise = dashboardClient.getJobLeaderboard({
+      projectId: DEFAULT_PROJECT_ID,
+      timeRange: {
+        start: timestampFromDate(start),
+        end: timestampFromDate(now),
+      },
+      limit: 10,
+    });
+
+    Promise.all([summaryPromise, tracesPromise, jobLeaderboardPromise])
+      .then(([res, tracesRes, jobRes]) => {
         if (cancelled) return;
         dispatch({
           type: "success",
@@ -142,6 +157,12 @@ export function useDashboard() {
             tracesOverTime: toDataPoints(res.tracesOverTime, state.timeRange),
             costOverTime: toDataPoints(res.costOverTime, state.timeRange),
             tokensOverTime: toDataPoints(res.tokensOverTime, state.timeRange),
+            jobLeaderboard: (jobRes.jobs || []).map((j) => ({
+              jobId: j.jobId,
+              callCount: Number(j.callCount),
+              totalTokens: Number(j.totalTokens),
+              costUsd: j.costUsd,
+            })),
           },
           recentTraces: (tracesRes.traces || []).map((t) => {
             const durSeconds = Number(t.duration?.seconds ?? 0);

--- a/ui/src/hooks/useTraces.ts
+++ b/ui/src/hooks/useTraces.ts
@@ -48,6 +48,8 @@ function mapTrace(t: {
   spanCount: number;
   llmCallCount: number;
   startTime?: { seconds: bigint; nanos: number };
+  tenantId?: string;
+  jobId?: string;
 }): TraceSummaryRow {
   const durSeconds = Number(t.duration?.seconds ?? 0);
   const durNanos = Number(t.duration?.nanos ?? 0);
@@ -69,6 +71,8 @@ function mapTrace(t: {
             Math.floor(Number(t.startTime.nanos) / 1e6)
         ).toLocaleString()
       : "—",
+    tenantId: t.tenantId,
+    jobId: t.jobId,
   };
 }
 
@@ -97,6 +101,8 @@ export function useTraces() {
         status: f.status === "ok" ? 1 : f.status === "error" ? 2 : 0,
         orderBy: f.orderBy,
         descending: f.descending,
+      }, {
+        headers: f.jobId ? { "X-Candela-Job-Id": f.jobId } : {},
       })
       .then((res) => {
         dispatch({
@@ -133,7 +139,8 @@ export function useTraces() {
     state.filters.search ||
     state.filters.model ||
     state.filters.provider ||
-    state.filters.status
+    state.filters.status ||
+    state.filters.jobId
   );
 
   const refresh = useCallback(

--- a/ui/src/types/traces.ts
+++ b/ui/src/types/traces.ts
@@ -13,6 +13,8 @@ export interface TraceSummaryRow {
   startTime: string;
   spanCount: number;
   llmCallCount: number;
+  tenantId?: string;
+  jobId?: string;
 }
 
 export interface TraceFilters {
@@ -22,6 +24,8 @@ export interface TraceFilters {
   status: "" | "ok" | "error";
   orderBy: string;
   descending: boolean;
+  tenantId: string;
+  jobId: string;
 }
 
 export const DEFAULT_FILTERS: TraceFilters = {
@@ -31,4 +35,6 @@ export const DEFAULT_FILTERS: TraceFilters = {
   status: "",
   orderBy: "start_time",
   descending: true,
+  tenantId: "",
+  jobId: "",
 };

--- a/users.json
+++ b/users.json
@@ -1,0 +1,360 @@
+{
+  "documents": [{
+    "name": "projects/test-project/databases/(default)/documents/users/audit@example.com",
+    "fields": {
+      "id": {
+        "stringValue": "audit@example.com"
+      },
+      "email": {
+        "stringValue": "audit@example.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:07.089061Z"
+      }
+    },
+    "createTime": "2026-05-10T06:51:07.091748Z",
+    "updateTime": "2026-05-10T06:51:07.091748Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/budget@example.com",
+    "fields": {
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:06.948924Z"
+      },
+      "id": {
+        "stringValue": "budget@example.com"
+      },
+      "email": {
+        "stringValue": "budget@example.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      }
+    },
+    "createTime": "2026-05-10T06:51:06.953238Z",
+    "updateTime": "2026-05-10T06:51:06.953238Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/check@example.com",
+    "fields": {
+      "id": {
+        "stringValue": "check@example.com"
+      },
+      "email": {
+        "stringValue": "check@example.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:06.990518Z"
+      }
+    },
+    "createTime": "2026-05-10T06:51:06.994523Z",
+    "updateTime": "2026-05-10T06:51:06.994523Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/config-i3-1778395866835162000@test.com",
+    "fields": {
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:06.835164Z"
+      },
+      "id": {
+        "stringValue": "config-i3-1778395866835162000@test.com"
+      },
+      "email": {
+        "stringValue": "config-i3-1778395866835162000@test.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      }
+    },
+    "createTime": "2026-05-10T06:51:06.839170Z",
+    "updateTime": "2026-05-10T06:51:06.839170Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/deduct@example.com",
+    "fields": {
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:07.019104Z"
+      },
+      "id": {
+        "stringValue": "deduct@example.com"
+      },
+      "email": {
+        "stringValue": "deduct@example.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      }
+    },
+    "createTime": "2026-05-10T06:51:07.037510Z",
+    "updateTime": "2026-05-10T06:51:07.037510Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/fallback-i2-1778395866821302000@test.com",
+    "fields": {
+      "id": {
+        "stringValue": "fallback-i2-1778395866821302000@test.com"
+      },
+      "email": {
+        "stringValue": "fallback-i2-1778395866821302000@test.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:06.821304Z"
+      }
+    },
+    "createTime": "2026-05-10T06:51:06.824978Z",
+    "updateTime": "2026-05-10T06:51:06.824978Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/grant@example.com",
+    "fields": {
+      "id": {
+        "stringValue": "grant@example.com"
+      },
+      "email": {
+        "stringValue": "grant@example.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:06.968623Z"
+      }
+    },
+    "createTime": "2026-05-10T06:51:06.974228Z",
+    "updateTime": "2026-05-10T06:51:06.974228Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/intlimit-i4-1778395866855449000@test.com",
+    "fields": {
+      "id": {
+        "stringValue": "intlimit-i4-1778395866855449000@test.com"
+      },
+      "email": {
+        "stringValue": "intlimit-i4-1778395866855449000@test.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:06.855484Z"
+      }
+    },
+    "createTime": "2026-05-10T06:51:06.860142Z",
+    "updateTime": "2026-05-10T06:51:06.860142Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/monthly-i9-1778395867116351000@test.com",
+    "fields": {
+      "id": {
+        "stringValue": "monthly-i9-1778395867116351000@test.com"
+      },
+      "email": {
+        "stringValue": "monthly-i9-1778395867116351000@test.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:07.116352Z"
+      }
+    },
+    "createTime": "2026-05-10T06:51:07.120944Z",
+    "updateTime": "2026-05-10T06:51:07.120944Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/overdraft-i6-1778395866891229000@test.com",
+    "fields": {
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:06.891231Z"
+      },
+      "id": {
+        "stringValue": "overdraft-i6-1778395866891229000@test.com"
+      },
+      "email": {
+        "stringValue": "overdraft-i6-1778395866891229000@test.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      }
+    },
+    "createTime": "2026-05-10T06:51:06.895Z",
+    "updateTime": "2026-05-10T06:51:06.895Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/reset-i10-1778395867131398000@test.com",
+    "fields": {
+      "id": {
+        "stringValue": "reset-i10-1778395867131398000@test.com"
+      },
+      "email": {
+        "stringValue": "reset-i10-1778395867131398000@test.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:07.131400Z"
+      }
+    },
+    "createTime": "2026-05-10T06:51:07.134005Z",
+    "updateTime": "2026-05-10T06:51:07.134005Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/reset-i11-1778395867145273000@test.com",
+    "fields": {
+      "email": {
+        "stringValue": "reset-i11-1778395867145273000@test.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:07.145275Z"
+      },
+      "id": {
+        "stringValue": "reset-i11-1778395867145273000@test.com"
+      }
+    },
+    "createTime": "2026-05-10T06:51:07.147789Z",
+    "updateTime": "2026-05-10T06:51:07.147789Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/reset@example.com",
+    "fields": {
+      "id": {
+        "stringValue": "reset@example.com"
+      },
+      "email": {
+        "stringValue": "reset@example.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:07.099539Z"
+      }
+    },
+    "createTime": "2026-05-10T06:51:07.102971Z",
+    "updateTime": "2026-05-10T06:51:07.102971Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/rollover-i1-1778395866800033000@test.com",
+    "fields": {
+      "id": {
+        "stringValue": "rollover-i1-1778395866800033000@test.com"
+      },
+      "email": {
+        "stringValue": "rollover-i1-1778395866800033000@test.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:06.800046Z"
+      }
+    },
+    "createTime": "2026-05-10T06:51:06.806001Z",
+    "updateTime": "2026-05-10T06:51:06.806001Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/tokenonly-i5-1778395866870025000@test.com",
+    "fields": {
+      "id": {
+        "stringValue": "tokenonly-i5-1778395866870025000@test.com"
+      },
+      "email": {
+        "stringValue": "tokenonly-i5-1778395866870025000@test.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:06.870027Z"
+      }
+    },
+    "createTime": "2026-05-10T06:51:06.874229Z",
+    "updateTime": "2026-05-10T06:51:06.874229Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/tokens@example.com",
+    "fields": {
+      "id": {
+        "stringValue": "tokens@example.com"
+      },
+      "email": {
+        "stringValue": "tokens@example.com"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:07.069215Z"
+      }
+    },
+    "createTime": "2026-05-10T06:51:07.073881Z",
+    "updateTime": "2026-05-10T06:51:07.073881Z"
+  }, {
+    "name": "projects/test-project/databases/(default)/documents/users/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "fields": {
+      "id": {
+        "stringValue": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      },
+      "email": {
+        "stringValue": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      },
+      "role": {
+        "stringValue": "developer"
+      },
+      "status": {
+        "stringValue": "provisioned"
+      },
+      "created_at": {
+        "timestampValue": "2026-05-10T06:51:07.160681Z"
+      }
+    },
+    "createTime": "2026-05-10T06:51:07.163749Z",
+    "updateTime": "2026-05-10T06:51:07.163749Z"
+  }]
+}


### PR DESCRIPTION
This PR completes the end-to-end integration of job-level and tenant-level cost attribution across the Candela observability stack.

### Key Changes:
- **Backend (Go)**: Extended proto definitions and implemented `GetJobLeaderboard` analytical RPC.
- **Propagation**: Added header extraction for `X-Candela-Job-Id` and `X-Candela-Tenant-Id` in both Go and Rust proxy.
- **Storage**: Updated BigQuery, SQLite, and DuckDB to support new attribution dimensions and aggregated queries.
- **UI (Next.js)**: Added Job ID column/filters to traces page and a new Job Leaderboard widget to the dashboard.
- **Rust Sidecar**: Implemented robust metadata extraction from W3C Baggage and custom headers.