### PR TITLE
fix(ci): add packages:read to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ on:
       - "v*"
 
 permissions:
-  contents: write   # Create GitHub releases and upload assets
+  contents: write    # Create GitHub releases and upload assets
+  packages: read     # Pull ghcr.io/candelahq/candela-dev container
 
 jobs:
   goreleaser:


### PR DESCRIPTION
The release workflow needs `packages: read` to pull `ghcr.io/candelahq/candela-dev:latest`. Without it, tag pushes fail at container init with `Error response from daemon: denied`.

See failed run: https://github.com/candelahq/candela/actions/runs/25717473845