### PR TITLE
feat: add anthropic-vertex provider for Claude Code LLM gateway

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -238,10 +238,9 @@ func main() {
 			}
 
 			for i, p := range allProviders {
-				if p.Name == "anthropic" {
+				if p.Name == "anthropic" || p.Name == "anthropic-vertex" {
 					allProviders[i].UpstreamURL = fmt.Sprintf(
 						"https://%s-aiplatform.googleapis.com", region)
-					allProviders[i].FormatTranslator = &proxy.AnthropicFormatTranslator{}
 					allProviders[i].PathRewriter = &proxy.VertexAIPathRewriter{
 						ProjectID: cfg.Proxy.VertexAI.ProjectID,
 						Region:    region,
@@ -249,11 +248,17 @@ func main() {
 					if tokenSource != nil {
 						allProviders[i].TokenSource = tokenSource
 					}
+					// Only add format translation for the OpenAI-compat "anthropic" provider.
+					// anthropic-vertex is a native Messages API passthrough (for Claude Code).
+					if p.Name == "anthropic" {
+						allProviders[i].FormatTranslator = &proxy.AnthropicFormatTranslator{}
+					}
 					slog.Info("🔐 Anthropic via Vertex AI configured",
+						"provider", p.Name,
 						"project", cfg.Proxy.VertexAI.ProjectID,
 						"region", region,
-						"adc", tokenSource != nil)
-					break
+						"adc", tokenSource != nil,
+						"format_translation", p.Name == "anthropic")
 				}
 			}
 		}

--- a/cmd/candela-sidecar/main.go
+++ b/cmd/candela-sidecar/main.go
@@ -133,10 +133,9 @@ func main() {
 		}
 
 		for i, p := range allProviders {
-			if p.Name == "anthropic" {
+			if p.Name == "anthropic" || p.Name == "anthropic-vertex" {
 				allProviders[i].UpstreamURL = fmt.Sprintf(
 					"https://%s-aiplatform.googleapis.com", vertexRegion)
-				allProviders[i].FormatTranslator = &proxy.AnthropicFormatTranslator{}
 				allProviders[i].PathRewriter = &proxy.VertexAIPathRewriter{
 					ProjectID: gcpProject,
 					Region:    vertexRegion,
@@ -144,9 +143,15 @@ func main() {
 				if tokenSource != nil {
 					allProviders[i].TokenSource = tokenSource
 				}
+				// Only add format translation for the OpenAI-compat "anthropic" provider.
+				// anthropic-vertex is a native Messages API passthrough (for Claude Code).
+				if p.Name == "anthropic" {
+					allProviders[i].FormatTranslator = &proxy.AnthropicFormatTranslator{}
+				}
 				slog.Info("🔐 Anthropic via Vertex AI configured",
-					"project", gcpProject, "region", vertexRegion)
-				break
+					"provider", p.Name,
+					"project", gcpProject, "region", vertexRegion,
+					"format_translation", p.Name == "anthropic")
 			}
 		}
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -35,6 +35,7 @@ proxy:
   #   /proxy/google/      → https://generativelanguage.googleapis.com
   #   /proxy/gemini-oai/  → https://generativelanguage.googleapis.com/v1beta/openai (OpenAI-compat)
   #   /proxy/anthropic/   → Vertex AI (with format translation + ADC auth)
+  #   /proxy/anthropic-vertex/ → Vertex AI (native Anthropic Messages API + ADC auth, for Claude Code)
   #   /proxy/anthropic-direct/ → https://api.anthropic.com (native Messages API, client provides key)
   #
   # Editor integration (Zed, OpenCode, etc.):
@@ -42,6 +43,7 @@ proxy:
   #   Gemini:     Base URL = http://localhost:8181/proxy/gemini-oai/v1
   #   Anthropic:  Base URL = http://localhost:8181/proxy/anthropic/v1  (via Vertex AI)
   #   Claude Code / pencil.dev: ANTHROPIC_BASE_URL = http://localhost:8181/proxy/anthropic-direct
+  #   Claude Code (Vertex AI): ANTHROPIC_BASE_URL = http://localhost:8181/proxy/anthropic-vertex
   #
   # Local models (Ollama/vLLM/LM Studio) are handled by candela-local.
   # See ~/.candela.yaml for local runtime configuration.
@@ -49,6 +51,7 @@ proxy:
     - openai
     - google
     - anthropic
+    - anthropic-vertex
     - anthropic-direct
     - gemini-oai
 

--- a/pkg/proxy/parsers.go
+++ b/pkg/proxy/parsers.go
@@ -27,6 +27,7 @@ var parserRegistry = map[string]ProviderParser{
 	"gemini-oai":       &openaiParser{}, // Gemini OpenAI-compat returns standard OpenAI format.
 	"anthropic":        &anthropicParser{},
 	"anthropic-direct": &anthropicParser{}, // Same wire format, just no Vertex AI translation.
+	"anthropic-vertex": &anthropicParser{}, // Native Anthropic format routed via Vertex AI.
 	"google":           &googleParser{},
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -111,6 +111,11 @@ func DefaultProviders() []Provider {
 		// Anthropic via Vertex AI. Override upstream via config for your region/project:
 		// https://{REGION}-aiplatform.googleapis.com/v1/projects/{PROJECT}/locations/{REGION}/publishers/anthropic/models
 		{Name: "anthropic", UpstreamURL: "https://us-central1-aiplatform.googleapis.com"},
+		// Anthropic via Vertex AI (native Messages API) — for Claude Code LLM gateway mode.
+		// No format translation. Client speaks native Anthropic, routed via Vertex rawPredict.
+		// Candela handles GCP auth (ADC) — no ANTHROPIC_API_KEY needed.
+		// Use this with: ANTHROPIC_BASE_URL=http://localhost:8181/proxy/anthropic-vertex
+		{Name: "anthropic-vertex", UpstreamURL: "https://us-central1-aiplatform.googleapis.com"},
 		// Anthropic Direct — native Messages API passthrough to api.anthropic.com.
 		// No format translation, no Vertex AI, no ADC. Client provides its own API key.
 		// Use this for Claude Code, pencil.dev, and other tools that speak native Anthropic.
@@ -550,8 +555,14 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// --- Path rewriting ---
 	// If the provider has a PathRewriter, rewrite the upstream URL path
 	// (e.g. Vertex AI project-scoped model endpoints).
-	if provider.PathRewriter != nil && translatedModel != "" {
-		upstreamPath = provider.PathRewriter.RewritePath(translatedModel, isStreaming)
+	// When FormatTranslator is nil (e.g. anthropic-vertex), the model comes
+	// from the request body rather than from translation.
+	modelForPath := translatedModel
+	if modelForPath == "" && provider.PathRewriter != nil {
+		modelForPath, _ = extractRequestInfo(providerName, reqBody)
+	}
+	if provider.PathRewriter != nil && modelForPath != "" {
+		upstreamPath = provider.PathRewriter.RewritePath(modelForPath, isStreaming)
 	}
 
 	// Build the upstream request.
@@ -1213,6 +1224,15 @@ func forwardHeaders(src *http.Request, dst *http.Request, provider string) {
 		// Native Anthropic Messages API — forward all required headers.
 		// Claude Code requires anthropic-beta and anthropic-version to be forwarded.
 		for _, h := range []string{"X-Api-Key", "Anthropic-Version", "Anthropic-Beta"} {
+			if v := src.Header.Get(h); v != "" {
+				dst.Header.Set(h, v)
+			}
+		}
+	case "anthropic-vertex":
+		// Native Anthropic Messages API routed via Vertex AI.
+		// Claude Code requires anthropic-beta and anthropic-version to be forwarded.
+		// Auth is handled by ADC TokenSource — no client API key needed.
+		for _, h := range []string{"Anthropic-Version", "Anthropic-Beta"} {
 			if v := src.Header.Get(h); v != "" {
 				dst.Header.Set(h, v)
 			}


### PR DESCRIPTION
## Summary

Add a new `anthropic-vertex` proxy provider that enables **Claude Code** to route through Candela team mode via Google Vertex AI — with full observability, cost attribution, and budget gates. **No `ANTHROPIC_API_KEY` needed** — Candela handles GCP auth via ADC.

## How It Works

Claude Code sets `ANTHROPIC_BASE_URL=http://localhost:8181/proxy/anthropic-vertex` and Candela:

1. Accepts native Anthropic Messages API requests (no format translation)
2. Extracts the model from the request body
3. Rewrites paths to Vertex AI `rawPredict` / `streamRawPredict` endpoints
4. Injects GCP ADC Bearer token
5. Captures the full exchange as an observability span

```
Claude Code → Candela (anthropic-vertex) → Vertex AI rawPredict
                  ↓
        trace + cost + budget gate
```

## Changes

### Proxy core (`pkg/proxy/`)
- **`proxy.go`**: New `anthropic-vertex` in `DefaultProviders()`, model extraction fix for path rewriting when `FormatTranslator` is nil, header forwarding for `Anthropic-Version` and `Anthropic-Beta`
- **`parsers.go`**: Registered `anthropic-vertex` → `anthropicParser`

### Server wiring
- **`cmd/candela-server/main.go`**: Wires `anthropic-vertex` with `PathRewriter` + `TokenSource` (no `FormatTranslator`)
- **`cmd/candela-sidecar/main.go`**: Same

### Config
- **`config.example.yaml`**: Added provider + route documentation

## Provider Comparison

| Provider | Format | Upstream | Auth | Use Case |
|----------|--------|----------|------|----------|
| `anthropic` | OpenAI → Anthropic translation | Vertex AI | ADC | Zed, IntelliJ, OpenCode |
| **`anthropic-vertex`** | **Native Anthropic passthrough** | **Vertex AI** | **ADC** | **Claude Code** |
| `anthropic-direct` | Native Anthropic passthrough | api.anthropic.com | Client API key | Claude Code (direct API) |

## Testing

- `pkg/proxy` — all tests pass ✅
- `cmd/candela-local` — all tests pass ✅
- `cmd/candela-sidecar` — all tests pass ✅
- `go build ./...` — clean ✅
- `golangci-lint` — 0 issues ✅

## Docs (separate PR in candela-docs)

- New guide: `guides/ide/claude-code.md`
- Updated proxy routes API reference
- Added to sidebar + IDE overview