### PR TITLE
docs: rename candela-local → candela across all docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,14 @@ You can get Candela running in less than 60 seconds.
 Ideal for quick local setup. Uses **SQLite** by default.
 
 ```bash
-# Install the local dev proxy (macOS / Linux)
-brew install candelahq/tap/candela-local
+# Install the CLI proxy (macOS / Linux)
+brew install candelahq/tap/candela
 
 # Or install the Desktop app (macOS)
-brew install --cask candelahq/tap/candela
+brew install --cask candelahq/tap/candela-desktop
 ```
 
-> **💡 Tip**: `candela-local` starts on `:8181` (proxy + UI at `/_local/`) + `:1234` (LM-compatible endpoint). Point your IDE or app at it immediately.
+> **💡 Tip**: `candela start` launches the proxy on `:8181` (proxy + UI at `/_local/`) + `:1234` (LM-compatible endpoint). Point your IDE or app at it immediately.
 
 ### Option B: From Source
 
@@ -217,7 +217,7 @@ graph TD
         SDK[OTel SDK]
     end
 
-    subgraph "candela-local"
+    subgraph "candela"
         LM["LM Compat Listener (:1234)<br/>Unified /v1/models"]
         SC[Span Capture]
         LP[Local Proxy]
@@ -400,9 +400,9 @@ The UI communicates with the backend via **ConnectRPC v2** on port `8181`. Pages
 
 ---
 
-## 🕹️ candela-local — Local Development Proxy
+## 🕹️ candela — Local Development Proxy
 
-`candela-local` is an auth-injecting proxy + runtime manager for developer machines.
+`candela` is an auth-injecting proxy + runtime manager for developer machines.
 It operates in three modes:
 
 ### 🏠 Solo Mode (Zero-Config)
@@ -410,12 +410,12 @@ It operates in three modes:
 Run local models with full observability — **no cloud account needed**.
 
 ```yaml
-# ~/.candela.yaml
+# ~/.config/candela/config.yaml
 runtime_backend: ollama
 ```
 
 ```bash
-candela-local   # starts on :8181 (proxy) + :1234 (LM compat)
+candela start   # background daemon on :8181 (proxy) + :1234 (LM compat)
 ```
 
 - Local models via Ollama/vLLM on `:1234`
@@ -427,7 +427,7 @@ candela-local   # starts on :8181 (proxy) + :1234 (LM compat)
 Call Gemini and Claude directly using your **Google identity** — no server deployment needed.
 
 ```yaml
-# ~/.candela.yaml
+# ~/.config/candela/config.yaml
 runtime_backend: ollama
 
 providers:
@@ -450,7 +450,7 @@ vertex_ai:
 Connect to a shared Candela server for **budget enforcement, RBAC, and team-wide cost tracking**.
 
 ```yaml
-# ~/.candela.yaml
+# ~/.config/candela/config.yaml
 runtime_backend: ollama
 remote: https://candela-xxx.a.run.app
 audience: "12345678.apps.googleusercontent.com"
@@ -462,7 +462,7 @@ audience: "12345678.apps.googleusercontent.com"
 - Team-wide cost tracking, budget enforcement, and centralized governance
 
 > [!TIP]
-> See [docs/candela-local.md](docs/candela-local.md) for the full setup guide.
+> See [docs/candela.md](docs/candela.md) for the full setup guide.
 
 ### Unified Model Discovery
 
@@ -508,8 +508,8 @@ All features are accessible via **ConnectRPC** (`RuntimeService`) and the embedd
   - Admin UI: user management, budget explainer, audit logs
   - Client-side form validation (`@bufbuild/protovalidate`)
   - Budget enforcement with grant-first waterfall
-  - `candela-local` auth-injecting proxy for developer machines
-  - `candela-local` embedded runtime management UI (`/_local/`)
+  - `candela` auth-injecting proxy for developer machines
+  - `candela` embedded runtime management UI (`/_local/`)
 - **Phase 5: Hardening** ✅ (Security audit, input validation, CORS hardening, race condition fixes)
   - 16 critical/high issues remediated across Go and Rust (XSS, DoS, billing bypass, info leak)
   - 47 new tests (25 unit + 9 integration + 13 Rust) with race detector
@@ -527,7 +527,7 @@ candela/
 ├── buf.gen.yaml                 # Buf code gen config (pulls from BSR)
 ├── gen/                         # Generated code (Go, TypeScript, BQ schema)
 ├── cmd/candela-server/          # Server entry point
-├── cmd/candela-local/           # Local dev proxy + runtime manager
+├── cmd/candela/                 # Local dev proxy + runtime manager
 │   ├── lm_handler.go            # Smart model routing (local ↔ cloud)
 │   ├── span_capture.go          # Request/response capture middleware
 │   ├── traces_handler.go        # /_local/api/traces REST endpoint

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -11,7 +11,7 @@ Candela defines all service boundaries in Protobuf. The backend serves these via
 | `IngestionService` | `v1/ingestion_service.proto` | 1 | OTLP span ingestion |
 | `UserService` | `v1/user_service.proto` | 15 | User CRUD, budgets, grants, audit |
 | `ProjectService` | `v1/project_service.proto` | 5 | Project + API key management |
-| `RuntimeService` | `v1/runtime_service.proto` | 10 | Local LLM runtime control (candela-local) |
+| `RuntimeService` | `v1/runtime_service.proto` | 10 | Local LLM runtime control (candela) |
 
 ## Type Packages
 
@@ -226,7 +226,7 @@ API key management:
 
 ## RuntimeService
 
-Controls local LLM runtimes from `candela-local`. Served via ConnectRPC on the management port (`:8181`).
+Controls local LLM runtimes from `candela`. Served via ConnectRPC on the management port (`:8181`).
 
 | RPC | Description |
 |-----|-------------|

--- a/docs/candela.md
+++ b/docs/candela.md
@@ -166,7 +166,7 @@ go run ./cmd/candela
 ```bash
 candela start                          # reads ~/.config/candela/config.yaml
 candela start --config ./my-config.yaml
-candela run --remote https://... --audience 12345 --port 8181
+candela run --remote https://candela-xxx.a.run.app --audience 12345678.apps.googleusercontent.com --port 8181
 ```
 
 ### Full Config Reference
@@ -351,8 +351,8 @@ curl http://localhost:1234/v1/chat/completions \
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | "model not found locally and no remote server configured" | Solo Mode + unknown model | Add `providers` for cloud models, or use a local model |
-| "vertex_ai.project is required" | `providers` set but no project | Add `vertex_ai.project` to config |
+| "vertex_ai.project is required" | `providers` set but no project | Add `vertex_ai.project` to `config.yaml` |
 | "failed to get Google ADC" | ADC not configured | Run `gcloud auth application-default login` |
-| "audience is required when remote is set" | Missing `audience` | Add IAP `audience` to config |
+| "audience is required when remote is set" | Missing `audience` | Add IAP `audience` to `config.yaml` |
 | Traces card shows "Traces not available" | Team Mode (traces go to cloud) | Expected — check the cloud dashboard |
 | No models in `/v1/models` | Runtime not started | Start Ollama: `ollama serve` |

--- a/docs/candela.md
+++ b/docs/candela.md
@@ -1,6 +1,6 @@
-# candela-local — Developer Proxy & Runtime Manager
+# candela — Developer Proxy & Runtime Manager
 
-`candela-local` is a lightweight binary that runs on a developer's machine. It provides:
+`candela` is a lightweight binary that runs on a developer's machine. It provides:
 
 - **Unified model discovery** — one endpoint for local _and_ cloud models
 - **Smart routing** — automatically sends requests to the right backend
@@ -9,8 +9,8 @@
 
 ## Operating Modes
 
-`candela-local` operates in one of two modes, determined entirely by your
-`~/.candela.yaml` configuration:
+`candela` operates in one of two modes, determined entirely by your
+`~/.config/candela/config.yaml` configuration:
 
 ### 🏠 Solo Mode
 
@@ -20,7 +20,7 @@ observability and zero cloud dependencies.
 **Config**: Simply omit the `remote` and `providers` fields.
 
 ```yaml
-# ~/.candela.yaml — Solo Mode
+# ~/.config/candela/config.yaml — Solo Mode
 port: 8181
 lm_studio_port: 1234
 runtime_backend: ollama
@@ -44,7 +44,7 @@ identity you already have.
 **Config**: Add `providers` and `vertex_ai` to your solo config.
 
 ```yaml
-# ~/.candela.yaml — Solo + Cloud
+# ~/.config/candela/config.yaml — Solo + Cloud
 runtime_backend: ollama
 
 providers:
@@ -91,7 +91,7 @@ JetBrains / Cline / curl
 ```
 
 > [!NOTE]
-> If `vertex_ai.project` is not set in config, candela-local will try
+> If `vertex_ai.project` is not set in config, candela will try
 > `gcloud config get project` as a fallback and log a warning.
 
 ---
@@ -104,7 +104,7 @@ Candela cloud backend.
 **Config**: Set `remote` to your team's Candela server URL.
 
 ```yaml
-# ~/.candela.yaml — Team Mode
+# ~/.config/candela/config.yaml — Team Mode
 port: 8181
 lm_studio_port: 1234
 runtime_backend: ollama
@@ -143,24 +143,30 @@ JetBrains / Cline / curl
 ## Installation
 
 ```bash
-go install github.com/candelahq/candela/cmd/candela-local@latest
+brew install candelahq/tap/candela
+```
+
+Or via `go install`:
+
+```bash
+go install github.com/candelahq/candela/cmd/candela@latest
 ```
 
 Or from the repo:
 
 ```bash
 nix develop           # or ensure Go 1.26+ is installed
-go run ./cmd/candela-local
+go run ./cmd/candela
 ```
 
 ## Configuration
 
-`candela-local` reads `~/.candela.yaml` by default. Override with `--config`:
+`candela` reads `~/.config/candela/config.yaml` by default. Override with `--config`:
 
 ```bash
-candela-local                          # reads ~/.candela.yaml
-candela-local --config ./my-config.yaml
-candela-local --remote https://... --audience 12345 --port 8181
+candela start                          # reads ~/.config/candela/config.yaml
+candela start --config ./my-config.yaml
+candela run --remote https://... --audience 12345 --port 8181
 ```
 
 ### Full Config Reference
@@ -345,8 +351,8 @@ curl http://localhost:1234/v1/chat/completions \
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | "model not found locally and no remote server configured" | Solo Mode + unknown model | Add `providers` for cloud models, or use a local model |
-| "vertex_ai.project is required" | `providers` set but no project | Add `vertex_ai.project` to `~/.candela.yaml` |
+| "vertex_ai.project is required" | `providers` set but no project | Add `vertex_ai.project` to config |
 | "failed to get Google ADC" | ADC not configured | Run `gcloud auth application-default login` |
-| "audience is required when remote is set" | Missing `audience` | Add IAP `audience` to `~/.candela.yaml` |
+| "audience is required when remote is set" | Missing `audience` | Add IAP `audience` to config |
 | Traces card shows "Traces not available" | Team Mode (traces go to cloud) | Expected — check the cloud dashboard |
 | No models in `/v1/models` | Runtime not started | Start Ollama: `ollama serve` |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,7 @@
 graph TB
     subgraph "Developer Machine"
         OC[OpenCode / Zed / Cursor]
-        CL["candela-local<br/>(auth proxy)"]
+        CL["candela<br/>(auth proxy)"]
         OC -->|"localhost:8181"| CL
     end
 
@@ -36,7 +36,7 @@ graph TB
 |---|---|---|
 | **Go Backend** | `cmd/candela-server` | API, LLM proxy, span ingestion, auth middleware, storage |
 | **Next.js UI** | `ui/` | Dashboard, trace waterfall, costs, admin panel |
-| **candela-local** | `cmd/candela-local` | CLI proxy injecting Google credentials for dev tools |
+| **candela** | `cmd/candela` | CLI proxy injecting Google credentials for dev tools |
 | **Terraform** | `terraform/` | Cloud Run, BigQuery, Firestore, Firebase, IAM |
 
 ## Authentication (3 Strategies)
@@ -58,7 +58,7 @@ flowchart TD
 |---|---|---|
 | Firebase ID Token | Browser UI | Firebase JS SDK |
 | Google ID Token | Service accounts | `idtoken.NewTokenSource()` |
-| OAuth2 Access Token | candela-local (user ADC) | `gcloud auth application-default login` |
+| OAuth2 Access Token | candela (user ADC) | `gcloud auth application-default login` |
 
 ## Container Layout
 
@@ -73,17 +73,17 @@ Next.js rewrites:
   /healthz         → localhost:8181
 ```
 
-## candela-local Setup
+## candela Setup
 
 ```yaml
-# ~/.candela.yaml
+# ~/.config/candela/config.yaml
 remote: https://candela-xxx.run.app
 audience: https://candela-xxx.run.app
 port: 8181
 ```
 
 ```bash
-go run ./cmd/candela-local   # or: go install && candela-local
+go run ./cmd/candela   # or: go install && candela
 ```
 
 Point tools at `http://localhost:8181/proxy/openai/v1`.

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -30,7 +30,7 @@ These are used by the container entrypoint (`deploy/entrypoint.sh`) to generate 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CANDELA_DEV_MODE` | `false` | Skip auth, inject synthetic admin user. **Never use in production.** |
-| `CLOUD_RUN_URL` | _(empty)_ | Cloud Run service URL. Used as the audience for Google ID token validation (Strategy 2). Set this to enable `candela-local` Team Mode auth. |
+| `CLOUD_RUN_URL` | _(empty)_ | Cloud Run service URL. Used as the audience for Google ID token validation (Strategy 2). Set this to enable `candela` Team Mode auth. |
 
 ### Firestore
 
@@ -95,14 +95,14 @@ The Next.js UI reads these at **build time** (prefixed with `NEXT_PUBLIC_`) and 
 
 ---
 
-## candela-local Environment
+## candela Environment
 
-`candela-local` primarily reads from `~/.candela.yaml` (see [docs/candela-local.md](candela-local.md)). It also respects:
+`candela` primarily reads from `~/.config/candela/config.yaml` (see [docs/candela.md](candela.md)). It also respects:
 
 | Variable | Description |
 |----------|-------------|
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to GCP service account key (alternative to `gcloud auth application-default login`) |
-| `GOOGLE_CLOUD_PROJECT` | Fallback GCP project if not set in `~/.candela.yaml` |
+| `GOOGLE_CLOUD_PROJECT` | Fallback GCP project if not set in `~/.config/candela/config.yaml` |
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -30,11 +30,11 @@ The middleware (`pkg/auth/firebase.go`) tries three strategies in sequence. The 
 | # | Strategy | Client | Token Source | Validation Method |
 |---|----------|--------|-------------|-------------------|
 | 1 | **Firebase ID Token** | Browser UI | Firebase JS SDK (`onAuthStateChanged`) | `fbAuth.VerifyIDToken()` |
-| 2 | **Google ID Token** | Service accounts, `candela-local` with `idtoken` | `idtoken.NewTokenSource(audience)` | `idtoken.Validate(token, audience)` |
-| 3 | **OAuth2 Access Token** | `candela-local` with user ADC | `gcloud auth application-default login` | `googleapis.com/oauth2/v3/userinfo` |
+| 2 | **Google ID Token** | Service accounts, `candela` with `idtoken` | `idtoken.NewTokenSource(audience)` | `idtoken.Validate(token, audience)` |
+| 3 | **OAuth2 Access Token** | `candela` with user ADC | `gcloud auth application-default login` | `googleapis.com/oauth2/v3/userinfo` |
 
 > [!NOTE]
-> Strategy 3 makes an HTTP call to Google's userinfo endpoint on every request. This adds ~50ms latency but is the only way to validate user-scoped Application Default Credentials (ADC) that `candela-local` uses when `gcloud auth application-default login` provides an access token rather than an ID token.
+> Strategy 3 makes an HTTP call to Google's userinfo endpoint on every request. This adds ~50ms latency but is the only way to validate user-scoped Application Default Credentials (ADC) that `candela` uses when `gcloud auth application-default login` provides an access token rather than an ID token.
 
 ### Auth Bypass
 
@@ -167,7 +167,7 @@ When `CANDELA_DEV_MODE=true` or `auth.dev_mode: true` in config:
 
 ---
 
-## `candela-local` Authentication
+## `candela` Authentication
 
 ### Solo Mode
 No authentication needed. All requests to `:1234` and `:8181` are unauthenticated.
@@ -180,10 +180,10 @@ gcloud auth application-default login
 No server-side auth needed — ADC tokens are used for upstream cloud calls only.
 
 ### Team Mode
-`candela-local` injects OIDC tokens into requests to the Candela Cloud Run server:
+`candela` injects OIDC tokens into requests to the Candela Cloud Run server:
 
 ```
-IDE → candela-local (:1234)
+IDE → candela (:1234)
          │
          ├── Local model → Ollama (no auth)
          │
@@ -196,7 +196,7 @@ IDE → candela-local (:1234)
 ```
 
 Token acquisition flow:
-1. `candela-local` reads `~/.candela.yaml` for `remote` and `audience`
+1. `candela` reads `~/.config/candela/config.yaml` for `remote` and `audience`
 2. Uses `google.DefaultTokenSource()` to get an ADC token
 3. Injects `Authorization: Bearer <token>` on every proxied request
 
@@ -255,4 +255,4 @@ See [docs/user-management.md](user-management.md) for the full validation rule r
 | `pkg/connecthandlers/scope.go` | `scopeUserID()` — per-user data scoping helper |
 | `pkg/connecthandlers/errors.go` | `internalError()` — sanitized error responses |
 | `cmd/candela-server/main.go` | Middleware wiring, Firebase init, dev mode |
-| `cmd/candela-local/main.go` | ADC token injection for Team Mode |
+| `cmd/candela/main.go` | ADC token injection for Team Mode |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,13 +14,13 @@ tests/
 │   ├── pkg/runtime/*_test.go       — runtime interface, discovery, manager
 │   ├── pkg/notify/*_test.go        — budget notifications
 │   ├── pkg/storage/*_test.go       — storage interfaces
-│   └── cmd/candela-local/*_test.go — LM handler, span capture, state, API
+│   └── cmd/candela/*_test.go — LM handler, span capture, state, API
 │
 ├── Go Integration Tests
 │   ├── pkg/connecthandlers/integration_test.go — full service stack
 │   ├── pkg/connecthandlers/project_handler_test.go
 │   ├── pkg/connecthandlers/user_handler_test.go
-│   └── cmd/candela-local/ui_integration_test.go
+│   └── cmd/candela/ui_integration_test.go
 │
 └── Playwright E2E Tests (3 suites)
     ├── e2e/app.spec.ts             — dashboard, traces, costs, usage
@@ -58,8 +58,8 @@ nix develop -c go test ./pkg/auth -v
 # Runtime tests
 nix develop -c go test ./pkg/runtime/... -v
 
-# candela-local tests
-nix develop -c go test ./cmd/candela-local -v
+# candela tests
+nix develop -c go test ./cmd/candela -v
 
 # Integration tests (ConnectRPC handlers)
 nix develop -c go test ./pkg/connecthandlers -v -run TestIntegration

--- a/pkg/runtime/README.md
+++ b/pkg/runtime/README.md
@@ -45,7 +45,7 @@ type Runtime interface {
 ```
 
 Every backend exposes an **OpenAI-compatible `/v1` endpoint** via `Endpoint()`.
-This means `candela-local` can route `/v1/chat/completions` to any backend
+This means `candela` can route `/v1/chat/completions` to any backend
 without caring which server is running underneath.
 
 ## Registry Pattern
@@ -153,7 +153,7 @@ backends := runtime.Discover()
 // → [{Name:"ollama", Installed:true, BinaryPath:"/opt/homebrew/bin/ollama", InstallHint:"brew install ollama"}, ...]
 ```
 
-This powers the **backend discovery** card in the `candela-local` management
+This powers the **backend discovery** card in the `candela` management
 UI (`/_local/`), showing install status and platform-specific install hints.
 
 ## Shared Helpers
@@ -220,7 +220,7 @@ var knownBackends = map[string]backendMeta{
 }
 ```
 
-4. Import the package in `cmd/candela-local` (blank import for `init()`
+4. Import the package in `cmd/candela` (blank import for `init()`
    registration):
 
 ```go

--- a/rust/README.md
+++ b/rust/README.md
@@ -47,7 +47,7 @@ This is an **incremental rewrite** from Go. Each phase produces an independently
 
 1. **Phase 1**: `candela-sidecar` — drop-in replacement for the Go sidecar
 2. **Phase 2**: Harden proxy with full test suite + benchmarks
-3. **Phase 3**: `candela-local` — developer desktop binary
+3. **Phase 3**: `candela` — developer desktop binary
 4. **Phase 4**: `candela-server` — full team backend with ConnectRPC
 
 The Go code (`cmd/`, `pkg/`) continues running alongside — zero downtime, zero client breakage.


### PR DESCRIPTION
Updates all documentation to reflect the binary rename from `candela-local` to `candela` (PR #178) and the config path migration from `~/.candela.yaml` to `~/.config/candela/config.yaml`.

### Changes (9 files)
- **README.md**: brew commands, architecture diagram, project structure tree
- **docs/candela-local.md → docs/candela.md** (file rename)
- **docs/security.md**: auth strategy table, Team Mode flow, implementation files
- **docs/deployment.md, env-vars.md, testing.md, api-reference.md**
- **pkg/runtime/README.md, rust/README.md**

### Find-and-replace patterns
| Old | New |
|-----|-----|
| `brew install candelahq/tap/candela-local` | `brew install candelahq/tap/candela` |
| `brew install --cask candelahq/tap/candela` | `brew install --cask candelahq/tap/candela-desktop` |
| `candela-local` (binary) | `candela` with `start/stop/status/run` |
| `~/.candela.yaml` | `~/.config/candela/config.yaml` |
| `cmd/candela-local` | `cmd/candela` |