### PR TITLE
fix(deploy): approve pnpm build scripts and pin pnpm version

### DIFF
--- a/deploy/Dockerfile.server
+++ b/deploy/Dockerfile.server
@@ -23,7 +23,7 @@ WORKDIR /build/ui
 
 # Install dependencies first (cache layer).
 COPY ui/package.json ui/pnpm-lock.yaml ./
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10 --activate
 RUN pnpm install --frozen-lockfile
 
 # Copy UI source and build.

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,5 +30,13 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "typescript": "^5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@firebase/util",
+      "protobufjs",
+      "sharp",
+      "unrs-resolver"
+    ]
   }
 }


### PR DESCRIPTION
## Problem

Every deploy has been failing since May 11 (~20+ consecutive failures). Cloud Build fails at the `pnpm install --frozen-lockfile` step with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @firebase/util@1.15.0, protobufjs@7.5.4, sharp@0.34.5, unrs-resolver@1.11.1
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

The Dockerfile uses `corepack prepare pnpm@latest`, and newer pnpm versions enforce explicit approval for dependency build scripts. Without approval, `pnpm install` exits non-zero.

## Fix

1. **`ui/package.json`**: Add `pnpm.onlyBuiltDependencies` to explicitly allow build scripts for the 4 packages that need them
2. **`deploy/Dockerfile.server`**: Pin pnpm to major version 10 instead of `@latest` to prevent future surprise breakage

## Verification

- `pnpm install --frozen-lockfile` passes locally with these changes
- CI will validate the full build