### PR TITLE
fix(ui): replace explicit any casts with proper proto types

### DIFF
--- a/ui/src/hooks/useDashboard.ts
+++ b/ui/src/hooks/useDashboard.ts
@@ -158,7 +158,7 @@ export function useDashboard() {
             tracesOverTime: toDataPoints(res.tracesOverTime, state.timeRange),
             costOverTime: toDataPoints(res.costOverTime, state.timeRange),
             tokensOverTime: toDataPoints(res.tokensOverTime, state.timeRange),
-            jobLeaderboard: ((jobRes as Pick<GetJobLeaderboardResponse, "jobs">).jobs || []).map((j: JobUsage) => ({
+            jobLeaderboard: (jobRes as Pick<GetJobLeaderboardResponse, "jobs">).jobs.map((j: JobUsage) => ({
               jobId: j.jobId,
               callCount: Number(j.callCount),
               totalTokens: Number(j.totalTokens),

--- a/ui/src/hooks/useDashboard.ts
+++ b/ui/src/hooks/useDashboard.ts
@@ -5,6 +5,7 @@ import { dashboardClient, traceClient } from "@/lib/api";
 import { DEFAULT_PROJECT_ID } from "@/lib/constants";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import type { DataPoint } from "@/components/chart";
+import type { GetJobLeaderboardResponse, JobUsage } from "@/gen/candela/v1/dashboard_service_pb";
 
 export interface DashboardSummary {
   totalTraces: number;
@@ -157,7 +158,7 @@ export function useDashboard() {
             tracesOverTime: toDataPoints(res.tracesOverTime, state.timeRange),
             costOverTime: toDataPoints(res.costOverTime, state.timeRange),
             tokensOverTime: toDataPoints(res.tokensOverTime, state.timeRange),
-            jobLeaderboard: ((jobRes as any).jobs || []).map((j: any) => ({
+            jobLeaderboard: ((jobRes as Pick<GetJobLeaderboardResponse, "jobs">).jobs || []).map((j: JobUsage) => ({
               jobId: j.jobId,
               callCount: Number(j.callCount),
               totalTokens: Number(j.totalTokens),


### PR DESCRIPTION
Fixes CI failure on main caused by `@typescript-eslint/no-explicit-any` lint errors in `useDashboard.ts`.

## Changes
- Import `GetJobLeaderboardResponse` and `JobUsage` from generated proto types
- Replace `(jobRes as any)` with `(jobRes as Pick<GetJobLeaderboardResponse, "jobs">)`
- Replace `(j: any)` with `(j: JobUsage)`

## Context
The `.catch(() => ({ jobs: [] }))` fallback for graceful degradation returns a plain object, not the full proto type. Using `Pick<>` covers both the real response and the fallback shape.

This unblocks the deploy pipeline which was skipped due to CI being red on main.