### PR TITLE
fix(proxy): trace duration 0ms + cache token visibility for all providers

### DIFF
--- a/pkg/proxy/parsers.go
+++ b/pkg/proxy/parsers.go
@@ -364,3 +364,145 @@ func (p *fallbackParser) ParseResponse(_ []byte) (string, int64, int64) { return
 func (p *fallbackParser) ParseStreamingResponse(_ []byte) (string, int64, int64) {
 	return "", 0, 0
 }
+
+// ──────────────────────────────────────────
+// Cache token extraction (all providers)
+// ──────────────────────────────────────────
+
+// CacheTokens holds the raw prompt caching breakdown from the provider API.
+// These are the unmodified counts — not cost-normalized.
+type CacheTokens struct {
+	CacheReadTokens     int64
+	CacheCreationTokens int64 // Anthropic-only (cache writes); 0 for OpenAI/Google
+}
+
+// extractCacheTokens extracts raw cache token counts from a standard response.
+func extractCacheTokens(provider string, body []byte) CacheTokens {
+	var resp map[string]interface{}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return CacheTokens{}
+	}
+
+	switch provider {
+	case "anthropic", "anthropic-direct", "anthropic-vertex":
+		if usage, ok := resp["usage"].(map[string]interface{}); ok {
+			return CacheTokens{
+				CacheReadTokens:     toInt64(usage["cache_read_input_tokens"]),
+				CacheCreationTokens: toInt64(usage["cache_creation_input_tokens"]),
+			}
+		}
+
+	case "openai", "gemini-oai":
+		// OpenAI reports cached tokens inside usage.prompt_tokens_details.cached_tokens
+		if usage, ok := resp["usage"].(map[string]interface{}); ok {
+			if details, ok := usage["prompt_tokens_details"].(map[string]interface{}); ok {
+				return CacheTokens{
+					CacheReadTokens: toInt64(details["cached_tokens"]),
+				}
+			}
+		}
+
+	case "google":
+		// Google reports cached tokens in usageMetadata.cachedContentTokenCount
+		if meta, ok := resp["usageMetadata"].(map[string]interface{}); ok {
+			return CacheTokens{
+				CacheReadTokens: toInt64(meta["cachedContentTokenCount"]),
+			}
+		}
+	}
+
+	return CacheTokens{}
+}
+
+// extractStreamingCacheTokens extracts raw cache token counts from SSE stream data.
+func extractStreamingCacheTokens(provider string, data []byte) CacheTokens {
+	switch provider {
+	case "anthropic", "anthropic-direct", "anthropic-vertex":
+		return extractAnthropicStreamingCache(data)
+
+	case "openai", "gemini-oai":
+		return extractOpenAIStreamingCache(data)
+
+	case "google":
+		return extractGoogleStreamingCache(data)
+	}
+
+	return CacheTokens{}
+}
+
+func extractAnthropicStreamingCache(data []byte) CacheTokens {
+	var ct CacheTokens
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		if payload == "[DONE]" {
+			continue
+		}
+		var chunk map[string]interface{}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		if msg, ok := chunk["message"].(map[string]interface{}); ok {
+			if usage, ok := msg["usage"].(map[string]interface{}); ok {
+				ct.CacheReadTokens = toInt64(usage["cache_read_input_tokens"])
+				ct.CacheCreationTokens = toInt64(usage["cache_creation_input_tokens"])
+			}
+		}
+	}
+	return ct
+}
+
+func extractOpenAIStreamingCache(data []byte) CacheTokens {
+	var ct CacheTokens
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		if payload == "[DONE]" {
+			continue
+		}
+		var chunk map[string]interface{}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		// OpenAI includes usage in the final chunk when stream_options.include_usage is set.
+		if usage, ok := chunk["usage"].(map[string]interface{}); ok {
+			if details, ok := usage["prompt_tokens_details"].(map[string]interface{}); ok {
+				ct.CacheReadTokens = toInt64(details["cached_tokens"])
+			}
+		}
+	}
+	return ct
+}
+
+func extractGoogleStreamingCache(data []byte) CacheTokens {
+	var ct CacheTokens
+	// Google streaming returns JSON array or newline-delimited JSON.
+	// The last chunk contains usageMetadata. Try JSON array first.
+	var chunks []map[string]interface{}
+	if err := json.Unmarshal(data, &chunks); err == nil {
+		for _, chunk := range chunks {
+			if meta, ok := chunk["usageMetadata"].(map[string]interface{}); ok {
+				ct.CacheReadTokens = toInt64(meta["cachedContentTokenCount"])
+			}
+		}
+	} else {
+		// Fallback: newline-delimited JSON.
+		dec := json.NewDecoder(bytes.NewReader(data))
+		for dec.More() {
+			var chunk map[string]interface{}
+			if err := dec.Decode(&chunk); err != nil {
+				break
+			}
+			if meta, ok := chunk["usageMetadata"].(map[string]interface{}); ok {
+				ct.CacheReadTokens = toInt64(meta["cachedContentTokenCount"])
+			}
+		}
+	}
+	return ct
+}

--- a/pkg/proxy/parsers_test.go
+++ b/pkg/proxy/parsers_test.go
@@ -237,3 +237,103 @@ func TestGetParser_UnknownProvider_ReturnsFallback(t *testing.T) {
 		t.Error("expected fallback parser for unknown provider")
 	}
 }
+
+// ── Cache token extraction tests ────────────────────────────────────────────
+
+func TestExtractCacheTokens_Anthropic(t *testing.T) {
+	body := []byte(`{
+		"usage": {
+			"input_tokens": 21,
+			"cache_read_input_tokens": 188086,
+			"cache_creation_input_tokens": 500,
+			"output_tokens": 393
+		}
+	}`)
+
+	ct := extractCacheTokens("anthropic", body)
+	if ct.CacheReadTokens != 188086 {
+		t.Errorf("CacheReadTokens = %d, want 188086", ct.CacheReadTokens)
+	}
+	if ct.CacheCreationTokens != 500 {
+		t.Errorf("CacheCreationTokens = %d, want 500", ct.CacheCreationTokens)
+	}
+
+	// Also works for anthropic-direct and anthropic-vertex.
+	for _, provider := range []string{"anthropic-direct", "anthropic-vertex"} {
+		ct2 := extractCacheTokens(provider, body)
+		if ct2.CacheReadTokens != 188086 {
+			t.Errorf("%s: CacheReadTokens = %d, want 188086", provider, ct2.CacheReadTokens)
+		}
+	}
+}
+
+func TestExtractCacheTokens_OpenAI(t *testing.T) {
+	body := []byte(`{
+		"usage": {
+			"prompt_tokens": 5000,
+			"completion_tokens": 200,
+			"prompt_tokens_details": {
+				"cached_tokens": 4096
+			}
+		}
+	}`)
+
+	ct := extractCacheTokens("openai", body)
+	if ct.CacheReadTokens != 4096 {
+		t.Errorf("CacheReadTokens = %d, want 4096", ct.CacheReadTokens)
+	}
+	if ct.CacheCreationTokens != 0 {
+		t.Errorf("CacheCreationTokens = %d, want 0 (OpenAI has no creation concept)", ct.CacheCreationTokens)
+	}
+
+	// gemini-oai uses the same OpenAI format.
+	ct2 := extractCacheTokens("gemini-oai", body)
+	if ct2.CacheReadTokens != 4096 {
+		t.Errorf("gemini-oai: CacheReadTokens = %d, want 4096", ct2.CacheReadTokens)
+	}
+}
+
+func TestExtractCacheTokens_Google(t *testing.T) {
+	body := []byte(`{
+		"candidates": [{"content": {"parts": [{"text": "hi"}]}}],
+		"usageMetadata": {
+			"promptTokenCount": 100,
+			"candidatesTokenCount": 50,
+			"cachedContentTokenCount": 80,
+			"totalTokenCount": 150
+		}
+	}`)
+
+	ct := extractCacheTokens("google", body)
+	if ct.CacheReadTokens != 80 {
+		t.Errorf("CacheReadTokens = %d, want 80", ct.CacheReadTokens)
+	}
+	if ct.CacheCreationTokens != 0 {
+		t.Errorf("CacheCreationTokens = %d, want 0 (Google has no creation concept)", ct.CacheCreationTokens)
+	}
+}
+
+func TestExtractCacheTokens_UnknownProvider(t *testing.T) {
+	body := []byte(`{"usage": {"cached_tokens": 999}}`)
+	ct := extractCacheTokens("unknown-provider", body)
+	if ct.CacheReadTokens != 0 || ct.CacheCreationTokens != 0 {
+		t.Errorf("unknown provider should return zeros, got read=%d creation=%d",
+			ct.CacheReadTokens, ct.CacheCreationTokens)
+	}
+}
+
+func TestExtractStreamingCacheTokens_Anthropic(t *testing.T) {
+	stream := []byte(`data: {"type":"message_start","message":{"usage":{"input_tokens":10,"cache_read_input_tokens":50000,"cache_creation_input_tokens":200}}}
+data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hello"}}
+data: {"type":"message_delta","usage":{"output_tokens":42}}
+data: [DONE]
+`)
+
+	ct := extractStreamingCacheTokens("anthropic", stream)
+	if ct.CacheReadTokens != 50000 {
+		t.Errorf("CacheReadTokens = %d, want 50000", ct.CacheReadTokens)
+	}
+	if ct.CacheCreationTokens != 200 {
+		t.Errorf("CacheCreationTokens = %d, want 200", ct.CacheCreationTokens)
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -905,6 +905,7 @@ type spanParams struct {
 	outputContent   string
 	inputTokens     int64
 	outputTokens    int64
+	cacheTokens     CacheTokens // raw prompt cache breakdown
 	startTime       time.Time
 	endTime         time.Time
 	status          storage.SpanStatus
@@ -1008,6 +1009,14 @@ func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 	for k, v := range params.extraAttrs {
 		attrs[k] = v
 	}
+	// Expose raw cache token counts as attributes so the UI can show
+	// cache utilization regardless of provider (Anthropic, OpenAI, Google).
+	if params.cacheTokens.CacheReadTokens > 0 {
+		attrs["gen_ai.usage.cache_read_tokens"] = fmt.Sprintf("%d", params.cacheTokens.CacheReadTokens)
+	}
+	if params.cacheTokens.CacheCreationTokens > 0 {
+		attrs["gen_ai.usage.cache_creation_tokens"] = fmt.Sprintf("%d", params.cacheTokens.CacheCreationTokens)
+	}
 
 	// Use caller's trace context if present (W3C Trace Context propagation).
 	// This nests the proxy span under the caller's OTel span.
@@ -1030,14 +1039,16 @@ func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 		Duration:     params.endTime.Sub(params.startTime),
 		ProjectID:    p.projectID,
 		GenAI: &storage.GenAIAttributes{
-			Model:         params.model,
-			Provider:      params.provider.Name,
-			InputTokens:   params.inputTokens,
-			OutputTokens:  params.outputTokens,
-			TotalTokens:   totalTokens,
-			CostUSD:       cost,
-			InputContent:  params.inputContent,
-			OutputContent: params.outputContent,
+			Model:               params.model,
+			Provider:            params.provider.Name,
+			InputTokens:         params.inputTokens,
+			OutputTokens:        params.outputTokens,
+			TotalTokens:         totalTokens,
+			CostUSD:             cost,
+			InputContent:        params.inputContent,
+			OutputContent:       params.outputContent,
+			CacheReadTokens:     params.cacheTokens.CacheReadTokens,
+			CacheCreationTokens: params.cacheTokens.CacheCreationTokens,
 		},
 		Attributes: attrs,
 	}
@@ -1085,6 +1096,7 @@ func (p *Proxy) createSpan(
 ) {
 	model, inputContent := extractRequestInfo(provider.Name, reqBody)
 	outputContent, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
+	ct := extractCacheTokens(provider.Name, respBody)
 
 	status := storage.SpanStatusOK
 	if statusCode >= 400 {
@@ -1101,6 +1113,7 @@ func (p *Proxy) createSpan(
 		outputContent:   outputContent,
 		inputTokens:     inputTokens,
 		outputTokens:    outputTokens,
+		cacheTokens:     ct,
 		startTime:       startTime,
 		endTime:         endTime,
 		status:          status,
@@ -1133,6 +1146,7 @@ func (p *Proxy) createStreamingSpan(
 ) {
 	model, inputContent := extractRequestInfo(provider.Name, reqBody)
 	outputContent, inputTokens, outputTokens := extractStreamingUsage(provider.Name, streamData)
+	ct := extractStreamingCacheTokens(provider.Name, streamData)
 
 	p.buildSpan(ctx, spanParams{
 		provider:        provider,
@@ -1144,6 +1158,7 @@ func (p *Proxy) createStreamingSpan(
 		outputContent:   outputContent,
 		inputTokens:     inputTokens,
 		outputTokens:    outputTokens,
+		cacheTokens:     ct,
 		startTime:       startTime,
 		endTime:         endTime,
 		status:          streamStatus,

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -80,32 +80,34 @@ type AttributeKV struct {
 
 // spanRow is the BigQuery row schema for a span.
 type spanRow struct {
-	SpanID        string        `bigquery:"span_id"`
-	TraceID       string        `bigquery:"trace_id"`
-	ParentSpanID  string        `bigquery:"parent_span_id"`
-	Name          string        `bigquery:"name"`
-	Kind          int           `bigquery:"kind"`
-	Status        int           `bigquery:"status"`
-	StatusMessage string        `bigquery:"status_message"`
-	StartTime     time.Time     `bigquery:"start_time"`
-	EndTime       time.Time     `bigquery:"end_time"`
-	DurationNs    int64         `bigquery:"duration_ns"`
-	ProjectID     string        `bigquery:"project_id"`
-	Environment   string        `bigquery:"environment"`
-	ServiceName   string        `bigquery:"service_name"`
-	GenAIModel    string        `bigquery:"gen_ai_model"`
-	GenAIProvider string        `bigquery:"gen_ai_provider"`
-	InputTokens   int64         `bigquery:"gen_ai_input_tokens"`
-	OutputTokens  int64         `bigquery:"gen_ai_output_tokens"`
-	TotalTokens   int64         `bigquery:"gen_ai_total_tokens"`
-	CostUSD       float64       `bigquery:"gen_ai_cost_usd"`
-	Temperature   float64       `bigquery:"gen_ai_temperature"`
-	MaxTokens     int64         `bigquery:"gen_ai_max_tokens"`
-	InputContent  string        `bigquery:"gen_ai_input_content"`
-	OutputContent string        `bigquery:"gen_ai_output_content"`
-	Attributes    []AttributeKV `bigquery:"attributes"`
-	UserID        string        `bigquery:"user_id"`
-	SessionID     string        `bigquery:"session_id"`
+	SpanID              string        `bigquery:"span_id"`
+	TraceID             string        `bigquery:"trace_id"`
+	ParentSpanID        string        `bigquery:"parent_span_id"`
+	Name                string        `bigquery:"name"`
+	Kind                int           `bigquery:"kind"`
+	Status              int           `bigquery:"status"`
+	StatusMessage       string        `bigquery:"status_message"`
+	StartTime           time.Time     `bigquery:"start_time"`
+	EndTime             time.Time     `bigquery:"end_time"`
+	DurationNs          int64         `bigquery:"duration_ns"`
+	ProjectID           string        `bigquery:"project_id"`
+	Environment         string        `bigquery:"environment"`
+	ServiceName         string        `bigquery:"service_name"`
+	GenAIModel          string        `bigquery:"gen_ai_model"`
+	GenAIProvider       string        `bigquery:"gen_ai_provider"`
+	InputTokens         int64         `bigquery:"gen_ai_input_tokens"`
+	OutputTokens        int64         `bigquery:"gen_ai_output_tokens"`
+	TotalTokens         int64         `bigquery:"gen_ai_total_tokens"`
+	CostUSD             float64       `bigquery:"gen_ai_cost_usd"`
+	Temperature         float64       `bigquery:"gen_ai_temperature"`
+	MaxTokens           int64         `bigquery:"gen_ai_max_tokens"`
+	InputContent        string        `bigquery:"gen_ai_input_content"`
+	OutputContent       string        `bigquery:"gen_ai_output_content"`
+	CacheReadTokens     int64         `bigquery:"gen_ai_cache_read_tokens"`
+	CacheCreationTokens int64         `bigquery:"gen_ai_cache_creation_tokens"`
+	Attributes          []AttributeKV `bigquery:"attributes"`
+	UserID              string        `bigquery:"user_id"`
+	SessionID           string        `bigquery:"session_id"`
 	// TenantID identifies the downstream customer on whose behalf this LLM call
 	// was made. Populated from X-Candela-Tenant-Id header or W3C Baggage.
 	TenantID string `bigquery:"tenant_id"`
@@ -142,6 +144,8 @@ func spanToRow(span storage.Span) spanRow {
 		row.MaxTokens = span.GenAI.MaxTokens
 		row.InputContent = span.GenAI.InputContent
 		row.OutputContent = span.GenAI.OutputContent
+		row.CacheReadTokens = span.GenAI.CacheReadTokens
+		row.CacheCreationTokens = span.GenAI.CacheCreationTokens
 	}
 
 	for k, v := range span.Attributes {
@@ -173,16 +177,18 @@ func rowToSpan(row spanRow) storage.Span {
 
 	if row.GenAIModel != "" {
 		span.GenAI = &storage.GenAIAttributes{
-			Model:         row.GenAIModel,
-			Provider:      row.GenAIProvider,
-			InputTokens:   row.InputTokens,
-			OutputTokens:  row.OutputTokens,
-			TotalTokens:   row.TotalTokens,
-			CostUSD:       row.CostUSD,
-			Temperature:   row.Temperature,
-			MaxTokens:     row.MaxTokens,
-			InputContent:  row.InputContent,
-			OutputContent: row.OutputContent,
+			Model:               row.GenAIModel,
+			Provider:            row.GenAIProvider,
+			InputTokens:         row.InputTokens,
+			OutputTokens:        row.OutputTokens,
+			TotalTokens:         row.TotalTokens,
+			CostUSD:             row.CostUSD,
+			Temperature:         row.Temperature,
+			MaxTokens:           row.MaxTokens,
+			InputContent:        row.InputContent,
+			OutputContent:       row.OutputContent,
+			CacheReadTokens:     row.CacheReadTokens,
+			CacheCreationTokens: row.CacheCreationTokens,
 		}
 	}
 
@@ -884,15 +890,31 @@ func buildTrace(traceID string, spans []storage.Span) *storage.Trace {
 		trace.Environment = spans[0].Environment
 	}
 
+	// Track the latest EndTime across all spans so we can compute trace
+	// duration even when no root span exists (W3C trace context propagation
+	// gives every proxy span a parentSpanID, so ParentSpanID=="" never matches).
+	var latestEnd time.Time
+
 	for _, span := range spans {
 		if span.ParentSpanID == "" {
 			trace.RootSpanName = span.Name
 			trace.Duration = span.EndTime.Sub(span.StartTime)
 		}
+		if span.EndTime.After(latestEnd) {
+			latestEnd = span.EndTime
+		}
 		if span.GenAI != nil {
 			trace.TotalTokens += span.GenAI.TotalTokens
 			trace.TotalCostUSD += span.GenAI.CostUSD
 		}
+	}
+
+	trace.EndTime = latestEnd
+
+	// Fallback: if no root span was found (all spans have a parent from an
+	// external trace), compute duration from the full time range of all spans.
+	if trace.Duration == 0 && !trace.StartTime.IsZero() && !trace.EndTime.IsZero() {
+		trace.Duration = trace.EndTime.Sub(trace.StartTime)
 	}
 
 	return trace

--- a/pkg/storage/bigquery/bigquery_test.go
+++ b/pkg/storage/bigquery/bigquery_test.go
@@ -246,3 +246,128 @@ func TestBuildTrace_TenantIDPreserved(t *testing.T) {
 		t.Errorf("TenantID = %q, want acme-corp", trace.Spans[0].TenantID)
 	}
 }
+
+// ── Duration fix integration tests ──────────────────────────────────────────
+
+func TestBuildTrace_DurationWithParentSpan(t *testing.T) {
+	// Regression test for the 0ms duration bug:
+	// When ALL spans have a ParentSpanID (W3C trace context propagation),
+	// buildTrace must still compute a non-zero duration from the time range.
+	now := time.Now().UTC()
+	spans := []storage.Span{
+		{
+			SpanID:       "proxy-span-1",
+			TraceID:      "external-trace-id",
+			ParentSpanID: "external-parent-id", // ← has parent, NOT a root span
+			Name:         "anthropic.chat.stream",
+			StartTime:    now,
+			EndTime:      now.Add(5 * time.Second),
+			GenAI: &storage.GenAIAttributes{
+				TotalTokens: 1000,
+				CostUSD:     0.10,
+			},
+		},
+		{
+			SpanID:       "proxy-span-2",
+			TraceID:      "external-trace-id",
+			ParentSpanID: "external-parent-id", // also has parent
+			Name:         "anthropic.chat.stream",
+			StartTime:    now.Add(6 * time.Second),
+			EndTime:      now.Add(10 * time.Second),
+			GenAI: &storage.GenAIAttributes{
+				TotalTokens: 2000,
+				CostUSD:     0.20,
+			},
+		},
+	}
+
+	trace := buildTrace("external-trace-id", spans)
+
+	if trace.Duration == 0 {
+		t.Fatal("Duration is 0 — the fallback for traces without root spans is broken")
+	}
+	if trace.Duration != 10*time.Second {
+		t.Errorf("Duration = %v, want 10s (from earliest start to latest end)", trace.Duration)
+	}
+	// RootSpanName should be empty since no span has ParentSpanID=="".
+	if trace.RootSpanName != "" {
+		t.Errorf("RootSpanName = %q, want empty (no root span exists)", trace.RootSpanName)
+	}
+	// Tokens and cost should still be aggregated.
+	if trace.TotalTokens != 3000 {
+		t.Errorf("TotalTokens = %d, want 3000", trace.TotalTokens)
+	}
+}
+
+func TestBuildTrace_DurationWithRootSpan(t *testing.T) {
+	// Regression guard: when a root span EXISTS, its duration should be used
+	// (not the fallback). This ensures the fix didn't break the normal path.
+	now := time.Now().UTC()
+	spans := []storage.Span{
+		{
+			SpanID:       "root-span",
+			TraceID:      "trace-normal",
+			ParentSpanID: "", // root span
+			Name:         "openai.chat",
+			StartTime:    now,
+			EndTime:      now.Add(3 * time.Second),
+		},
+		{
+			SpanID:       "child-span",
+			TraceID:      "trace-normal",
+			ParentSpanID: "root-span",
+			Name:         "tool.call",
+			StartTime:    now.Add(500 * time.Millisecond),
+			EndTime:      now.Add(2 * time.Second),
+		},
+	}
+
+	trace := buildTrace("trace-normal", spans)
+
+	if trace.Duration != 3*time.Second {
+		t.Errorf("Duration = %v, want 3s (from root span)", trace.Duration)
+	}
+	if trace.RootSpanName != "openai.chat" {
+		t.Errorf("RootSpanName = %q, want openai.chat", trace.RootSpanName)
+	}
+}
+
+func TestSpanRowRoundtrip_CacheTokens(t *testing.T) {
+	// Verify that cache token fields survive the spanToRow → rowToSpan roundtrip.
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	original := storage.Span{
+		SpanID:    "span-cache",
+		TraceID:   "trace-cache",
+		Name:      "anthropic.chat.stream",
+		StartTime: now,
+		EndTime:   now.Add(2 * time.Second),
+		Duration:  2 * time.Second,
+		GenAI: &storage.GenAIAttributes{
+			Model:               "claude-sonnet-4-20250514",
+			Provider:            "anthropic",
+			InputTokens:         19455, // cost-normalized
+			OutputTokens:        393,
+			TotalTokens:         19848,
+			CostUSD:             0.64,
+			CacheReadTokens:     188086, // raw from API
+			CacheCreationTokens: 500,    // raw from API
+		},
+	}
+
+	row := spanToRow(original)
+	roundtripped := rowToSpan(row)
+
+	if roundtripped.GenAI == nil {
+		t.Fatal("GenAI is nil after roundtrip")
+	}
+	if roundtripped.GenAI.CacheReadTokens != 188086 {
+		t.Errorf("CacheReadTokens = %d, want 188086", roundtripped.GenAI.CacheReadTokens)
+	}
+	if roundtripped.GenAI.CacheCreationTokens != 500 {
+		t.Errorf("CacheCreationTokens = %d, want 500", roundtripped.GenAI.CacheCreationTokens)
+	}
+	// Also verify the cost-normalized tokens survived.
+	if roundtripped.GenAI.InputTokens != 19455 {
+		t.Errorf("InputTokens = %d, want 19455", roundtripped.GenAI.InputTokens)
+	}
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -91,6 +91,13 @@ type GenAIAttributes struct {
 	TopP          float64 `json:"top_p,omitempty"`
 	InputContent  string  `json:"input_content,omitempty"`
 	OutputContent string  `json:"output_content,omitempty"`
+
+	// Cache token breakdown (Anthropic prompt caching).
+	// These are the RAW counts from the API — not cost-normalized.
+	// InputTokens above is the cost-equivalent value (base + cache_read×0.1 + cache_creation×1.25).
+	// Showing both lets developers see their cache hit rate and optimize prompts.
+	CacheReadTokens     int64 `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens int64 `json:"cache_creation_tokens,omitempty"`
 }
 
 // Span represents a single span in the storage layer.

--- a/test/functional/mock/upstream.go
+++ b/test/functional/mock/upstream.go
@@ -101,6 +101,9 @@ func serveOpenAI(w http.ResponseWriter, r *http.Request) {
 			"prompt_tokens":     15,
 			"completion_tokens": 8,
 			"total_tokens":      23,
+			"prompt_tokens_details": map[string]any{
+				"cached_tokens": 10,
+			},
 		},
 	})
 }
@@ -116,8 +119,10 @@ func serveAnthropic(w http.ResponseWriter, r *http.Request) {
 		},
 		"stop_reason": "end_turn",
 		"usage": map[string]any{
-			"input_tokens":  15,
-			"output_tokens": 8,
+			"input_tokens":                15,
+			"output_tokens":               8,
+			"cache_read_input_tokens":     12,
+			"cache_creation_input_tokens": 3,
 		},
 	})
 }
@@ -134,7 +139,7 @@ func serveAnthropicStream(w http.ResponseWriter, r *http.Request) {
 	}
 
 	events := []string{
-		`data: {"type":"message_start","message":{"id":"msg_mock123","type":"message","role":"assistant","content":[],"usage":{"input_tokens":15,"output_tokens":0}}}`,
+		`data: {"type":"message_start","message":{"id":"msg_mock123","type":"message","role":"assistant","content":[],"usage":{"input_tokens":15,"output_tokens":0,"cache_read_input_tokens":12,"cache_creation_input_tokens":3}}}`,
 		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
 		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello from "}}`,
 		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"the mock upstream!"}}`,

--- a/test/functional/proxy/proxy_cache_tokens.hurl
+++ b/test/functional/proxy/proxy_cache_tokens.hurl
@@ -1,0 +1,48 @@
+# PROXY-07: Cache token passthrough — Anthropic cache fields visible in response
+# Verifies:
+#   - Anthropic cache_read_input_tokens and cache_creation_input_tokens
+#     are present in the upstream response forwarded by the proxy.
+#   - OpenAI prompt_tokens_details.cached_tokens is forwarded.
+#   - Proxy does not strip provider-specific cache metadata.
+#
+# Note: The proxy also extracts these into span attributes
+# (gen_ai.usage.cache_read_tokens, gen_ai.usage.cache_creation_tokens),
+# but those are only visible in the trace detail API, not in the proxied response.
+
+# ── Anthropic direct — cache tokens in response ──────────────────────────────
+POST {{CANDELA_URL}}/proxy/anthropic-direct/v1/messages
+x-api-key: sk-ant-test-key
+Content-Type: application/json
+{
+  "model": "claude-sonnet-4-20250514",
+  "messages": [{"role": "user", "content": "Cache test"}],
+  "max_tokens": 1024
+}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.usage.input_tokens" isInteger
+jsonpath "$.usage.output_tokens" isInteger
+jsonpath "$.usage.cache_read_input_tokens" isInteger
+jsonpath "$.usage.cache_read_input_tokens" >= 0
+jsonpath "$.usage.cache_creation_input_tokens" isInteger
+jsonpath "$.usage.cache_creation_input_tokens" >= 0
+
+
+# ── OpenAI — cached tokens in prompt_tokens_details ──────────────────────────
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test-key
+Content-Type: application/json
+{
+  "model": "gpt-4o",
+  "messages": [{"role": "user", "content": "Cache test"}]
+}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.usage.prompt_tokens" isInteger
+jsonpath "$.usage.completion_tokens" isInteger
+jsonpath "$.usage.prompt_tokens_details.cached_tokens" isInteger
+jsonpath "$.usage.prompt_tokens_details.cached_tokens" >= 0

--- a/test/functional/proxy/proxy_streaming_cache.hurl
+++ b/test/functional/proxy/proxy_streaming_cache.hurl
@@ -1,0 +1,25 @@
+# PROXY-09: Streaming with cache tokens — Anthropic SSE stream contains cache metadata
+# Verifies:
+#   - Anthropic streaming response includes cache tokens in message_start event
+#   - Stream format is correct text/event-stream
+#   - Proxy forwards cache-bearing SSE events without stripping them
+
+# ── Anthropic streaming with cache tokens ────────────────────────────────────
+POST {{CANDELA_URL}}/proxy/anthropic/v1/messages
+Authorization: Bearer test-gcp-token
+Content-Type: application/json
+{
+  "model": "claude-sonnet-4-20250514",
+  "messages": [{"role": "user", "content": "Stream with cache"}],
+  "stream": true
+}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "text/event-stream"
+# Stream should contain SSE data lines
+body contains "data:"
+# The message_start event should include cache token counts
+body contains "cache_read_input_tokens"
+# Stream must end with [DONE] (proxy translates Anthropic message_stop → OpenAI [DONE])
+body contains "data: [DONE]"

--- a/test/functional/proxy/proxy_trace_context.hurl
+++ b/test/functional/proxy/proxy_trace_context.hurl
@@ -1,0 +1,40 @@
+# PROXY-08: W3C Trace Context propagation — parentSpanID preserved
+# Verifies:
+#   - Proxy accepts Traceparent header (W3C Trace Context)
+#   - Response still returns successfully (no 0ms duration regression)
+#   - X-Request-ID is still generated/echoed
+
+# ── Request with Traceparent → should succeed (no crash, proper forwarding) ──
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test-key
+Content-Type: application/json
+Traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+{
+  "model": "gpt-4o",
+  "messages": [{"role": "user", "content": "Trace context test"}]
+}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+header "X-Request-ID" exists
+jsonpath "$.object" == "chat.completion"
+jsonpath "$.usage.prompt_tokens" isInteger
+
+
+# ── Request with Traceparent + Session-Id ─────────────────────────────────────
+# Both W3C trace context and session tracking should coexist without error.
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test-key
+Content-Type: application/json
+Traceparent: 00-11111111111111111111111111111111-2222222222222222-01
+X-Session-Id: session-abc-123
+{
+  "model": "gpt-4o",
+  "messages": [{"role": "user", "content": "Session + trace context"}]
+}
+
+HTTP 200
+[Asserts]
+header "X-Request-ID" exists
+jsonpath "$.object" == "chat.completion"


### PR DESCRIPTION
## What

Two fixes in one:

### 🐛 Duration 0ms bug
BigQuery `buildTrace` only computed trace duration from root spans (`ParentSpanID==""`). W3C trace context propagation from OpenCode/Claude Code always sets a parentSpanID, so duration stayed at zero for every proxy-generated trace.

**Fix**: Fall back to computing duration from the full span time range when no root span exists.

### ✨ Cache token visibility (all providers)
Developers had no way to see their prompt caching efficiency. Now raw cache token counts are extracted from all three providers and exposed as span attributes:

| Provider | Source field | Attribute |
|----------|-------------|-----------|
| Anthropic | `cache_read_input_tokens` | `gen_ai.usage.cache_read_tokens` |
| Anthropic | `cache_creation_input_tokens` | `gen_ai.usage.cache_creation_tokens` |
| OpenAI | `prompt_tokens_details.cached_tokens` | `gen_ai.usage.cache_read_tokens` |
| Google | `cachedContentTokenCount` | `gen_ai.usage.cache_read_tokens` |

Also persisted to BigQuery via new `gen_ai_cache_read_tokens` / `gen_ai_cache_creation_tokens` columns (auto-added by schema evolution).

## Files changed
- `pkg/storage/bigquery/bigquery.go` — duration fix + cache columns
- `pkg/proxy/parsers.go` — cache token extraction for all providers
- `pkg/proxy/proxy.go` — wire cache tokens through span pipeline
- `pkg/storage/store.go` — CacheReadTokens/CacheCreationTokens fields

## Testing
All pre-commit hooks pass (gofmt, go-vet, golangci-lint, go-test across all packages).