### PR TITLE
docs: remove docker-compose references

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,14 +167,6 @@ cd ui && pnpm install && pnpm run dev
 
 > **💡 Quick Start Tip**: Copy `config.example.yaml` to `config.yaml` to use port 8181 and enable all features.
 
-### Option C: Docker Compose (Full Stack)
-Ideal for testing the full multi-service experience.
-
-```bash
-# Start all services (server + collector)
-docker compose -f deploy/docker-compose.yml up
-```
-
 ---
 
 ## 🛠️ Route an LLM Call
@@ -308,7 +300,7 @@ Candela uses port `8181` by default.
 | Setup | Port | When Used |
 |-------|------|-----------|
 | **Default** | `8181` | Running `go run ./cmd/candela-server` |
-| **Docker Compose** | `8181` | As specified in `docker-compose.yml` |
+
 
 ### Quick Setup
 ```bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,7 +17,6 @@ This will automatically install:
 - **Node.js 22** & **pnpm**
 - **Python 3.12** & **uv**
 - **cloudflared** (Cloudflare tunnel for Cursor 3 integration)
-- **docker-compose**
 
 ---
 


### PR DESCRIPTION
Remove docker-compose from documentation:

- Remove **Option C: Docker Compose (Full Stack)** quick start section from README
- Remove Docker Compose row from port configuration table in README
- Remove `docker-compose` from dev shell prerequisites in `docs/development.md`

The `deploy/docker-compose.yml` file is retained for now.