### PR TITLE
test: add dashboard ConnectRPC auth and contract hurl tests

### DIFF
--- a/test/functional/dashboard/dashboard_auth.hurl
+++ b/test/functional/dashboard/dashboard_auth.hurl
@@ -1,0 +1,65 @@
+# DASH-01..06: Dashboard ConnectRPC auth and endpoint validation
+# These tests verify the candela-analysis DashboardService endpoints
+# used by Candela Desktop in Team mode.
+
+# ── DASH-01: GetModelBreakdown without auth → 401 ──────────────────────────
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetModelBreakdown
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.error" == "missing authentication"
+
+
+# ── DASH-02: GetUsageSummary without auth → 401 ────────────────────────────
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetUsageSummary
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.error" == "missing authentication"
+
+
+# ── DASH-03: GetMyUsage without auth → 401 ─────────────────────────────────
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetMyUsage
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.error" == "missing authentication"
+
+
+# ── DASH-04: Invalid Bearer token → 401 ────────────────────────────────────
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetModelBreakdown
+Authorization: Bearer invalid-garbage-token
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.error" == "invalid authentication token"
+
+
+# ── DASH-05: Malformed Authorization header → 401 ──────────────────────────
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetModelBreakdown
+Authorization: Basic dXNlcjpwYXNz
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.error" == "missing authentication"
+
+
+# ── DASH-06: Health check bypasses auth ─────────────────────────────────────
+GET {{ANALYSIS_URL}}/healthz
+
+HTTP 200

--- a/test/functional/dashboard/dashboard_auth.hurl
+++ b/test/functional/dashboard/dashboard_auth.hurl
@@ -1,6 +1,11 @@
 # DASH-01..06: Dashboard ConnectRPC auth and endpoint validation
 # These tests verify the candela-analysis DashboardService endpoints
 # used by Candela Desktop in Team mode.
+#
+# NOTE: Auth failures return plain HTTP JSON from the auth middleware
+# (pkg/auth/{firebase,iap}.go writeError), NOT ConnectRPC error format.
+# The middleware uses {"error": "..."}, while ConnectRPC uses {"message": "..."}.
+# These assertions use $.error because auth is rejected BEFORE reaching ConnectRPC.
 
 # ── DASH-01: GetModelBreakdown without auth → 401 ──────────────────────────
 POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetModelBreakdown

--- a/test/functional/dashboard/dashboard_contract.hurl
+++ b/test/functional/dashboard/dashboard_contract.hurl
@@ -1,0 +1,96 @@
+# DASH-10..15: Dashboard ConnectRPC contract tests
+# These validate the JSON serialization contract between the desktop client
+# and the ConnectRPC backend — specifically the proto3 JSON mapping for
+# google.protobuf.Timestamp fields in TimeRange.
+#
+# IMPORTANT: These tests require a valid auth token passed via the
+# AUTH_TOKEN variable (e.g. from `gcloud auth print-access-token`).
+
+# ── DASH-10: GetModelBreakdown with valid TimeRange → 200 ──────────────────
+# Proto: time_range is candela.types.TimeRange with google.protobuf.Timestamp
+# The JSON mapping uses RFC 3339 strings, NOT protobuf enum names.
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetModelBreakdown
+Authorization: Bearer {{AUTH_TOKEN}}
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{
+  "project_id": "",
+  "time_range": {
+    "start": "2026-01-01T00:00:00Z",
+    "end": "2026-12-31T23:59:59Z"
+  }
+}
+
+HTTP 200
+[Asserts]
+# Response is valid JSON (may be empty {} if no data, which is fine).
+header "Content-Type" contains "application/json"
+
+
+# ── DASH-11: GetModelBreakdown with string enum time_range → 400 ────────────
+# This is exactly the bug the desktop would hit if it sent "24h" instead
+# of the proper TimeRange message. Regression guard.
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetModelBreakdown
+Authorization: Bearer {{AUTH_TOKEN}}
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{
+  "project_id": "",
+  "time_range": "24h"
+}
+
+HTTP *
+[Asserts]
+# Must return 400 (invalid_argument), not 500 or 200.
+status == 400
+jsonpath "$.code" == "invalid_argument"
+
+
+# ── DASH-12: GetUsageSummary with empty body → 200 (defaults to 24h) ───────
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetUsageSummary
+Authorization: Bearer {{AUTH_TOKEN}}
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+
+
+# ── DASH-13: GetMyUsage returns budget fields when available ───────────────
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetMyUsage
+Authorization: Bearer {{AUTH_TOKEN}}
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{
+  "project_id": "",
+  "time_range": {
+    "start": "2026-01-01T00:00:00Z",
+    "end": "2026-12-31T23:59:59Z"
+  }
+}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+
+
+# ── DASH-14: Missing Connect-Protocol-Version header still works ───────────
+# ConnectRPC should accept requests without the version header.
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetModelBreakdown
+Authorization: Bearer {{AUTH_TOKEN}}
+Content-Type: application/json
+{}
+
+HTTP 200
+
+
+# ── DASH-15: Non-existent RPC method → 404 ─────────────────────────────────
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/DoesNotExist
+Authorization: Bearer {{AUTH_TOKEN}}
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{}
+
+HTTP 404

--- a/test/functional/dashboard/dashboard_contract.hurl
+++ b/test/functional/dashboard/dashboard_contract.hurl
@@ -39,10 +39,8 @@ Connect-Protocol-Version: 1
   "time_range": "24h"
 }
 
-HTTP *
+HTTP 400
 [Asserts]
-# Must return 400 (invalid_argument), not 500 or 200.
-status == 400
 jsonpath "$.code" == "invalid_argument"
 
 

--- a/test/functional/run.sh
+++ b/test/functional/run.sh
@@ -14,6 +14,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # ── Defaults ────────────────────────────────────────────────────────────────
 CANDELA_URL="${HURL_CANDELA_URL:-http://localhost:8080}"
 MOCK_URL="${HURL_MOCK_UPSTREAM_URL:-http://localhost:9999}"
+ANALYSIS_URL="${HURL_ANALYSIS_URL:-http://localhost:8090}"
 REPORT_DIR="${SCRIPT_DIR}/../../test-results"
 
 # ── Flag parsing ─────────────────────────────────────────────────────────────
@@ -30,6 +31,7 @@ done
 echo "🕯️  Candela functional tests"
 echo "   Target:   $TARGET ($CANDELA_URL)"
 echo "   Upstream: $MOCK_URL"
+echo "   Analysis: $ANALYSIS_URL"
 echo ""
 
 mkdir -p "$REPORT_DIR"
@@ -37,9 +39,24 @@ mkdir -p "$REPORT_DIR"
 hurl --test \
   --variable CANDELA_URL="$CANDELA_URL" \
   --variable MOCK_UPSTREAM_URL="$MOCK_URL" \
+  --variable ANALYSIS_URL="$ANALYSIS_URL" \
   --report-junit "$REPORT_DIR/functional-$TARGET.xml" \
   "${EXTRA_ARGS[@]}" \
   "$SCRIPT_DIR"/proxy/*.hurl \
   "$SCRIPT_DIR"/billing/*.hurl \
   "$SCRIPT_DIR"/compat/*.hurl \
-  "$SCRIPT_DIR"/security/*.hurl
+  "$SCRIPT_DIR"/security/*.hurl \
+  "$SCRIPT_DIR"/dashboard/dashboard_auth.hurl
+
+# Dashboard contract tests require AUTH_TOKEN and are run separately.
+if [[ -n "${HURL_AUTH_TOKEN:-}" ]]; then
+  echo ""
+  echo "🔐 Running authenticated dashboard contract tests..."
+  hurl --test \
+    --variable ANALYSIS_URL="$ANALYSIS_URL" \
+    --variable AUTH_TOKEN="$HURL_AUTH_TOKEN" \
+    --report-junit "$REPORT_DIR/functional-dashboard-$TARGET.xml" \
+    "${EXTRA_ARGS[@]}" \
+    "$SCRIPT_DIR"/dashboard/dashboard_contract.hurl
+fi
+


### PR DESCRIPTION
## Summary

Adds 12 hurl functional tests for the DashboardService ConnectRPC endpoints used by Candela Desktop in team mode.

### Tests

| File | IDs | Coverage |
|---|---|---|
| `dashboard_auth.hurl` | DASH-01..06 | Auth enforcement: missing/invalid/wrong-scheme tokens → 401, healthz bypass |
| `dashboard_contract.hurl` | DASH-10..15 | JSON contract: valid TimeRange, string enum rejection, empty body defaults, missing header, unknown RPC |

### Runner updates
- Added `ANALYSIS_URL` variable (defaults to `:8090`)
- Contract tests run conditionally when `HURL_AUTH_TOKEN` is set

Related: candelahq/candela-desktop#43