### PR TITLE
fix: make project_id filter optional in BigQuery dashboard queries

### DIFF
--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -389,7 +389,7 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 	query := fmt.Sprintf(`
 		SELECT trace_id, MIN(start_time) AS earliest
 		FROM %s
-		WHERE project_id = @projectID
+		WHERE (@projectID = '' OR project_id = @projectID)
 		  AND start_time >= @startTime
 		  AND start_time <= @endTime
 		  AND (@userID = '' OR user_id = @userID)
@@ -497,7 +497,7 @@ func (s *Store) SearchSpans(ctx context.Context, sq storage.SpanQuery) (*storage
 
 	query := fmt.Sprintf(`
 		SELECT * FROM %s
-		WHERE project_id = @projectID
+		WHERE (@projectID = '' OR project_id = @projectID)
 		  AND start_time >= @startTime
 		  AND start_time <= @endTime
 		  AND (@kind = 0 OR kind = @kind)
@@ -544,7 +544,7 @@ func (s *Store) GetUsageSummary(ctx context.Context, uq storage.UsageQuery) (*st
 			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
 			COALESCE(AVG(duration_ns), 0) AS avg_duration_ns
 		FROM %s
-		WHERE project_id = @projectID
+		WHERE (@projectID = '' OR project_id = @projectID)
 		  AND start_time >= @startTime
 		  AND start_time <= @endTime
 		  AND (@userID = '' OR user_id = @userID)
@@ -609,7 +609,7 @@ func (s *Store) GetModelBreakdown(ctx context.Context, uq storage.UsageQuery) ([
 			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
 			COALESCE(AVG(duration_ns), 0) AS avg_duration_ns
 		FROM %s
-		WHERE project_id = @projectID
+		WHERE (@projectID = '' OR project_id = @projectID)
 		  AND start_time >= @startTime
 		  AND start_time <= @endTime
 		  AND gen_ai_model != ''
@@ -680,7 +680,7 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, uq storage.UsageQuery, l
 			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
 			COALESCE(AVG(duration_ns), 0) AS avg_duration_ns
 		FROM %s
-		WHERE project_id = @projectID
+		WHERE (@projectID = '' OR project_id = @projectID)
 		  AND start_time >= @startTime
 		  AND start_time <= @endTime
 		  AND user_id != ''
@@ -753,7 +753,7 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, uq storage.UsageQuery,
 				duration_ns,
 				SUM(gen_ai_cost_usd) OVER (PARTITION BY tenant_id, gen_ai_model) AS model_cost
 			FROM %s
-			WHERE project_id = @projectID
+			WHERE (@projectID = '' OR project_id = @projectID)
 			  AND start_time >= @startTime
 			  AND start_time <= @endTime
 			  AND tenant_id IS NOT NULL AND tenant_id != '' AND gen_ai_model != ''
@@ -814,14 +814,14 @@ func (s *Store) GetJobLeaderboard(ctx context.Context, uq storage.UsageQuery, li
 		COALESCE((
 			SELECT s2.gen_ai_model FROM %s s2
 			WHERE s2.job_id = spans.job_id
-				AND s2.project_id = @projectID AND s2.start_time >= @startTime AND s2.start_time <= @endTime
+				AND (@projectID = '' OR s2.project_id = @projectID) AND s2.start_time >= @startTime AND s2.start_time <= @endTime
 				AND s2.gen_ai_model IS NOT NULL AND s2.gen_ai_model != ''
 			GROUP BY s2.gen_ai_model
 			ORDER BY SUM(s2.gen_ai_cost_usd) DESC
 			LIMIT 1
 		), '') AS top_model
 	FROM %s spans
-	WHERE project_id = @projectID AND start_time >= @startTime AND start_time <= @endTime
+	WHERE (@projectID = '' OR project_id = @projectID) AND start_time >= @startTime AND start_time <= @endTime
 		AND job_id IS NOT NULL AND job_id != ''
 	GROUP BY job_id
 	ORDER BY total_cost_usd DESC

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -814,14 +814,18 @@ func (s *Store) GetJobLeaderboard(ctx context.Context, uq storage.UsageQuery, li
 		COALESCE((
 			SELECT s2.gen_ai_model FROM %s s2
 			WHERE s2.job_id = spans.job_id
-				AND (@projectID = '' OR s2.project_id = @projectID) AND s2.start_time >= @startTime AND s2.start_time <= @endTime
+				AND (@projectID = '' OR s2.project_id = @projectID)
+				AND s2.start_time >= @startTime
+				AND s2.start_time <= @endTime
 				AND s2.gen_ai_model IS NOT NULL AND s2.gen_ai_model != ''
 			GROUP BY s2.gen_ai_model
 			ORDER BY SUM(s2.gen_ai_cost_usd) DESC
 			LIMIT 1
 		), '') AS top_model
 	FROM %s spans
-	WHERE (@projectID = '' OR project_id = @projectID) AND start_time >= @startTime AND start_time <= @endTime
+	WHERE (@projectID = '' OR project_id = @projectID)
+		AND start_time >= @startTime
+		AND start_time <= @endTime
 		AND job_id IS NOT NULL AND job_id != ''
 	GROUP BY job_id
 	ORDER BY total_cost_usd DESC

--- a/pkg/storage/sqlite/optional_filters_test.go
+++ b/pkg/storage/sqlite/optional_filters_test.go
@@ -1,0 +1,303 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// seedMultiProjectSpans inserts spans across multiple projects, users, tenants,
+// and jobs for comprehensive filter testing. Returns the time anchor used.
+func seedMultiProjectSpans(t *testing.T, s *Store) time.Time {
+	t.Helper()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	spans := []storage.Span{
+		{
+			SpanID: "mp-s1", TraceID: "mp-t1", Name: "openai.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-1 * time.Hour), EndTime: now.Add(-59 * time.Minute),
+			Duration: time.Minute, ProjectID: "default", UserID: "alice@example.com",
+			TenantID: "acme", JobID: "job-1",
+			GenAI: &storage.GenAIAttributes{
+				Model: "gpt-4o", Provider: "openai",
+				InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.05,
+			},
+		},
+		{
+			SpanID: "mp-s2", TraceID: "mp-t2", Name: "claude.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-30 * time.Minute), EndTime: now.Add(-29 * time.Minute),
+			Duration: time.Minute, ProjectID: "default", UserID: "bob@example.com",
+			TenantID: "acme", JobID: "job-2",
+			GenAI: &storage.GenAIAttributes{
+				Model: "claude-sonnet-4-20250514", Provider: "anthropic",
+				InputTokens: 200, OutputTokens: 100, TotalTokens: 300, CostUSD: 0.10,
+			},
+		},
+		{
+			SpanID: "mp-s3", TraceID: "mp-t3", Name: "gemini.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-15 * time.Minute), EndTime: now.Add(-14 * time.Minute),
+			Duration: time.Minute, ProjectID: "other-project", UserID: "alice@example.com",
+			TenantID: "beta-corp", JobID: "job-3",
+			GenAI: &storage.GenAIAttributes{
+				Model: "gemini-2.5-pro", Provider: "google",
+				InputTokens: 300, OutputTokens: 150, TotalTokens: 450, CostUSD: 0.15,
+			},
+		},
+	}
+	if err := s.IngestSpans(context.Background(), spans); err != nil {
+		t.Fatalf("seeding spans: %v", err)
+	}
+	return now
+}
+
+func newFilterTestStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := New(Config{Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("creating test store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// ── Issue 1: Empty project_id must return all projects ──────────────────────
+
+func TestGetUsageSummary_EmptyProjectID_ReturnsAll(t *testing.T) {
+	s := newFilterTestStore(t)
+	now := seedMultiProjectSpans(t, s)
+
+	summary, err := s.GetUsageSummary(context.Background(), storage.UsageQuery{
+		ProjectID: "", // ← the bug: this used to match only project_id=''
+		StartTime: now.Add(-2 * time.Hour),
+		EndTime:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetUsageSummary: %v", err)
+	}
+	if summary.TotalSpans != 3 {
+		t.Errorf("TotalSpans = %d, want 3 (all projects)", summary.TotalSpans)
+	}
+	if summary.TotalCostUSD != 0.30 {
+		t.Errorf("TotalCostUSD = %f, want 0.30", summary.TotalCostUSD)
+	}
+}
+
+func TestGetUsageSummary_SpecificProjectID_FiltersCorrectly(t *testing.T) {
+	s := newFilterTestStore(t)
+	now := seedMultiProjectSpans(t, s)
+
+	summary, err := s.GetUsageSummary(context.Background(), storage.UsageQuery{
+		ProjectID: "default",
+		StartTime: now.Add(-2 * time.Hour),
+		EndTime:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetUsageSummary: %v", err)
+	}
+	if summary.TotalSpans != 2 {
+		t.Errorf("TotalSpans = %d, want 2 (default project only)", summary.TotalSpans)
+	}
+}
+
+func TestGetModelBreakdown_EmptyProjectID_ReturnsAll(t *testing.T) {
+	s := newFilterTestStore(t)
+	now := seedMultiProjectSpans(t, s)
+
+	models, err := s.GetModelBreakdown(context.Background(), storage.UsageQuery{
+		ProjectID: "",
+		StartTime: now.Add(-2 * time.Hour),
+		EndTime:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetModelBreakdown: %v", err)
+	}
+	if len(models) != 3 {
+		t.Errorf("model count = %d, want 3", len(models))
+	}
+}
+
+func TestGetModelBreakdown_SpecificProjectID(t *testing.T) {
+	s := newFilterTestStore(t)
+	now := seedMultiProjectSpans(t, s)
+
+	models, err := s.GetModelBreakdown(context.Background(), storage.UsageQuery{
+		ProjectID: "other-project",
+		StartTime: now.Add(-2 * time.Hour),
+		EndTime:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetModelBreakdown: %v", err)
+	}
+	if len(models) != 1 {
+		t.Errorf("model count = %d, want 1", len(models))
+	}
+	if len(models) > 0 && models[0].Model != "gemini-2.5-pro" {
+		t.Errorf("model = %q, want gemini-2.5-pro", models[0].Model)
+	}
+}
+
+func TestQueryTraces_EmptyProjectID_ReturnsAll(t *testing.T) {
+	s := newFilterTestStore(t)
+	now := seedMultiProjectSpans(t, s)
+
+	result, err := s.QueryTraces(context.Background(), storage.TraceQuery{
+		ProjectID: "",
+		StartTime: now.Add(-2 * time.Hour),
+		EndTime:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("QueryTraces: %v", err)
+	}
+	if result.TotalCount != 3 {
+		t.Errorf("TotalCount = %d, want 3 (all projects)", result.TotalCount)
+	}
+}
+
+func TestSearchSpans_EmptyProjectID_ReturnsAll(t *testing.T) {
+	s := newFilterTestStore(t)
+	now := seedMultiProjectSpans(t, s)
+
+	result, err := s.SearchSpans(context.Background(), storage.SpanQuery{
+		ProjectID: "",
+		StartTime: now.Add(-2 * time.Hour),
+		EndTime:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("SearchSpans: %v", err)
+	}
+	if result.TotalCount != 3 {
+		t.Errorf("TotalCount = %d, want 3 (all projects)", result.TotalCount)
+	}
+}
+
+func TestGetUserLeaderboard_EmptyProjectID_ReturnsAll(t *testing.T) {
+	s := newFilterTestStore(t)
+	now := seedMultiProjectSpans(t, s)
+
+	users, err := s.GetUserLeaderboard(context.Background(), storage.UsageQuery{
+		ProjectID: "",
+		StartTime: now.Add(-2 * time.Hour),
+		EndTime:   now.Add(time.Hour),
+	}, 10)
+	if err != nil {
+		t.Fatalf("GetUserLeaderboard: %v", err)
+	}
+	if len(users) != 2 {
+		t.Errorf("user count = %d, want 2 (alice + bob across all projects)", len(users))
+	}
+}
+
+func TestGetTenantLeaderboard_EmptyProjectID_ReturnsAll(t *testing.T) {
+	s := newFilterTestStore(t)
+	now := seedMultiProjectSpans(t, s)
+
+	tenants, err := s.GetTenantLeaderboard(context.Background(), storage.UsageQuery{
+		ProjectID: "",
+		StartTime: now.Add(-2 * time.Hour),
+		EndTime:   now.Add(time.Hour),
+	}, 10)
+	if err != nil {
+		t.Fatalf("GetTenantLeaderboard: %v", err)
+	}
+	if len(tenants) != 2 {
+		t.Errorf("tenant count = %d, want 2 (acme + beta-corp)", len(tenants))
+	}
+}
+
+func TestGetJobLeaderboard_EmptyProjectID_ReturnsAll(t *testing.T) {
+	s := newFilterTestStore(t)
+	now := seedMultiProjectSpans(t, s)
+
+	jobs, err := s.GetJobLeaderboard(context.Background(), storage.UsageQuery{
+		ProjectID: "",
+		StartTime: now.Add(-2 * time.Hour),
+		EndTime:   now.Add(time.Hour),
+	}, 10)
+	if err != nil {
+		t.Fatalf("GetJobLeaderboard: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Errorf("job count = %d, want 3", len(jobs))
+	}
+}
+
+// ── Issue 2: UserID scoping still works with optional project_id ────────────
+
+func TestGetUsageSummary_UserAndProjectScoping(t *testing.T) {
+	s := newFilterTestStore(t)
+	now := seedMultiProjectSpans(t, s)
+
+	t.Run("empty_project_alice_sees_both_projects", func(t *testing.T) {
+		summary, err := s.GetUsageSummary(context.Background(), storage.UsageQuery{
+			ProjectID: "",
+			UserID:    "alice@example.com",
+			StartTime: now.Add(-2 * time.Hour),
+			EndTime:   now.Add(time.Hour),
+		})
+		if err != nil {
+			t.Fatalf("GetUsageSummary: %v", err)
+		}
+		if summary.TotalSpans != 2 {
+			t.Errorf("TotalSpans = %d, want 2 (alice across all projects)", summary.TotalSpans)
+		}
+	})
+
+	t.Run("specific_project_alice_sees_one", func(t *testing.T) {
+		summary, err := s.GetUsageSummary(context.Background(), storage.UsageQuery{
+			ProjectID: "default",
+			UserID:    "alice@example.com",
+			StartTime: now.Add(-2 * time.Hour),
+			EndTime:   now.Add(time.Hour),
+		})
+		if err != nil {
+			t.Fatalf("GetUsageSummary: %v", err)
+		}
+		if summary.TotalSpans != 1 {
+			t.Errorf("TotalSpans = %d, want 1 (alice in default only)", summary.TotalSpans)
+		}
+	})
+}
+
+// ── Issue 3: TenantID scoping with optional project_id ──────────────────────
+
+func TestGetUsageSummary_TenantScoping_WithEmptyProject(t *testing.T) {
+	s := newFilterTestStore(t)
+	now := seedMultiProjectSpans(t, s)
+
+	summary, err := s.GetUsageSummary(context.Background(), storage.UsageQuery{
+		ProjectID: "",
+		TenantID:  "acme",
+		StartTime: now.Add(-2 * time.Hour),
+		EndTime:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetUsageSummary: %v", err)
+	}
+	if summary.TotalSpans != 2 {
+		t.Errorf("TotalSpans = %d, want 2 (acme tenant across all projects)", summary.TotalSpans)
+	}
+}
+
+// ── Regression guard: nonexistent project returns empty ─────────────────────
+
+func TestGetUsageSummary_NonexistentProject_ReturnsZero(t *testing.T) {
+	s := newFilterTestStore(t)
+	now := seedMultiProjectSpans(t, s)
+
+	summary, err := s.GetUsageSummary(context.Background(), storage.UsageQuery{
+		ProjectID: "does-not-exist",
+		StartTime: now.Add(-2 * time.Hour),
+		EndTime:   now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetUsageSummary: %v", err)
+	}
+	if summary.TotalSpans != 0 {
+		t.Errorf("TotalSpans = %d, want 0 for nonexistent project", summary.TotalSpans)
+	}
+}

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -245,14 +245,14 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 			MAX(gen_ai_provider) as primary_provider,
 			MAX(status) as status
 		FROM spans
-		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
 			AND (? = '' OR user_id = ?)
 			AND (? = '' OR tenant_id = ?)
 			AND (? = '' OR environment = ?)
 		GROUP BY trace_id
 		ORDER BY `+orderExpr+` `+dir+`
 		LIMIT ?
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+	`, q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
 		q.UserID, q.UserID, q.TenantID, q.TenantID, q.Environment, q.Environment, q.PageSize)
 	if err != nil {
 		return nil, fmt.Errorf("querying traces: %w", err)
@@ -300,7 +300,7 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
 			gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id, tenant_id, job_id
 		FROM spans
-		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
 			AND (? = 0 OR kind = ?)
 			AND (? = '' OR gen_ai_model = ?)
 			AND (? = '' OR name LIKE '%' || ? || '%' ESCAPE '\')
@@ -308,7 +308,7 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			AND (? = '' OR tenant_id = ?)
 		ORDER BY start_time DESC
 		LIMIT ?
-	`, q.ProjectID,
+	`, q.ProjectID, q.ProjectID,
 		q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
 		int(q.Kind), int(q.Kind),
 		q.Model, q.Model,
@@ -336,7 +336,7 @@ func (s *Store) GetUsageSummary(ctx context.Context, q storage.UsageQuery) (*sto
 		SELECT
 			COUNT(DISTINCT trace_id),
 			COUNT(*),
-			SUM(CASE WHEN kind = 1 THEN 1 ELSE 0 END),
+			COALESCE(SUM(CASE WHEN kind = 1 THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(gen_ai_input_tokens), 0),
 			COALESCE(SUM(gen_ai_output_tokens), 0),
 			COALESCE(SUM(gen_ai_cost_usd), 0),
@@ -345,10 +345,10 @@ func (s *Store) GetUsageSummary(ctx context.Context, q storage.UsageQuery) (*sto
 				THEN CAST(SUM(CASE WHEN status = 2 THEN 1 ELSE 0 END) AS REAL) / COUNT(*)
 				ELSE 0 END
 		FROM spans
-		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
 			AND (? = '' OR user_id = ?)
 			AND (? = '' OR tenant_id = ?)
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID, q.TenantID, q.TenantID).Scan(
+	`, q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID, q.TenantID, q.TenantID).Scan(
 		&summary.TotalTraces, &summary.TotalSpans, &summary.TotalLLMCalls,
 		&summary.TotalInputTokens, &summary.TotalOutputTokens, &summary.TotalCostUSD,
 		&summary.AvgLatencyMs, &summary.ErrorRate,
@@ -365,13 +365,13 @@ func (s *Store) GetModelBreakdown(ctx context.Context, q storage.UsageQuery) ([]
 			COUNT(*), SUM(gen_ai_input_tokens), SUM(gen_ai_output_tokens),
 			SUM(gen_ai_cost_usd), AVG(duration_ns) / 1000000.0
 		FROM spans
-		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
 			AND gen_ai_model != ''
 			AND (? = '' OR user_id = ?)
 			AND (? = '' OR tenant_id = ?)
 		GROUP BY gen_ai_model, gen_ai_provider
 		ORDER BY SUM(gen_ai_cost_usd) DESC
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID, q.TenantID, q.TenantID)
+	`, q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID, q.TenantID, q.TenantID)
 	if err != nil {
 		return nil, fmt.Errorf("querying model breakdown: %w", err)
 	}
@@ -407,20 +407,20 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, q storage.UsageQuery, li
 			COALESCE((
 				SELECT s2.gen_ai_model FROM spans s2
 				WHERE s2.user_id = spans.user_id
-					AND s2.project_id = ? AND s2.start_time >= ? AND s2.start_time <= ?
+					AND (? = '' OR s2.project_id = ?) AND s2.start_time >= ? AND s2.start_time <= ?
 					AND s2.gen_ai_model != ''
 				GROUP BY s2.gen_ai_model
 				ORDER BY SUM(s2.gen_ai_cost_usd) DESC
 				LIMIT 1
 			), '') AS top_model
 		FROM spans
-		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
 			AND user_id != ''
 		GROUP BY user_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
-		q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)
+	`, q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+		q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying user leaderboard: %w", err)
 	}
@@ -457,20 +457,20 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, q storage.UsageQuery, 
 			COALESCE((
 				SELECT s2.gen_ai_model FROM spans s2
 				WHERE s2.tenant_id = spans.tenant_id
-					AND s2.project_id = ? AND s2.start_time >= ? AND s2.start_time <= ?
+					AND (? = '' OR s2.project_id = ?) AND s2.start_time >= ? AND s2.start_time <= ?
 					AND s2.gen_ai_model != ''
 				GROUP BY s2.gen_ai_model
 				ORDER BY SUM(s2.gen_ai_cost_usd) DESC
 				LIMIT 1
 			), '') AS top_model
 		FROM spans
-		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
 			AND tenant_id IS NOT NULL AND tenant_id != ''
 		GROUP BY tenant_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
-		q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)
+	`, q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+		q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying tenant leaderboard: %w", err)
 	}
@@ -500,20 +500,20 @@ func (s *Store) GetJobLeaderboard(ctx context.Context, q storage.UsageQuery, lim
 			COALESCE((
 				SELECT s2.gen_ai_model FROM spans s2
 				WHERE s2.job_id = spans.job_id
-					AND s2.project_id = ? AND s2.start_time >= ? AND s2.start_time <= ?
+					AND (? = '' OR s2.project_id = ?) AND s2.start_time >= ? AND s2.start_time <= ?
 					AND s2.gen_ai_model != ''
 				GROUP BY s2.gen_ai_model
 				ORDER BY SUM(s2.gen_ai_cost_usd) DESC
 				LIMIT 1
 			), '') AS top_model
 		FROM spans
-		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
+		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
 			AND job_id IS NOT NULL AND job_id != ''
 		GROUP BY job_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
-	`, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
-		q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)
+	`, q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+		q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying job leaderboard: %w", err)
 	}


### PR DESCRIPTION
## Problem

Candela Desktop team mode shows **no data** in all dashboard views, despite the web UI showing data correctly.

## Root Cause

All BigQuery **and** SQLite dashboard queries used strict equality for `project_id`:

```sql
WHERE project_id = @projectID
```

When the desktop (or curl) sends an empty `project_id`, this becomes `WHERE project_id = ''`, matching **zero rows** — even though data exists with `project_id = 'default'`.

The web UI works because it explicitly sends `project_id: 'default'` from its config.

## 4 Critical Issues Fixed

### 1. BigQuery: strict project_id filter (8 queries)
All BQ dashboard queries excluded data when `project_id` was empty.

### 2. SQLite: same strict project_id filter (10 queries)
The local-mode SQLite backend had the identical bug — Desktop local mode would also show empty dashboards.

### 3. SQLite: NULL scan crash in GetUsageSummary
`SUM(CASE WHEN kind = 1 THEN 1 ELSE 0 END)` returns NULL when no rows match, causing a scan error. Wrapped in `COALESCE(..., 0)`.

### 4. SQL formatting inconsistency (Gemini review)
`GetJobLeaderboard` had long single-line WHERE clauses. Split onto separate lines for readability and consistency with other query functions.

## Fix

Applied the same optional filter pattern already used for `userID` and `tenantID`:

```sql
-- Before (broken)
WHERE project_id = @projectID

-- After (works)
WHERE (@projectID = '' OR project_id = @projectID)
```

Empty `project_id` → no filter (all projects). Non-empty → exact match.

## Tests Added

**12 new SQLite integration tests** covering:
- Empty project_id returns data across all projects (7 query functions)
- Specific project_id scopes correctly (2 tests)
- UserID + project_id cross-filtering (2 subtests)
- TenantID + empty project_id (1 test)
- Nonexistent project returns zero (regression guard)

## Verification

```bash
# Before fix — empty result
curl -d '{}' .../GetUsageSummary  # {}

# After fix — returns data across all projects
curl -d '{}' .../GetUsageSummary
# {"totalTraces":"16", "totalSpans":"16", "totalCostUsd":1.19...}
```