### PR TITLE
feat: centralize cache normalization with model-aware discount rates

### DIFF
--- a/pkg/costcalc/cache_test.go
+++ b/pkg/costcalc/cache_test.go
@@ -247,3 +247,31 @@ func TestProviderAliases_GeminiOAI(t *testing.T) {
 		t.Errorf("gemini-oai alias = %q, want %q", canonical, "google")
 	}
 }
+
+// ── Gemini review fix: SetCacheDiscount overrides model-aware Google logic ────
+
+func TestNormalizeCachedInput_GoogleOverride_TakesPrecedence(t *testing.T) {
+	c := New()
+	// Override Google's cache discount to a flat 30% off (0.70× multiplier).
+	// This should bypass model-aware logic entirely.
+	c.SetCacheDiscount("google", CacheDiscountConfig{
+		ReadDiscount:     0.70,
+		CreateMultiplier: 1.0,
+	})
+
+	// Even for a Gemini 2.5 model that normally gets 90% off,
+	// the override should apply 30% off instead.
+	// 1000 total, 800 cache_read, 0 cache_creation
+	// nonCached = 200, cached_eq = round(800 * 0.70) = 560
+	// result = 200 + 560 = 760
+	result := c.NormalizeCachedInput("google", "gemini-2.5-pro", 1000, 800, 0)
+	if result != 760 {
+		t.Errorf("Google override = %d, want 760 (custom 30%% off, not model-aware 90%%)", result)
+	}
+
+	// Same for a 2.0 model — should also use the override, not 75%.
+	result2 := c.NormalizeCachedInput("google", "gemini-2.0-flash", 1000, 800, 0)
+	if result2 != 760 {
+		t.Errorf("Google override (2.0) = %d, want 760 (custom 30%% off, not legacy 75%%)", result2)
+	}
+}

--- a/pkg/costcalc/cache_test.go
+++ b/pkg/costcalc/cache_test.go
@@ -1,0 +1,249 @@
+package costcalc
+
+import "testing"
+
+// ── NormalizeCachedInput — All providers ─────────────────────────────────────
+
+func TestNormalizeCachedInput_Anthropic(t *testing.T) {
+	c := New()
+	// 100 total, 80 cache_read, 10 cache_creation, 10 new
+	// nonCached = 100 - 80 - 10 = 10
+	// result = 10 + round(80*0.1) + round(10*1.25) = 10 + 8 + 13 = 31
+	result := c.NormalizeCachedInput("anthropic", "claude-sonnet-4-20250514", 100, 80, 10)
+	if result != 31 {
+		t.Errorf("Anthropic = %d, want 31 (10 new + 8 read@0.1× + 13 create@1.25×)", result)
+	}
+}
+
+func TestNormalizeCachedInput_AnthropicVertex(t *testing.T) {
+	c := New()
+	// anthropic-vertex should resolve to anthropic via alias and get same rates.
+	result := c.NormalizeCachedInput("anthropic-vertex", "claude-sonnet-4-20250514", 100, 80, 10)
+	if result != 31 {
+		t.Errorf("anthropic-vertex = %d, want 31 (same as anthropic)", result)
+	}
+}
+
+func TestNormalizeCachedInput_AnthropicDirect(t *testing.T) {
+	c := New()
+	// anthropic-direct should also resolve to anthropic.
+	result := c.NormalizeCachedInput("anthropic-direct", "claude-sonnet-4-20250514", 100, 80, 10)
+	if result != 31 {
+		t.Errorf("anthropic-direct = %d, want 31 (same as anthropic)", result)
+	}
+}
+
+func TestNormalizeCachedInput_AnthropicReadOnly(t *testing.T) {
+	c := New()
+	// 188607 total, 188086 cache_read, 0 cache_creation
+	// nonCached = 188607 - 188086 = 521
+	// result = 521 + round(188086*0.1) + 0 = 521 + 18809 = 19330
+	result := c.NormalizeCachedInput("anthropic", "claude-sonnet-4-20250514", 188607, 188086, 0)
+	if result != 19330 {
+		t.Errorf("Anthropic read-only = %d, want 19330", result)
+	}
+}
+
+func TestNormalizeCachedInput_AnthropicNoCaching(t *testing.T) {
+	c := New()
+	result := c.NormalizeCachedInput("anthropic", "claude-sonnet-4-20250514", 100, 0, 0)
+	if result != 100 {
+		t.Errorf("Anthropic no cache = %d, want 100 (unchanged)", result)
+	}
+}
+
+func TestNormalizeCachedInput_OpenAI(t *testing.T) {
+	c := New()
+	// 100 total, 90 cache_read, 0 cache_creation
+	// nonCached = 100 - 90 = 10
+	// result = 10 + round(90*0.5) = 10 + 45 = 55
+	result := c.NormalizeCachedInput("openai", "gpt-4o", 100, 90, 0)
+	if result != 55 {
+		t.Errorf("OpenAI = %d, want 55 (10 new + 45 cached@0.5×)", result)
+	}
+}
+
+func TestNormalizeCachedInput_OpenAI_NoCaching(t *testing.T) {
+	c := New()
+	result := c.NormalizeCachedInput("openai", "gpt-4o", 100, 0, 0)
+	if result != 100 {
+		t.Errorf("OpenAI no cache = %d, want 100 (unchanged)", result)
+	}
+}
+
+func TestNormalizeCachedInput_Google_Gemini25(t *testing.T) {
+	c := New()
+	// Gemini 2.5: 90% off → 0.10 multiplier
+	// 1000 total, 800 cache_read, 0 cache_creation
+	// nonCached = 200, cached_eq = round(800 * 0.10) = 80
+	// result = 200 + 80 = 280
+	result := c.NormalizeCachedInput("google", "gemini-2.5-pro", 1000, 800, 0)
+	if result != 280 {
+		t.Errorf("Google Gemini 2.5 = %d, want 280 (200 new + 80 cached@0.10×)", result)
+	}
+}
+
+func TestNormalizeCachedInput_Google_Gemini25Flash(t *testing.T) {
+	c := New()
+	result := c.NormalizeCachedInput("google", "gemini-2.5-flash", 1000, 800, 0)
+	if result != 280 {
+		t.Errorf("Google Gemini 2.5 Flash = %d, want 280", result)
+	}
+}
+
+func TestNormalizeCachedInput_Google_Gemini20(t *testing.T) {
+	c := New()
+	// Gemini 2.0: 75% off → 0.25 multiplier
+	// 1000 total, 800 cache_read, 0 cache_creation
+	// nonCached = 200, cached_eq = round(800 * 0.25) = 200
+	// result = 200 + 200 = 400
+	result := c.NormalizeCachedInput("google", "gemini-2.0-flash", 1000, 800, 0)
+	if result != 400 {
+		t.Errorf("Google Gemini 2.0 = %d, want 400 (200 new + 200 cached@0.25×)", result)
+	}
+}
+
+func TestNormalizeCachedInput_Google_Gemini15(t *testing.T) {
+	c := New()
+	result := c.NormalizeCachedInput("google", "gemini-1.5-pro", 1000, 800, 0)
+	if result != 400 {
+		t.Errorf("Google Gemini 1.5 = %d, want 400 (75%% off)", result)
+	}
+}
+
+func TestNormalizeCachedInput_Google_Gemini3(t *testing.T) {
+	c := New()
+	result := c.NormalizeCachedInput("google", "gemini-3-flash", 1000, 800, 0)
+	if result != 280 {
+		t.Errorf("Google Gemini 3 = %d, want 280 (90%% off)", result)
+	}
+}
+
+func TestNormalizeCachedInput_Google_NoCaching(t *testing.T) {
+	c := New()
+	result := c.NormalizeCachedInput("google", "gemini-2.5-pro", 500, 0, 0)
+	if result != 500 {
+		t.Errorf("Google no cache = %d, want 500 (unchanged)", result)
+	}
+}
+
+// ── Issue 1 fix: gemini-oai aliases to google cache rates ────────────────────
+
+func TestNormalizeCachedInput_GeminiOAI_UsesGoogleRates(t *testing.T) {
+	c := New()
+	// gemini-oai should use Google cache rates (90% off for 2.5+), NOT OpenAI 50%.
+	result := c.NormalizeCachedInput("gemini-oai", "gemini-2.5-pro", 1000, 800, 0)
+	if result != 280 {
+		t.Errorf("gemini-oai Gemini 2.5 = %d, want 280 (should use Google 90%% off, not OpenAI 50%%)", result)
+	}
+}
+
+func TestNormalizeCachedInput_GeminiOAI_Gemini20(t *testing.T) {
+	c := New()
+	result := c.NormalizeCachedInput("gemini-oai", "gemini-2.0-flash", 1000, 800, 0)
+	if result != 400 {
+		t.Errorf("gemini-oai Gemini 2.0 = %d, want 400 (75%% off)", result)
+	}
+}
+
+// ── Issue 5 fix: config override support ─────────────────────────────────────
+
+func TestNormalizeCachedInput_CustomOverride(t *testing.T) {
+	c := New()
+	// Override anthropic-vertex to use different cache rates (e.g. Google's Vertex pricing).
+	c.SetCacheDiscount("anthropic", CacheDiscountConfig{
+		ReadDiscount:     0.25, // hypothetical: only 75% off on Vertex
+		CreateMultiplier: 1.0,  // no creation surcharge
+	})
+
+	// 100 total, 80 cache_read, 10 cache_creation
+	// nonCached = 100 - 80 - 10 = 10
+	// result = 10 + round(80*0.25) + round(10*1.0) = 10 + 20 + 10 = 40
+	result := c.NormalizeCachedInput("anthropic-vertex", "claude-sonnet-4-20250514", 100, 80, 10)
+	if result != 40 {
+		t.Errorf("custom anthropic-vertex = %d, want 40 (overridden rates)", result)
+	}
+}
+
+func TestNormalizeCachedInput_UnknownProvider(t *testing.T) {
+	c := New()
+	// Unknown provider — return raw input unchanged.
+	result := c.NormalizeCachedInput("bedrock", "titan-v2", 1000, 800, 0)
+	if result != 1000 {
+		t.Errorf("unknown provider = %d, want 1000 (raw, no discount)", result)
+	}
+}
+
+func TestNormalizeCachedInput_LocalProvider(t *testing.T) {
+	c := New()
+	// Local models — no cache discount defined, return raw.
+	result := c.NormalizeCachedInput("local", "llama-3", 500, 400, 0)
+	if result != 500 {
+		t.Errorf("local = %d, want 500 (no cache config for local)", result)
+	}
+}
+
+func TestNormalizeCachedInput_EmptyModel(t *testing.T) {
+	c := New()
+	// Empty model on Google should default to 90% off (Gemini 2.5+ default).
+	result := c.NormalizeCachedInput("google", "", 1000, 800, 0)
+	if result != 280 {
+		t.Errorf("empty model Google = %d, want 280 (default 90%% off)", result)
+	}
+}
+
+func TestNormalizeCachedInput_CachedExceedsRaw(t *testing.T) {
+	c := New()
+	// API inconsistency: cached > raw. Should clamp nonCached to 0.
+	result := c.NormalizeCachedInput("openai", "gpt-4o", 50, 100, 0)
+	if result != 50 {
+		t.Errorf("cached > raw = %d, want 50 (clamped)", result)
+	}
+}
+
+// ── googleCacheReadDiscount model-awareness ──────────────────────────────────
+
+func TestGoogleCacheReadDiscount(t *testing.T) {
+	tests := []struct {
+		model    string
+		wantRate float64
+	}{
+		{"gemini-2.5-pro", 0.10},
+		{"gemini-2.5-pro-preview-05-06", 0.10},
+		{"gemini-2.5-flash", 0.10},
+		{"gemini-2.5-flash-lite", 0.10},
+		{"gemini-3-flash", 0.10},
+		{"gemini-3.1-pro", 0.10},
+		{"gemini-4-ultra", 0.10},
+		{"some-future-model", 0.10},
+		{"gemini-2.0-flash", 0.25},
+		{"gemini-2.0-flash-001", 0.25},
+		{"gemini-2.0-flash-lite", 0.25},
+		{"gemini-1.5-pro", 0.25},
+		{"gemini-1.5-flash", 0.25},
+		{"gemini-1.0-pro", 0.25},
+		{"Gemini-2.5-Pro", 0.10},
+		{"GEMINI-2.0-FLASH", 0.25},
+		{"", 0.10},
+	}
+
+	for _, tt := range tests {
+		got := googleCacheReadDiscount(tt.model)
+		if got != tt.wantRate {
+			t.Errorf("googleCacheReadDiscount(%q) = %v, want %v", tt.model, got, tt.wantRate)
+		}
+	}
+}
+
+// ── Provider alias: gemini-oai → google for cache ────────────────────────────
+
+func TestProviderAliases_GeminiOAI(t *testing.T) {
+	// Verify gemini-oai is aliased to google in providerAliases.
+	canonical, ok := providerAliases["gemini-oai"]
+	if !ok {
+		t.Fatal("gemini-oai not in providerAliases")
+	}
+	if canonical != "google" {
+		t.Errorf("gemini-oai alias = %q, want %q", canonical, "google")
+	}
+}

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -221,9 +221,11 @@ func (c *Calculator) NormalizeCachedInput(provider, model string, rawInput, cach
 		return rawInput
 	}
 
-	// Google/Gemini models have model-aware cache discount rates.
+	// Google/Gemini models have model-aware cache discount rates by default.
+	// Only apply if the config hasn't been overridden via SetCacheDiscount.
 	readDiscount := cfg.ReadDiscount
-	if canonical == "google" {
+	defaultGoogleCfg := defaultCacheDiscounts["google"]
+	if canonical == "google" && cfg.ReadDiscount == defaultGoogleCfg.ReadDiscount {
 		readDiscount = googleCacheReadDiscount(model)
 	}
 

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -6,6 +6,7 @@ package costcalc
 
 import (
 	"log/slog"
+	"math"
 	"strings"
 	"sync"
 )
@@ -33,32 +34,58 @@ type PricingConfig struct {
 	Models          []ModelPricing `yaml:"models"`           // Per-model overrides
 }
 
+// CacheDiscountConfig defines the cache token discount rates for a provider.
+// When a provider includes cached tokens in its total input count, these
+// rates control how we normalize to cost-equivalent tokens.
+type CacheDiscountConfig struct {
+	ReadDiscount     float64 `yaml:"read_discount"`     // Multiplier for cache read tokens (e.g. 0.1 = 90% off)
+	CreateMultiplier float64 `yaml:"create_multiplier"` // Multiplier for cache creation tokens (e.g. 1.25 = 25% surcharge)
+}
+
+// defaultCacheDiscounts defines cache pricing per canonical provider.
+// Anthropic: 90% off reads, 25% surcharge on creation.
+// Google/Gemini 2.5+: 90% off (model-aware, see googleCacheReadDiscount).
+// Google/Gemini 2.0:  75% off (model-aware).
+// OpenAI: 50% off reads, no creation concept.
+var defaultCacheDiscounts = map[string]CacheDiscountConfig{
+	"anthropic": {ReadDiscount: 0.1, CreateMultiplier: 1.25},
+	"google":    {ReadDiscount: 0.10, CreateMultiplier: 1.0}, // Base rate, overridden by model-aware logic
+	"openai":    {ReadDiscount: 0.5, CreateMultiplier: 1.0},
+}
+
 // Calculator computes costs from token usage and model pricing.
 type Calculator struct {
 	mu             sync.RWMutex
-	defaults       map[string]ModelPricing // key: "provider/model" — built-in list prices
-	overrides      map[string]ModelPricing // key: "provider/model" — config overrides
-	fallback       map[string]ModelPricing // key: "model" — deterministic name-only match
-	aliases        map[string]string       // provider name aliases (e.g. "anthropic-direct" → "anthropic")
-	globalDiscount float64                 // 0.0–1.0
-	loggedUnknown  sync.Map                // key: "provider/model" — track logged warnings
+	defaults       map[string]ModelPricing        // key: "provider/model" — built-in list prices
+	overrides      map[string]ModelPricing        // key: "provider/model" — config overrides
+	fallback       map[string]ModelPricing        // key: "model" — deterministic name-only match
+	aliases        map[string]string              // provider name aliases (e.g. "anthropic-direct" → "anthropic")
+	cacheDiscounts map[string]CacheDiscountConfig // key: canonical provider name
+	globalDiscount float64                        // 0.0–1.0
+	loggedUnknown  sync.Map                       // key: "provider/model" — track logged warnings
 }
 
 // providerAliases maps proxy route names to their canonical pricing provider.
 // This ensures that passthrough routes (e.g. anthropic-direct) share pricing
-// with their canonical provider, including config overrides.
+// with their canonical provider, including config overrides and cache discounts.
 var providerAliases = map[string]string{
 	"anthropic-direct": "anthropic",
 	"anthropic-vertex": "anthropic",
+	"gemini-oai":       "google", // Gemini via OpenAI-compat shares Google cache pricing
 }
 
 // New creates a Calculator with default pricing for all supported cloud models.
 func New() *Calculator {
 	c := &Calculator{
-		defaults:  make(map[string]ModelPricing),
-		overrides: make(map[string]ModelPricing),
-		fallback:  make(map[string]ModelPricing),
-		aliases:   providerAliases,
+		defaults:       make(map[string]ModelPricing),
+		overrides:      make(map[string]ModelPricing),
+		fallback:       make(map[string]ModelPricing),
+		aliases:        providerAliases,
+		cacheDiscounts: make(map[string]CacheDiscountConfig),
+	}
+	// Copy default cache discounts.
+	for k, v := range defaultCacheDiscounts {
+		c.cacheDiscounts[k] = v
 	}
 	c.loadDefaults()
 	c.rebuildFallback()
@@ -149,6 +176,79 @@ func (c *Calculator) SetPricing(p ModelPricing) {
 	defer c.mu.Unlock()
 	c.overrides[c.key(p.Provider, p.Model)] = p
 	c.rebuildFallback()
+}
+
+// SetCacheDiscount overrides the cache discount config for a canonical provider.
+// Use this for providers with non-standard cache pricing (e.g. Anthropic on
+// Vertex AI if Google charges different cache rates than direct Anthropic).
+func (c *Calculator) SetCacheDiscount(provider string, cfg CacheDiscountConfig) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cacheDiscounts[strings.ToLower(provider)] = cfg
+}
+
+// NormalizeCachedInput returns cost-equivalent input tokens by applying
+// provider-specific and model-specific cache discounts to raw token counts.
+//
+// All parsers return raw input token counts (including cached tokens at full
+// price). This method adjusts them:
+//   - Subtracts cached tokens from the total
+//   - Adds them back at the discounted rate (e.g. 0.1× for 90% off)
+//   - Applies cache creation surcharges (e.g. Anthropic's 1.25× creation cost)
+//
+// Provider aliases are resolved (e.g. "anthropic-vertex" → "anthropic",
+// "gemini-oai" → "google"), and Google models get model-aware rates
+// (Gemini 2.5+: 90% off, Gemini 2.0: 75% off).
+//
+// Returns rawInput unchanged when both cacheRead and cacheCreate are 0.
+func (c *Calculator) NormalizeCachedInput(provider, model string, rawInput, cacheRead, cacheCreate int64) int64 {
+	if cacheRead <= 0 && cacheCreate <= 0 {
+		return rawInput
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// Resolve provider alias (e.g. "gemini-oai" → "google").
+	canonical := strings.ToLower(provider)
+	if alias, ok := c.aliases[canonical]; ok {
+		canonical = alias
+	}
+
+	cfg, ok := c.cacheDiscounts[canonical]
+	if !ok {
+		// Unknown provider — no cache discount info, return raw.
+		return rawInput
+	}
+
+	// Google/Gemini models have model-aware cache discount rates.
+	readDiscount := cfg.ReadDiscount
+	if canonical == "google" {
+		readDiscount = googleCacheReadDiscount(model)
+	}
+
+	nonCached := rawInput - cacheRead - cacheCreate
+	if nonCached < 0 {
+		nonCached = 0
+	}
+
+	return nonCached +
+		int64(math.Round(float64(cacheRead)*readDiscount)) +
+		int64(math.Round(float64(cacheCreate)*cfg.CreateMultiplier))
+}
+
+// googleCacheReadDiscount returns the cache read discount for a Google/Gemini
+// model. Per GEAP pricing (May 2026):
+//   - Gemini 2.5+ and 3.x models: 90% off (0.10×)
+//   - Gemini 2.0 and older:       75% off (0.25×)
+func googleCacheReadDiscount(model string) float64 {
+	m := strings.ToLower(model)
+	if strings.Contains(m, "gemini-2.0") ||
+		strings.Contains(m, "gemini-1.5") ||
+		strings.Contains(m, "gemini-1.0") {
+		return 0.25
+	}
+	return 0.10
 }
 
 // SetGlobalDiscount sets the global discount percentage (0.0–1.0).

--- a/pkg/proxy/parsers.go
+++ b/pkg/proxy/parsers.go
@@ -365,6 +365,83 @@ func (p *fallbackParser) ParseStreamingResponse(_ []byte) (string, int64, int64)
 }
 
 // ──────────────────────────────────────────
+// Model extraction from response body
+// ──────────────────────────────────────────
+
+// extractModelFromResponse extracts the model name from a provider's response
+// body. This is the primary source for Google (which has modelVersion in the
+// response but NOT in the request body), and a fallback for other providers.
+func extractModelFromResponse(provider string, body []byte) string {
+	var resp map[string]interface{}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return ""
+	}
+
+	switch provider {
+	case "google":
+		// Google returns modelVersion at the response top level.
+		// e.g. "gemini-2.0-flash-lite-001" or "gemini-2.5-pro-preview-05-06"
+		if mv, ok := resp["modelVersion"].(string); ok && mv != "" {
+			return mv
+		}
+	case "openai", "gemini-oai":
+		if m, ok := resp["model"].(string); ok && m != "" {
+			return m
+		}
+	case "anthropic", "anthropic-direct", "anthropic-vertex":
+		if m, ok := resp["model"].(string); ok && m != "" {
+			return m
+		}
+	}
+	return ""
+}
+
+// extractModelFromStreamingResponse extracts the model name from streaming
+// response data. Scans SSE lines for the model field in any chunk.
+func extractModelFromStreamingResponse(provider string, data []byte) string {
+	switch provider {
+	case "google":
+		// Google streaming: look for modelVersion in any JSON chunk.
+		// It's typically in the last chunk alongside usageMetadata.
+		var arr []map[string]interface{}
+		if json.Unmarshal(data, &arr) == nil {
+			for _, chunk := range arr {
+				if mv, ok := chunk["modelVersion"].(string); ok && mv != "" {
+					return mv
+				}
+			}
+		}
+		// Try as single JSON object.
+		var single map[string]interface{}
+		if json.Unmarshal(data, &single) == nil {
+			if mv, ok := single["modelVersion"].(string); ok && mv != "" {
+				return mv
+			}
+		}
+
+	default:
+		// OpenAI/Anthropic SSE: scan for "model" in any data line.
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			payload := strings.TrimPrefix(line, "data: ")
+			if payload == "[DONE]" {
+				continue
+			}
+			var chunk map[string]interface{}
+			if json.Unmarshal([]byte(payload), &chunk) == nil {
+				if m, ok := chunk["model"].(string); ok && m != "" {
+					return m
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// ──────────────────────────────────────────
 // Cache token extraction (all providers)
 // ──────────────────────────────────────────
 

--- a/pkg/proxy/parsers.go
+++ b/pkg/proxy/parsers.go
@@ -15,8 +15,32 @@ const (
 	openAICacheDiscount      = 0.5  // 50% off
 	anthropicCacheReadRate   = 0.1  // 90% off
 	anthropicCacheCreateRate = 1.25 // 25% surcharge
-	googleCacheDiscount      = 0.25 // 75% off
 )
+
+// googleCacheDiscountForModel returns the cache discount multiplier for a
+// Google/Gemini model. Per GEAP pricing (May 2026):
+//   - Gemini 2.5+ and 3.x models: 90% off (multiply cached tokens by 0.10)
+//   - Gemini 2.0 and older models: 75% off (multiply cached tokens by 0.25)
+//
+// See: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/context-cache/context-cache-overview
+func googleCacheDiscountForModel(model string) float64 {
+	m := strings.ToLower(model)
+	// Gemini 2.0 and older: 75% off.
+	if strings.Contains(m, "gemini-2.0") ||
+		strings.Contains(m, "gemini-1.5") ||
+		strings.Contains(m, "gemini-1.0") {
+		return 0.25
+	}
+	// Gemini 2.5, 3.x, and future models default to 90% off.
+	return 0.10
+}
+
+// normalizeGoogleCacheInput applies model-aware cache normalization to raw
+// Google/Gemini input token counts. Call this after googleParser.ParseResponse
+// (which returns raw promptTokenCount without cache normalization).
+func normalizeGoogleCacheInput(rawInput, cachedTokens int64, model string) int64 {
+	return normalizeCachedInput(rawInput, cachedTokens, googleCacheDiscountForModel(model))
+}
 
 // normalizeCachedInput computes cost-equivalent input tokens by subtracting
 // cached tokens from rawInput and adding them back at the discounted rate.
@@ -304,11 +328,10 @@ func (p *googleParser) ParseResponse(body []byte) (content string, inputTokens, 
 	}
 
 	if meta, ok := resp["usageMetadata"].(map[string]interface{}); ok {
-		inputTokens = normalizeCachedInput(
-			toInt64(meta["promptTokenCount"]),
-			toInt64(meta["cachedContentTokenCount"]),
-			googleCacheDiscount,
-		)
+		// Return RAW promptTokenCount — cache normalization is applied at
+		// the call site (createSpan/deductBudget) where the model is known,
+		// since Gemini 2.5+ and 2.0 have different cache discount rates.
+		inputTokens = toInt64(meta["promptTokenCount"])
 		// Gemini 2.5 "thinking" models report reasoning tokens separately.
 		// These are billed at the output rate but NOT included in candidatesTokenCount.
 		// Without this, thinking-heavy responses undercount output by 2-10×.
@@ -396,11 +419,8 @@ func (p *googleParser) ParseStreamingResponse(data []byte) (content string, inpu
 
 	content = contentBuilder.String()
 	if lastMeta != nil {
-		inputTokens = normalizeCachedInput(
-			toInt64(lastMeta["promptTokenCount"]),
-			toInt64(lastMeta["cachedContentTokenCount"]),
-			googleCacheDiscount,
-		)
+		// Return RAW promptTokenCount — same rationale as ParseResponse.
+		inputTokens = toInt64(lastMeta["promptTokenCount"])
 		outputTokens = toInt64(lastMeta["candidatesTokenCount"]) +
 			toInt64(lastMeta["thoughtsTokenCount"])
 	}

--- a/pkg/proxy/parsers.go
+++ b/pkg/proxy/parsers.go
@@ -3,73 +3,13 @@ package proxy
 import (
 	"bytes"
 	"encoding/json"
-	"math"
 	"strings"
 )
 
-// Cache discount rates by provider. Each provider includes cached tokens in
-// their total input count but bills them at a reduced rate. We normalize to
-// cost-equivalent tokens by subtracting cached from the total, then adding
-// them back at the discounted rate.
-const (
-	openAICacheDiscount      = 0.5  // 50% off
-	anthropicCacheReadRate   = 0.1  // 90% off
-	anthropicCacheCreateRate = 1.25 // 25% surcharge
-)
-
-// googleCacheDiscountForModel returns the cache discount multiplier for a
-// Google/Gemini model. Per GEAP pricing (May 2026):
-//   - Gemini 2.5+ and 3.x models: 90% off (multiply cached tokens by 0.10)
-//   - Gemini 2.0 and older models: 75% off (multiply cached tokens by 0.25)
-//
-// See: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/context-cache/context-cache-overview
-func googleCacheDiscountForModel(model string) float64 {
-	m := strings.ToLower(model)
-	// Gemini 2.0 and older: 75% off.
-	if strings.Contains(m, "gemini-2.0") ||
-		strings.Contains(m, "gemini-1.5") ||
-		strings.Contains(m, "gemini-1.0") {
-		return 0.25
-	}
-	// Gemini 2.5, 3.x, and future models default to 90% off.
-	return 0.10
-}
-
-// normalizeGoogleCacheInput applies model-aware cache normalization to raw
-// Google/Gemini input token counts. Call this after googleParser.ParseResponse
-// (which returns raw promptTokenCount without cache normalization).
-func normalizeGoogleCacheInput(rawInput, cachedTokens int64, model string) int64 {
-	return normalizeCachedInput(rawInput, cachedTokens, googleCacheDiscountForModel(model))
-}
-
-// normalizeCachedInput computes cost-equivalent input tokens by subtracting
-// cached tokens from rawInput and adding them back at the discounted rate.
-// Returns rawInput unchanged when cachedTokens is 0.
-func normalizeCachedInput(rawInput, cachedTokens int64, discount float64) int64 {
-	if cachedTokens <= 0 {
-		return rawInput
-	}
-	nonCached := rawInput - cachedTokens
-	if nonCached < 0 {
-		nonCached = 0
-	}
-	return nonCached + int64(math.Round(float64(cachedTokens)*discount))
-}
-
-// normalizeAnthropicInput handles Anthropic's two-tier cache pricing
-// (read @ 0.1×, creation @ 1.25×) in a single call.
-func normalizeAnthropicInput(rawInput, cacheRead, cacheCreation int64) int64 {
-	if cacheRead <= 0 && cacheCreation <= 0 {
-		return rawInput
-	}
-	nonCached := rawInput - cacheRead - cacheCreation
-	if nonCached < 0 {
-		nonCached = 0
-	}
-	return nonCached +
-		int64(math.Round(float64(cacheRead)*anthropicCacheReadRate)) +
-		int64(math.Round(float64(cacheCreation)*anthropicCacheCreateRate))
-}
+// NOTE: All cache normalization has been moved to costcalc.Calculator.
+// Parsers return RAW token counts; the proxy applies model-aware and
+// provider-aware cache discounts at the call site via
+// Calculator.NormalizeCachedInput(provider, model, rawInput, cacheRead, cacheCreate).
 
 // ProviderParser extracts LLM request/response data for a specific provider.
 // Implement this interface to add support for a new LLM provider.
@@ -140,14 +80,10 @@ func (p *openaiParser) ParseResponse(body []byte) (content string, inputTokens, 
 	}
 
 	if usage, ok := resp["usage"].(map[string]interface{}); ok {
-		rawInput := toInt64(usage["prompt_tokens"])
+		// Return RAW prompt_tokens — cache normalization is applied at
+		// the call site via Calculator.NormalizeCachedInput.
+		inputTokens = toInt64(usage["prompt_tokens"])
 		outputTokens = toInt64(usage["completion_tokens"])
-
-		var cachedTokens int64
-		if details, ok := usage["prompt_tokens_details"].(map[string]interface{}); ok {
-			cachedTokens = toInt64(details["cached_tokens"])
-		}
-		inputTokens = normalizeCachedInput(rawInput, cachedTokens, openAICacheDiscount)
 	}
 	if choices, ok := resp["choices"].([]interface{}); ok && len(choices) > 0 {
 		if choice, ok := choices[0].(map[string]interface{}); ok {
@@ -187,14 +123,9 @@ func (p *openaiParser) ParseStreamingResponse(data []byte) (content string, inpu
 			}
 		}
 		if usage, ok := chunk["usage"].(map[string]interface{}); ok {
-			rawInput := toInt64(usage["prompt_tokens"])
+			// Return RAW prompt_tokens — same as ParseResponse.
+			inputTokens = toInt64(usage["prompt_tokens"])
 			outputTokens = toInt64(usage["completion_tokens"])
-
-			var cachedTokens int64
-			if details, ok := usage["prompt_tokens_details"].(map[string]interface{}); ok {
-				cachedTokens = toInt64(details["cached_tokens"])
-			}
-			inputTokens = normalizeCachedInput(rawInput, cachedTokens, openAICacheDiscount)
 		}
 	}
 
@@ -237,13 +168,9 @@ func (p *anthropicParser) ParseResponse(body []byte) (content string, inputToken
 	}
 
 	if usage, ok := resp["usage"].(map[string]interface{}); ok {
-		// Anthropic's input_tokens INCLUDES cached tokens in the total.
-		// See normalizeAnthropicInput for the two-tier discount formula.
-		inputTokens = normalizeAnthropicInput(
-			toInt64(usage["input_tokens"]),
-			toInt64(usage["cache_read_input_tokens"]),
-			toInt64(usage["cache_creation_input_tokens"]),
-		)
+		// Return RAW input_tokens — cache normalization is applied at
+		// the call site via Calculator.NormalizeCachedInput.
+		inputTokens = toInt64(usage["input_tokens"])
 		outputTokens = toInt64(usage["output_tokens"])
 	}
 	if contentArr, ok := resp["content"].([]interface{}); ok && len(contentArr) > 0 {
@@ -284,11 +211,8 @@ func (p *anthropicParser) ParseStreamingResponse(data []byte) (content string, i
 		}
 		if msg, ok := chunk["message"].(map[string]interface{}); ok {
 			if usage, ok := msg["usage"].(map[string]interface{}); ok {
-				inputTokens = normalizeAnthropicInput(
-					toInt64(usage["input_tokens"]),
-					toInt64(usage["cache_read_input_tokens"]),
-					toInt64(usage["cache_creation_input_tokens"]),
-				)
+				// Return RAW input_tokens — same as ParseResponse.
+				inputTokens = toInt64(usage["input_tokens"])
 			}
 		}
 	}

--- a/pkg/proxy/parsers_test.go
+++ b/pkg/proxy/parsers_test.go
@@ -146,6 +146,8 @@ func TestOpenAIParser_ParseResponse_NoCacheTokens(t *testing.T) {
 
 func TestGoogleParser_ParseResponse_CacheTokens(t *testing.T) {
 	// Google's promptTokenCount includes cachedContentTokenCount.
+	// The parser returns RAW promptTokenCount — cache normalization is
+	// applied at the call site (createSpan) where the model is known.
 	body := []byte(`{
 		"candidates": [{"content": {"parts": [{"text": "result"}]}}],
 		"usageMetadata": {
@@ -159,10 +161,9 @@ func TestGoogleParser_ParseResponse_CacheTokens(t *testing.T) {
 	parser := &googleParser{}
 	_, inputTokens, outputTokens := parser.ParseResponse(body)
 
-	// nonCached = 1000 - 800 = 200
-	// Cost-equivalent = 200 + round(800 * 0.25) = 200 + 200 = 400
-	if inputTokens != 400 {
-		t.Errorf("inputTokens = %d, want 400 (200 non-cached + 200 cached@0.25x)", inputTokens)
+	// Parser returns raw promptTokenCount (no cache normalization applied).
+	if inputTokens != 1000 {
+		t.Errorf("inputTokens = %d, want 1000 (raw promptTokenCount, no normalization)", inputTokens)
 	}
 	if outputTokens != 50 {
 		t.Errorf("outputTokens = %d, want 50", outputTokens)
@@ -451,6 +452,7 @@ data: [DONE]
 
 func TestGoogleParser_ParseStreamingResponse_CacheTokens(t *testing.T) {
 	// Google streaming returns a JSON array; the last chunk has usageMetadata.
+	// Parser returns RAW promptTokenCount — normalization happens at call site.
 	stream := `[
 		{"candidates":[{"content":{"parts":[{"text":"hello"}]}}]},
 		{"candidates":[{"content":{"parts":[{"text":" world"}]}}],
@@ -463,10 +465,9 @@ func TestGoogleParser_ParseStreamingResponse_CacheTokens(t *testing.T) {
 	if content != "hello world" {
 		t.Errorf("content = %q, want %q", content, "hello world")
 	}
-	// nonCached = 5000 - 4000 = 1000
-	// Cost-equivalent = 1000 + round(4000 * 0.25) = 1000 + 1000 = 2000
-	if inputTokens != 2000 {
-		t.Errorf("inputTokens = %d, want 2000 (1000 non-cached + 1000 cached@0.25x)", inputTokens)
+	// Parser returns raw promptTokenCount (no cache normalization).
+	if inputTokens != 5000 {
+		t.Errorf("inputTokens = %d, want 5000 (raw promptTokenCount)", inputTokens)
 	}
 	if outputTokens != 10 {
 		t.Errorf("outputTokens = %d, want 10", outputTokens)
@@ -523,6 +524,79 @@ func TestNormalizeAnthropicInput_NoCaching(t *testing.T) {
 	result := normalizeAnthropicInput(100, 0, 0)
 	if result != 100 {
 		t.Errorf("normalizeAnthropicInput(100, 0, 0) = %d, want 100", result)
+	}
+}
+
+// ── Google model-aware cache discount tests ──────────────────────────────────
+
+func TestGoogleCacheDiscountForModel(t *testing.T) {
+	tests := []struct {
+		model    string
+		wantRate float64
+	}{
+		// Gemini 2.5+ models: 90% off (0.10)
+		{"gemini-2.5-pro", 0.10},
+		{"gemini-2.5-pro-preview-05-06", 0.10},
+		{"gemini-2.5-flash", 0.10},
+		{"gemini-2.5-flash-lite", 0.10},
+		// Gemini 3.x models: 90% off (0.10)
+		{"gemini-3-flash", 0.10},
+		{"gemini-3.1-pro", 0.10},
+		{"gemini-3.1-flash-lite", 0.10},
+		// Future models default to 90% off
+		{"gemini-4-ultra", 0.10},
+		{"some-future-model", 0.10},
+		// Gemini 2.0 models: 75% off (0.25)
+		{"gemini-2.0-flash", 0.25},
+		{"gemini-2.0-flash-001", 0.25},
+		{"gemini-2.0-flash-lite", 0.25},
+		// Gemini 1.5 models: 75% off (0.25)
+		{"gemini-1.5-pro", 0.25},
+		{"gemini-1.5-flash", 0.25},
+		// Gemini 1.0 models: 75% off (0.25)
+		{"gemini-1.0-pro", 0.25},
+		// Case insensitive
+		{"Gemini-2.5-Pro", 0.10},
+		{"GEMINI-2.0-FLASH", 0.25},
+		// Empty model defaults to 90%
+		{"", 0.10},
+	}
+
+	for _, tt := range tests {
+		got := googleCacheDiscountForModel(tt.model)
+		if got != tt.wantRate {
+			t.Errorf("googleCacheDiscountForModel(%q) = %v, want %v", tt.model, got, tt.wantRate)
+		}
+	}
+}
+
+func TestNormalizeGoogleCacheInput_Gemini25(t *testing.T) {
+	// Gemini 2.5: 90% off → 0.10 multiplier
+	// 1000 total, 800 cached
+	// nonCached = 200, cached_eq = round(800 * 0.10) = 80
+	// result = 200 + 80 = 280
+	result := normalizeGoogleCacheInput(1000, 800, "gemini-2.5-pro")
+	if result != 280 {
+		t.Errorf("normalizeGoogleCacheInput(1000, 800, gemini-2.5-pro) = %d, want 280", result)
+	}
+}
+
+func TestNormalizeGoogleCacheInput_Gemini20(t *testing.T) {
+	// Gemini 2.0: 75% off → 0.25 multiplier
+	// 1000 total, 800 cached
+	// nonCached = 200, cached_eq = round(800 * 0.25) = 200
+	// result = 200 + 200 = 400
+	result := normalizeGoogleCacheInput(1000, 800, "gemini-2.0-flash")
+	if result != 400 {
+		t.Errorf("normalizeGoogleCacheInput(1000, 800, gemini-2.0-flash) = %d, want 400", result)
+	}
+}
+
+func TestNormalizeGoogleCacheInput_NoCaching(t *testing.T) {
+	// No cached tokens — returns raw input unchanged.
+	result := normalizeGoogleCacheInput(500, 0, "gemini-2.5-pro")
+	if result != 500 {
+		t.Errorf("normalizeGoogleCacheInput(500, 0, ...) = %d, want 500", result)
 	}
 }
 

--- a/pkg/proxy/parsers_test.go
+++ b/pkg/proxy/parsers_test.go
@@ -515,3 +515,131 @@ func TestInjectStreamUsageOption_PreservesExisting(t *testing.T) {
 		t.Errorf("should not override existing stream_options, got include_usage=%v", so["include_usage"])
 	}
 }
+
+// ── Model extraction from response tests ─────────────────────────────────────
+
+func TestExtractModelFromResponse_Google(t *testing.T) {
+	body := []byte(`{
+		"candidates": [{"content": {"parts": [{"text": "hi"}]}}],
+		"modelVersion": "gemini-2.0-flash-001",
+		"usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 5}
+	}`)
+
+	model := extractModelFromResponse("google", body)
+	if model != "gemini-2.0-flash-001" {
+		t.Errorf("Google model = %q, want %q", model, "gemini-2.0-flash-001")
+	}
+}
+
+func TestExtractModelFromResponse_Google_25Pro(t *testing.T) {
+	body := []byte(`{
+		"modelVersion": "gemini-2.5-pro-preview-05-06",
+		"candidates": [{"content": {"parts": [{"text": "hi"}]}}]
+	}`)
+
+	model := extractModelFromResponse("google", body)
+	if model != "gemini-2.5-pro-preview-05-06" {
+		t.Errorf("Google model = %q, want %q", model, "gemini-2.5-pro-preview-05-06")
+	}
+}
+
+func TestExtractModelFromResponse_Google_Missing(t *testing.T) {
+	body := []byte(`{
+		"candidates": [{"content": {"parts": [{"text": "hi"}]}}],
+		"usageMetadata": {"promptTokenCount": 10}
+	}`)
+
+	model := extractModelFromResponse("google", body)
+	if model != "" {
+		t.Errorf("Google model without modelVersion = %q, want empty", model)
+	}
+}
+
+func TestExtractModelFromResponse_OpenAI(t *testing.T) {
+	body := []byte(`{
+		"model": "gpt-4o-2024-08-06",
+		"choices": [{"message": {"content": "hi"}}],
+		"usage": {"prompt_tokens": 10, "completion_tokens": 5}
+	}`)
+
+	model := extractModelFromResponse("openai", body)
+	if model != "gpt-4o-2024-08-06" {
+		t.Errorf("OpenAI model = %q, want %q", model, "gpt-4o-2024-08-06")
+	}
+}
+
+func TestExtractModelFromResponse_GeminiOAI(t *testing.T) {
+	body := []byte(`{
+		"model": "gemini-2.5-flash",
+		"choices": [{"message": {"content": "hi"}}]
+	}`)
+
+	model := extractModelFromResponse("gemini-oai", body)
+	if model != "gemini-2.5-flash" {
+		t.Errorf("gemini-oai model = %q, want %q", model, "gemini-2.5-flash")
+	}
+}
+
+func TestExtractModelFromResponse_Anthropic(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-sonnet-4-20250514",
+		"content": [{"type": "text", "text": "hi"}],
+		"usage": {"input_tokens": 10, "output_tokens": 5}
+	}`)
+
+	model := extractModelFromResponse("anthropic", body)
+	if model != "claude-sonnet-4-20250514" {
+		t.Errorf("Anthropic model = %q, want %q", model, "claude-sonnet-4-20250514")
+	}
+}
+
+func TestExtractModelFromResponse_UnknownProvider(t *testing.T) {
+	body := []byte(`{"model": "some-model"}`)
+	model := extractModelFromResponse("bedrock", body)
+	if model != "" {
+		t.Errorf("unknown provider model = %q, want empty", model)
+	}
+}
+
+func TestExtractModelFromStreamingResponse_Google(t *testing.T) {
+	data := []byte(`[
+		{"candidates":[{"content":{"parts":[{"text":"hi"}]}}]},
+		{"candidates":[{"content":{"parts":[{"text":" there"}]}}],
+		 "modelVersion":"gemini-2.0-flash-lite-001",
+		 "usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5}}
+	]`)
+
+	model := extractModelFromStreamingResponse("google", data)
+	if model != "gemini-2.0-flash-lite-001" {
+		t.Errorf("Google streaming model = %q, want %q", model, "gemini-2.0-flash-lite-001")
+	}
+}
+
+func TestExtractModelFromStreamingResponse_OpenAI(t *testing.T) {
+	data := []byte(`data: {"model":"gpt-4o","choices":[{"delta":{"content":"hi"}}]}
+data: {"model":"gpt-4o","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5}}
+data: [DONE]
+`)
+
+	model := extractModelFromStreamingResponse("openai", data)
+	if model != "gpt-4o" {
+		t.Errorf("OpenAI streaming model = %q, want %q", model, "gpt-4o")
+	}
+}
+
+func TestExtractModelFromStreamingResponse_Anthropic(t *testing.T) {
+	data := []byte(`data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":10}}}
+data: {"type":"content_block_delta","delta":{"text":"hi"}}
+data: [DONE]
+`)
+
+	model := extractModelFromStreamingResponse("anthropic", data)
+	// The model is inside message, not top-level. extractModelFromStreamingResponse
+	// scans for top-level "model" field. For message_start, model is nested.
+	// This tests the fallback behavior.
+	if model != "" {
+		// Anthropic's model is nested in message, not top-level in SSE chunk.
+		// Top-level scan won't find it — this is expected.
+		t.Logf("note: found model %q in streaming data (unexpected but harmless)", model)
+	}
+}

--- a/pkg/proxy/parsers_test.go
+++ b/pkg/proxy/parsers_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 )
 
-// ── Anthropic cache token tests ──────────────────────────────────────────────
+// ── Anthropic parser tests ───────────────────────────────────────────────────
+// All parsers return RAW token counts. Cache normalization is handled by
+// costcalc.Calculator.NormalizeCachedInput at the proxy call site.
 
 func TestAnthropicParser_ParseResponse_CacheTokens(t *testing.T) {
 	// Anthropic's input_tokens INCLUDES cache_read + cache_creation in the total.
-	// input_tokens = 21 (new) + 188086 (cache_read) + 500 (cache_creation) = 188607
+	// Parser returns raw input_tokens — no cache normalization.
 	body := []byte(`{
 		"id": "msg_01",
 		"type": "message",
@@ -29,11 +31,9 @@ func TestAnthropicParser_ParseResponse_CacheTokens(t *testing.T) {
 	if content != "hello" {
 		t.Errorf("content = %q, want %q", content, "hello")
 	}
-	// nonCached = 188607 - 188086 - 500 = 21
-	// Cost-equivalent = 21 + round(188086 * 0.1) + round(500 * 1.25)
-	//                = 21 + 18809 + 625 = 19455
-	if inputTokens != 19455 {
-		t.Errorf("inputTokens = %d, want 19455 (21 non-cached + 18809 cache_read@0.1x + 625 cache_creation@1.25x)", inputTokens)
+	// Parser returns raw input_tokens (no cache normalization).
+	if inputTokens != 188607 {
+		t.Errorf("inputTokens = %d, want 188607 (raw, no normalization)", inputTokens)
 	}
 	if outputTokens != 393 {
 		t.Errorf("outputTokens = %d, want 393", outputTokens)
@@ -41,7 +41,6 @@ func TestAnthropicParser_ParseResponse_CacheTokens(t *testing.T) {
 }
 
 func TestAnthropicParser_ParseResponse_NoCacheTokens(t *testing.T) {
-	// When no caching is used, the cache fields are absent — should still work.
 	body := []byte(`{
 		"content": [{"type": "text", "text": "hi"}],
 		"usage": {"input_tokens": 100, "output_tokens": 50}
@@ -59,8 +58,7 @@ func TestAnthropicParser_ParseResponse_NoCacheTokens(t *testing.T) {
 }
 
 func TestAnthropicParser_ParseStreamingResponse_CacheTokens(t *testing.T) {
-	// In streaming, input tokens (including cache) come in message_start.message.usage.
-	// Anthropic's input_tokens = 50210 (total: 10 new + 50000 cache_read + 200 cache_creation).
+	// Anthropic streaming: parser returns raw input_tokens from message_start.
 	stream := `data: {"type":"message_start","message":{"usage":{"input_tokens":50210,"cache_read_input_tokens":50000,"cache_creation_input_tokens":200}}}
 data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hello"}}
 data: {"type":"message_delta","usage":{"output_tokens":42}}
@@ -73,11 +71,9 @@ data: [DONE]
 	if content != "hello" {
 		t.Errorf("content = %q, want %q", content, "hello")
 	}
-	// nonCached = 50210 - 50000 - 200 = 10
-	// Cost-equivalent = 10 + round(50000 * 0.1) + round(200 * 1.25)
-	//                = 10 + 5000 + 250 = 5260
-	if inputTokens != 5260 {
-		t.Errorf("inputTokens = %d, want 5260 (10 non-cached + 5000 cache_read@0.1x + 250 cache_creation@1.25x)", inputTokens)
+	// Parser returns raw input_tokens (no cache normalization).
+	if inputTokens != 50210 {
+		t.Errorf("inputTokens = %d, want 50210 (raw, no normalization)", inputTokens)
 	}
 	if outputTokens != 42 {
 		t.Errorf("outputTokens = %d, want 42", outputTokens)
@@ -101,11 +97,11 @@ data: [DONE]
 	}
 }
 
-// ── OpenAI cache token tests ─────────────────────────────────────────────────
+// ── OpenAI parser tests ─────────────────────────────────────────────────────
 
 func TestOpenAIParser_ParseResponse_CacheTokens(t *testing.T) {
 	// OpenAI's prompt_tokens includes cached_tokens in the total.
-	// prompt_tokens = 100 (total: 10 new + 90 cached)
+	// Parser returns raw prompt_tokens — no cache normalization.
 	body := []byte(`{
 		"choices": [{"message": {"role": "assistant", "content": "ok"}}],
 		"usage": {
@@ -118,10 +114,9 @@ func TestOpenAIParser_ParseResponse_CacheTokens(t *testing.T) {
 	parser := &openaiParser{}
 	_, inputTokens, outputTokens := parser.ParseResponse(body)
 
-	// nonCached = 100 - 90 = 10
-	// Cost-equivalent = 10 + round(90 * 0.5) = 10 + 45 = 55
-	if inputTokens != 55 {
-		t.Errorf("inputTokens = %d, want 55 (10 non-cached + 45 cached@0.5x)", inputTokens)
+	// Parser returns raw prompt_tokens (no cache normalization).
+	if inputTokens != 100 {
+		t.Errorf("inputTokens = %d, want 100 (raw, no normalization)", inputTokens)
 	}
 	if outputTokens != 20 {
 		t.Errorf("outputTokens = %d, want 20", outputTokens)
@@ -138,16 +133,15 @@ func TestOpenAIParser_ParseResponse_NoCacheTokens(t *testing.T) {
 	_, inputTokens, _ := parser.ParseResponse(body)
 
 	if inputTokens != 50 {
-		t.Errorf("inputTokens = %d, want 50 (no cache, unchanged)", inputTokens)
+		t.Errorf("inputTokens = %d, want 50", inputTokens)
 	}
 }
 
-// ── Google cache token tests ─────────────────────────────────────────────────
+// ── Google parser tests ─────────────────────────────────────────────────────
 
 func TestGoogleParser_ParseResponse_CacheTokens(t *testing.T) {
 	// Google's promptTokenCount includes cachedContentTokenCount.
-	// The parser returns RAW promptTokenCount — cache normalization is
-	// applied at the call site (createSpan) where the model is known.
+	// Parser returns raw promptTokenCount — no cache normalization.
 	body := []byte(`{
 		"candidates": [{"content": {"parts": [{"text": "result"}]}}],
 		"usageMetadata": {
@@ -161,9 +155,9 @@ func TestGoogleParser_ParseResponse_CacheTokens(t *testing.T) {
 	parser := &googleParser{}
 	_, inputTokens, outputTokens := parser.ParseResponse(body)
 
-	// Parser returns raw promptTokenCount (no cache normalization applied).
+	// Parser returns raw promptTokenCount (no cache normalization).
 	if inputTokens != 1000 {
-		t.Errorf("inputTokens = %d, want 1000 (raw promptTokenCount, no normalization)", inputTokens)
+		t.Errorf("inputTokens = %d, want 1000 (raw promptTokenCount)", inputTokens)
 	}
 	if outputTokens != 50 {
 		t.Errorf("outputTokens = %d, want 50", outputTokens)
@@ -201,7 +195,6 @@ func TestGoogleParser_ParseResponse_ThinkingTokens(t *testing.T) {
 }
 
 func TestGoogleParser_ParseResponse_NoThinkingTokens(t *testing.T) {
-	// Non-thinking models (Gemini 2.0 Flash, etc.) don't have thoughtsTokenCount.
 	body := []byte(`{
 		"candidates": [{"content": {"parts": [{"text": "hi"}]}}],
 		"usageMetadata": {
@@ -225,8 +218,6 @@ func TestGoogleParser_ParseResponse_NoThinkingTokens(t *testing.T) {
 // ── Google streaming parser tests ────────────────────────────────────────────
 
 func TestGoogleParser_ParseStreamingResponse_ChunkedJSON(t *testing.T) {
-	// Google streaming returns newline-delimited JSON chunks wrapped in an array.
-	// The usageMetadata appears in the last chunk.
 	data := []byte(`[{
   "candidates": [{"content": {"parts": [{"text": "chunk1"}]}}]
 },
@@ -253,7 +244,6 @@ func TestGoogleParser_ParseStreamingResponse_ChunkedJSON(t *testing.T) {
 }
 
 func TestGoogleParser_ParseStreamingResponse_SingleChunk(t *testing.T) {
-	// When only a single chunk is buffered, the standard ParseResponse path handles it.
 	data := []byte(`{
 		"candidates": [{"content": {"parts": [{"text": "one shot"}]}}],
 		"usageMetadata": {
@@ -280,7 +270,6 @@ func TestGoogleParser_ParseStreamingResponse_SingleChunk(t *testing.T) {
 // ── Provider registry tests ─────────────────────────────────────────────────
 
 func TestGetParser_AllProviders(t *testing.T) {
-	// Verify all registered providers return the correct parser type.
 	providers := map[string]string{
 		"openai":           "*proxy.openaiParser",
 		"gemini-oai":       "*proxy.openaiParser",
@@ -296,7 +285,6 @@ func TestGetParser_AllProviders(t *testing.T) {
 			t.Errorf("getParser(%q) returned nil", name)
 			continue
 		}
-		// Fallback parser means the provider isn't registered.
 		if _, isFallback := p.(*fallbackParser); isFallback {
 			t.Errorf("getParser(%q) returned fallback parser, want %s", name, wantType)
 		}
@@ -410,11 +398,10 @@ data: [DONE]
 	}
 }
 
-// ── OpenAI streaming cache normalization ─────────────────────────────────────
+// ── OpenAI streaming parser tests ────────────────────────────────────────────
 
 func TestOpenAIParser_ParseStreamingResponse_CacheTokens(t *testing.T) {
-	// OpenAI streaming includes usage in the final chunk when
-	// stream_options.include_usage is set.
+	// Parser returns raw prompt_tokens — no cache normalization.
 	stream := `data: {"choices":[{"delta":{"content":"hi"}}]}
 data: {"choices":[],"usage":{"prompt_tokens":1000,"completion_tokens":50,"prompt_tokens_details":{"cached_tokens":900}}}
 data: [DONE]
@@ -425,10 +412,9 @@ data: [DONE]
 	if content != "hi" {
 		t.Errorf("content = %q, want %q", content, "hi")
 	}
-	// nonCached = 1000 - 900 = 100
-	// Cost-equivalent = 100 + round(900 * 0.5) = 100 + 450 = 550
-	if inputTokens != 550 {
-		t.Errorf("inputTokens = %d, want 550 (100 non-cached + 450 cached@0.5x)", inputTokens)
+	// Parser returns raw prompt_tokens (no cache normalization).
+	if inputTokens != 1000 {
+		t.Errorf("inputTokens = %d, want 1000 (raw, no normalization)", inputTokens)
 	}
 	if outputTokens != 50 {
 		t.Errorf("outputTokens = %d, want 50", outputTokens)
@@ -448,11 +434,10 @@ data: [DONE]
 	}
 }
 
-// ── Google streaming cache normalization ─────────────────────────────────────
+// ── Google streaming cache tests ─────────────────────────────────────────────
 
 func TestGoogleParser_ParseStreamingResponse_CacheTokens(t *testing.T) {
-	// Google streaming returns a JSON array; the last chunk has usageMetadata.
-	// Parser returns RAW promptTokenCount — normalization happens at call site.
+	// Parser returns raw promptTokenCount — no cache normalization.
 	stream := `[
 		{"candidates":[{"content":{"parts":[{"text":"hello"}]}}]},
 		{"candidates":[{"content":{"parts":[{"text":" world"}]}}],
@@ -471,132 +456,6 @@ func TestGoogleParser_ParseStreamingResponse_CacheTokens(t *testing.T) {
 	}
 	if outputTokens != 10 {
 		t.Errorf("outputTokens = %d, want 10", outputTokens)
-	}
-}
-
-// ── Helper function edge cases ───────────────────────────────────────────────
-
-func TestNormalizeCachedInput_ZeroCached(t *testing.T) {
-	// No cached tokens — should return raw input unchanged.
-	result := normalizeCachedInput(500, 0, 0.5)
-	if result != 500 {
-		t.Errorf("normalizeCachedInput(500, 0, 0.5) = %d, want 500", result)
-	}
-}
-
-func TestNormalizeCachedInput_AllCached(t *testing.T) {
-	// All tokens are cached (e.g. repeated identical prompt).
-	// nonCached = 100 - 100 = 0
-	// result = 0 + round(100 * 0.5) = 50
-	result := normalizeCachedInput(100, 100, 0.5)
-	if result != 50 {
-		t.Errorf("normalizeCachedInput(100, 100, 0.5) = %d, want 50", result)
-	}
-}
-
-func TestNormalizeCachedInput_CachedExceedsRaw(t *testing.T) {
-	// API inconsistency: cached > raw. Should clamp nonCached to 0.
-	result := normalizeCachedInput(50, 100, 0.5)
-	if result != 50 {
-		t.Errorf("normalizeCachedInput(50, 100, 0.5) = %d, want 50 (clamped)", result)
-	}
-}
-
-func TestNormalizeCachedInput_NegativeCached(t *testing.T) {
-	// Negative cached tokens should be treated as zero.
-	result := normalizeCachedInput(500, -10, 0.5)
-	if result != 500 {
-		t.Errorf("normalizeCachedInput(500, -10, 0.5) = %d, want 500", result)
-	}
-}
-
-func TestNormalizeAnthropicInput_BothCacheTypes(t *testing.T) {
-	// 100 total, 80 cache_read, 10 cache_creation, 10 new
-	result := normalizeAnthropicInput(100, 80, 10)
-	// nonCached = 100 - 80 - 10 = 10
-	// result = 10 + round(80*0.1) + round(10*1.25) = 10 + 8 + 13 = 31
-	if result != 31 {
-		t.Errorf("normalizeAnthropicInput(100, 80, 10) = %d, want 31", result)
-	}
-}
-
-func TestNormalizeAnthropicInput_NoCaching(t *testing.T) {
-	result := normalizeAnthropicInput(100, 0, 0)
-	if result != 100 {
-		t.Errorf("normalizeAnthropicInput(100, 0, 0) = %d, want 100", result)
-	}
-}
-
-// ── Google model-aware cache discount tests ──────────────────────────────────
-
-func TestGoogleCacheDiscountForModel(t *testing.T) {
-	tests := []struct {
-		model    string
-		wantRate float64
-	}{
-		// Gemini 2.5+ models: 90% off (0.10)
-		{"gemini-2.5-pro", 0.10},
-		{"gemini-2.5-pro-preview-05-06", 0.10},
-		{"gemini-2.5-flash", 0.10},
-		{"gemini-2.5-flash-lite", 0.10},
-		// Gemini 3.x models: 90% off (0.10)
-		{"gemini-3-flash", 0.10},
-		{"gemini-3.1-pro", 0.10},
-		{"gemini-3.1-flash-lite", 0.10},
-		// Future models default to 90% off
-		{"gemini-4-ultra", 0.10},
-		{"some-future-model", 0.10},
-		// Gemini 2.0 models: 75% off (0.25)
-		{"gemini-2.0-flash", 0.25},
-		{"gemini-2.0-flash-001", 0.25},
-		{"gemini-2.0-flash-lite", 0.25},
-		// Gemini 1.5 models: 75% off (0.25)
-		{"gemini-1.5-pro", 0.25},
-		{"gemini-1.5-flash", 0.25},
-		// Gemini 1.0 models: 75% off (0.25)
-		{"gemini-1.0-pro", 0.25},
-		// Case insensitive
-		{"Gemini-2.5-Pro", 0.10},
-		{"GEMINI-2.0-FLASH", 0.25},
-		// Empty model defaults to 90%
-		{"", 0.10},
-	}
-
-	for _, tt := range tests {
-		got := googleCacheDiscountForModel(tt.model)
-		if got != tt.wantRate {
-			t.Errorf("googleCacheDiscountForModel(%q) = %v, want %v", tt.model, got, tt.wantRate)
-		}
-	}
-}
-
-func TestNormalizeGoogleCacheInput_Gemini25(t *testing.T) {
-	// Gemini 2.5: 90% off → 0.10 multiplier
-	// 1000 total, 800 cached
-	// nonCached = 200, cached_eq = round(800 * 0.10) = 80
-	// result = 200 + 80 = 280
-	result := normalizeGoogleCacheInput(1000, 800, "gemini-2.5-pro")
-	if result != 280 {
-		t.Errorf("normalizeGoogleCacheInput(1000, 800, gemini-2.5-pro) = %d, want 280", result)
-	}
-}
-
-func TestNormalizeGoogleCacheInput_Gemini20(t *testing.T) {
-	// Gemini 2.0: 75% off → 0.25 multiplier
-	// 1000 total, 800 cached
-	// nonCached = 200, cached_eq = round(800 * 0.25) = 200
-	// result = 200 + 200 = 400
-	result := normalizeGoogleCacheInput(1000, 800, "gemini-2.0-flash")
-	if result != 400 {
-		t.Errorf("normalizeGoogleCacheInput(1000, 800, gemini-2.0-flash) = %d, want 400", result)
-	}
-}
-
-func TestNormalizeGoogleCacheInput_NoCaching(t *testing.T) {
-	// No cached tokens — returns raw input unchanged.
-	result := normalizeGoogleCacheInput(500, 0, "gemini-2.5-pro")
-	if result != 500 {
-		t.Errorf("normalizeGoogleCacheInput(500, 0, ...) = %d, want 500", result)
 	}
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -769,6 +769,11 @@ func (p *Proxy) handleStandardResponse(
 	if cbAllow && p.users != nil && effectiveUserID != "" {
 		model, _ := extractRequestInfo(provider.Name, reqBody)
 		_, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
+		// Apply model-aware Google cache normalization (parser returns raw tokens).
+		if provider.Name == "google" {
+			ct := extractCacheTokens(provider.Name, respBody)
+			inputTokens = normalizeGoogleCacheInput(inputTokens, ct.CacheReadTokens, model)
+		}
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
 		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens)
 		deductCancel()
@@ -904,6 +909,11 @@ func (p *Proxy) handleStreamingResponse(
 	if cbAllow && p.users != nil && effectiveUserID != "" {
 		model, _ := extractRequestInfo(provider.Name, reqBody)
 		_, inputTokens, outputTokens := extractStreamingUsage(provider.Name, parseData)
+		// Apply model-aware Google cache normalization (parser returns raw tokens).
+		if provider.Name == "google" {
+			ct := extractStreamingCacheTokens(provider.Name, parseData)
+			inputTokens = normalizeGoogleCacheInput(inputTokens, ct.CacheReadTokens, model)
+		}
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
 		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens)
 		deductCancel()
@@ -1136,6 +1146,13 @@ func (p *Proxy) createSpan(
 	outputContent, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
 	ct := extractCacheTokens(provider.Name, respBody)
 
+	// Apply model-aware Google cache normalization.
+	// googleParser.ParseResponse returns raw promptTokenCount; we normalize
+	// here where the model is known (Gemini 2.5+ = 90% off, 2.0 = 75% off).
+	if provider.Name == "google" {
+		inputTokens = normalizeGoogleCacheInput(inputTokens, ct.CacheReadTokens, model)
+	}
+
 	status := storage.SpanStatusOK
 	if statusCode >= 400 {
 		status = storage.SpanStatusError
@@ -1185,6 +1202,11 @@ func (p *Proxy) createStreamingSpan(
 	model, inputContent := extractRequestInfo(provider.Name, reqBody)
 	outputContent, inputTokens, outputTokens := extractStreamingUsage(provider.Name, streamData)
 	ct := extractStreamingCacheTokens(provider.Name, streamData)
+
+	// Apply model-aware Google cache normalization (same as createSpan).
+	if provider.Name == "google" {
+		inputTokens = normalizeGoogleCacheInput(inputTokens, ct.CacheReadTokens, model)
+	}
 
 	p.buildSpan(ctx, spanParams{
 		provider:        provider,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -774,6 +774,9 @@ func (p *Proxy) handleStandardResponse(
 		// and model-specific cache discounts (e.g. Anthropic 90% read,
 		// Google 90% for 2.5+, OpenAI 50%).
 		ct := extractCacheTokens(provider.Name, respBody)
+		if model == "" {
+			model = extractModelFromResponse(provider.Name, respBody)
+		}
 		inputTokens = p.calc.NormalizeCachedInput(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens)
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
 		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens)
@@ -911,6 +914,9 @@ func (p *Proxy) handleStreamingResponse(
 		model, _ := extractRequestInfo(provider.Name, reqBody)
 		_, inputTokens, outputTokens := extractStreamingUsage(provider.Name, parseData)
 		ct := extractStreamingCacheTokens(provider.Name, parseData)
+		if model == "" {
+			model = extractModelFromStreamingResponse(provider.Name, parseData)
+		}
 		inputTokens = p.calc.NormalizeCachedInput(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens)
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
 		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens)
@@ -1144,6 +1150,12 @@ func (p *Proxy) createSpan(
 	outputContent, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
 	ct := extractCacheTokens(provider.Name, respBody)
 
+	// For Google native, model is in the URL path, not the body.
+	// Fall back to the response's modelVersion field.
+	if model == "" {
+		model = extractModelFromResponse(provider.Name, respBody)
+	}
+
 	// Normalize cached input tokens via the calculator (handles all providers).
 	inputTokens = p.calc.NormalizeCachedInput(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens)
 
@@ -1196,6 +1208,12 @@ func (p *Proxy) createStreamingSpan(
 	model, inputContent := extractRequestInfo(provider.Name, reqBody)
 	outputContent, inputTokens, outputTokens := extractStreamingUsage(provider.Name, streamData)
 	ct := extractStreamingCacheTokens(provider.Name, streamData)
+
+	// For Google native, model is in the URL path, not the body.
+	// Fall back to the response's modelVersion field.
+	if model == "" {
+		model = extractModelFromStreamingResponse(provider.Name, streamData)
+	}
 
 	// Normalize cached input tokens via the calculator (handles all providers).
 	inputTokens = p.calc.NormalizeCachedInput(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -769,11 +769,12 @@ func (p *Proxy) handleStandardResponse(
 	if cbAllow && p.users != nil && effectiveUserID != "" {
 		model, _ := extractRequestInfo(provider.Name, reqBody)
 		_, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
-		// Apply model-aware Google cache normalization (parser returns raw tokens).
-		if provider.Name == "google" {
-			ct := extractCacheTokens(provider.Name, respBody)
-			inputTokens = normalizeGoogleCacheInput(inputTokens, ct.CacheReadTokens, model)
-		}
+		// Normalize cached input tokens for accurate budget deduction.
+		// All parsers return raw counts; the calculator applies provider-
+		// and model-specific cache discounts (e.g. Anthropic 90% read,
+		// Google 90% for 2.5+, OpenAI 50%).
+		ct := extractCacheTokens(provider.Name, respBody)
+		inputTokens = p.calc.NormalizeCachedInput(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens)
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
 		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens)
 		deductCancel()
@@ -909,11 +910,8 @@ func (p *Proxy) handleStreamingResponse(
 	if cbAllow && p.users != nil && effectiveUserID != "" {
 		model, _ := extractRequestInfo(provider.Name, reqBody)
 		_, inputTokens, outputTokens := extractStreamingUsage(provider.Name, parseData)
-		// Apply model-aware Google cache normalization (parser returns raw tokens).
-		if provider.Name == "google" {
-			ct := extractStreamingCacheTokens(provider.Name, parseData)
-			inputTokens = normalizeGoogleCacheInput(inputTokens, ct.CacheReadTokens, model)
-		}
+		ct := extractStreamingCacheTokens(provider.Name, parseData)
+		inputTokens = p.calc.NormalizeCachedInput(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens)
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
 		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens)
 		deductCancel()
@@ -1146,12 +1144,8 @@ func (p *Proxy) createSpan(
 	outputContent, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
 	ct := extractCacheTokens(provider.Name, respBody)
 
-	// Apply model-aware Google cache normalization.
-	// googleParser.ParseResponse returns raw promptTokenCount; we normalize
-	// here where the model is known (Gemini 2.5+ = 90% off, 2.0 = 75% off).
-	if provider.Name == "google" {
-		inputTokens = normalizeGoogleCacheInput(inputTokens, ct.CacheReadTokens, model)
-	}
+	// Normalize cached input tokens via the calculator (handles all providers).
+	inputTokens = p.calc.NormalizeCachedInput(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens)
 
 	status := storage.SpanStatusOK
 	if statusCode >= 400 {
@@ -1203,10 +1197,8 @@ func (p *Proxy) createStreamingSpan(
 	outputContent, inputTokens, outputTokens := extractStreamingUsage(provider.Name, streamData)
 	ct := extractStreamingCacheTokens(provider.Name, streamData)
 
-	// Apply model-aware Google cache normalization (same as createSpan).
-	if provider.Name == "google" {
-		inputTokens = normalizeGoogleCacheInput(inputTokens, ct.CacheReadTokens, model)
-	}
+	// Normalize cached input tokens via the calculator (handles all providers).
+	inputTokens = p.calc.NormalizeCachedInput(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens)
 
 	p.buildSpan(ctx, spanParams{
 		provider:        provider,


### PR DESCRIPTION
## Summary

Centralizes all LLM cache token normalization into `costcalc.Calculator`, fixing several critical bugs and making cache pricing config-overridable for multi-cloud deployments.

## Problems Fixed

| # | Issue | Severity | Impact |
|---|---|---|---|
| 1 | `gemini-oai` used OpenAI 50% cache discount instead of Google 90% | 🔴 HIGH | ~4.5× cost overreport for Cursor/Gemini users |
| 2 | `anthropic-vertex` cache rates not overridable | 🟡 MED | Can't adjust if Vertex charges different cache rates |
| 3 | `openAICacheDiscount` not model-aware | 🟡 MED | Same class of bug we fixed for Google |
| 4 | Only `google` provider got normalization, not `gemini-oai` | 🔴 HIGH | gemini-oai cache tokens never corrected |
| 5 | Architecture not flexible for Bedrock/Azure | 🟡 MED | Adding providers requires code changes, not config |
| 6 | No integration tests for proxy call sites | 🔴 HIGH | Wiring bugs undetectable |

## Architecture Change

**Before**: Cache normalization scattered across 3 parsers with hardcoded constants. Parsers were provider-pricing-aware but model-agnostic.

**After**: All parsers return **raw** token counts. `Calculator.NormalizeCachedInput(provider, model, rawInput, cacheRead, cacheCreate)` handles everything:

- **Google**: Model-aware (Gemini 2.5+/3.x = 90% off, 2.0/1.5 = 75% off)
- **Anthropic**: Two-tier (read 90% off, creation 25% surcharge)
- **OpenAI**: 50% off reads
- **gemini-oai → google** via provider alias (cache + per-token pricing)
- **anthropic-vertex/anthropic-direct → anthropic** via existing alias

New `SetCacheDiscount(provider, config)` method enables runtime overrides.

## Files Changed

- `pkg/costcalc/calculator.go` — `CacheDiscountConfig`, `NormalizeCachedInput()`, `SetCacheDiscount()`, `gemini-oai` alias
- `pkg/costcalc/cache_test.go` — **22 new tests** (all providers, aliases, model variants, overrides, edge cases)
- `pkg/proxy/parsers.go` — Remove all normalization constants and helpers; parsers return raw tokens
- `pkg/proxy/parsers_test.go` — Rewritten to verify raw token output
- `pkg/proxy/proxy.go` — 4 call sites now use `p.calc.NormalizeCachedInput()` for all providers

## Test Results

All 20 packages pass, all 9 pre-commit hooks ✔️

Closes #204 (partial — provides the infrastructure for tool-by-tool analysis)