### PR TITLE
fix: latency fallback to LLM spans when no root spans exist

### DIFF
--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -628,7 +628,11 @@ func (s *Store) GetUsageSummary(ctx context.Context, uq storage.UsageQuery) (*st
 			COALESCE(SUM(gen_ai_output_tokens), 0) AS total_output_tokens,
 			COALESCE(SUM(gen_ai_total_tokens), 0) AS total_tokens,
 			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
-			COALESCE(AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END), 0) AS avg_duration_ns,
+			COALESCE(
+				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = @llmKind THEN duration_ns ELSE NULL END),
+				0
+			) AS avg_duration_ns,
 			CASE WHEN COUNT(DISTINCT trace_id) > 0
 				THEN CAST(COUNT(DISTINCT CASE WHEN status = 2 THEN trace_id ELSE NULL END) AS FLOAT64) / COUNT(DISTINCT trace_id)
 				ELSE 0 END AS error_rate
@@ -769,7 +773,11 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, uq storage.UsageQuery, l
 			COUNT(DISTINCT trace_id) AS call_count,
 			COALESCE(SUM(gen_ai_total_tokens), 0) AS total_tokens,
 			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
-			COALESCE(AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END), 0) AS avg_duration_ns
+			COALESCE(
+				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = 1 THEN duration_ns ELSE NULL END),
+				0
+			) AS avg_duration_ns
 		FROM %s
 		WHERE (@projectID = '' OR project_id = @projectID)
 		  AND start_time >= @startTime
@@ -833,7 +841,11 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, uq storage.UsageQuery,
 			COUNT(DISTINCT trace_id) AS call_count,
 			COALESCE(SUM(gen_ai_total_tokens), 0) AS total_tokens,
 			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
-			COALESCE(AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END), 0) AS avg_duration_ns,
+			COALESCE(
+				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = 1 THEN duration_ns ELSE NULL END),
+				0
+			) AS avg_duration_ns,
 			COALESCE(
 				(SELECT m FROM UNNEST(ARRAY_AGG(gen_ai_model ORDER BY model_cost DESC LIMIT 1)) AS m),
 				''
@@ -901,7 +913,11 @@ func (s *Store) GetJobLeaderboard(ctx context.Context, uq storage.UsageQuery, li
 	query := fmt.Sprintf(`SELECT job_id, COUNT(DISTINCT trace_id) AS call_count,
 		COALESCE(SUM(gen_ai_total_tokens),0) AS total_tokens,
 		COALESCE(SUM(gen_ai_cost_usd),0) AS total_cost_usd,
-		COALESCE(AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),0) AS avg_duration_ns,
+		COALESCE(
+			AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+			AVG(CASE WHEN kind = 1 THEN duration_ns ELSE NULL END),
+			0
+		) AS avg_duration_ns,
 		COALESCE((
 			SELECT s2.gen_ai_model FROM %s s2
 			WHERE s2.job_id = spans.job_id

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -775,7 +775,7 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, uq storage.UsageQuery, l
 			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
 			COALESCE(
 				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
-				AVG(CASE WHEN kind = 1 THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = @llmKind THEN duration_ns ELSE NULL END),
 				0
 			) AS avg_duration_ns
 		FROM %s
@@ -793,6 +793,7 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, uq storage.UsageQuery, l
 		{Name: "projectID", Value: uq.ProjectID},
 		{Name: "startTime", Value: uq.StartTime},
 		{Name: "endTime", Value: uq.EndTime},
+		{Name: "llmKind", Value: int(storage.SpanKindLLM)},
 		{Name: "limit", Value: limit},
 	}
 
@@ -843,7 +844,7 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, uq storage.UsageQuery,
 			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
 			COALESCE(
 				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
-				AVG(CASE WHEN kind = 1 THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = @llmKind THEN duration_ns ELSE NULL END),
 				0
 			) AS avg_duration_ns,
 			COALESCE(
@@ -853,13 +854,13 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, uq storage.UsageQuery,
 		FROM (
 			SELECT
 				tenant_id, gen_ai_model, gen_ai_total_tokens, gen_ai_cost_usd,
-				duration_ns,
+				duration_ns, parent_span_id, kind,
 				SUM(gen_ai_cost_usd) OVER (PARTITION BY tenant_id, gen_ai_model) AS model_cost
 			FROM %s
 			WHERE (@projectID = '' OR project_id = @projectID)
 			  AND start_time >= @startTime
 			  AND start_time <= @endTime
-			  AND tenant_id IS NOT NULL AND tenant_id != '' AND gen_ai_model != ''
+			  AND tenant_id IS NOT NULL AND tenant_id != ''
 		)
 		GROUP BY tenant_id
 		ORDER BY total_cost_usd DESC
@@ -871,6 +872,7 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, uq storage.UsageQuery,
 		{Name: "projectID", Value: uq.ProjectID},
 		{Name: "startTime", Value: uq.StartTime},
 		{Name: "endTime", Value: uq.EndTime},
+		{Name: "llmKind", Value: int(storage.SpanKindLLM)},
 		{Name: "limit", Value: limit},
 	}
 
@@ -915,7 +917,7 @@ func (s *Store) GetJobLeaderboard(ctx context.Context, uq storage.UsageQuery, li
 		COALESCE(SUM(gen_ai_cost_usd),0) AS total_cost_usd,
 		COALESCE(
 			AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
-			AVG(CASE WHEN kind = 1 THEN duration_ns ELSE NULL END),
+			AVG(CASE WHEN kind = @llmKind THEN duration_ns ELSE NULL END),
 			0
 		) AS avg_duration_ns,
 		COALESCE((
@@ -938,7 +940,7 @@ func (s *Store) GetJobLeaderboard(ctx context.Context, uq storage.UsageQuery, li
 	ORDER BY total_cost_usd DESC
 	LIMIT @limit`, quoteTable(s.tableID), quoteTable(s.tableID))
 	q := s.client.Query(query)
-	q.Parameters = []bigquery.QueryParameter{{Name: "projectID", Value: uq.ProjectID}, {Name: "startTime", Value: uq.StartTime}, {Name: "endTime", Value: uq.EndTime}, {Name: "limit", Value: limit}}
+	q.Parameters = []bigquery.QueryParameter{{Name: "projectID", Value: uq.ProjectID}, {Name: "startTime", Value: uq.StartTime}, {Name: "endTime", Value: uq.EndTime}, {Name: "llmKind", Value: int(storage.SpanKindLLM)}, {Name: "limit", Value: limit}}
 	it, err := q.Read(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("querying job leaderboard: %w", err)

--- a/pkg/storage/duckdb/counting_math_test.go
+++ b/pkg/storage/duckdb/counting_math_test.go
@@ -437,10 +437,10 @@ func TestUserLeaderboard_AvgLatency_RootSpansOnly(t *testing.T) {
 	}
 }
 
-// TestGetUsageSummary_AvgLatency_NoRootSpans_FallsBackToZero tests the edge
+// TestGetUsageSummary_AvgLatency_NoRootSpans_FallsBackToLLMSpans tests the edge
 // case where all spans have a parent (e.g. W3C trace context propagation).
 // AVG(CASE WHEN parent_span_id=” ...) returns NULL → COALESCE to 0.
-func TestGetUsageSummary_AvgLatency_NoRootSpans_FallsBackToZero(t *testing.T) {
+func TestGetUsageSummary_AvgLatency_NoRootSpans_FallsBackToLLMSpans(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 	now := time.Now().Truncate(time.Microsecond)
@@ -468,9 +468,9 @@ func TestGetUsageSummary_AvgLatency_NoRootSpans_FallsBackToZero(t *testing.T) {
 		t.Fatalf("usage summary: %v", err)
 	}
 
-	// No root spans → latency should be 0 (COALESCE NULL → 0), not crash.
-	if summary.AvgLatencyMs != 0 {
-		t.Errorf("AvgLatencyMs = %.1f, want 0 (no root spans)", summary.AvgLatencyMs)
+	// No root spans → falls back to LLM span latency (~500ms).
+	if summary.AvgLatencyMs < 400 || summary.AvgLatencyMs > 600 {
+		t.Errorf("AvgLatencyMs = %.1f, want ~500 (LLM span fallback when no root spans)", summary.AvgLatencyMs)
 	}
 }
 

--- a/pkg/storage/duckdb/duckdb.go
+++ b/pkg/storage/duckdb/duckdb.go
@@ -360,14 +360,18 @@ func (s *Store) GetUsageSummary(ctx context.Context, q storage.UsageQuery) (*sto
 			COALESCE(SUM(gen_ai_input_tokens), 0)::BIGINT,
 			COALESCE(SUM(gen_ai_output_tokens), 0)::BIGINT,
 			COALESCE(SUM(gen_ai_cost_usd), 0)::DOUBLE,
-			COALESCE(AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END), 0)::DOUBLE / 1000000.0,
+			COALESCE(
+				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = ? THEN duration_ns ELSE NULL END),
+				0
+			)::DOUBLE / 1000000.0,
 			CASE WHEN COUNT(DISTINCT trace_id) > 0
 				THEN CAST(COUNT(DISTINCT CASE WHEN status = 2 THEN trace_id ELSE NULL END) AS DOUBLE) / COUNT(DISTINCT trace_id)
 				ELSE 0 END
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND (? = '' OR user_id = ?)
-	`, q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID).Scan(
+	`, int(storage.SpanKindLLM), q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID).Scan(
 		&summary.TotalTraces, &summary.TotalSpans, &summary.TotalLLMCalls,
 		&summary.TotalInputTokens, &summary.TotalOutputTokens, &summary.TotalCostUSD,
 		&summary.AvgLatencyMs, &summary.ErrorRate,
@@ -424,7 +428,11 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, q storage.UsageQuery, li
 			COUNT(DISTINCT trace_id)::BIGINT,
 			COALESCE(SUM(gen_ai_total_tokens), 0)::BIGINT,
 			COALESCE(SUM(gen_ai_cost_usd), 0)::DOUBLE,
-			COALESCE(AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END), 0)::DOUBLE / 1000000.0,
+			COALESCE(
+				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = ? THEN duration_ns ELSE NULL END),
+				0
+			)::DOUBLE / 1000000.0,
 			COALESCE((
 				SELECT s2.gen_ai_model FROM spans s2
 				WHERE s2.user_id = spans.user_id
@@ -440,7 +448,7 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, q storage.UsageQuery, li
 		GROUP BY user_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
-	`, q.ProjectID, q.StartTime, q.EndTime,
+	`, int(storage.SpanKindLLM), q.ProjectID, q.StartTime, q.EndTime,
 		q.ProjectID, q.StartTime, q.EndTime, limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying user leaderboard: %w", err)
@@ -474,7 +482,11 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, q storage.UsageQuery, 
 			COUNT(DISTINCT trace_id)::BIGINT,
 			COALESCE(SUM(gen_ai_total_tokens), 0)::BIGINT,
 			COALESCE(SUM(gen_ai_cost_usd), 0)::DOUBLE,
-			COALESCE(AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END), 0)::DOUBLE / 1000000.0,
+			COALESCE(
+				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = ? THEN duration_ns ELSE NULL END),
+				0
+			)::DOUBLE / 1000000.0,
 			COALESCE((
 				SELECT s2.gen_ai_model FROM spans s2
 				WHERE s2.tenant_id = spans.tenant_id
@@ -490,7 +502,7 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, q storage.UsageQuery, 
 		GROUP BY tenant_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
-	`, q.ProjectID, q.StartTime, q.EndTime, q.ProjectID, q.StartTime, q.EndTime, limit)
+	`, int(storage.SpanKindLLM), q.ProjectID, q.StartTime, q.EndTime, q.ProjectID, q.StartTime, q.EndTime, limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying tenant leaderboard: %w", err)
 	}
@@ -516,7 +528,11 @@ func (s *Store) GetJobLeaderboard(ctx context.Context, q storage.UsageQuery, lim
 		SELECT job_id, COUNT(DISTINCT trace_id)::BIGINT,
 			COALESCE(SUM(gen_ai_total_tokens), 0)::BIGINT,
 			COALESCE(SUM(gen_ai_cost_usd), 0)::DOUBLE,
-			COALESCE(AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END), 0)::DOUBLE / 1000000.0,
+			COALESCE(
+				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = ? THEN duration_ns ELSE NULL END),
+				0
+			)::DOUBLE / 1000000.0,
 			COALESCE((
 				SELECT s2.gen_ai_model FROM spans s2
 				WHERE s2.job_id = spans.job_id
@@ -532,7 +548,7 @@ func (s *Store) GetJobLeaderboard(ctx context.Context, q storage.UsageQuery, lim
 		GROUP BY job_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
-	`, q.ProjectID, q.StartTime, q.EndTime,
+	`, int(storage.SpanKindLLM), q.ProjectID, q.StartTime, q.EndTime,
 		q.ProjectID, q.StartTime, q.EndTime, limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying job leaderboard: %w", err)

--- a/pkg/storage/sqlite/counting_math_test.go
+++ b/pkg/storage/sqlite/counting_math_test.go
@@ -327,9 +327,9 @@ func TestUserLeaderboard_AvgLatency_RootSpansOnly(t *testing.T) {
 	}
 }
 
-// TestGetUsageSummary_AvgLatency_NoRootSpans_ReturnsZero tests the edge case
-// where all spans have a parent (W3C trace propagation). Should not crash.
-func TestGetUsageSummary_AvgLatency_NoRootSpans_ReturnsZero(t *testing.T) {
+// TestGetUsageSummary_AvgLatency_NoRootSpans_FallsBackToLLMSpans tests the edge case
+// where all spans have a parent (W3C trace propagation). Falls back to LLM span latency.
+func TestGetUsageSummary_AvgLatency_NoRootSpans_FallsBackToLLMSpans(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 	now := time.Now().UTC().Truncate(time.Microsecond)
@@ -357,8 +357,9 @@ func TestGetUsageSummary_AvgLatency_NoRootSpans_ReturnsZero(t *testing.T) {
 		t.Fatalf("usage summary: %v", err)
 	}
 
-	if summary.AvgLatencyMs != 0 {
-		t.Errorf("AvgLatencyMs = %.1f, want 0 (no root spans)", summary.AvgLatencyMs)
+	// No root spans → falls back to LLM span latency (~500ms).
+	if summary.AvgLatencyMs < 400 || summary.AvgLatencyMs > 600 {
+		t.Errorf("AvgLatencyMs = %.1f, want ~500 (LLM span fallback when no root spans)", summary.AvgLatencyMs)
 	}
 }
 

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -391,7 +391,11 @@ func (s *Store) GetUsageSummary(ctx context.Context, q storage.UsageQuery) (*sto
 			COALESCE(SUM(gen_ai_input_tokens), 0),
 			COALESCE(SUM(gen_ai_output_tokens), 0),
 			COALESCE(SUM(gen_ai_cost_usd), 0),
-			COALESCE(AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END), 0) / 1000000.0,
+			COALESCE(
+				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = ? THEN duration_ns ELSE NULL END),
+				0
+			) / 1000000.0,
 			CASE WHEN COUNT(DISTINCT trace_id) > 0
 				THEN CAST(COUNT(DISTINCT CASE WHEN status = 2 THEN trace_id ELSE NULL END) AS REAL) / COUNT(DISTINCT trace_id)
 				ELSE 0 END
@@ -399,7 +403,7 @@ func (s *Store) GetUsageSummary(ctx context.Context, q storage.UsageQuery) (*sto
 		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
 			AND (? = '' OR user_id = ?)
 			AND (? = '' OR tenant_id = ?)
-	`, q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID, q.TenantID, q.TenantID).Scan(
+	`, int(storage.SpanKindLLM), q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), q.UserID, q.UserID, q.TenantID, q.TenantID).Scan(
 		&summary.TotalTraces, &summary.TotalSpans, &summary.TotalLLMCalls,
 		&summary.TotalInputTokens, &summary.TotalOutputTokens, &summary.TotalCostUSD,
 		&summary.AvgLatencyMs, &summary.ErrorRate,
@@ -454,7 +458,11 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, q storage.UsageQuery, li
 			COUNT(DISTINCT trace_id),
 			COALESCE(SUM(gen_ai_total_tokens), 0),
 			COALESCE(SUM(gen_ai_cost_usd), 0),
-			COALESCE(AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END), 0) / 1000000.0,
+			COALESCE(
+				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = ? THEN duration_ns ELSE NULL END),
+				0
+			) / 1000000.0,
 			COALESCE((
 				SELECT s2.gen_ai_model FROM spans s2
 				WHERE s2.user_id = spans.user_id
@@ -470,7 +478,7 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, q storage.UsageQuery, li
 		GROUP BY user_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
-	`, q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+	`, int(storage.SpanKindLLM), q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
 		q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying user leaderboard: %w", err)
@@ -504,7 +512,11 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, q storage.UsageQuery, 
 			COUNT(DISTINCT trace_id),
 			COALESCE(SUM(gen_ai_total_tokens), 0),
 			COALESCE(SUM(gen_ai_cost_usd), 0),
-			COALESCE(AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END), 0) / 1000000.0,
+			COALESCE(
+				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = ? THEN duration_ns ELSE NULL END),
+				0
+			) / 1000000.0,
 			COALESCE((
 				SELECT s2.gen_ai_model FROM spans s2
 				WHERE s2.tenant_id = spans.tenant_id
@@ -520,7 +532,7 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, q storage.UsageQuery, 
 		GROUP BY tenant_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
-	`, q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+	`, int(storage.SpanKindLLM), q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
 		q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying tenant leaderboard: %w", err)
@@ -547,7 +559,11 @@ func (s *Store) GetJobLeaderboard(ctx context.Context, q storage.UsageQuery, lim
 		SELECT job_id, COUNT(DISTINCT trace_id),
 			COALESCE(SUM(gen_ai_total_tokens), 0),
 			COALESCE(SUM(gen_ai_cost_usd), 0),
-			COALESCE(AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END), 0) / 1000000.0,
+			COALESCE(
+				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = ? THEN duration_ns ELSE NULL END),
+				0
+			) / 1000000.0,
 			COALESCE((
 				SELECT s2.gen_ai_model FROM spans s2
 				WHERE s2.job_id = spans.job_id
@@ -563,7 +579,7 @@ func (s *Store) GetJobLeaderboard(ctx context.Context, q storage.UsageQuery, lim
 		GROUP BY job_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
-	`, q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+	`, int(storage.SpanKindLLM), q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
 		q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying job leaderboard: %w", err)


### PR DESCRIPTION
## Problem

When all spans have a `parent_span_id` (common with W3C trace context propagation from IDE tools like VS Code / Cursor), the root-span-only latency filter returned NULL → 0ms average latency across all dashboard views.

## Root Cause

The SQL query `AVG(CASE WHEN parent_span_id = '' THEN duration_ns ...)` matched nothing because every IDE-originated span inherits a parent from the W3C trace context header. The COALESCE then fell through to 0.

## Fix

Added a 3-level COALESCE fallback chain:
1. **Root span latency** (ideal — full request time)
2. **LLM span latency** (`kind = 1`) — fallback when no root spans exist
3. **0** — no data at all

Applied consistently across all 4 query methods in:
- `pkg/storage/bigquery/bigquery.go`
- `pkg/storage/duckdb/duckdb.go`
- `pkg/storage/sqlite/sqlite.go`

## Testing

- Updated `counting_math_test.go` in both DuckDB and SQLite to verify the fallback reports ~500ms (LLM span duration) instead of 0ms
- All existing tests pass with pre-commit hooks clean (go-vet, golangci-lint, go-test)