### PR TITLE
feat: consolidated BQ query for GetMyUsage via GROUPING SETS

### DIFF
--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -179,7 +179,7 @@ func (h *DashboardHandler) GetMyUsage(
 	var models []storage.ModelUsage
 
 	if combined, ok := h.store.(storage.CombinedUsageReader); ok {
-		// Single BQ query via GROUP BY ROLLUP — halves BQ cost for this RPC.
+		// Single BQ query via GROUP BY GROUPING SETS — halves BQ cost for this RPC.
 		s, m, err := combined.GetUsageWithModelBreakdown(ctx, q)
 		if err != nil {
 			return nil, internalError("failed to get combined usage", err)

--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -172,53 +172,63 @@ func (h *DashboardHandler) GetMyUsage(
 		q.EndTime = time.Now()
 	}
 
-	// ── BigQuery: usage summary + model breakdown (truly concurrent) ─────────
-	// Both queries hit BigQuery independently (~800ms each). Run them in
-	// separate goroutines so total wait is max(summary, breakdown) ≈ 800ms
-	// instead of sum ≈ 1600ms.
-	type summaryResult struct {
-		v   *storage.UsageSummary
-		err error
-	}
-	type modelsResult struct {
-		v   []storage.ModelUsage
-		err error
-	}
-	summaryCh := make(chan summaryResult, 1)
-	modelsCh := make(chan modelsResult, 1)
-	go func() {
-		v, err := h.store.GetUsageSummary(ctx, q)
-		summaryCh <- summaryResult{v, err}
-	}()
-	go func() {
-		v, err := h.store.GetModelBreakdown(ctx, q)
-		modelsCh <- modelsResult{v, err}
-	}()
-	sr := <-summaryCh
-	mr := <-modelsCh
-	if sr.err != nil {
-		return nil, internalError("failed to get usage summary", sr.err)
-	}
-	if mr.err != nil {
-		return nil, internalError("failed to get model breakdown", mr.err)
-	}
-	type bqResult struct {
-		summary *storage.UsageSummary
-		models  []storage.ModelUsage
-	}
-	bq := bqResult{summary: sr.v, models: mr.v}
+	// ── Storage query: usage summary + model breakdown ──────────────────────
+	// If the store implements CombinedUsageReader (BigQuery), fetch both in a
+	// single scan. Otherwise fall back to two concurrent reads.
+	var summary *storage.UsageSummary
+	var models []storage.ModelUsage
 
-	// Build response — token/cost figures are always from BigQuery.
+	if combined, ok := h.store.(storage.CombinedUsageReader); ok {
+		// Single BQ query via GROUP BY ROLLUP — halves BQ cost for this RPC.
+		s, m, err := combined.GetUsageWithModelBreakdown(ctx, q)
+		if err != nil {
+			return nil, internalError("failed to get combined usage", err)
+		}
+		summary = s
+		models = m
+	} else {
+		// Fallback: two concurrent reads for non-BigQuery backends.
+		type summaryResult struct {
+			v   *storage.UsageSummary
+			err error
+		}
+		type modelsResult struct {
+			v   []storage.ModelUsage
+			err error
+		}
+		summaryCh := make(chan summaryResult, 1)
+		modelsCh := make(chan modelsResult, 1)
+		go func() {
+			v, err := h.store.GetUsageSummary(ctx, q)
+			summaryCh <- summaryResult{v, err}
+		}()
+		go func() {
+			v, err := h.store.GetModelBreakdown(ctx, q)
+			modelsCh <- modelsResult{v, err}
+		}()
+		sr := <-summaryCh
+		mr := <-modelsCh
+		if sr.err != nil {
+			return nil, internalError("failed to get usage summary", sr.err)
+		}
+		if mr.err != nil {
+			return nil, internalError("failed to get model breakdown", mr.err)
+		}
+		summary = sr.v
+		models = mr.v
+	}
+
+	// Build response — token/cost figures are always from the storage backend.
 	// Budget progress bars and grant remaining: call UserService.GetMyBudget.
 	resp := &v1.GetMyUsageResponse{}
-	if bq.summary != nil {
-		resp.TotalCalls = bq.summary.TotalLLMCalls
-		resp.TotalInputTokens = bq.summary.TotalInputTokens
-		resp.TotalOutputTokens = bq.summary.TotalOutputTokens
-		resp.TotalCostUsd = bq.summary.TotalCostUSD
-		resp.AvgLatencyMs = bq.summary.AvgLatencyMs
+	if summary != nil {
+		resp.TotalCalls = summary.TotalLLMCalls
+		resp.TotalInputTokens = summary.TotalInputTokens
+		resp.TotalOutputTokens = summary.TotalOutputTokens
+		resp.TotalCostUsd = summary.TotalCostUSD
+		resp.AvgLatencyMs = summary.AvgLatencyMs
 	}
-	for _, m := range bq.models {
+	for _, m := range models {
 		resp.Models = append(resp.Models, &v1.ModelUsage{
 			Model:        m.Model,
 			Provider:     m.Provider,

--- a/pkg/connecthandlers/dashboard_handler_test.go
+++ b/pkg/connecthandlers/dashboard_handler_test.go
@@ -1,0 +1,164 @@
+package connecthandlers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	connect "connectrpc.com/connect"
+	v1 "github.com/candelahq/candela/gen/go/candela/v1"
+	"github.com/candelahq/candela/gen/go/candela/v1/candelav1connect"
+	"github.com/candelahq/candela/pkg/auth"
+	"github.com/candelahq/candela/pkg/connecthandlers"
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// ── Mock store that implements CombinedUsageReader ───────────────────────────
+
+// combinedStore embeds a minimal SpanReader and adds CombinedUsageReader.
+type combinedStore struct {
+	storage.SpanReader // nil — only GetUsageWithModelBreakdown is called
+	summary            *storage.UsageSummary
+	models             []storage.ModelUsage
+}
+
+func (s *combinedStore) GetUsageWithModelBreakdown(_ context.Context, _ storage.UsageQuery) (*storage.UsageSummary, []storage.ModelUsage, error) {
+	return s.summary, s.models, nil
+}
+
+// ── Mock store that does NOT implement CombinedUsageReader ───────────────────
+
+type fallbackStore struct {
+	summary *storage.UsageSummary
+	models  []storage.ModelUsage
+}
+
+func (s *fallbackStore) GetTrace(context.Context, string) (*storage.Trace, error) {
+	return nil, nil
+}
+func (s *fallbackStore) QueryTraces(context.Context, storage.TraceQuery) (*storage.TraceResult, error) {
+	return nil, nil
+}
+func (s *fallbackStore) SearchSpans(context.Context, storage.SpanQuery) (*storage.SpanResult, error) {
+	return nil, nil
+}
+func (s *fallbackStore) GetUsageSummary(_ context.Context, _ storage.UsageQuery) (*storage.UsageSummary, error) {
+	return s.summary, nil
+}
+func (s *fallbackStore) GetModelBreakdown(_ context.Context, _ storage.UsageQuery) ([]storage.ModelUsage, error) {
+	return s.models, nil
+}
+func (s *fallbackStore) GetUserLeaderboard(context.Context, storage.UsageQuery, int) ([]storage.UserUsageSummary, error) {
+	return nil, nil
+}
+func (s *fallbackStore) GetTenantLeaderboard(context.Context, storage.UsageQuery, int) ([]storage.TenantUsageSummary, error) {
+	return nil, nil
+}
+func (s *fallbackStore) GetJobLeaderboard(context.Context, storage.UsageQuery, int) ([]storage.JobUsageSummary, error) {
+	return nil, nil
+}
+func (s *fallbackStore) Ping(context.Context) error { return nil }
+func (s *fallbackStore) Close() error               { return nil }
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+func startDashboardServer(t *testing.T, store storage.SpanReader) candelav1connect.DashboardServiceClient {
+	t.Helper()
+	mux := http.NewServeMux()
+	path, handler := candelav1connect.NewDashboardServiceHandler(
+		connecthandlers.NewDashboardHandler(store, nil),
+	)
+	mux.Handle(path, handler)
+
+	// Inject an authenticated user into every request so GetMyUsage passes auth.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.NewContext(r.Context(), &auth.User{ID: "test-user", Email: "test@test.com"})
+		mux.ServeHTTP(w, r.WithContext(ctx))
+	}))
+	t.Cleanup(server.Close)
+
+	return candelav1connect.NewDashboardServiceClient(http.DefaultClient, server.URL)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+func TestGetMyUsage_CombinedReaderBranch(t *testing.T) {
+	// When the store implements CombinedUsageReader, the handler should use it
+	// instead of the two-concurrent-query fallback.
+	store := &combinedStore{
+		summary: &storage.UsageSummary{
+			TotalLLMCalls:    42,
+			TotalInputTokens: 10000,
+			TotalCostUSD:     1.23,
+		},
+		models: []storage.ModelUsage{
+			{Model: "claude-sonnet-4-20250514", Provider: "anthropic", CallCount: 30, CostUSD: 0.90,
+				CacheReadTokens: 5000, CacheCreationTokens: 200},
+			{Model: "gpt-4o", Provider: "openai", CallCount: 12, CostUSD: 0.33},
+		},
+	}
+
+	client := startDashboardServer(t, store)
+
+	resp, err := client.GetMyUsage(context.Background(), connect.NewRequest(&v1.GetMyUsageRequest{}))
+	if err != nil {
+		t.Fatalf("GetMyUsage failed: %v", err)
+	}
+
+	if resp.Msg.TotalCalls != 42 {
+		t.Errorf("TotalCalls = %d, want 42", resp.Msg.TotalCalls)
+	}
+	if resp.Msg.TotalCostUsd != 1.23 {
+		t.Errorf("TotalCostUsd = %f, want 1.23", resp.Msg.TotalCostUsd)
+	}
+	if len(resp.Msg.Models) != 2 {
+		t.Fatalf("Models count = %d, want 2", len(resp.Msg.Models))
+	}
+	if resp.Msg.Models[0].Model != "claude-sonnet-4-20250514" {
+		t.Errorf("Models[0].Model = %q, want claude-sonnet-4-20250514", resp.Msg.Models[0].Model)
+	}
+}
+
+func TestGetMyUsage_FallbackBranch(t *testing.T) {
+	// When the store does NOT implement CombinedUsageReader, the handler should
+	// fall back to concurrent GetUsageSummary + GetModelBreakdown.
+	store := &fallbackStore{
+		summary: &storage.UsageSummary{
+			TotalLLMCalls: 10,
+			TotalCostUSD:  0.50,
+		},
+		models: []storage.ModelUsage{
+			{Model: "gpt-4o", Provider: "openai", CallCount: 10, CostUSD: 0.50},
+		},
+	}
+
+	// Verify the store does NOT satisfy CombinedUsageReader.
+	if _, ok := storage.SpanReader(store).(storage.CombinedUsageReader); ok {
+		t.Fatal("fallbackStore should NOT implement CombinedUsageReader")
+	}
+
+	client := startDashboardServer(t, store)
+
+	resp, err := client.GetMyUsage(context.Background(), connect.NewRequest(&v1.GetMyUsageRequest{}))
+	if err != nil {
+		t.Fatalf("GetMyUsage fallback failed: %v", err)
+	}
+	if resp.Msg.TotalCalls != 10 {
+		t.Errorf("TotalCalls = %d, want 10", resp.Msg.TotalCalls)
+	}
+	if len(resp.Msg.Models) != 1 {
+		t.Errorf("Models count = %d, want 1", len(resp.Msg.Models))
+	}
+}
+
+// Compile-time assertion: combinedStore satisfies CombinedUsageReader.
+var _ storage.CombinedUsageReader = (*combinedStore)(nil)
+
+// Compile-time assertion: fallbackStore does NOT satisfy CombinedUsageReader.
+// (Verified at runtime in TestGetMyUsage_FallbackBranch above — can't
+// assert "does not implement" at compile time.)
+
+// Suppress unused-import lint for time (used by mock stubs if needed).
+var _ = time.Now

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -767,6 +767,139 @@ func (s *Store) GetModelBreakdown(ctx context.Context, uq storage.UsageQuery) ([
 	return models, nil
 }
 
+// GetUsageWithModelBreakdown fetches the usage summary and per-model breakdown
+// in a single BigQuery scan using GROUPING SETS. The overall summary is the row
+// where model IS NULL (the grand-total grouping set). Per-model rows have
+// model != NULL. This halves the BQ query count vs. running GetUsageSummary +
+// GetModelBreakdown separately.
+//
+// Implements [storage.CombinedUsageReader].
+func (s *Store) GetUsageWithModelBreakdown(ctx context.Context, uq storage.UsageQuery) (*storage.UsageSummary, []storage.ModelUsage, error) {
+	query := fmt.Sprintf(`
+		SELECT
+			gen_ai_model AS model,
+			gen_ai_provider AS provider,
+			COUNT(DISTINCT trace_id) AS total_traces,
+			COUNT(*) AS total_spans,
+			COUNTIF(kind = @llmKind) AS total_llm_calls,
+			COALESCE(SUM(gen_ai_input_tokens), 0) AS total_input_tokens,
+			COALESCE(SUM(gen_ai_output_tokens), 0) AS total_output_tokens,
+			COALESCE(SUM(gen_ai_total_tokens), 0) AS total_tokens,
+			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
+			COALESCE(
+				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN kind = @llmKind THEN duration_ns ELSE NULL END),
+				0
+			) AS avg_duration_ns,
+			CASE WHEN COUNT(DISTINCT trace_id) > 0
+				THEN CAST(COUNT(DISTINCT CASE WHEN status = 2 THEN trace_id ELSE NULL END) AS FLOAT64) / COUNT(DISTINCT trace_id)
+				ELSE 0 END AS error_rate,
+			COALESCE(SUM(gen_ai_cache_read_tokens), 0) AS total_cache_read_tokens,
+			COALESCE(SUM(gen_ai_cache_creation_tokens), 0) AS total_cache_creation_tokens,
+			GROUPING(gen_ai_model) AS is_total
+		FROM %s
+		WHERE (@projectID = '' OR project_id = @projectID)
+		  AND start_time >= @startTime
+		  AND start_time <= @endTime
+		  AND (@userID = '' OR user_id = @userID)
+		  AND (@tenantID = '' OR tenant_id = @tenantID)
+		GROUP BY GROUPING SETS (
+			(gen_ai_model, gen_ai_provider),
+			()
+		)
+		ORDER BY is_total DESC, total_cost_usd DESC
+	`, quoteTable(s.tableID))
+
+	q := s.client.Query(query)
+	q.Parameters = []bigquery.QueryParameter{
+		{Name: "projectID", Value: uq.ProjectID},
+		{Name: "startTime", Value: uq.StartTime},
+		{Name: "endTime", Value: uq.EndTime},
+		{Name: "llmKind", Value: int(storage.SpanKindLLM)},
+		{Name: "userID", Value: uq.UserID},
+		{Name: "tenantID", Value: uq.TenantID},
+	}
+
+	it, err := q.Read(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("querying combined usage: %w", err)
+	}
+
+	var summary *storage.UsageSummary
+	var models []storage.ModelUsage
+
+	for {
+		var row struct {
+			Model                    bigquery.NullString `bigquery:"model"`
+			Provider                 bigquery.NullString `bigquery:"provider"`
+			TotalTraces              int64               `bigquery:"total_traces"`
+			TotalSpans               int64               `bigquery:"total_spans"`
+			TotalLLMCalls            int64               `bigquery:"total_llm_calls"`
+			TotalInputTokens         int64               `bigquery:"total_input_tokens"`
+			TotalOutputTokens        int64               `bigquery:"total_output_tokens"`
+			TotalTokens              int64               `bigquery:"total_tokens"`
+			TotalCostUSD             float64             `bigquery:"total_cost_usd"`
+			AvgDurationNs            float64             `bigquery:"avg_duration_ns"`
+			ErrorRate                float64             `bigquery:"error_rate"`
+			TotalCacheReadTokens     int64               `bigquery:"total_cache_read_tokens"`
+			TotalCacheCreationTokens int64               `bigquery:"total_cache_creation_tokens"`
+			IsTotal                  int64               `bigquery:"is_total"`
+		}
+		err := it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, nil, fmt.Errorf("iterating combined usage: %w", err)
+		}
+
+		if row.IsTotal == 1 {
+			// Grand-total row → summary.
+			summary = &storage.UsageSummary{
+				TotalTraces:              row.TotalTraces,
+				TotalSpans:               row.TotalSpans,
+				TotalLLMCalls:            row.TotalLLMCalls,
+				TotalInputTokens:         row.TotalInputTokens,
+				TotalOutputTokens:        row.TotalOutputTokens,
+				TotalCostUSD:             row.TotalCostUSD,
+				AvgLatencyMs:             float64(row.AvgDurationNs) / 1e6,
+				ErrorRate:                row.ErrorRate,
+				TotalCacheReadTokens:     row.TotalCacheReadTokens,
+				TotalCacheCreationTokens: row.TotalCacheCreationTokens,
+			}
+		} else {
+			// Per-model row → model breakdown.
+			model := ""
+			if row.Model.Valid {
+				model = row.Model.StringVal
+			}
+			if model == "" {
+				continue // Skip rows with empty model (non-LLM spans).
+			}
+			provider := ""
+			if row.Provider.Valid {
+				provider = row.Provider.StringVal
+			}
+			models = append(models, storage.ModelUsage{
+				Model:        model,
+				Provider:     provider,
+				CallCount:    row.TotalLLMCalls,
+				InputTokens:  row.TotalInputTokens,
+				OutputTokens: row.TotalOutputTokens,
+				CostUSD:      row.TotalCostUSD,
+				AvgLatencyMs: float64(row.AvgDurationNs) / 1e6,
+			})
+		}
+	}
+
+	// If no rows at all, return an empty summary.
+	if summary == nil {
+		summary = &storage.UsageSummary{}
+	}
+
+	return summary, models, nil
+}
+
 // GetUserLeaderboard returns per-user usage aggregations ranked by cost.
 func (s *Store) GetUserLeaderboard(ctx context.Context, uq storage.UsageQuery, limit int) ([]storage.UserUsageSummary, error) {
 	if limit <= 0 {

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -767,6 +767,44 @@ func (s *Store) GetModelBreakdown(ctx context.Context, uq storage.UsageQuery) ([
 	return models, nil
 }
 
+// combinedUsageSQL is the GROUPING SETS query used by GetUsageWithModelBreakdown.
+// Extracted as a const for reviewability. The single %s placeholder is the
+// fully-qualified table name injected via quoteTable().
+const combinedUsageSQL = `
+	SELECT
+		gen_ai_model AS model,
+		gen_ai_provider AS provider,
+		COUNT(DISTINCT trace_id) AS total_traces,
+		COUNT(*) AS total_spans,
+		COUNTIF(kind = @llmKind) AS total_llm_calls,
+		COALESCE(SUM(gen_ai_input_tokens), 0) AS total_input_tokens,
+		COALESCE(SUM(gen_ai_output_tokens), 0) AS total_output_tokens,
+		COALESCE(SUM(gen_ai_total_tokens), 0) AS total_tokens,
+		COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
+		COALESCE(
+			AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
+			AVG(CASE WHEN kind = @llmKind THEN duration_ns ELSE NULL END),
+			0
+		) AS avg_duration_ns,
+		CASE WHEN COUNT(DISTINCT trace_id) > 0
+			THEN CAST(COUNT(DISTINCT CASE WHEN status = 2 THEN trace_id ELSE NULL END) AS FLOAT64) / COUNT(DISTINCT trace_id)
+			ELSE 0 END AS error_rate,
+		COALESCE(SUM(gen_ai_cache_read_tokens), 0) AS total_cache_read_tokens,
+		COALESCE(SUM(gen_ai_cache_creation_tokens), 0) AS total_cache_creation_tokens,
+		GROUPING(gen_ai_model) AS is_total
+	FROM %s
+	WHERE (@projectID = '' OR project_id = @projectID)
+	  AND start_time >= @startTime
+	  AND start_time <= @endTime
+	  AND (@userID = '' OR user_id = @userID)
+	  AND (@tenantID = '' OR tenant_id = @tenantID)
+	GROUP BY GROUPING SETS (
+		(gen_ai_model, gen_ai_provider),
+		()
+	)
+	ORDER BY is_total DESC, total_cost_usd DESC
+`
+
 // GetUsageWithModelBreakdown fetches the usage summary and per-model breakdown
 // in a single BigQuery scan using GROUPING SETS. The overall summary is the row
 // where model IS NULL (the grand-total grouping set). Per-model rows have
@@ -775,40 +813,7 @@ func (s *Store) GetModelBreakdown(ctx context.Context, uq storage.UsageQuery) ([
 //
 // Implements [storage.CombinedUsageReader].
 func (s *Store) GetUsageWithModelBreakdown(ctx context.Context, uq storage.UsageQuery) (*storage.UsageSummary, []storage.ModelUsage, error) {
-	query := fmt.Sprintf(`
-		SELECT
-			gen_ai_model AS model,
-			gen_ai_provider AS provider,
-			COUNT(DISTINCT trace_id) AS total_traces,
-			COUNT(*) AS total_spans,
-			COUNTIF(kind = @llmKind) AS total_llm_calls,
-			COALESCE(SUM(gen_ai_input_tokens), 0) AS total_input_tokens,
-			COALESCE(SUM(gen_ai_output_tokens), 0) AS total_output_tokens,
-			COALESCE(SUM(gen_ai_total_tokens), 0) AS total_tokens,
-			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
-			COALESCE(
-				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
-				AVG(CASE WHEN kind = @llmKind THEN duration_ns ELSE NULL END),
-				0
-			) AS avg_duration_ns,
-			CASE WHEN COUNT(DISTINCT trace_id) > 0
-				THEN CAST(COUNT(DISTINCT CASE WHEN status = 2 THEN trace_id ELSE NULL END) AS FLOAT64) / COUNT(DISTINCT trace_id)
-				ELSE 0 END AS error_rate,
-			COALESCE(SUM(gen_ai_cache_read_tokens), 0) AS total_cache_read_tokens,
-			COALESCE(SUM(gen_ai_cache_creation_tokens), 0) AS total_cache_creation_tokens,
-			GROUPING(gen_ai_model) AS is_total
-		FROM %s
-		WHERE (@projectID = '' OR project_id = @projectID)
-		  AND start_time >= @startTime
-		  AND start_time <= @endTime
-		  AND (@userID = '' OR user_id = @userID)
-		  AND (@tenantID = '' OR tenant_id = @tenantID)
-		GROUP BY GROUPING SETS (
-			(gen_ai_model, gen_ai_provider),
-			()
-		)
-		ORDER BY is_total DESC, total_cost_usd DESC
-	`, quoteTable(s.tableID))
+	query := fmt.Sprintf(combinedUsageSQL, quoteTable(s.tableID))
 
 	q := s.client.Query(query)
 	q.Parameters = []bigquery.QueryParameter{
@@ -862,7 +867,7 @@ func (s *Store) GetUsageWithModelBreakdown(ctx context.Context, uq storage.Usage
 				TotalInputTokens:         row.TotalInputTokens,
 				TotalOutputTokens:        row.TotalOutputTokens,
 				TotalCostUSD:             row.TotalCostUSD,
-				AvgLatencyMs:             float64(row.AvgDurationNs) / 1e6,
+				AvgLatencyMs:             row.AvgDurationNs / 1e6,
 				ErrorRate:                row.ErrorRate,
 				TotalCacheReadTokens:     row.TotalCacheReadTokens,
 				TotalCacheCreationTokens: row.TotalCacheCreationTokens,
@@ -881,13 +886,15 @@ func (s *Store) GetUsageWithModelBreakdown(ctx context.Context, uq storage.Usage
 				provider = row.Provider.StringVal
 			}
 			models = append(models, storage.ModelUsage{
-				Model:        model,
-				Provider:     provider,
-				CallCount:    row.TotalLLMCalls,
-				InputTokens:  row.TotalInputTokens,
-				OutputTokens: row.TotalOutputTokens,
-				CostUSD:      row.TotalCostUSD,
-				AvgLatencyMs: float64(row.AvgDurationNs) / 1e6,
+				Model:               model,
+				Provider:            provider,
+				CallCount:           row.TotalLLMCalls,
+				InputTokens:         row.TotalInputTokens,
+				OutputTokens:        row.TotalOutputTokens,
+				CostUSD:             row.TotalCostUSD,
+				AvgLatencyMs:        row.AvgDurationNs / 1e6,
+				CacheReadTokens:     row.TotalCacheReadTokens,
+				CacheCreationTokens: row.TotalCacheCreationTokens,
 			})
 		}
 	}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -336,6 +336,18 @@ type SpanReader interface {
 	Close() error
 }
 
+// CombinedUsageReader is an optional interface that storage backends can
+// implement to fetch a usage summary and per-model breakdown in a single
+// query instead of two separate queries. This is particularly beneficial
+// for columnar analytics engines (BigQuery, Databricks, Athena) where each
+// query job has fixed overhead.
+//
+// Backends that do not implement this interface will fall back to calling
+// GetUsageSummary + GetModelBreakdown concurrently.
+type CombinedUsageReader interface {
+	GetUsageWithModelBreakdown(ctx context.Context, q UsageQuery) (*UsageSummary, []ModelUsage, error)
+}
+
 // TraceStore combines read and write capabilities.
 // Embedded databases (DuckDB, SQLite) implement this. In production,
 // the write side (BigQuery Storage Write API) and read side (BigQuery SQL)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -280,6 +280,11 @@ type ModelUsage struct {
 	OutputTokens int64
 	CostUSD      float64
 	AvgLatencyMs float64
+
+	// Cache token aggregates per model — raw counts from provider APIs.
+	// Populated by CombinedUsageReader; zero when fetched via GetModelBreakdown.
+	CacheReadTokens     int64
+	CacheCreationTokens int64
 }
 
 type JobUsageSummary struct {

--- a/test/functional/mock/upstream.go
+++ b/test/functional/mock/upstream.go
@@ -81,6 +81,13 @@ func serveOpenAI(w http.ResponseWriter, r *http.Request) {
 		req.Model = "gpt-4o"
 	}
 
+	// Echo whether the internal header leaked.
+	if r.Header.Get("X-Candela-Caching") != "" {
+		w.Header().Set("X-Mock-Candela-Header-Leaked", "true")
+	} else {
+		w.Header().Set("X-Mock-Candela-Header-Leaked", "false")
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"id":      "chatcmpl-mock123",
@@ -109,6 +116,55 @@ func serveOpenAI(w http.ResponseWriter, r *http.Request) {
 }
 
 func serveAnthropic(w http.ResponseWriter, r *http.Request) {
+	// Decode request body to inspect cache_control injection.
+	var rawBody map[string]any
+	_ = json.NewDecoder(r.Body).Decode(&rawBody)
+
+	// Check if any system content block has cache_control.
+	hasCacheControl := false
+	if sys, ok := rawBody["system"]; ok {
+		if blocks, ok := sys.([]interface{}); ok {
+			for _, b := range blocks {
+				if block, ok := b.(map[string]interface{}); ok {
+					if _, ok := block["cache_control"]; ok {
+						hasCacheControl = true
+					}
+				}
+			}
+		}
+	}
+
+	// Check if any message content has cache_control (last user message).
+	if msgs, ok := rawBody["messages"].([]interface{}); ok {
+		for _, m := range msgs {
+			if msg, ok := m.(map[string]interface{}); ok {
+				if content, ok := msg["content"].([]interface{}); ok {
+					for _, c := range content {
+						if block, ok := c.(map[string]interface{}); ok {
+							if _, ok := block["cache_control"]; ok {
+								hasCacheControl = true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Echo what the mock received for test assertions.
+	if hasCacheControl {
+		w.Header().Set("X-Mock-Cache-Control-Present", "true")
+	} else {
+		w.Header().Set("X-Mock-Cache-Control-Present", "false")
+	}
+
+	// Echo whether the internal header leaked.
+	if r.Header.Get("X-Candela-Caching") != "" {
+		w.Header().Set("X-Mock-Candela-Header-Leaked", "true")
+	} else {
+		w.Header().Set("X-Mock-Candela-Header-Leaked", "false")
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"id":   "msg_mock123",

--- a/test/functional/proxy/proxy_caching_config.hurl
+++ b/test/functional/proxy/proxy_caching_config.hurl
@@ -92,20 +92,78 @@ HTTP 400
 jsonpath "$.error" == "invalid JSON"
 
 
-# ── X-Candela-Caching header is stripped from proxy requests ─────────────────
-# When sending a request with the override header to any provider,
-# the header must NOT be forwarded upstream (verified via mock upstream).
+# ── CACHE-07: Default (auto) → cache_control injected ────────────────────────
+# With no X-Candela-Caching header, the default mode (auto) should inject
+# cache_control blocks into the translated Anthropic request.
 POST {{CANDELA_URL}}/proxy/anthropic/v1/chat/completions
+Authorization: Bearer test-gcp-token
+Content-Type: application/json
+{
+  "model": "claude-sonnet-4-20250514",
+  "messages": [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Hello"}
+  ]
+}
+
+HTTP 200
+[Asserts]
+header "X-Mock-Cache-Control-Present" == "true"
+header "X-Mock-Candela-Header-Leaked" == "false"
+
+
+# ── CACHE-08: X-Candela-Caching: off → no cache_control injected ─────────────
+# Per-request override should suppress cache_control even though default is auto.
+POST {{CANDELA_URL}}/proxy/anthropic/v1/chat/completions
+Authorization: Bearer test-gcp-token
 Content-Type: application/json
 X-Candela-Caching: off
 {
   "model": "claude-sonnet-4-20250514",
-  "messages": [{"role": "user", "content": "hello"}]
+  "messages": [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Hello"}
+  ]
 }
 
-# We expect either 200 (mock) or 502 (no upstream) — but the request
-# should be accepted and header should not cause a 400 or 500.
-HTTP *
+HTTP 200
 [Asserts]
-status >= 200
-status <= 502
+header "X-Mock-Cache-Control-Present" == "false"
+header "X-Mock-Candela-Header-Leaked" == "false"
+
+
+# ── CACHE-09: X-Candela-Caching: auto → cache_control injected ───────────────
+# Explicit auto should behave the same as default.
+POST {{CANDELA_URL}}/proxy/anthropic/v1/chat/completions
+Authorization: Bearer test-gcp-token
+Content-Type: application/json
+X-Candela-Caching: auto
+{
+  "model": "claude-sonnet-4-20250514",
+  "messages": [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Hello"}
+  ]
+}
+
+HTTP 200
+[Asserts]
+header "X-Mock-Cache-Control-Present" == "true"
+header "X-Mock-Candela-Header-Leaked" == "false"
+
+
+# ── CACHE-10: X-Candela-Caching header never leaks to non-Anthropic providers ─
+# Even for providers without a FormatTranslator, the header must be stripped.
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test-key
+Content-Type: application/json
+X-Candela-Caching: auto
+{
+  "model": "gpt-4o",
+  "messages": [{"role": "user", "content": "Hello"}]
+}
+
+HTTP 200
+[Asserts]
+header "X-Mock-Candela-Header-Leaked" == "false"
+


### PR DESCRIPTION
Adds CombinedUsageReader interface + BigQuery implementation to fetch usage summary and model breakdown in a single table scan (was 2 separate queries).

**How:** GROUP BY GROUPING SETS computes grand-total + per-model rows in one pass. Handler uses type assertion — non-BQ backends fall back to concurrent reads.

**Impact:** Halves BQ query count for every GetMyUsage call.

**Backend agnostic:** CombinedUsageReader interface works for Databricks, Athena, etc.

**Verification:** All tests pass, pre-commit hooks green.

Related client PR: candelahq/candela-desktop#61