### PR TITLE
feat: add 'candela auth' subcommands for native OAuth login

### DIFF
--- a/cmd/candela/auth.go
+++ b/cmd/candela/auth.go
@@ -1,0 +1,390 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// adcCredentials represents the Application Default Credentials file format.
+// This is the same structure that `gcloud auth application-default login` writes.
+type adcCredentials struct {
+	Account      string `json:"account"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	QuotaProject string `json:"quota_project_id,omitempty"`
+	RefreshToken string `json:"refresh_token"`
+	Type         string `json:"type"`
+}
+
+// Google's well-known OAuth client for CLI tools. This is the same client_id
+// used by `gcloud auth application-default login` — it's public and intended
+// for native/desktop applications.
+var oauthConfig = &oauth2.Config{
+	ClientID:     "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com",
+	ClientSecret: "d-FL95Q19q7MQmFpd7hHD0Ty",
+	Scopes: []string{
+		"openid",
+		"https://www.googleapis.com/auth/userinfo.email",
+		"https://www.googleapis.com/auth/cloud-platform",
+	},
+	Endpoint: google.Endpoint,
+}
+
+// adcPath returns the standard Application Default Credentials file path.
+func adcPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "gcloud", "application_default_credentials.json"), nil
+}
+
+// handleAuth dispatches auth subcommands.
+func handleAuth(args []string) {
+	sub := ""
+	if len(args) > 0 {
+		sub = args[0]
+	}
+
+	switch sub {
+	case "login":
+		cmdAuthLogin()
+	case "status":
+		cmdAuthStatus()
+	case "token":
+		cmdAuthToken()
+	default:
+		_, _ = fmt.Fprintf(os.Stderr, `candela auth — manage Google Cloud credentials
+
+Usage:
+  candela auth login      Login via browser (writes ADC credentials)
+  candela auth status     Show current credential status
+  candela auth token      Print a fresh access token
+`)
+		if sub != "" {
+			os.Exit(1)
+		}
+	}
+}
+
+// cmdAuthLogin performs the OAuth2 authorization code flow via browser.
+func cmdAuthLogin() {
+	// Start a temporary HTTP server on a random port.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: failed to start local server: %v\n", err)
+		os.Exit(1)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	redirectURL := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
+	oauthConfig.RedirectURL = redirectURL
+
+	// Generate a random state parameter for CSRF protection.
+	stateBytes := make([]byte, 16)
+	if _, err := rand.Read(stateBytes); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: failed to generate random state: %v\n", err)
+		os.Exit(1)
+	}
+	state := base64.URLEncoding.EncodeToString(stateBytes)
+
+	// Channel to receive the auth result.
+	type authResult struct {
+		code string
+		err  error
+	}
+	resultCh := make(chan authResult, 1)
+
+	// Set up the callback handler.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("state") != state {
+			http.Error(w, "Invalid state parameter", http.StatusBadRequest)
+			resultCh <- authResult{err: fmt.Errorf("state mismatch")}
+			return
+		}
+
+		if errParam := r.URL.Query().Get("error"); errParam != "" {
+			desc := r.URL.Query().Get("error_description")
+			http.Error(w, "Authorization failed: "+desc, http.StatusBadRequest)
+			resultCh <- authResult{err: fmt.Errorf("authorization error: %s — %s", errParam, desc)}
+			return
+		}
+
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			http.Error(w, "No authorization code received", http.StatusBadRequest)
+			resultCh <- authResult{err: fmt.Errorf("no authorization code")}
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<!DOCTYPE html>
+<html><body style="font-family:system-ui;text-align:center;padding:60px">
+<h2>✅ Authenticated</h2>
+<p>You can close this tab and return to your terminal.</p>
+</body></html>`)
+		resultCh <- authResult{code: code}
+	})
+
+	server := &http.Server{Handler: mux}
+	go func() { _ = server.Serve(listener) }()
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	}()
+
+	// Build authorization URL and open browser.
+	authURL := oauthConfig.AuthCodeURL(state, oauth2.AccessTypeOffline)
+
+	fmt.Println("Opening browser to authenticate...")
+	fmt.Printf("If the browser doesn't open, visit:\n  %s\n\n", authURL)
+
+	if err := openBrowser(authURL); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "warning: could not open browser: %v\n", err)
+	}
+
+	// Wait for the callback (with timeout).
+	fmt.Println("Waiting for authentication...")
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", result.err)
+			os.Exit(1)
+		}
+
+		// Exchange the authorization code for tokens.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		token, err := oauthConfig.Exchange(ctx, result.code)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error: failed to exchange authorization code: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Write credentials to the standard ADC path.
+		if err := writeADC(token); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error: failed to write credentials: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Display the authenticated identity.
+		email := extractEmail(token)
+		path, _ := adcPath()
+		fmt.Printf("\n🕯️  Authenticated as: %s\n", email)
+		fmt.Printf("   Credentials saved to: %s\n", path)
+
+	case <-time.After(5 * time.Minute):
+		_, _ = fmt.Fprintf(os.Stderr, "error: authentication timed out (5 minutes)\n")
+		os.Exit(1)
+	}
+}
+
+// cmdAuthStatus reads the ADC file and displays credential status.
+func cmdAuthStatus() {
+	path, err := adcPath()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	creds, err := readADC(path)
+	if err != nil {
+		fmt.Println("● credentials: not configured")
+		fmt.Printf("  Run: candela auth login\n")
+		return
+	}
+
+	fmt.Printf("● credentials: %s\n", path)
+	fmt.Printf("  type:     %s\n", creds.Type)
+	if creds.QuotaProject != "" {
+		fmt.Printf("  project:  %s\n", creds.QuotaProject)
+	}
+
+	// Try to refresh and get identity info.
+	token, err := refreshFromADC(creds)
+	if err != nil {
+		fmt.Printf("  status:   ❌ refresh failed — %v\n", err)
+		fmt.Printf("  Run: candela auth login\n")
+		return
+	}
+
+	email := extractEmail(token)
+	remaining := time.Until(token.Expiry)
+
+	fmt.Printf("  account:  %s\n", email)
+	fmt.Printf("  status:   ✅ valid (expires in %s)\n", formatDuration(remaining))
+}
+
+// cmdAuthToken refreshes and prints a fresh access token (for piping).
+func cmdAuthToken() {
+	path, err := adcPath()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	creds, err := readADC(path)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: no credentials found — run: candela auth login\n")
+		os.Exit(1)
+	}
+
+	token, err := refreshFromADC(creds)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: failed to refresh token: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print just the token (suitable for piping to curl, etc.).
+	fmt.Print(token.AccessToken)
+}
+
+// writeADC writes OAuth2 credentials to the standard ADC file path.
+func writeADC(token *oauth2.Token) error {
+	path, err := adcPath()
+	if err != nil {
+		return err
+	}
+
+	// Ensure the directory exists.
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
+	creds := adcCredentials{
+		Account:      "",
+		ClientID:     oauthConfig.ClientID,
+		ClientSecret: oauthConfig.ClientSecret,
+		RefreshToken: token.RefreshToken,
+		Type:         "authorized_user",
+	}
+
+	data, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal credentials: %w", err)
+	}
+
+	// Write atomically: write to temp file then rename.
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write credentials: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed to save credentials: %w", err)
+	}
+
+	return nil
+}
+
+// readADC reads and parses the ADC credentials file.
+func readADC(path string) (*adcCredentials, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var creds adcCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("invalid credentials file: %w", err)
+	}
+
+	if creds.RefreshToken == "" {
+		return nil, fmt.Errorf("credentials file has no refresh token")
+	}
+
+	return &creds, nil
+}
+
+// refreshFromADC uses the refresh token to get a fresh access token.
+func refreshFromADC(creds *adcCredentials) (*oauth2.Token, error) {
+	cfg := &oauth2.Config{
+		ClientID:     creds.ClientID,
+		ClientSecret: creds.ClientSecret,
+		Endpoint:     google.Endpoint,
+	}
+
+	tokenSource := cfg.TokenSource(context.Background(), &oauth2.Token{
+		RefreshToken: creds.RefreshToken,
+	})
+
+	return tokenSource.Token()
+}
+
+// extractEmail attempts to extract the email from the ID token in the
+// OAuth2 token response. Falls back to "unknown" if unavailable.
+func extractEmail(token *oauth2.Token) string {
+	// The ID token is in token.Extra("id_token").
+	rawIDToken, ok := token.Extra("id_token").(string)
+	if !ok || rawIDToken == "" {
+		return "unknown"
+	}
+
+	// Decode the JWT payload (second segment).
+	parts := strings.Split(rawIDToken, ".")
+	if len(parts) < 2 {
+		return "unknown"
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "unknown"
+	}
+
+	var claims struct {
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "unknown"
+	}
+
+	if claims.Email != "" {
+		return claims.Email
+	}
+	return "unknown"
+}
+
+// formatDuration returns a human-friendly duration string.
+func formatDuration(d time.Duration) string {
+	if d < 0 {
+		return "expired"
+	}
+	if d < time.Minute {
+		return "< 1 min"
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%d min", int(d.Minutes()))
+	}
+	return fmt.Sprintf("%dh %dm", int(d.Hours()), int(d.Minutes())%60)
+}
+
+// openBrowser opens a URL in the system's default browser.
+func openBrowser(url string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", url).Start()
+	case "linux":
+		return exec.Command("xdg-open", url).Start()
+	case "windows":
+		return exec.Command("cmd", "/c", "start", url).Start()
+	default:
+		return fmt.Errorf("unsupported platform %s", runtime.GOOS)
+	}
+}

--- a/cmd/candela/auth.go
+++ b/cmd/candela/auth.go
@@ -45,7 +45,19 @@ var oauthConfig = &oauth2.Config{
 }
 
 // adcPath returns the standard Application Default Credentials file path.
+// Supports CLOUDSDK_CONFIG override, Windows (APPDATA), and Unix (~/.config).
 func adcPath() (string, error) {
+	// Respect CLOUDSDK_CONFIG if set (same as gcloud).
+	if p := os.Getenv("CLOUDSDK_CONFIG"); p != "" {
+		return filepath.Join(p, "application_default_credentials.json"), nil
+	}
+	if runtime.GOOS == "windows" {
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			return "", fmt.Errorf("APPDATA environment variable not set")
+		}
+		return filepath.Join(appData, "gcloud", "application_default_credentials.json"), nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("cannot determine home directory: %w", err)
@@ -140,7 +152,7 @@ func cmdAuthLogin() {
 		resultCh <- authResult{code: code}
 	})
 
-	server := &http.Server{Handler: mux}
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 	go func() { _ = server.Serve(listener) }()
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -286,6 +298,10 @@ func writeADC(token *oauth2.Token) error {
 	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
 		return fmt.Errorf("failed to write credentials: %w", err)
 	}
+	// On Windows, os.Rename fails if the destination exists.
+	if runtime.GOOS == "windows" {
+		_ = os.Remove(path)
+	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed to save credentials: %w", err)
@@ -321,7 +337,10 @@ func refreshFromADC(creds *adcCredentials) (*oauth2.Token, error) {
 		Endpoint:     google.Endpoint,
 	}
 
-	tokenSource := cfg.TokenSource(context.Background(), &oauth2.Token{
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tokenSource := cfg.TokenSource(ctx, &oauth2.Token{
 		RefreshToken: creds.RefreshToken,
 	})
 
@@ -383,7 +402,7 @@ func openBrowser(url string) error {
 	case "linux":
 		return exec.Command("xdg-open", url).Start()
 	case "windows":
-		return exec.Command("cmd", "/c", "start", url).Start()
+		return exec.Command("cmd", "/c", "start", "", url).Start()
 	default:
 		return fmt.Errorf("unsupported platform %s", runtime.GOOS)
 	}

--- a/cmd/candela/auth_test.go
+++ b/cmd/candela/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -121,7 +122,7 @@ func TestAdcPath(t *testing.T) {
 	if !filepath.IsAbs(path) {
 		t.Errorf("adcPath returned relative path: %s", path)
 	}
-	if !contains(path, "application_default_credentials.json") {
+	if !strings.Contains(path, "application_default_credentials.json") {
 		t.Errorf("adcPath missing expected filename: %s", path)
 	}
 }
@@ -153,17 +154,4 @@ func TestHandleAuth_Help(t *testing.T) {
 	// Just verify handleAuth doesn't panic with empty args.
 	// It writes to stderr but shouldn't crash.
 	handleAuth(nil)
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
-}
-
-func containsHelper(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/candela/auth_test.go
+++ b/cmd/candela/auth_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func TestWriteAndReadADC(t *testing.T) {
+	// Use a temp dir to avoid touching real credentials.
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "application_default_credentials.json")
+
+	token := &oauth2.Token{
+		RefreshToken: "test-refresh-token-12345",
+	}
+
+	creds := adcCredentials{
+		Account:      "",
+		ClientID:     oauthConfig.ClientID,
+		ClientSecret: oauthConfig.ClientSecret,
+		RefreshToken: token.RefreshToken,
+		Type:         "authorized_user",
+	}
+
+	data, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Read it back.
+	got, err := readADC(path)
+	if err != nil {
+		t.Fatalf("readADC: %v", err)
+	}
+
+	if got.Type != "authorized_user" {
+		t.Errorf("type = %q, want %q", got.Type, "authorized_user")
+	}
+	if got.RefreshToken != "test-refresh-token-12345" {
+		t.Errorf("refresh_token = %q, want %q", got.RefreshToken, "test-refresh-token-12345")
+	}
+	if got.ClientID != oauthConfig.ClientID {
+		t.Errorf("client_id = %q, want %q", got.ClientID, oauthConfig.ClientID)
+	}
+}
+
+func TestReadADC_MissingFile(t *testing.T) {
+	_, err := readADC("/nonexistent/path/to/adc.json")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestReadADC_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "bad.json")
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := readADC(path)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestReadADC_NoRefreshToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "no_refresh.json")
+	data := `{"type":"authorized_user","client_id":"id","client_secret":"secret"}`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := readADC(path)
+	if err == nil {
+		t.Fatal("expected error for missing refresh token")
+	}
+}
+
+func TestExtractEmail(t *testing.T) {
+	// Token with no id_token extra → "unknown".
+	token := &oauth2.Token{AccessToken: "test"}
+	if got := extractEmail(token); got != "unknown" {
+		t.Errorf("extractEmail(no id_token) = %q, want %q", got, "unknown")
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{-time.Second, "expired"},
+		{30 * time.Second, "< 1 min"},
+		{5 * time.Minute, "5 min"},
+		{45 * time.Minute, "45 min"},
+		{90 * time.Minute, "1h 30m"},
+		{2*time.Hour + 15*time.Minute, "2h 15m"},
+	}
+	for _, tt := range tests {
+		if got := formatDuration(tt.d); got != tt.want {
+			t.Errorf("formatDuration(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}
+
+func TestAdcPath(t *testing.T) {
+	path, err := adcPath()
+	if err != nil {
+		t.Fatalf("adcPath: %v", err)
+	}
+	if !filepath.IsAbs(path) {
+		t.Errorf("adcPath returned relative path: %s", path)
+	}
+	if !contains(path, "application_default_credentials.json") {
+		t.Errorf("adcPath missing expected filename: %s", path)
+	}
+}
+
+func TestRefreshFromADC_InvalidCreds(t *testing.T) {
+	// Mock a token endpoint that returns an error.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Token has been revoked"}`))
+	}))
+	defer server.Close()
+
+	// refreshFromADC uses google.Endpoint which points to real Google servers,
+	// so this test validates that an invalid refresh token returns an error
+	// (the actual HTTP call to Google will fail with invalid credentials).
+	creds := &adcCredentials{
+		ClientID:     "fake-client-id",
+		ClientSecret: "fake-secret",
+		RefreshToken: "fake-refresh-token",
+	}
+	_, err := refreshFromADC(creds)
+	if err == nil {
+		t.Fatal("expected error for invalid credentials")
+	}
+}
+
+func TestHandleAuth_Help(t *testing.T) {
+	// Just verify handleAuth doesn't panic with empty args.
+	// It writes to stderr but shouldn't crash.
+	handleAuth(nil)
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -129,6 +129,8 @@ func main() {
 		cmdStop()
 	case "status":
 		cmdStatus()
+	case "auth":
+		handleAuth(os.Args[2:])
 	case "version":
 		fmt.Printf("candela %s\n", version)
 	default:
@@ -140,6 +142,9 @@ Usage:
   candela stop           Stop the background proxy
   candela status         Show proxy status
   candela run [flags]    Run in foreground
+  candela auth login     Login via browser (Google OAuth)
+  candela auth status    Show credential status
+  candela auth token     Print a fresh access token
   candela version        Print version
 
 Run flags:
@@ -437,7 +442,7 @@ func runForeground() {
 			slog.Debug("idtoken.NewTokenSource unavailable (user credentials fallback)", "reason", err)
 			ts2, err2 := google.DefaultTokenSource(ctx, "openid", "email")
 			if err2 != nil {
-				slog.Error("failed to get credentials — run 'gcloud auth application-default login' first",
+				slog.Error("failed to get credentials — run 'candela auth login' first",
 					"error", err2)
 				os.Exit(1)
 			}
@@ -932,7 +937,7 @@ func buildCloudProxy(cfg Config, submitter *processor.SpanProcessor) (*proxy.Pro
 	tokenSource, adcErr := google.DefaultTokenSource(context.Background(),
 		"https://www.googleapis.com/auth/cloud-platform")
 	if adcErr != nil {
-		slog.Error("failed to get Google ADC — run 'gcloud auth application-default login'", "error", adcErr)
+		slog.Error("failed to get Google ADC — run 'candela auth login'", "error", adcErr)
 		return nil, nil
 	}
 


### PR DESCRIPTION
## Summary

Adds native OAuth2 authentication to the candela CLI, eliminating the gcloud dependency for credential management.

### New subcommands

- `candela auth login` — opens browser, runs full OAuth2 authorization code flow, writes to standard ADC path
- `candela auth status` — shows credential identity, type, and expiry
- `candela auth token` — prints a fresh access token (for piping to curl etc.)

### How it works

Uses Google's well-known OAuth client ID (same one gcloud uses for ADC) and writes credentials to `~/.config/gcloud/application_default_credentials.json` so that `google.DefaultTokenSource()` picks them up automatically. No new dependencies — only `golang.org/x/oauth2` which was already in go.mod.

### What changes

- Error messages now suggest `candela auth login` instead of `gcloud auth application-default login`
- Help text updated with auth commands
- All existing tests pass