### PR TITLE
feat: implement GetDashboardData consolidated RPC handler

### DIFF
--- a/gen/go/candela/v1/candelav1connect/dashboard_service.connect.go
+++ b/gen/go/candela/v1/candelav1connect/dashboard_service.connect.go
@@ -33,6 +33,9 @@ const (
 // reflection-formatted method names, remove the leading slash and convert the remaining slash to a
 // period.
 const (
+	// DashboardServiceGetDashboardDataProcedure is the fully-qualified name of the DashboardService's
+	// GetDashboardData RPC.
+	DashboardServiceGetDashboardDataProcedure = "/candela.v1.DashboardService/GetDashboardData"
 	// DashboardServiceGetUsageSummaryProcedure is the fully-qualified name of the DashboardService's
 	// GetUsageSummary RPC.
 	DashboardServiceGetUsageSummaryProcedure = "/candela.v1.DashboardService/GetUsageSummary"
@@ -55,14 +58,25 @@ const (
 
 // DashboardServiceClient is a client for the candela.v1.DashboardService service.
 type DashboardServiceClient interface {
-	// GetUsageSummary returns aggregated token usage, cost, and request counts.
+	// GetDashboardData returns a consolidated dashboard view including usage
+	// summary, per-model breakdown, and (if authenticated) per-user budget
+	// context. Replaces the concurrent fan-out of GetUsageSummary +
+	// GetModelBreakdown + GetMyUsage with a single round-trip.
+	GetDashboardData(context.Context, *connect.Request[v1.GetDashboardDataRequest]) (*connect.Response[v1.GetDashboardDataResponse], error)
+	// Deprecated: use GetDashboardData instead.
+	//
+	// Deprecated: do not use.
 	GetUsageSummary(context.Context, *connect.Request[v1.GetUsageSummaryRequest]) (*connect.Response[v1.GetUsageSummaryResponse], error)
-	// GetModelBreakdown returns usage broken down by model.
+	// Deprecated: use GetDashboardData instead.
+	//
+	// Deprecated: do not use.
 	GetModelBreakdown(context.Context, *connect.Request[v1.GetModelBreakdownRequest]) (*connect.Response[v1.GetModelBreakdownResponse], error)
 	// GetLatencyPercentiles returns latency distribution data.
 	GetLatencyPercentiles(context.Context, *connect.Request[v1.GetLatencyPercentilesRequest]) (*connect.Response[v1.GetLatencyPercentilesResponse], error)
-	// GetMyUsage returns the calling user's personal usage summary (BigQuery).
+	// Deprecated: use GetDashboardData with include_budget=true instead.
 	// For real-time budget/grant progress, see UserService.GetMyBudget.
+	//
+	// Deprecated: do not use.
 	GetMyUsage(context.Context, *connect.Request[v1.GetMyUsageRequest]) (*connect.Response[v1.GetMyUsageResponse], error)
 	// GetTeamLeaderboard returns per-user usage for the team (admin only).
 	GetTeamLeaderboard(context.Context, *connect.Request[v1.GetTeamLeaderboardRequest]) (*connect.Response[v1.GetTeamLeaderboardResponse], error)
@@ -81,6 +95,12 @@ func NewDashboardServiceClient(httpClient connect.HTTPClient, baseURL string, op
 	baseURL = strings.TrimRight(baseURL, "/")
 	dashboardServiceMethods := v1.File_candela_v1_dashboard_service_proto.Services().ByName("DashboardService").Methods()
 	return &dashboardServiceClient{
+		getDashboardData: connect.NewClient[v1.GetDashboardDataRequest, v1.GetDashboardDataResponse](
+			httpClient,
+			baseURL+DashboardServiceGetDashboardDataProcedure,
+			connect.WithSchema(dashboardServiceMethods.ByName("GetDashboardData")),
+			connect.WithClientOptions(opts...),
+		),
 		getUsageSummary: connect.NewClient[v1.GetUsageSummaryRequest, v1.GetUsageSummaryResponse](
 			httpClient,
 			baseURL+DashboardServiceGetUsageSummaryProcedure,
@@ -122,6 +142,7 @@ func NewDashboardServiceClient(httpClient connect.HTTPClient, baseURL string, op
 
 // dashboardServiceClient implements DashboardServiceClient.
 type dashboardServiceClient struct {
+	getDashboardData      *connect.Client[v1.GetDashboardDataRequest, v1.GetDashboardDataResponse]
 	getUsageSummary       *connect.Client[v1.GetUsageSummaryRequest, v1.GetUsageSummaryResponse]
 	getModelBreakdown     *connect.Client[v1.GetModelBreakdownRequest, v1.GetModelBreakdownResponse]
 	getLatencyPercentiles *connect.Client[v1.GetLatencyPercentilesRequest, v1.GetLatencyPercentilesResponse]
@@ -130,12 +151,21 @@ type dashboardServiceClient struct {
 	getJobLeaderboard     *connect.Client[v1.GetJobLeaderboardRequest, v1.GetJobLeaderboardResponse]
 }
 
+// GetDashboardData calls candela.v1.DashboardService.GetDashboardData.
+func (c *dashboardServiceClient) GetDashboardData(ctx context.Context, req *connect.Request[v1.GetDashboardDataRequest]) (*connect.Response[v1.GetDashboardDataResponse], error) {
+	return c.getDashboardData.CallUnary(ctx, req)
+}
+
 // GetUsageSummary calls candela.v1.DashboardService.GetUsageSummary.
+//
+// Deprecated: do not use.
 func (c *dashboardServiceClient) GetUsageSummary(ctx context.Context, req *connect.Request[v1.GetUsageSummaryRequest]) (*connect.Response[v1.GetUsageSummaryResponse], error) {
 	return c.getUsageSummary.CallUnary(ctx, req)
 }
 
 // GetModelBreakdown calls candela.v1.DashboardService.GetModelBreakdown.
+//
+// Deprecated: do not use.
 func (c *dashboardServiceClient) GetModelBreakdown(ctx context.Context, req *connect.Request[v1.GetModelBreakdownRequest]) (*connect.Response[v1.GetModelBreakdownResponse], error) {
 	return c.getModelBreakdown.CallUnary(ctx, req)
 }
@@ -146,6 +176,8 @@ func (c *dashboardServiceClient) GetLatencyPercentiles(ctx context.Context, req 
 }
 
 // GetMyUsage calls candela.v1.DashboardService.GetMyUsage.
+//
+// Deprecated: do not use.
 func (c *dashboardServiceClient) GetMyUsage(ctx context.Context, req *connect.Request[v1.GetMyUsageRequest]) (*connect.Response[v1.GetMyUsageResponse], error) {
 	return c.getMyUsage.CallUnary(ctx, req)
 }
@@ -162,14 +194,25 @@ func (c *dashboardServiceClient) GetJobLeaderboard(ctx context.Context, req *con
 
 // DashboardServiceHandler is an implementation of the candela.v1.DashboardService service.
 type DashboardServiceHandler interface {
-	// GetUsageSummary returns aggregated token usage, cost, and request counts.
+	// GetDashboardData returns a consolidated dashboard view including usage
+	// summary, per-model breakdown, and (if authenticated) per-user budget
+	// context. Replaces the concurrent fan-out of GetUsageSummary +
+	// GetModelBreakdown + GetMyUsage with a single round-trip.
+	GetDashboardData(context.Context, *connect.Request[v1.GetDashboardDataRequest]) (*connect.Response[v1.GetDashboardDataResponse], error)
+	// Deprecated: use GetDashboardData instead.
+	//
+	// Deprecated: do not use.
 	GetUsageSummary(context.Context, *connect.Request[v1.GetUsageSummaryRequest]) (*connect.Response[v1.GetUsageSummaryResponse], error)
-	// GetModelBreakdown returns usage broken down by model.
+	// Deprecated: use GetDashboardData instead.
+	//
+	// Deprecated: do not use.
 	GetModelBreakdown(context.Context, *connect.Request[v1.GetModelBreakdownRequest]) (*connect.Response[v1.GetModelBreakdownResponse], error)
 	// GetLatencyPercentiles returns latency distribution data.
 	GetLatencyPercentiles(context.Context, *connect.Request[v1.GetLatencyPercentilesRequest]) (*connect.Response[v1.GetLatencyPercentilesResponse], error)
-	// GetMyUsage returns the calling user's personal usage summary (BigQuery).
+	// Deprecated: use GetDashboardData with include_budget=true instead.
 	// For real-time budget/grant progress, see UserService.GetMyBudget.
+	//
+	// Deprecated: do not use.
 	GetMyUsage(context.Context, *connect.Request[v1.GetMyUsageRequest]) (*connect.Response[v1.GetMyUsageResponse], error)
 	// GetTeamLeaderboard returns per-user usage for the team (admin only).
 	GetTeamLeaderboard(context.Context, *connect.Request[v1.GetTeamLeaderboardRequest]) (*connect.Response[v1.GetTeamLeaderboardResponse], error)
@@ -184,6 +227,12 @@ type DashboardServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewDashboardServiceHandler(svc DashboardServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	dashboardServiceMethods := v1.File_candela_v1_dashboard_service_proto.Services().ByName("DashboardService").Methods()
+	dashboardServiceGetDashboardDataHandler := connect.NewUnaryHandler(
+		DashboardServiceGetDashboardDataProcedure,
+		svc.GetDashboardData,
+		connect.WithSchema(dashboardServiceMethods.ByName("GetDashboardData")),
+		connect.WithHandlerOptions(opts...),
+	)
 	dashboardServiceGetUsageSummaryHandler := connect.NewUnaryHandler(
 		DashboardServiceGetUsageSummaryProcedure,
 		svc.GetUsageSummary,
@@ -222,6 +271,8 @@ func NewDashboardServiceHandler(svc DashboardServiceHandler, opts ...connect.Han
 	)
 	return "/candela.v1.DashboardService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case DashboardServiceGetDashboardDataProcedure:
+			dashboardServiceGetDashboardDataHandler.ServeHTTP(w, r)
 		case DashboardServiceGetUsageSummaryProcedure:
 			dashboardServiceGetUsageSummaryHandler.ServeHTTP(w, r)
 		case DashboardServiceGetModelBreakdownProcedure:
@@ -242,6 +293,10 @@ func NewDashboardServiceHandler(svc DashboardServiceHandler, opts ...connect.Han
 
 // UnimplementedDashboardServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedDashboardServiceHandler struct{}
+
+func (UnimplementedDashboardServiceHandler) GetDashboardData(context.Context, *connect.Request[v1.GetDashboardDataRequest]) (*connect.Response[v1.GetDashboardDataResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("candela.v1.DashboardService.GetDashboardData is not implemented"))
+}
 
 func (UnimplementedDashboardServiceHandler) GetUsageSummary(context.Context, *connect.Request[v1.GetUsageSummaryRequest]) (*connect.Response[v1.GetUsageSummaryResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("candela.v1.DashboardService.GetUsageSummary is not implemented"))

--- a/gen/go/candela/v1/dashboard_service.pb.go
+++ b/gen/go/candela/v1/dashboard_service.pb.go
@@ -83,23 +83,29 @@ func (x *GetUsageSummaryRequest) GetEnvironment() string {
 }
 
 type GetUsageSummaryResponse struct {
-	state                    protoimpl.MessageState `protogen:"open.v1"`
-	TotalTraces              int64                  `protobuf:"varint,1,opt,name=total_traces,json=totalTraces,proto3" json:"total_traces,omitempty"`
-	TotalSpans               int64                  `protobuf:"varint,2,opt,name=total_spans,json=totalSpans,proto3" json:"total_spans,omitempty"`
-	TotalLlmCalls            int64                  `protobuf:"varint,3,opt,name=total_llm_calls,json=totalLlmCalls,proto3" json:"total_llm_calls,omitempty"`
-	TotalInputTokens         int64                  `protobuf:"varint,4,opt,name=total_input_tokens,json=totalInputTokens,proto3" json:"total_input_tokens,omitempty"`
-	TotalOutputTokens        int64                  `protobuf:"varint,5,opt,name=total_output_tokens,json=totalOutputTokens,proto3" json:"total_output_tokens,omitempty"`
-	TotalCostUsd             float64                `protobuf:"fixed64,6,opt,name=total_cost_usd,json=totalCostUsd,proto3" json:"total_cost_usd,omitempty"`
-	AvgLatencyMs             float64                `protobuf:"fixed64,7,opt,name=avg_latency_ms,json=avgLatencyMs,proto3" json:"avg_latency_ms,omitempty"`
-	ErrorRate                float64                `protobuf:"fixed64,8,opt,name=error_rate,json=errorRate,proto3" json:"error_rate,omitempty"`
-	TotalCacheReadTokens     int64                  `protobuf:"varint,9,opt,name=total_cache_read_tokens,json=totalCacheReadTokens,proto3" json:"total_cache_read_tokens,omitempty"`
-	TotalCacheCreationTokens int64                  `protobuf:"varint,10,opt,name=total_cache_creation_tokens,json=totalCacheCreationTokens,proto3" json:"total_cache_creation_tokens,omitempty"`
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	TotalTraces       int64                  `protobuf:"varint,1,opt,name=total_traces,json=totalTraces,proto3" json:"total_traces,omitempty"`
+	TotalSpans        int64                  `protobuf:"varint,2,opt,name=total_spans,json=totalSpans,proto3" json:"total_spans,omitempty"`
+	TotalLlmCalls     int64                  `protobuf:"varint,3,opt,name=total_llm_calls,json=totalLlmCalls,proto3" json:"total_llm_calls,omitempty"`
+	TotalInputTokens  int64                  `protobuf:"varint,4,opt,name=total_input_tokens,json=totalInputTokens,proto3" json:"total_input_tokens,omitempty"`
+	TotalOutputTokens int64                  `protobuf:"varint,5,opt,name=total_output_tokens,json=totalOutputTokens,proto3" json:"total_output_tokens,omitempty"`
+	TotalCostUsd      float64                `protobuf:"fixed64,6,opt,name=total_cost_usd,json=totalCostUsd,proto3" json:"total_cost_usd,omitempty"`
+	AvgLatencyMs      float64                `protobuf:"fixed64,7,opt,name=avg_latency_ms,json=avgLatencyMs,proto3" json:"avg_latency_ms,omitempty"`
+	ErrorRate         float64                `protobuf:"fixed64,8,opt,name=error_rate,json=errorRate,proto3" json:"error_rate,omitempty"`
+	// Cache metrics — these fields are subsets of total_input_tokens.
+	// Cache hit rate = cache_read_tokens / input_tokens (excludes output tokens).
+	TotalCacheReadTokens     int64 `protobuf:"varint,9,opt,name=total_cache_read_tokens,json=totalCacheReadTokens,proto3" json:"total_cache_read_tokens,omitempty"`
+	TotalCacheCreationTokens int64 `protobuf:"varint,10,opt,name=total_cache_creation_tokens,json=totalCacheCreationTokens,proto3" json:"total_cache_creation_tokens,omitempty"`
 	// Time series for charts
-	TracesOverTime []*TimeSeriesPoint `protobuf:"bytes,20,rep,name=traces_over_time,json=tracesOverTime,proto3" json:"traces_over_time,omitempty"`
-	CostOverTime   []*TimeSeriesPoint `protobuf:"bytes,21,rep,name=cost_over_time,json=costOverTime,proto3" json:"cost_over_time,omitempty"`
-	TokensOverTime []*TimeSeriesPoint `protobuf:"bytes,22,rep,name=tokens_over_time,json=tokensOverTime,proto3" json:"tokens_over_time,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	TracesOverTime              []*TimeSeriesPoint `protobuf:"bytes,20,rep,name=traces_over_time,json=tracesOverTime,proto3" json:"traces_over_time,omitempty"`
+	CostOverTime                []*TimeSeriesPoint `protobuf:"bytes,21,rep,name=cost_over_time,json=costOverTime,proto3" json:"cost_over_time,omitempty"`
+	TokensOverTime              []*TimeSeriesPoint `protobuf:"bytes,22,rep,name=tokens_over_time,json=tokensOverTime,proto3" json:"tokens_over_time,omitempty"`
+	CacheReadTokensOverTime     []*TimeSeriesPoint `protobuf:"bytes,23,rep,name=cache_read_tokens_over_time,json=cacheReadTokensOverTime,proto3" json:"cache_read_tokens_over_time,omitempty"`
+	CacheCreationTokensOverTime []*TimeSeriesPoint `protobuf:"bytes,24,rep,name=cache_creation_tokens_over_time,json=cacheCreationTokensOverTime,proto3" json:"cache_creation_tokens_over_time,omitempty"`
+	InputTokensOverTime         []*TimeSeriesPoint `protobuf:"bytes,25,rep,name=input_tokens_over_time,json=inputTokensOverTime,proto3" json:"input_tokens_over_time,omitempty"`
+	OutputTokensOverTime        []*TimeSeriesPoint `protobuf:"bytes,26,rep,name=output_tokens_over_time,json=outputTokensOverTime,proto3" json:"output_tokens_over_time,omitempty"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *GetUsageSummaryResponse) Reset() {
@@ -219,6 +225,34 @@ func (x *GetUsageSummaryResponse) GetCostOverTime() []*TimeSeriesPoint {
 func (x *GetUsageSummaryResponse) GetTokensOverTime() []*TimeSeriesPoint {
 	if x != nil {
 		return x.TokensOverTime
+	}
+	return nil
+}
+
+func (x *GetUsageSummaryResponse) GetCacheReadTokensOverTime() []*TimeSeriesPoint {
+	if x != nil {
+		return x.CacheReadTokensOverTime
+	}
+	return nil
+}
+
+func (x *GetUsageSummaryResponse) GetCacheCreationTokensOverTime() []*TimeSeriesPoint {
+	if x != nil {
+		return x.CacheCreationTokensOverTime
+	}
+	return nil
+}
+
+func (x *GetUsageSummaryResponse) GetInputTokensOverTime() []*TimeSeriesPoint {
+	if x != nil {
+		return x.InputTokensOverTime
+	}
+	return nil
+}
+
+func (x *GetUsageSummaryResponse) GetOutputTokensOverTime() []*TimeSeriesPoint {
+	if x != nil {
+		return x.OutputTokensOverTime
 	}
 	return nil
 }
@@ -372,16 +406,20 @@ func (x *GetModelBreakdownResponse) GetModels() []*ModelUsage {
 }
 
 type ModelUsage struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Model         string                 `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
-	Provider      string                 `protobuf:"bytes,2,opt,name=provider,proto3" json:"provider,omitempty"`
-	CallCount     int64                  `protobuf:"varint,3,opt,name=call_count,json=callCount,proto3" json:"call_count,omitempty"`
-	InputTokens   int64                  `protobuf:"varint,4,opt,name=input_tokens,json=inputTokens,proto3" json:"input_tokens,omitempty"`
-	OutputTokens  int64                  `protobuf:"varint,5,opt,name=output_tokens,json=outputTokens,proto3" json:"output_tokens,omitempty"`
-	CostUsd       float64                `protobuf:"fixed64,6,opt,name=cost_usd,json=costUsd,proto3" json:"cost_usd,omitempty"`
-	AvgLatencyMs  float64                `protobuf:"fixed64,7,opt,name=avg_latency_ms,json=avgLatencyMs,proto3" json:"avg_latency_ms,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Model        string                 `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
+	Provider     string                 `protobuf:"bytes,2,opt,name=provider,proto3" json:"provider,omitempty"`
+	CallCount    int64                  `protobuf:"varint,3,opt,name=call_count,json=callCount,proto3" json:"call_count,omitempty"`
+	InputTokens  int64                  `protobuf:"varint,4,opt,name=input_tokens,json=inputTokens,proto3" json:"input_tokens,omitempty"`
+	OutputTokens int64                  `protobuf:"varint,5,opt,name=output_tokens,json=outputTokens,proto3" json:"output_tokens,omitempty"`
+	CostUsd      float64                `protobuf:"fixed64,6,opt,name=cost_usd,json=costUsd,proto3" json:"cost_usd,omitempty"`
+	AvgLatencyMs float64                `protobuf:"fixed64,7,opt,name=avg_latency_ms,json=avgLatencyMs,proto3" json:"avg_latency_ms,omitempty"`
+	// Cache metrics per model — subset of input_tokens.
+	// Cache hit rate = cache_read_tokens / input_tokens.
+	CacheReadTokens     int64 `protobuf:"varint,8,opt,name=cache_read_tokens,json=cacheReadTokens,proto3" json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens int64 `protobuf:"varint,9,opt,name=cache_creation_tokens,json=cacheCreationTokens,proto3" json:"cache_creation_tokens,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *ModelUsage) Reset() {
@@ -459,6 +497,20 @@ func (x *ModelUsage) GetCostUsd() float64 {
 func (x *ModelUsage) GetAvgLatencyMs() float64 {
 	if x != nil {
 		return x.AvgLatencyMs
+	}
+	return 0
+}
+
+func (x *ModelUsage) GetCacheReadTokens() int64 {
+	if x != nil {
+		return x.CacheReadTokens
+	}
+	return 0
+}
+
+func (x *ModelUsage) GetCacheCreationTokens() int64 {
+	if x != nil {
+		return x.CacheCreationTokens
 	}
 	return 0
 }
@@ -658,6 +710,9 @@ type GetMyUsageResponse struct {
 	TotalOutputTokens int64                  `protobuf:"varint,3,opt,name=total_output_tokens,json=totalOutputTokens,proto3" json:"total_output_tokens,omitempty"`
 	TotalCostUsd      float64                `protobuf:"fixed64,4,opt,name=total_cost_usd,json=totalCostUsd,proto3" json:"total_cost_usd,omitempty"`
 	AvgLatencyMs      float64                `protobuf:"fixed64,5,opt,name=avg_latency_ms,json=avgLatencyMs,proto3" json:"avg_latency_ms,omitempty"`
+	// Cache metrics — subset of total_input_tokens.
+	TotalCacheReadTokens     int64 `protobuf:"varint,6,opt,name=total_cache_read_tokens,json=totalCacheReadTokens,proto3" json:"total_cache_read_tokens,omitempty"`
+	TotalCacheCreationTokens int64 `protobuf:"varint,7,opt,name=total_cache_creation_tokens,json=totalCacheCreationTokens,proto3" json:"total_cache_creation_tokens,omitempty"`
 	// Per-model breakdown for this user
 	Models []*ModelUsage `protobuf:"bytes,10,rep,name=models,proto3" json:"models,omitempty"`
 	// Budget context
@@ -730,6 +785,20 @@ func (x *GetMyUsageResponse) GetTotalCostUsd() float64 {
 func (x *GetMyUsageResponse) GetAvgLatencyMs() float64 {
 	if x != nil {
 		return x.AvgLatencyMs
+	}
+	return 0
+}
+
+func (x *GetMyUsageResponse) GetTotalCacheReadTokens() int64 {
+	if x != nil {
+		return x.TotalCacheReadTokens
+	}
+	return 0
+}
+
+func (x *GetMyUsageResponse) GetTotalCacheCreationTokens() int64 {
+	if x != nil {
+		return x.TotalCacheCreationTokens
 	}
 	return 0
 }
@@ -1154,6 +1223,285 @@ func (x *JobUsage) GetTopModel() string {
 	return ""
 }
 
+type GetDashboardDataRequest struct {
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	ProjectId   string                 `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	TimeRange   *types.TimeRange       `protobuf:"bytes,2,opt,name=time_range,json=timeRange,proto3" json:"time_range,omitempty"`
+	Environment string                 `protobuf:"bytes,3,opt,name=environment,proto3" json:"environment,omitempty"`
+	// If true, includes per-user budget and grant context (requires auth).
+	// When false or unauthenticated, the budget/grant fields are omitted.
+	IncludeBudget bool `protobuf:"varint,4,opt,name=include_budget,json=includeBudget,proto3" json:"include_budget,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetDashboardDataRequest) Reset() {
+	*x = GetDashboardDataRequest{}
+	mi := &file_candela_v1_dashboard_service_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetDashboardDataRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetDashboardDataRequest) ProtoMessage() {}
+
+func (x *GetDashboardDataRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_candela_v1_dashboard_service_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetDashboardDataRequest.ProtoReflect.Descriptor instead.
+func (*GetDashboardDataRequest) Descriptor() ([]byte, []int) {
+	return file_candela_v1_dashboard_service_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *GetDashboardDataRequest) GetProjectId() string {
+	if x != nil {
+		return x.ProjectId
+	}
+	return ""
+}
+
+func (x *GetDashboardDataRequest) GetTimeRange() *types.TimeRange {
+	if x != nil {
+		return x.TimeRange
+	}
+	return nil
+}
+
+func (x *GetDashboardDataRequest) GetEnvironment() string {
+	if x != nil {
+		return x.Environment
+	}
+	return ""
+}
+
+func (x *GetDashboardDataRequest) GetIncludeBudget() bool {
+	if x != nil {
+		return x.IncludeBudget
+	}
+	return false
+}
+
+type GetDashboardDataResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ── Aggregate summary ──
+	TotalTraces       int64   `protobuf:"varint,1,opt,name=total_traces,json=totalTraces,proto3" json:"total_traces,omitempty"`
+	TotalSpans        int64   `protobuf:"varint,2,opt,name=total_spans,json=totalSpans,proto3" json:"total_spans,omitempty"`
+	TotalLlmCalls     int64   `protobuf:"varint,3,opt,name=total_llm_calls,json=totalLlmCalls,proto3" json:"total_llm_calls,omitempty"`
+	TotalInputTokens  int64   `protobuf:"varint,4,opt,name=total_input_tokens,json=totalInputTokens,proto3" json:"total_input_tokens,omitempty"`
+	TotalOutputTokens int64   `protobuf:"varint,5,opt,name=total_output_tokens,json=totalOutputTokens,proto3" json:"total_output_tokens,omitempty"`
+	TotalCostUsd      float64 `protobuf:"fixed64,6,opt,name=total_cost_usd,json=totalCostUsd,proto3" json:"total_cost_usd,omitempty"`
+	AvgLatencyMs      float64 `protobuf:"fixed64,7,opt,name=avg_latency_ms,json=avgLatencyMs,proto3" json:"avg_latency_ms,omitempty"`
+	ErrorRate         float64 `protobuf:"fixed64,8,opt,name=error_rate,json=errorRate,proto3" json:"error_rate,omitempty"`
+	// Cache metrics — subsets of total_input_tokens.
+	TotalCacheReadTokens     int64 `protobuf:"varint,9,opt,name=total_cache_read_tokens,json=totalCacheReadTokens,proto3" json:"total_cache_read_tokens,omitempty"`
+	TotalCacheCreationTokens int64 `protobuf:"varint,10,opt,name=total_cache_creation_tokens,json=totalCacheCreationTokens,proto3" json:"total_cache_creation_tokens,omitempty"`
+	// ── Time series for charts ──
+	TracesOverTime              []*TimeSeriesPoint `protobuf:"bytes,20,rep,name=traces_over_time,json=tracesOverTime,proto3" json:"traces_over_time,omitempty"`
+	CostOverTime                []*TimeSeriesPoint `protobuf:"bytes,21,rep,name=cost_over_time,json=costOverTime,proto3" json:"cost_over_time,omitempty"`
+	TokensOverTime              []*TimeSeriesPoint `protobuf:"bytes,22,rep,name=tokens_over_time,json=tokensOverTime,proto3" json:"tokens_over_time,omitempty"`
+	CacheReadTokensOverTime     []*TimeSeriesPoint `protobuf:"bytes,23,rep,name=cache_read_tokens_over_time,json=cacheReadTokensOverTime,proto3" json:"cache_read_tokens_over_time,omitempty"`
+	CacheCreationTokensOverTime []*TimeSeriesPoint `protobuf:"bytes,24,rep,name=cache_creation_tokens_over_time,json=cacheCreationTokensOverTime,proto3" json:"cache_creation_tokens_over_time,omitempty"`
+	InputTokensOverTime         []*TimeSeriesPoint `protobuf:"bytes,25,rep,name=input_tokens_over_time,json=inputTokensOverTime,proto3" json:"input_tokens_over_time,omitempty"`
+	OutputTokensOverTime        []*TimeSeriesPoint `protobuf:"bytes,26,rep,name=output_tokens_over_time,json=outputTokensOverTime,proto3" json:"output_tokens_over_time,omitempty"`
+	// ── Per-model breakdown ──
+	Models []*ModelUsage `protobuf:"bytes,30,rep,name=models,proto3" json:"models,omitempty"`
+	// ── Per-user budget context (populated when include_budget=true + auth) ──
+	Budget            *types.UserBudget    `protobuf:"bytes,40,opt,name=budget,proto3" json:"budget,omitempty"`
+	TotalRemainingUsd float64              `protobuf:"fixed64,41,opt,name=total_remaining_usd,json=totalRemainingUsd,proto3" json:"total_remaining_usd,omitempty"`
+	ActiveGrants      []*types.BudgetGrant `protobuf:"bytes,42,rep,name=active_grants,json=activeGrants,proto3" json:"active_grants,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *GetDashboardDataResponse) Reset() {
+	*x = GetDashboardDataResponse{}
+	mi := &file_candela_v1_dashboard_service_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetDashboardDataResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetDashboardDataResponse) ProtoMessage() {}
+
+func (x *GetDashboardDataResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_candela_v1_dashboard_service_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetDashboardDataResponse.ProtoReflect.Descriptor instead.
+func (*GetDashboardDataResponse) Descriptor() ([]byte, []int) {
+	return file_candela_v1_dashboard_service_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *GetDashboardDataResponse) GetTotalTraces() int64 {
+	if x != nil {
+		return x.TotalTraces
+	}
+	return 0
+}
+
+func (x *GetDashboardDataResponse) GetTotalSpans() int64 {
+	if x != nil {
+		return x.TotalSpans
+	}
+	return 0
+}
+
+func (x *GetDashboardDataResponse) GetTotalLlmCalls() int64 {
+	if x != nil {
+		return x.TotalLlmCalls
+	}
+	return 0
+}
+
+func (x *GetDashboardDataResponse) GetTotalInputTokens() int64 {
+	if x != nil {
+		return x.TotalInputTokens
+	}
+	return 0
+}
+
+func (x *GetDashboardDataResponse) GetTotalOutputTokens() int64 {
+	if x != nil {
+		return x.TotalOutputTokens
+	}
+	return 0
+}
+
+func (x *GetDashboardDataResponse) GetTotalCostUsd() float64 {
+	if x != nil {
+		return x.TotalCostUsd
+	}
+	return 0
+}
+
+func (x *GetDashboardDataResponse) GetAvgLatencyMs() float64 {
+	if x != nil {
+		return x.AvgLatencyMs
+	}
+	return 0
+}
+
+func (x *GetDashboardDataResponse) GetErrorRate() float64 {
+	if x != nil {
+		return x.ErrorRate
+	}
+	return 0
+}
+
+func (x *GetDashboardDataResponse) GetTotalCacheReadTokens() int64 {
+	if x != nil {
+		return x.TotalCacheReadTokens
+	}
+	return 0
+}
+
+func (x *GetDashboardDataResponse) GetTotalCacheCreationTokens() int64 {
+	if x != nil {
+		return x.TotalCacheCreationTokens
+	}
+	return 0
+}
+
+func (x *GetDashboardDataResponse) GetTracesOverTime() []*TimeSeriesPoint {
+	if x != nil {
+		return x.TracesOverTime
+	}
+	return nil
+}
+
+func (x *GetDashboardDataResponse) GetCostOverTime() []*TimeSeriesPoint {
+	if x != nil {
+		return x.CostOverTime
+	}
+	return nil
+}
+
+func (x *GetDashboardDataResponse) GetTokensOverTime() []*TimeSeriesPoint {
+	if x != nil {
+		return x.TokensOverTime
+	}
+	return nil
+}
+
+func (x *GetDashboardDataResponse) GetCacheReadTokensOverTime() []*TimeSeriesPoint {
+	if x != nil {
+		return x.CacheReadTokensOverTime
+	}
+	return nil
+}
+
+func (x *GetDashboardDataResponse) GetCacheCreationTokensOverTime() []*TimeSeriesPoint {
+	if x != nil {
+		return x.CacheCreationTokensOverTime
+	}
+	return nil
+}
+
+func (x *GetDashboardDataResponse) GetInputTokensOverTime() []*TimeSeriesPoint {
+	if x != nil {
+		return x.InputTokensOverTime
+	}
+	return nil
+}
+
+func (x *GetDashboardDataResponse) GetOutputTokensOverTime() []*TimeSeriesPoint {
+	if x != nil {
+		return x.OutputTokensOverTime
+	}
+	return nil
+}
+
+func (x *GetDashboardDataResponse) GetModels() []*ModelUsage {
+	if x != nil {
+		return x.Models
+	}
+	return nil
+}
+
+func (x *GetDashboardDataResponse) GetBudget() *types.UserBudget {
+	if x != nil {
+		return x.Budget
+	}
+	return nil
+}
+
+func (x *GetDashboardDataResponse) GetTotalRemainingUsd() float64 {
+	if x != nil {
+		return x.TotalRemainingUsd
+	}
+	return 0
+}
+
+func (x *GetDashboardDataResponse) GetActiveGrants() []*types.BudgetGrant {
+	if x != nil {
+		return x.ActiveGrants
+	}
+	return nil
+}
+
 var File_candela_v1_dashboard_service_proto protoreflect.FileDescriptor
 
 const file_candela_v1_dashboard_service_proto_rawDesc = "" +
@@ -1165,7 +1513,7 @@ const file_candela_v1_dashboard_service_proto_rawDesc = "" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x127\n" +
 	"\n" +
 	"time_range\x18\x02 \x01(\v2\x18.candela.types.TimeRangeR\ttimeRange\x12 \n" +
-	"\venvironment\x18\x03 \x01(\tR\venvironment\"\x95\x05\n" +
+	"\venvironment\x18\x03 \x01(\tR\venvironment\"\xf9\a\n" +
 	"\x17GetUsageSummaryResponse\x12!\n" +
 	"\ftotal_traces\x18\x01 \x01(\x03R\vtotalTraces\x12\x1f\n" +
 	"\vtotal_spans\x18\x02 \x01(\x03R\n" +
@@ -1182,7 +1530,11 @@ const file_candela_v1_dashboard_service_proto_rawDesc = "" +
 	" \x01(\x03R\x18totalCacheCreationTokens\x12E\n" +
 	"\x10traces_over_time\x18\x14 \x03(\v2\x1b.candela.v1.TimeSeriesPointR\x0etracesOverTime\x12A\n" +
 	"\x0ecost_over_time\x18\x15 \x03(\v2\x1b.candela.v1.TimeSeriesPointR\fcostOverTime\x12E\n" +
-	"\x10tokens_over_time\x18\x16 \x03(\v2\x1b.candela.v1.TimeSeriesPointR\x0etokensOverTime\"E\n" +
+	"\x10tokens_over_time\x18\x16 \x03(\v2\x1b.candela.v1.TimeSeriesPointR\x0etokensOverTime\x12Y\n" +
+	"\x1bcache_read_tokens_over_time\x18\x17 \x03(\v2\x1b.candela.v1.TimeSeriesPointR\x17cacheReadTokensOverTime\x12a\n" +
+	"\x1fcache_creation_tokens_over_time\x18\x18 \x03(\v2\x1b.candela.v1.TimeSeriesPointR\x1bcacheCreationTokensOverTime\x12P\n" +
+	"\x16input_tokens_over_time\x18\x19 \x03(\v2\x1b.candela.v1.TimeSeriesPointR\x13inputTokensOverTime\x12R\n" +
+	"\x17output_tokens_over_time\x18\x1a \x03(\v2\x1b.candela.v1.TimeSeriesPointR\x14outputTokensOverTime\"E\n" +
 	"\x0fTimeSeriesPoint\x12\x1c\n" +
 	"\ttimestamp\x18\x01 \x01(\tR\ttimestamp\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x01R\x05value\"r\n" +
@@ -1192,7 +1544,7 @@ const file_candela_v1_dashboard_service_proto_rawDesc = "" +
 	"\n" +
 	"time_range\x18\x02 \x01(\v2\x18.candela.types.TimeRangeR\ttimeRange\"K\n" +
 	"\x19GetModelBreakdownResponse\x12.\n" +
-	"\x06models\x18\x01 \x03(\v2\x16.candela.v1.ModelUsageR\x06models\"\xe6\x01\n" +
+	"\x06models\x18\x01 \x03(\v2\x16.candela.v1.ModelUsageR\x06models\"\xc6\x02\n" +
 	"\n" +
 	"ModelUsage\x12\x14\n" +
 	"\x05model\x18\x01 \x01(\tR\x05model\x12\x1a\n" +
@@ -1202,7 +1554,9 @@ const file_candela_v1_dashboard_service_proto_rawDesc = "" +
 	"\finput_tokens\x18\x04 \x01(\x03R\vinputTokens\x12#\n" +
 	"\routput_tokens\x18\x05 \x01(\x03R\foutputTokens\x12\x19\n" +
 	"\bcost_usd\x18\x06 \x01(\x01R\acostUsd\x12$\n" +
-	"\x0eavg_latency_ms\x18\a \x01(\x01R\favgLatencyMs\"\x8c\x01\n" +
+	"\x0eavg_latency_ms\x18\a \x01(\x01R\favgLatencyMs\x12*\n" +
+	"\x11cache_read_tokens\x18\b \x01(\x03R\x0fcacheReadTokens\x122\n" +
+	"\x15cache_creation_tokens\x18\t \x01(\x03R\x13cacheCreationTokens\"\x8c\x01\n" +
 	"\x1cGetLatencyPercentilesRequest\x12\x1d\n" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x127\n" +
@@ -1220,14 +1574,16 @@ const file_candela_v1_dashboard_service_proto_rawDesc = "" +
 	"\n" +
 	"project_id\x18\x01 \x01(\tR\tprojectId\x127\n" +
 	"\n" +
-	"time_range\x18\x02 \x01(\v2\x18.candela.types.TimeRangeR\ttimeRange\"\xb3\x03\n" +
+	"time_range\x18\x02 \x01(\v2\x18.candela.types.TimeRangeR\ttimeRange\"\xa9\x04\n" +
 	"\x12GetMyUsageResponse\x12\x1f\n" +
 	"\vtotal_calls\x18\x01 \x01(\x03R\n" +
 	"totalCalls\x12,\n" +
 	"\x12total_input_tokens\x18\x02 \x01(\x03R\x10totalInputTokens\x12.\n" +
 	"\x13total_output_tokens\x18\x03 \x01(\x03R\x11totalOutputTokens\x12$\n" +
 	"\x0etotal_cost_usd\x18\x04 \x01(\x01R\ftotalCostUsd\x12$\n" +
-	"\x0eavg_latency_ms\x18\x05 \x01(\x01R\favgLatencyMs\x12.\n" +
+	"\x0eavg_latency_ms\x18\x05 \x01(\x01R\favgLatencyMs\x125\n" +
+	"\x17total_cache_read_tokens\x18\x06 \x01(\x03R\x14totalCacheReadTokens\x12=\n" +
+	"\x1btotal_cache_creation_tokens\x18\a \x01(\x03R\x18totalCacheCreationTokens\x12.\n" +
 	"\x06models\x18\n" +
 	" \x03(\v2\x16.candela.v1.ModelUsageR\x06models\x121\n" +
 	"\x06budget\x18\x14 \x01(\v2\x19.candela.types.UserBudgetR\x06budget\x12.\n" +
@@ -1266,13 +1622,46 @@ const file_candela_v1_dashboard_service_proto_rawDesc = "" +
 	"\ftotal_tokens\x18\x03 \x01(\x03R\vtotalTokens\x12\x19\n" +
 	"\bcost_usd\x18\x04 \x01(\x01R\acostUsd\x12$\n" +
 	"\x0eavg_latency_ms\x18\x05 \x01(\x01R\favgLatencyMs\x12\x1b\n" +
-	"\ttop_model\x18\x06 \x01(\tR\btopModel2\xd2\x04\n" +
-	"\x10DashboardService\x12Z\n" +
-	"\x0fGetUsageSummary\x12\".candela.v1.GetUsageSummaryRequest\x1a#.candela.v1.GetUsageSummaryResponse\x12`\n" +
-	"\x11GetModelBreakdown\x12$.candela.v1.GetModelBreakdownRequest\x1a%.candela.v1.GetModelBreakdownResponse\x12l\n" +
-	"\x15GetLatencyPercentiles\x12(.candela.v1.GetLatencyPercentilesRequest\x1a).candela.v1.GetLatencyPercentilesResponse\x12K\n" +
+	"\ttop_model\x18\x06 \x01(\tR\btopModel\"\xba\x01\n" +
+	"\x17GetDashboardDataRequest\x12\x1d\n" +
 	"\n" +
-	"GetMyUsage\x12\x1d.candela.v1.GetMyUsageRequest\x1a\x1e.candela.v1.GetMyUsageResponse\x12c\n" +
+	"project_id\x18\x01 \x01(\tR\tprojectId\x127\n" +
+	"\n" +
+	"time_range\x18\x02 \x01(\v2\x18.candela.types.TimeRangeR\ttimeRange\x12 \n" +
+	"\venvironment\x18\x03 \x01(\tR\venvironment\x12%\n" +
+	"\x0einclude_budget\x18\x04 \x01(\bR\rincludeBudget\"\xce\t\n" +
+	"\x18GetDashboardDataResponse\x12!\n" +
+	"\ftotal_traces\x18\x01 \x01(\x03R\vtotalTraces\x12\x1f\n" +
+	"\vtotal_spans\x18\x02 \x01(\x03R\n" +
+	"totalSpans\x12&\n" +
+	"\x0ftotal_llm_calls\x18\x03 \x01(\x03R\rtotalLlmCalls\x12,\n" +
+	"\x12total_input_tokens\x18\x04 \x01(\x03R\x10totalInputTokens\x12.\n" +
+	"\x13total_output_tokens\x18\x05 \x01(\x03R\x11totalOutputTokens\x12$\n" +
+	"\x0etotal_cost_usd\x18\x06 \x01(\x01R\ftotalCostUsd\x12$\n" +
+	"\x0eavg_latency_ms\x18\a \x01(\x01R\favgLatencyMs\x12\x1d\n" +
+	"\n" +
+	"error_rate\x18\b \x01(\x01R\terrorRate\x125\n" +
+	"\x17total_cache_read_tokens\x18\t \x01(\x03R\x14totalCacheReadTokens\x12=\n" +
+	"\x1btotal_cache_creation_tokens\x18\n" +
+	" \x01(\x03R\x18totalCacheCreationTokens\x12E\n" +
+	"\x10traces_over_time\x18\x14 \x03(\v2\x1b.candela.v1.TimeSeriesPointR\x0etracesOverTime\x12A\n" +
+	"\x0ecost_over_time\x18\x15 \x03(\v2\x1b.candela.v1.TimeSeriesPointR\fcostOverTime\x12E\n" +
+	"\x10tokens_over_time\x18\x16 \x03(\v2\x1b.candela.v1.TimeSeriesPointR\x0etokensOverTime\x12Y\n" +
+	"\x1bcache_read_tokens_over_time\x18\x17 \x03(\v2\x1b.candela.v1.TimeSeriesPointR\x17cacheReadTokensOverTime\x12a\n" +
+	"\x1fcache_creation_tokens_over_time\x18\x18 \x03(\v2\x1b.candela.v1.TimeSeriesPointR\x1bcacheCreationTokensOverTime\x12P\n" +
+	"\x16input_tokens_over_time\x18\x19 \x03(\v2\x1b.candela.v1.TimeSeriesPointR\x13inputTokensOverTime\x12R\n" +
+	"\x17output_tokens_over_time\x18\x1a \x03(\v2\x1b.candela.v1.TimeSeriesPointR\x14outputTokensOverTime\x12.\n" +
+	"\x06models\x18\x1e \x03(\v2\x16.candela.v1.ModelUsageR\x06models\x121\n" +
+	"\x06budget\x18( \x01(\v2\x19.candela.types.UserBudgetR\x06budget\x12.\n" +
+	"\x13total_remaining_usd\x18) \x01(\x01R\x11totalRemainingUsd\x12?\n" +
+	"\ractive_grants\x18* \x03(\v2\x1a.candela.types.BudgetGrantR\factiveGrants2\xc0\x05\n" +
+	"\x10DashboardService\x12]\n" +
+	"\x10GetDashboardData\x12#.candela.v1.GetDashboardDataRequest\x1a$.candela.v1.GetDashboardDataResponse\x12_\n" +
+	"\x0fGetUsageSummary\x12\".candela.v1.GetUsageSummaryRequest\x1a#.candela.v1.GetUsageSummaryResponse\"\x03\x88\x02\x01\x12e\n" +
+	"\x11GetModelBreakdown\x12$.candela.v1.GetModelBreakdownRequest\x1a%.candela.v1.GetModelBreakdownResponse\"\x03\x88\x02\x01\x12l\n" +
+	"\x15GetLatencyPercentiles\x12(.candela.v1.GetLatencyPercentilesRequest\x1a).candela.v1.GetLatencyPercentilesResponse\x12P\n" +
+	"\n" +
+	"GetMyUsage\x12\x1d.candela.v1.GetMyUsageRequest\x1a\x1e.candela.v1.GetMyUsageResponse\"\x03\x88\x02\x01\x12c\n" +
 	"\x12GetTeamLeaderboard\x12%.candela.v1.GetTeamLeaderboardRequest\x1a&.candela.v1.GetTeamLeaderboardResponse\x12`\n" +
 	"\x11GetJobLeaderboard\x12$.candela.v1.GetJobLeaderboardRequest\x1a%.candela.v1.GetJobLeaderboardResponseB\xaa\x01\n" +
 	"\x0ecom.candela.v1B\x15DashboardServiceProtoP\x01Z8github.com/candelahq/candela/gen/go/candela/v1;candelav1\xa2\x02\x03CXX\xaa\x02\n" +
@@ -1291,7 +1680,7 @@ func file_candela_v1_dashboard_service_proto_rawDescGZIP() []byte {
 	return file_candela_v1_dashboard_service_proto_rawDescData
 }
 
-var file_candela_v1_dashboard_service_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_candela_v1_dashboard_service_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_candela_v1_dashboard_service_proto_goTypes = []any{
 	(*GetUsageSummaryRequest)(nil),        // 0: candela.v1.GetUsageSummaryRequest
 	(*GetUsageSummaryResponse)(nil),       // 1: candela.v1.GetUsageSummaryResponse
@@ -1309,44 +1698,63 @@ var file_candela_v1_dashboard_service_proto_goTypes = []any{
 	(*GetJobLeaderboardRequest)(nil),      // 13: candela.v1.GetJobLeaderboardRequest
 	(*GetJobLeaderboardResponse)(nil),     // 14: candela.v1.GetJobLeaderboardResponse
 	(*JobUsage)(nil),                      // 15: candela.v1.JobUsage
-	(*types.TimeRange)(nil),               // 16: candela.types.TimeRange
-	(*types.UserBudget)(nil),              // 17: candela.types.UserBudget
-	(*types.BudgetGrant)(nil),             // 18: candela.types.BudgetGrant
+	(*GetDashboardDataRequest)(nil),       // 16: candela.v1.GetDashboardDataRequest
+	(*GetDashboardDataResponse)(nil),      // 17: candela.v1.GetDashboardDataResponse
+	(*types.TimeRange)(nil),               // 18: candela.types.TimeRange
+	(*types.UserBudget)(nil),              // 19: candela.types.UserBudget
+	(*types.BudgetGrant)(nil),             // 20: candela.types.BudgetGrant
 }
 var file_candela_v1_dashboard_service_proto_depIdxs = []int32{
-	16, // 0: candela.v1.GetUsageSummaryRequest.time_range:type_name -> candela.types.TimeRange
+	18, // 0: candela.v1.GetUsageSummaryRequest.time_range:type_name -> candela.types.TimeRange
 	2,  // 1: candela.v1.GetUsageSummaryResponse.traces_over_time:type_name -> candela.v1.TimeSeriesPoint
 	2,  // 2: candela.v1.GetUsageSummaryResponse.cost_over_time:type_name -> candela.v1.TimeSeriesPoint
 	2,  // 3: candela.v1.GetUsageSummaryResponse.tokens_over_time:type_name -> candela.v1.TimeSeriesPoint
-	16, // 4: candela.v1.GetModelBreakdownRequest.time_range:type_name -> candela.types.TimeRange
-	5,  // 5: candela.v1.GetModelBreakdownResponse.models:type_name -> candela.v1.ModelUsage
-	16, // 6: candela.v1.GetLatencyPercentilesRequest.time_range:type_name -> candela.types.TimeRange
-	2,  // 7: candela.v1.GetLatencyPercentilesResponse.latency_over_time:type_name -> candela.v1.TimeSeriesPoint
-	16, // 8: candela.v1.GetMyUsageRequest.time_range:type_name -> candela.types.TimeRange
-	5,  // 9: candela.v1.GetMyUsageResponse.models:type_name -> candela.v1.ModelUsage
-	17, // 10: candela.v1.GetMyUsageResponse.budget:type_name -> candela.types.UserBudget
-	18, // 11: candela.v1.GetMyUsageResponse.active_grants:type_name -> candela.types.BudgetGrant
-	16, // 12: candela.v1.GetTeamLeaderboardRequest.time_range:type_name -> candela.types.TimeRange
-	12, // 13: candela.v1.GetTeamLeaderboardResponse.users:type_name -> candela.v1.UserUsage
-	16, // 14: candela.v1.GetJobLeaderboardRequest.time_range:type_name -> candela.types.TimeRange
-	15, // 15: candela.v1.GetJobLeaderboardResponse.jobs:type_name -> candela.v1.JobUsage
-	0,  // 16: candela.v1.DashboardService.GetUsageSummary:input_type -> candela.v1.GetUsageSummaryRequest
-	3,  // 17: candela.v1.DashboardService.GetModelBreakdown:input_type -> candela.v1.GetModelBreakdownRequest
-	6,  // 18: candela.v1.DashboardService.GetLatencyPercentiles:input_type -> candela.v1.GetLatencyPercentilesRequest
-	8,  // 19: candela.v1.DashboardService.GetMyUsage:input_type -> candela.v1.GetMyUsageRequest
-	10, // 20: candela.v1.DashboardService.GetTeamLeaderboard:input_type -> candela.v1.GetTeamLeaderboardRequest
-	13, // 21: candela.v1.DashboardService.GetJobLeaderboard:input_type -> candela.v1.GetJobLeaderboardRequest
-	1,  // 22: candela.v1.DashboardService.GetUsageSummary:output_type -> candela.v1.GetUsageSummaryResponse
-	4,  // 23: candela.v1.DashboardService.GetModelBreakdown:output_type -> candela.v1.GetModelBreakdownResponse
-	7,  // 24: candela.v1.DashboardService.GetLatencyPercentiles:output_type -> candela.v1.GetLatencyPercentilesResponse
-	9,  // 25: candela.v1.DashboardService.GetMyUsage:output_type -> candela.v1.GetMyUsageResponse
-	11, // 26: candela.v1.DashboardService.GetTeamLeaderboard:output_type -> candela.v1.GetTeamLeaderboardResponse
-	14, // 27: candela.v1.DashboardService.GetJobLeaderboard:output_type -> candela.v1.GetJobLeaderboardResponse
-	22, // [22:28] is the sub-list for method output_type
-	16, // [16:22] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	2,  // 4: candela.v1.GetUsageSummaryResponse.cache_read_tokens_over_time:type_name -> candela.v1.TimeSeriesPoint
+	2,  // 5: candela.v1.GetUsageSummaryResponse.cache_creation_tokens_over_time:type_name -> candela.v1.TimeSeriesPoint
+	2,  // 6: candela.v1.GetUsageSummaryResponse.input_tokens_over_time:type_name -> candela.v1.TimeSeriesPoint
+	2,  // 7: candela.v1.GetUsageSummaryResponse.output_tokens_over_time:type_name -> candela.v1.TimeSeriesPoint
+	18, // 8: candela.v1.GetModelBreakdownRequest.time_range:type_name -> candela.types.TimeRange
+	5,  // 9: candela.v1.GetModelBreakdownResponse.models:type_name -> candela.v1.ModelUsage
+	18, // 10: candela.v1.GetLatencyPercentilesRequest.time_range:type_name -> candela.types.TimeRange
+	2,  // 11: candela.v1.GetLatencyPercentilesResponse.latency_over_time:type_name -> candela.v1.TimeSeriesPoint
+	18, // 12: candela.v1.GetMyUsageRequest.time_range:type_name -> candela.types.TimeRange
+	5,  // 13: candela.v1.GetMyUsageResponse.models:type_name -> candela.v1.ModelUsage
+	19, // 14: candela.v1.GetMyUsageResponse.budget:type_name -> candela.types.UserBudget
+	20, // 15: candela.v1.GetMyUsageResponse.active_grants:type_name -> candela.types.BudgetGrant
+	18, // 16: candela.v1.GetTeamLeaderboardRequest.time_range:type_name -> candela.types.TimeRange
+	12, // 17: candela.v1.GetTeamLeaderboardResponse.users:type_name -> candela.v1.UserUsage
+	18, // 18: candela.v1.GetJobLeaderboardRequest.time_range:type_name -> candela.types.TimeRange
+	15, // 19: candela.v1.GetJobLeaderboardResponse.jobs:type_name -> candela.v1.JobUsage
+	18, // 20: candela.v1.GetDashboardDataRequest.time_range:type_name -> candela.types.TimeRange
+	2,  // 21: candela.v1.GetDashboardDataResponse.traces_over_time:type_name -> candela.v1.TimeSeriesPoint
+	2,  // 22: candela.v1.GetDashboardDataResponse.cost_over_time:type_name -> candela.v1.TimeSeriesPoint
+	2,  // 23: candela.v1.GetDashboardDataResponse.tokens_over_time:type_name -> candela.v1.TimeSeriesPoint
+	2,  // 24: candela.v1.GetDashboardDataResponse.cache_read_tokens_over_time:type_name -> candela.v1.TimeSeriesPoint
+	2,  // 25: candela.v1.GetDashboardDataResponse.cache_creation_tokens_over_time:type_name -> candela.v1.TimeSeriesPoint
+	2,  // 26: candela.v1.GetDashboardDataResponse.input_tokens_over_time:type_name -> candela.v1.TimeSeriesPoint
+	2,  // 27: candela.v1.GetDashboardDataResponse.output_tokens_over_time:type_name -> candela.v1.TimeSeriesPoint
+	5,  // 28: candela.v1.GetDashboardDataResponse.models:type_name -> candela.v1.ModelUsage
+	19, // 29: candela.v1.GetDashboardDataResponse.budget:type_name -> candela.types.UserBudget
+	20, // 30: candela.v1.GetDashboardDataResponse.active_grants:type_name -> candela.types.BudgetGrant
+	16, // 31: candela.v1.DashboardService.GetDashboardData:input_type -> candela.v1.GetDashboardDataRequest
+	0,  // 32: candela.v1.DashboardService.GetUsageSummary:input_type -> candela.v1.GetUsageSummaryRequest
+	3,  // 33: candela.v1.DashboardService.GetModelBreakdown:input_type -> candela.v1.GetModelBreakdownRequest
+	6,  // 34: candela.v1.DashboardService.GetLatencyPercentiles:input_type -> candela.v1.GetLatencyPercentilesRequest
+	8,  // 35: candela.v1.DashboardService.GetMyUsage:input_type -> candela.v1.GetMyUsageRequest
+	10, // 36: candela.v1.DashboardService.GetTeamLeaderboard:input_type -> candela.v1.GetTeamLeaderboardRequest
+	13, // 37: candela.v1.DashboardService.GetJobLeaderboard:input_type -> candela.v1.GetJobLeaderboardRequest
+	17, // 38: candela.v1.DashboardService.GetDashboardData:output_type -> candela.v1.GetDashboardDataResponse
+	1,  // 39: candela.v1.DashboardService.GetUsageSummary:output_type -> candela.v1.GetUsageSummaryResponse
+	4,  // 40: candela.v1.DashboardService.GetModelBreakdown:output_type -> candela.v1.GetModelBreakdownResponse
+	7,  // 41: candela.v1.DashboardService.GetLatencyPercentiles:output_type -> candela.v1.GetLatencyPercentilesResponse
+	9,  // 42: candela.v1.DashboardService.GetMyUsage:output_type -> candela.v1.GetMyUsageResponse
+	11, // 43: candela.v1.DashboardService.GetTeamLeaderboard:output_type -> candela.v1.GetTeamLeaderboardResponse
+	14, // 44: candela.v1.DashboardService.GetJobLeaderboard:output_type -> candela.v1.GetJobLeaderboardResponse
+	38, // [38:45] is the sub-list for method output_type
+	31, // [31:38] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_candela_v1_dashboard_service_proto_init() }
@@ -1360,7 +1768,7 @@ func file_candela_v1_dashboard_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_candela_v1_dashboard_service_proto_rawDesc), len(file_candela_v1_dashboard_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   16,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/candelahq/candela/gen/go/candela/v1"
 	"github.com/candelahq/candela/pkg/auth"
 	"github.com/candelahq/candela/pkg/storage"
+	"golang.org/x/sync/errgroup"
 )
 
 // DashboardHandler implements the DashboardService ConnectRPC handler.
@@ -409,4 +410,138 @@ func (h *DashboardHandler) GetJobLeaderboard(ctx context.Context, req *connect.R
 		pbJobs = append(pbJobs, &v1.JobUsage{JobId: j.JobID, CallCount: j.CallCount, TotalTokens: j.TotalTokens, CostUsd: j.CostUSD, AvgLatencyMs: j.AvgLatencyMs, TopModel: j.TopModel})
 	}
 	return connect.NewResponse(&v1.GetJobLeaderboardResponse{Jobs: pbJobs}), nil
+}
+
+// GetDashboardData returns a consolidated dashboard view: usage summary,
+// per-model breakdown, and (optionally) per-user budget context — all in a
+// single RPC. This replaces the client-side fan-out of GetUsageSummary +
+// GetModelBreakdown + GetMyUsage.
+func (h *DashboardHandler) GetDashboardData(
+	ctx context.Context,
+	req *connect.Request[v1.GetDashboardDataRequest],
+) (*connect.Response[v1.GetDashboardDataResponse], error) {
+	msg := req.Msg
+
+	// ── Build query ─────────────────────────────────────────────────────────
+	q := storage.UsageQuery{
+		ProjectID:   msg.ProjectId,
+		Environment: msg.Environment,
+		UserID:      scopeUserID(ctx, h.users),
+	}
+	if msg.TimeRange != nil {
+		if msg.TimeRange.Start != nil {
+			q.StartTime = msg.TimeRange.Start.AsTime()
+		}
+		if msg.TimeRange.End != nil {
+			q.EndTime = msg.TimeRange.End.AsTime()
+		}
+	}
+	if q.StartTime.IsZero() {
+		q.StartTime = time.Now().Add(-24 * time.Hour)
+	}
+	if q.EndTime.IsZero() {
+		q.EndTime = time.Now()
+	}
+
+	// ── Storage: usage summary + model breakdown ────────────────────────────
+	// If the store implements CombinedUsageReader (BigQuery), fetch both in a
+	// single scan. Otherwise fall back to two concurrent reads.
+	var summary *storage.UsageSummary
+	var models []storage.ModelUsage
+
+	if combined, ok := h.store.(storage.CombinedUsageReader); ok {
+		s, m, err := combined.GetUsageWithModelBreakdown(ctx, q)
+		if err != nil {
+			return nil, internalError("failed to get combined usage", err)
+		}
+		summary = s
+		models = m
+	} else {
+		g, gCtx := errgroup.WithContext(ctx)
+		g.Go(func() error {
+			v, err := h.store.GetUsageSummary(gCtx, q)
+			if err != nil {
+				return fmt.Errorf("usage summary: %w", err)
+			}
+			summary = v
+			return nil
+		})
+		g.Go(func() error {
+			v, err := h.store.GetModelBreakdown(gCtx, q)
+			if err != nil {
+				return fmt.Errorf("model breakdown: %w", err)
+			}
+			models = v
+			return nil
+		})
+		if err := g.Wait(); err != nil {
+			return nil, internalError("failed to get dashboard data", err)
+		}
+	}
+
+	// ── Build response ──────────────────────────────────────────────────────
+	resp := &v1.GetDashboardDataResponse{}
+	if summary != nil {
+		resp.TotalTraces = summary.TotalTraces
+		resp.TotalSpans = summary.TotalSpans
+		resp.TotalLlmCalls = summary.TotalLLMCalls
+		resp.TotalInputTokens = summary.TotalInputTokens
+		resp.TotalOutputTokens = summary.TotalOutputTokens
+		resp.TotalCostUsd = summary.TotalCostUSD
+		resp.AvgLatencyMs = summary.AvgLatencyMs
+		resp.ErrorRate = summary.ErrorRate
+		resp.TotalCacheReadTokens = summary.TotalCacheReadTokens
+		resp.TotalCacheCreationTokens = summary.TotalCacheCreationTokens
+	}
+	for _, m := range models {
+		resp.Models = append(resp.Models, &v1.ModelUsage{
+			Model:               m.Model,
+			Provider:            m.Provider,
+			CallCount:           m.CallCount,
+			InputTokens:         m.InputTokens,
+			OutputTokens:        m.OutputTokens,
+			CostUsd:             m.CostUSD,
+			AvgLatencyMs:        m.AvgLatencyMs,
+			CacheReadTokens:     m.CacheReadTokens,
+			CacheCreationTokens: m.CacheCreationTokens,
+		})
+	}
+
+	// ── Optional: budget + grants (requires auth) ───────────────────────────
+	if msg.IncludeBudget && h.users != nil {
+		authUser := auth.FromContext(ctx)
+		if authUser != nil {
+			userID, err := resolveUserID(ctx, h.users, authUser.Email)
+			if err != nil {
+				if !errors.Is(err, storage.ErrNotFound) {
+					slog.Warn("GetDashboardData: failed to resolve user for budget", "error", err)
+				}
+				// Non-fatal: return data without budget context.
+			} else {
+				budget, err := h.users.GetBudget(ctx, userID)
+				if err != nil {
+					slog.Warn("GetDashboardData: failed to get budget", "error", err)
+				} else {
+					resp.Budget = budgetToProto(budget)
+				}
+
+				grants, err := h.users.ListGrants(ctx, userID, true)
+				if err != nil {
+					slog.Warn("GetDashboardData: failed to list grants", "error", err)
+				} else {
+					for _, g := range grants {
+						resp.ActiveGrants = append(resp.ActiveGrants, grantToProto(g))
+					}
+				}
+
+				// Compute total remaining across budget + grants.
+				check, err := h.users.CheckBudget(ctx, userID, 0)
+				if err == nil && check != nil {
+					resp.TotalRemainingUsd = check.RemainingUSD
+				}
+			}
+		}
+	}
+
+	return connect.NewResponse(resp), nil
 }

--- a/pkg/connecthandlers/dashboard_handler_test.go
+++ b/pkg/connecthandlers/dashboard_handler_test.go
@@ -102,7 +102,7 @@ func TestGetMyUsage_CombinedReaderBranch(t *testing.T) {
 
 	client := startDashboardServer(t, store)
 
-	resp, err := client.GetMyUsage(context.Background(), connect.NewRequest(&v1.GetMyUsageRequest{}))
+	resp, err := client.GetMyUsage(context.Background(), connect.NewRequest(&v1.GetMyUsageRequest{})) //nolint:staticcheck
 	if err != nil {
 		t.Fatalf("GetMyUsage failed: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestGetMyUsage_FallbackBranch(t *testing.T) {
 
 	client := startDashboardServer(t, store)
 
-	resp, err := client.GetMyUsage(context.Background(), connect.NewRequest(&v1.GetMyUsageRequest{}))
+	resp, err := client.GetMyUsage(context.Background(), connect.NewRequest(&v1.GetMyUsageRequest{})) //nolint:staticcheck
 	if err != nil {
 		t.Fatalf("GetMyUsage fallback failed: %v", err)
 	}

--- a/pkg/connecthandlers/dashboard_handler_test.go
+++ b/pkg/connecthandlers/dashboard_handler_test.go
@@ -15,29 +15,24 @@ import (
 	"github.com/candelahq/candela/pkg/storage"
 )
 
-// ── Mock store that implements CombinedUsageReader ───────────────────────────
+// ── Mock stores ─────────────────────────────────────────────────────────────
 
-// combinedStore embeds a minimal SpanReader and adds CombinedUsageReader.
 type combinedStore struct {
-	storage.SpanReader // nil — only GetUsageWithModelBreakdown is called
-	summary            *storage.UsageSummary
-	models             []storage.ModelUsage
+	storage.SpanReader
+	summary *storage.UsageSummary
+	models  []storage.ModelUsage
 }
 
 func (s *combinedStore) GetUsageWithModelBreakdown(_ context.Context, _ storage.UsageQuery) (*storage.UsageSummary, []storage.ModelUsage, error) {
 	return s.summary, s.models, nil
 }
 
-// ── Mock store that does NOT implement CombinedUsageReader ───────────────────
-
 type fallbackStore struct {
 	summary *storage.UsageSummary
 	models  []storage.ModelUsage
 }
 
-func (s *fallbackStore) GetTrace(context.Context, string) (*storage.Trace, error) {
-	return nil, nil
-}
+func (s *fallbackStore) GetTrace(context.Context, string) (*storage.Trace, error) { return nil, nil }
 func (s *fallbackStore) QueryTraces(context.Context, storage.TraceQuery) (*storage.TraceResult, error) {
 	return nil, nil
 }
@@ -62,85 +57,90 @@ func (s *fallbackStore) GetJobLeaderboard(context.Context, storage.UsageQuery, i
 func (s *fallbackStore) Ping(context.Context) error { return nil }
 func (s *fallbackStore) Close() error               { return nil }
 
-// ── Test helpers ────────────────────────────────────────────────────────────
+type mockSpanReader struct {
+	storage.SpanReader
+	summary *storage.UsageSummary
+	models  []storage.ModelUsage
+}
+
+func (m *mockSpanReader) GetUsageSummary(_ context.Context, _ storage.UsageQuery) (*storage.UsageSummary, error) {
+	if m.summary == nil {
+		return &storage.UsageSummary{}, nil
+	}
+	return m.summary, nil
+}
+
+func (m *mockSpanReader) GetModelBreakdown(_ context.Context, _ storage.UsageQuery) ([]storage.ModelUsage, error) {
+	return m.models, nil
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
 
 func startDashboardServer(t *testing.T, store storage.SpanReader) candelav1connect.DashboardServiceClient {
 	t.Helper()
 	mux := http.NewServeMux()
-	path, handler := candelav1connect.NewDashboardServiceHandler(
-		connecthandlers.NewDashboardHandler(store, nil),
-	)
+	path, handler := candelav1connect.NewDashboardServiceHandler(connecthandlers.NewDashboardHandler(store, nil))
 	mux.Handle(path, handler)
-
-	// Inject an authenticated user into every request so GetMyUsage passes auth.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := auth.NewContext(r.Context(), &auth.User{ID: "test-user", Email: "test@test.com"})
 		mux.ServeHTTP(w, r.WithContext(ctx))
 	}))
 	t.Cleanup(server.Close)
-
 	return candelav1connect.NewDashboardServiceClient(http.DefaultClient, server.URL)
 }
 
-// ── Tests ────────────────────────────────────────────────────────────────────
+func startDashboardTestServer(t *testing.T, reader storage.SpanReader, users storage.UserStore) candelav1connect.DashboardServiceClient {
+	t.Helper()
+	mux := http.NewServeMux()
+	path, handler := candelav1connect.NewDashboardServiceHandler(connecthandlers.NewDashboardHandler(reader, users))
+	mux.Handle(path, handler)
+	server := httptest.NewServer(testAuthMiddleware(mux))
+	t.Cleanup(server.Close)
+	return candelav1connect.NewDashboardServiceClient(http.DefaultClient, server.URL,
+		connect.WithInterceptors(connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+				req.Header().Set("X-Test-Email", "user@test.com")
+				return next(ctx, req)
+			}
+		})),
+	)
+}
+
+var _ storage.CombinedUsageReader = (*combinedStore)(nil)
+var _ = time.Now
+
+// ── GetMyUsage Tests ────────────────────────────────────────────────────────
 
 func TestGetMyUsage_CombinedReaderBranch(t *testing.T) {
-	// When the store implements CombinedUsageReader, the handler should use it
-	// instead of the two-concurrent-query fallback.
 	store := &combinedStore{
-		summary: &storage.UsageSummary{
-			TotalLLMCalls:    42,
-			TotalInputTokens: 10000,
-			TotalCostUSD:     1.23,
-		},
+		summary: &storage.UsageSummary{TotalLLMCalls: 42, TotalInputTokens: 10000, TotalCostUSD: 1.23},
 		models: []storage.ModelUsage{
-			{Model: "claude-sonnet-4-20250514", Provider: "anthropic", CallCount: 30, CostUSD: 0.90,
-				CacheReadTokens: 5000, CacheCreationTokens: 200},
+			{Model: "claude-sonnet-4-20250514", Provider: "anthropic", CallCount: 30, CostUSD: 0.90, CacheReadTokens: 5000, CacheCreationTokens: 200},
 			{Model: "gpt-4o", Provider: "openai", CallCount: 12, CostUSD: 0.33},
 		},
 	}
-
 	client := startDashboardServer(t, store)
-
 	resp, err := client.GetMyUsage(context.Background(), connect.NewRequest(&v1.GetMyUsageRequest{})) //nolint:staticcheck
 	if err != nil {
 		t.Fatalf("GetMyUsage failed: %v", err)
 	}
-
 	if resp.Msg.TotalCalls != 42 {
 		t.Errorf("TotalCalls = %d, want 42", resp.Msg.TotalCalls)
-	}
-	if resp.Msg.TotalCostUsd != 1.23 {
-		t.Errorf("TotalCostUsd = %f, want 1.23", resp.Msg.TotalCostUsd)
 	}
 	if len(resp.Msg.Models) != 2 {
 		t.Fatalf("Models count = %d, want 2", len(resp.Msg.Models))
 	}
-	if resp.Msg.Models[0].Model != "claude-sonnet-4-20250514" {
-		t.Errorf("Models[0].Model = %q, want claude-sonnet-4-20250514", resp.Msg.Models[0].Model)
-	}
 }
 
 func TestGetMyUsage_FallbackBranch(t *testing.T) {
-	// When the store does NOT implement CombinedUsageReader, the handler should
-	// fall back to concurrent GetUsageSummary + GetModelBreakdown.
 	store := &fallbackStore{
-		summary: &storage.UsageSummary{
-			TotalLLMCalls: 10,
-			TotalCostUSD:  0.50,
-		},
-		models: []storage.ModelUsage{
-			{Model: "gpt-4o", Provider: "openai", CallCount: 10, CostUSD: 0.50},
-		},
+		summary: &storage.UsageSummary{TotalLLMCalls: 10, TotalCostUSD: 0.50},
+		models:  []storage.ModelUsage{{Model: "gpt-4o", Provider: "openai", CallCount: 10, CostUSD: 0.50}},
 	}
-
-	// Verify the store does NOT satisfy CombinedUsageReader.
 	if _, ok := storage.SpanReader(store).(storage.CombinedUsageReader); ok {
 		t.Fatal("fallbackStore should NOT implement CombinedUsageReader")
 	}
-
 	client := startDashboardServer(t, store)
-
 	resp, err := client.GetMyUsage(context.Background(), connect.NewRequest(&v1.GetMyUsageRequest{})) //nolint:staticcheck
 	if err != nil {
 		t.Fatalf("GetMyUsage fallback failed: %v", err)
@@ -148,17 +148,157 @@ func TestGetMyUsage_FallbackBranch(t *testing.T) {
 	if resp.Msg.TotalCalls != 10 {
 		t.Errorf("TotalCalls = %d, want 10", resp.Msg.TotalCalls)
 	}
-	if len(resp.Msg.Models) != 1 {
-		t.Errorf("Models count = %d, want 1", len(resp.Msg.Models))
+}
+
+// ── GetDashboardData Tests ──────────────────────────────────────────────────
+
+func TestGetDashboardData_EmptyBody_Returns200(t *testing.T) {
+	client := startDashboardTestServer(t, &mockSpanReader{}, nil)
+	resp, err := client.GetDashboardData(context.Background(), connect.NewRequest(&v1.GetDashboardDataRequest{}))
+	if err != nil {
+		t.Fatalf("GetDashboardData with empty body should return 200: %v", err)
+	}
+	if resp.Msg.TotalLlmCalls != 0 {
+		t.Errorf("TotalLlmCalls = %d, want 0", resp.Msg.TotalLlmCalls)
 	}
 }
 
-// Compile-time assertion: combinedStore satisfies CombinedUsageReader.
-var _ storage.CombinedUsageReader = (*combinedStore)(nil)
+func TestGetDashboardData_WithTimeRange_ReturnsSummary(t *testing.T) {
+	reader := &mockSpanReader{summary: &storage.UsageSummary{TotalLLMCalls: 42, TotalCostUSD: 1.23}}
+	client := startDashboardTestServer(t, reader, nil)
+	resp, err := client.GetDashboardData(context.Background(), connect.NewRequest(&v1.GetDashboardDataRequest{}))
+	if err != nil {
+		t.Fatalf("GetDashboardData should succeed: %v", err)
+	}
+	if resp.Msg.TotalLlmCalls != 42 {
+		t.Errorf("TotalLlmCalls = %d, want 42", resp.Msg.TotalLlmCalls)
+	}
+	if resp.Msg.TotalCostUsd != 1.23 {
+		t.Errorf("TotalCostUsd = %f, want 1.23", resp.Msg.TotalCostUsd)
+	}
+}
 
-// Compile-time assertion: fallbackStore does NOT satisfy CombinedUsageReader.
-// (Verified at runtime in TestGetMyUsage_FallbackBranch above — can't
-// assert "does not implement" at compile time.)
+func TestGetDashboardData_CombinedReader_SingleScan(t *testing.T) {
+	reader := &combinedStore{
+		summary: &storage.UsageSummary{TotalLLMCalls: 100, TotalInputTokens: 50000, TotalCostUSD: 5.00},
+		models: []storage.ModelUsage{
+			{Model: "gpt-4o", Provider: "openai", CallCount: 60, CostUSD: 3.00},
+			{Model: "claude-sonnet", Provider: "anthropic", CallCount: 40, CostUSD: 2.00},
+		},
+	}
+	client := startDashboardTestServer(t, reader, nil)
+	resp, err := client.GetDashboardData(context.Background(), connect.NewRequest(&v1.GetDashboardDataRequest{}))
+	if err != nil {
+		t.Fatalf("GetDashboardData (combined) should succeed: %v", err)
+	}
+	if resp.Msg.TotalLlmCalls != 100 {
+		t.Errorf("TotalLlmCalls = %d, want 100", resp.Msg.TotalLlmCalls)
+	}
+	if len(resp.Msg.Models) != 2 {
+		t.Errorf("Models count = %d, want 2", len(resp.Msg.Models))
+	}
+}
 
-// Suppress unused-import lint for time (used by mock stubs if needed).
-var _ = time.Now
+func TestGetDashboardData_WithBudget(t *testing.T) {
+	reader := &mockSpanReader{summary: &storage.UsageSummary{TotalLLMCalls: 5}}
+	store := newIntegrationStore()
+	store.users["uid-1"] = &storage.UserRecord{ID: "uid-1", Email: "user@test.com"}
+	store.budgets["uid-1"] = &storage.BudgetRecord{LimitUSD: 50.0, SpentUSD: 12.50}
+	client := startDashboardTestServer(t, reader, store)
+	resp, err := client.GetDashboardData(context.Background(), connect.NewRequest(&v1.GetDashboardDataRequest{IncludeBudget: true}))
+	if err != nil {
+		t.Fatalf("GetDashboardData with budget should succeed: %v", err)
+	}
+	if resp.Msg.Budget == nil {
+		t.Fatal("Budget should be populated when include_budget=true")
+	}
+	if resp.Msg.Budget.LimitUsd != 50.0 {
+		t.Errorf("Budget.LimitUsd = %f, want 50.0", resp.Msg.Budget.LimitUsd)
+	}
+}
+
+func TestGetDashboardData_NoBudget_WhenFlagFalse(t *testing.T) {
+	reader := &mockSpanReader{summary: &storage.UsageSummary{TotalLLMCalls: 5}}
+	store := newIntegrationStore()
+	store.users["uid-1"] = &storage.UserRecord{ID: "uid-1", Email: "user@test.com"}
+	store.budgets["uid-1"] = &storage.BudgetRecord{LimitUSD: 50.0, SpentUSD: 12.50}
+	client := startDashboardTestServer(t, reader, store)
+	resp, err := client.GetDashboardData(context.Background(), connect.NewRequest(&v1.GetDashboardDataRequest{IncludeBudget: false}))
+	if err != nil {
+		t.Fatalf("GetDashboardData should succeed: %v", err)
+	}
+	if resp.Msg.Budget != nil {
+		t.Error("Budget should be nil when include_budget=false")
+	}
+}
+
+func TestGetDashboardData_CacheTokenFields(t *testing.T) {
+	reader := &mockSpanReader{summary: &storage.UsageSummary{TotalLLMCalls: 15, TotalCacheReadTokens: 50000, TotalCacheCreationTokens: 10000}}
+	client := startDashboardTestServer(t, reader, nil)
+	resp, err := client.GetDashboardData(context.Background(), connect.NewRequest(&v1.GetDashboardDataRequest{}))
+	if err != nil {
+		t.Fatalf("GetDashboardData should succeed: %v", err)
+	}
+	if resp.Msg.TotalCacheReadTokens != 50000 {
+		t.Errorf("TotalCacheReadTokens = %d, want 50000", resp.Msg.TotalCacheReadTokens)
+	}
+	if resp.Msg.TotalCacheCreationTokens != 10000 {
+		t.Errorf("TotalCacheCreationTokens = %d, want 10000", resp.Msg.TotalCacheCreationTokens)
+	}
+}
+
+func TestLegacyRPCs_StillWork(t *testing.T) {
+	reader := &mockSpanReader{
+		summary: &storage.UsageSummary{TotalLLMCalls: 7},
+		models:  []storage.ModelUsage{{Model: "test", Provider: "p", CallCount: 7}},
+	}
+	client := startDashboardTestServer(t, reader, nil)
+	sumResp, err := client.GetUsageSummary(context.Background(), connect.NewRequest(&v1.GetUsageSummaryRequest{})) //nolint:staticcheck
+	if err != nil {
+		t.Fatalf("GetUsageSummary should still work: %v", err)
+	}
+	if sumResp.Msg.TotalLlmCalls != 7 {
+		t.Errorf("TotalLlmCalls = %d, want 7", sumResp.Msg.TotalLlmCalls)
+	}
+	modResp, err := client.GetModelBreakdown(context.Background(), connect.NewRequest(&v1.GetModelBreakdownRequest{})) //nolint:staticcheck
+	if err != nil {
+		t.Fatalf("GetModelBreakdown should still work: %v", err)
+	}
+	if len(modResp.Msg.Models) != 1 {
+		t.Errorf("len(Models) = %d, want 1", len(modResp.Msg.Models))
+	}
+}
+
+func TestGetDashboardData_UnauthenticatedUser_StillReturnsData(t *testing.T) {
+	reader := &mockSpanReader{summary: &storage.UsageSummary{TotalLLMCalls: 99}}
+	mux := http.NewServeMux()
+	path, handler := candelav1connect.NewDashboardServiceHandler(connecthandlers.NewDashboardHandler(reader, nil))
+	mux.Handle(path, handler)
+	server := httptest.NewServer(testAuthMiddleware(mux))
+	t.Cleanup(server.Close)
+	client := candelav1connect.NewDashboardServiceClient(http.DefaultClient, server.URL)
+	resp, err := client.GetDashboardData(context.Background(), connect.NewRequest(&v1.GetDashboardDataRequest{}))
+	if err != nil {
+		t.Fatalf("GetDashboardData without auth should succeed: %v", err)
+	}
+	if resp.Msg.TotalLlmCalls != 99 {
+		t.Errorf("TotalLlmCalls = %d, want 99", resp.Msg.TotalLlmCalls)
+	}
+}
+
+func TestGetDashboardData_AuthUserPropagated(t *testing.T) {
+	reader := &mockSpanReader{summary: &storage.UsageSummary{TotalLLMCalls: 5}}
+	store := newIntegrationStore()
+	connecthandlers.ResetUserIDCacheForTest()
+	client := startDashboardTestServer(t, reader, store)
+	resp, err := client.GetDashboardData(context.Background(), connect.NewRequest(&v1.GetDashboardDataRequest{IncludeBudget: true}))
+	if err != nil {
+		t.Fatalf("GetDashboardData should succeed even if user not in store: %v", err)
+	}
+	if resp.Msg.Budget != nil {
+		t.Error("Budget should be nil when user not found in store")
+	}
+	if resp.Msg.TotalLlmCalls != 5 {
+		t.Errorf("TotalLlmCalls = %d, want 5", resp.Msg.TotalLlmCalls)
+	}
+}

--- a/pkg/connecthandlers/export_test.go
+++ b/pkg/connecthandlers/export_test.go
@@ -1,0 +1,4 @@
+package connecthandlers
+
+// ResetUserIDCacheForTest exposes resetUserIDCache to external test packages.
+var ResetUserIDCacheForTest = resetUserIDCache

--- a/test/functional/dashboard/dashboard_data.hurl
+++ b/test/functional/dashboard/dashboard_data.hurl
@@ -1,0 +1,98 @@
+# DASH-20..25: GetDashboardData consolidated endpoint
+# Validates the new GetDashboardData RPC that replaces the concurrent
+# fan-out of GetUsageSummary + GetModelBreakdown + GetMyUsage.
+#
+# Usage:
+#   hurl --variable ANALYSIS_URL=http://localhost:8080 \
+#        --variable AUTH_TOKEN=$(gcloud auth print-access-token) \
+#        test/functional/dashboard/dashboard_data.hurl
+
+
+# ── DASH-20: GetDashboardData without auth → 401 ───────────────────────────
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetDashboardData
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.error" == "missing authentication"
+
+
+# ── DASH-21: GetDashboardData with valid auth + empty body → 200 ────────────
+# Empty body defaults to 24h window, no budget.
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetDashboardData
+Authorization: Bearer {{AUTH_TOKEN}}
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+
+
+# ── DASH-22: GetDashboardData with time range → 200 + models array ──────────
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetDashboardData
+Authorization: Bearer {{AUTH_TOKEN}}
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{
+  "project_id": "",
+  "time_range": {
+    "start": "2026-01-01T00:00:00Z",
+    "end": "2026-12-31T23:59:59Z"
+  }
+}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+
+
+# ── DASH-23: GetDashboardData with include_budget=true → 200 ────────────────
+# Budget fields are populated when the user has a budget configured.
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetDashboardData
+Authorization: Bearer {{AUTH_TOKEN}}
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{
+  "project_id": "",
+  "time_range": {
+    "start": "2026-01-01T00:00:00Z",
+    "end": "2026-12-31T23:59:59Z"
+  },
+  "include_budget": true
+}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+
+
+# ── DASH-24: GetDashboardData with malformed time_range → 400 ───────────────
+# Regression guard: string enum instead of TimeRange message.
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetDashboardData
+Authorization: Bearer {{AUTH_TOKEN}}
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{
+  "project_id": "",
+  "time_range": "24h"
+}
+
+HTTP 400
+[Asserts]
+jsonpath "$.code" == "invalid_argument"
+
+
+# ── DASH-25: GetDashboardData with invalid Bearer token → 401 ───────────────
+POST {{ANALYSIS_URL}}/candela.v1.DashboardService/GetDashboardData
+Authorization: Bearer invalid-garbage-token
+Content-Type: application/json
+Connect-Protocol-Version: 1
+{}
+
+HTTP 401
+[Asserts]
+jsonpath "$.error" == "invalid authentication token"

--- a/ui/src/gen/candela/v1/dashboard_service_connect.ts
+++ b/ui/src/gen/candela/v1/dashboard_service_connect.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { GetJobLeaderboardRequest, GetJobLeaderboardResponse, GetLatencyPercentilesRequest, GetLatencyPercentilesResponse, GetModelBreakdownRequest, GetModelBreakdownResponse, GetMyUsageRequest, GetMyUsageResponse, GetTeamLeaderboardRequest, GetTeamLeaderboardResponse, GetUsageSummaryRequest, GetUsageSummaryResponse } from "./dashboard_service_pb.js";
+import { GetDashboardDataRequest, GetDashboardDataResponse, GetJobLeaderboardRequest, GetJobLeaderboardResponse, GetLatencyPercentilesRequest, GetLatencyPercentilesResponse, GetModelBreakdownRequest, GetModelBreakdownResponse, GetMyUsageRequest, GetMyUsageResponse, GetTeamLeaderboardRequest, GetTeamLeaderboardResponse, GetUsageSummaryRequest, GetUsageSummaryResponse } from "./dashboard_service_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -16,9 +16,24 @@ export const DashboardService = {
   typeName: "candela.v1.DashboardService",
   methods: {
     /**
-     * GetUsageSummary returns aggregated token usage, cost, and request counts.
+     * GetDashboardData returns a consolidated dashboard view including usage
+     * summary, per-model breakdown, and (if authenticated) per-user budget
+     * context. Replaces the concurrent fan-out of GetUsageSummary +
+     * GetModelBreakdown + GetMyUsage with a single round-trip.
+     *
+     * @generated from rpc candela.v1.DashboardService.GetDashboardData
+     */
+    getDashboardData: {
+      name: "GetDashboardData",
+      I: GetDashboardDataRequest,
+      O: GetDashboardDataResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * Deprecated: use GetDashboardData instead.
      *
      * @generated from rpc candela.v1.DashboardService.GetUsageSummary
+     * @deprecated
      */
     getUsageSummary: {
       name: "GetUsageSummary",
@@ -27,9 +42,10 @@ export const DashboardService = {
       kind: MethodKind.Unary,
     },
     /**
-     * GetModelBreakdown returns usage broken down by model.
+     * Deprecated: use GetDashboardData instead.
      *
      * @generated from rpc candela.v1.DashboardService.GetModelBreakdown
+     * @deprecated
      */
     getModelBreakdown: {
       name: "GetModelBreakdown",
@@ -49,10 +65,11 @@ export const DashboardService = {
       kind: MethodKind.Unary,
     },
     /**
-     * GetMyUsage returns the calling user's personal usage summary (BigQuery).
+     * Deprecated: use GetDashboardData with include_budget=true instead.
      * For real-time budget/grant progress, see UserService.GetMyBudget.
      *
      * @generated from rpc candela.v1.DashboardService.GetMyUsage
+     * @deprecated
      */
     getMyUsage: {
       name: "GetMyUsage",

--- a/ui/src/gen/candela/v1/dashboard_service_pb.ts
+++ b/ui/src/gen/candela/v1/dashboard_service_pb.ts
@@ -14,7 +14,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file candela/v1/dashboard_service.proto.
  */
 export const file_candela_v1_dashboard_service: GenFile = /*@__PURE__*/
-  fileDesc("CiJjYW5kZWxhL3YxL2Rhc2hib2FyZF9zZXJ2aWNlLnByb3RvEgpjYW5kZWxhLnYxIm8KFkdldFVzYWdlU3VtbWFyeVJlcXVlc3QSEgoKcHJvamVjdF9pZBgBIAEoCRIsCgp0aW1lX3JhbmdlGAIgASgLMhguY2FuZGVsYS50eXBlcy5UaW1lUmFuZ2USEwoLZW52aXJvbm1lbnQYAyABKAkiwwMKF0dldFVzYWdlU3VtbWFyeVJlc3BvbnNlEhQKDHRvdGFsX3RyYWNlcxgBIAEoAxITCgt0b3RhbF9zcGFucxgCIAEoAxIXCg90b3RhbF9sbG1fY2FsbHMYAyABKAMSGgoSdG90YWxfaW5wdXRfdG9rZW5zGAQgASgDEhsKE3RvdGFsX291dHB1dF90b2tlbnMYBSABKAMSFgoOdG90YWxfY29zdF91c2QYBiABKAESFgoOYXZnX2xhdGVuY3lfbXMYByABKAESEgoKZXJyb3JfcmF0ZRgIIAEoARIfChd0b3RhbF9jYWNoZV9yZWFkX3Rva2VucxgJIAEoAxIjCht0b3RhbF9jYWNoZV9jcmVhdGlvbl90b2tlbnMYCiABKAMSNQoQdHJhY2VzX292ZXJfdGltZRgUIAMoCzIbLmNhbmRlbGEudjEuVGltZVNlcmllc1BvaW50EjMKDmNvc3Rfb3Zlcl90aW1lGBUgAygLMhsuY2FuZGVsYS52MS5UaW1lU2VyaWVzUG9pbnQSNQoQdG9rZW5zX292ZXJfdGltZRgWIAMoCzIbLmNhbmRlbGEudjEuVGltZVNlcmllc1BvaW50IjMKD1RpbWVTZXJpZXNQb2ludBIRCgl0aW1lc3RhbXAYASABKAkSDQoFdmFsdWUYAiABKAEiXAoYR2V0TW9kZWxCcmVha2Rvd25SZXF1ZXN0EhIKCnByb2plY3RfaWQYASABKAkSLAoKdGltZV9yYW5nZRgCIAEoCzIYLmNhbmRlbGEudHlwZXMuVGltZVJhbmdlIkMKGUdldE1vZGVsQnJlYWtkb3duUmVzcG9uc2USJgoGbW9kZWxzGAEgAygLMhYuY2FuZGVsYS52MS5Nb2RlbFVzYWdlIpgBCgpNb2RlbFVzYWdlEg0KBW1vZGVsGAEgASgJEhAKCHByb3ZpZGVyGAIgASgJEhIKCmNhbGxfY291bnQYAyABKAMSFAoMaW5wdXRfdG9rZW5zGAQgASgDEhUKDW91dHB1dF90b2tlbnMYBSABKAMSEAoIY29zdF91c2QYBiABKAESFgoOYXZnX2xhdGVuY3lfbXMYByABKAEibwocR2V0TGF0ZW5jeVBlcmNlbnRpbGVzUmVxdWVzdBISCgpwcm9qZWN0X2lkGAEgASgJEiwKCnRpbWVfcmFuZ2UYAiABKAsyGC5jYW5kZWxhLnR5cGVzLlRpbWVSYW5nZRINCgVtb2RlbBgDIAEoCSKXAQodR2V0TGF0ZW5jeVBlcmNlbnRpbGVzUmVzcG9uc2USDgoGcDUwX21zGAEgASgBEg4KBnA5MF9tcxgCIAEoARIOCgZwOTVfbXMYAyABKAESDgoGcDk5X21zGAQgASgBEjYKEWxhdGVuY3lfb3Zlcl90aW1lGAogAygLMhsuY2FuZGVsYS52MS5UaW1lU2VyaWVzUG9pbnQiVQoRR2V0TXlVc2FnZVJlcXVlc3QSEgoKcHJvamVjdF9pZBgBIAEoCRIsCgp0aW1lX3JhbmdlGAIgASgLMhguY2FuZGVsYS50eXBlcy5UaW1lUmFuZ2UitQIKEkdldE15VXNhZ2VSZXNwb25zZRITCgt0b3RhbF9jYWxscxgBIAEoAxIaChJ0b3RhbF9pbnB1dF90b2tlbnMYAiABKAMSGwoTdG90YWxfb3V0cHV0X3Rva2VucxgDIAEoAxIWCg50b3RhbF9jb3N0X3VzZBgEIAEoARIWCg5hdmdfbGF0ZW5jeV9tcxgFIAEoARImCgZtb2RlbHMYCiADKAsyFi5jYW5kZWxhLnYxLk1vZGVsVXNhZ2USKQoGYnVkZ2V0GBQgASgLMhkuY2FuZGVsYS50eXBlcy5Vc2VyQnVkZ2V0EhsKE3RvdGFsX3JlbWFpbmluZ191c2QYFSABKAESMQoNYWN0aXZlX2dyYW50cxgWIAMoCzIaLmNhbmRlbGEudHlwZXMuQnVkZ2V0R3JhbnQibAoZR2V0VGVhbUxlYWRlcmJvYXJkUmVxdWVzdBISCgpwcm9qZWN0X2lkGAEgASgJEiwKCnRpbWVfcmFuZ2UYAiABKAsyGC5jYW5kZWxhLnR5cGVzLlRpbWVSYW5nZRINCgVsaW1pdBgDIAEoBSJCChpHZXRUZWFtTGVhZGVyYm9hcmRSZXNwb25zZRIkCgV1c2VycxgBIAMoCzIVLmNhbmRlbGEudjEuVXNlclVzYWdlIqgBCglVc2VyVXNhZ2USDwoHdXNlcl9pZBgBIAEoCRINCgVlbWFpbBgCIAEoCRIUCgxkaXNwbGF5X25hbWUYAyABKAkSEgoKY2FsbF9jb3VudBgEIAEoAxIUCgx0b3RhbF90b2tlbnMYBSABKAMSEAoIY29zdF91c2QYBiABKAESFgoOYXZnX2xhdGVuY3lfbXMYByABKAESEQoJdG9wX21vZGVsGAggASgJImsKGEdldEpvYkxlYWRlcmJvYXJkUmVxdWVzdBISCgpwcm9qZWN0X2lkGAEgASgJEiwKCnRpbWVfcmFuZ2UYAiABKAsyGC5jYW5kZWxhLnR5cGVzLlRpbWVSYW5nZRINCgVsaW1pdBgDIAEoBSI/ChlHZXRKb2JMZWFkZXJib2FyZFJlc3BvbnNlEiIKBGpvYnMYASADKAsyFC5jYW5kZWxhLnYxLkpvYlVzYWdlIoEBCghKb2JVc2FnZRIOCgZqb2JfaWQYASABKAkSEgoKY2FsbF9jb3VudBgCIAEoAxIUCgx0b3RhbF90b2tlbnMYAyABKAMSEAoIY29zdF91c2QYBCABKAESFgoOYXZnX2xhdGVuY3lfbXMYBSABKAESEQoJdG9wX21vZGVsGAYgASgJMtIEChBEYXNoYm9hcmRTZXJ2aWNlEloKD0dldFVzYWdlU3VtbWFyeRIiLmNhbmRlbGEudjEuR2V0VXNhZ2VTdW1tYXJ5UmVxdWVzdBojLmNhbmRlbGEudjEuR2V0VXNhZ2VTdW1tYXJ5UmVzcG9uc2USYAoRR2V0TW9kZWxCcmVha2Rvd24SJC5jYW5kZWxhLnYxLkdldE1vZGVsQnJlYWtkb3duUmVxdWVzdBolLmNhbmRlbGEudjEuR2V0TW9kZWxCcmVha2Rvd25SZXNwb25zZRJsChVHZXRMYXRlbmN5UGVyY2VudGlsZXMSKC5jYW5kZWxhLnYxLkdldExhdGVuY3lQZXJjZW50aWxlc1JlcXVlc3QaKS5jYW5kZWxhLnYxLkdldExhdGVuY3lQZXJjZW50aWxlc1Jlc3BvbnNlEksKCkdldE15VXNhZ2USHS5jYW5kZWxhLnYxLkdldE15VXNhZ2VSZXF1ZXN0Gh4uY2FuZGVsYS52MS5HZXRNeVVzYWdlUmVzcG9uc2USYwoSR2V0VGVhbUxlYWRlcmJvYXJkEiUuY2FuZGVsYS52MS5HZXRUZWFtTGVhZGVyYm9hcmRSZXF1ZXN0GiYuY2FuZGVsYS52MS5HZXRUZWFtTGVhZGVyYm9hcmRSZXNwb25zZRJgChFHZXRKb2JMZWFkZXJib2FyZBIkLmNhbmRlbGEudjEuR2V0Sm9iTGVhZGVyYm9hcmRSZXF1ZXN0GiUuY2FuZGVsYS52MS5HZXRKb2JMZWFkZXJib2FyZFJlc3BvbnNlQqoBCg5jb20uY2FuZGVsYS52MUIVRGFzaGJvYXJkU2VydmljZVByb3RvUAFaOGdpdGh1Yi5jb20vY2FuZGVsYWhxL2NhbmRlbGEvZ2VuL2dvL2NhbmRlbGEvdjE7Y2FuZGVsYXYxogIDQ1hYqgIKQ2FuZGVsYS5WMcoCCkNhbmRlbGFcVjHiAhZDYW5kZWxhXFYxXEdQQk1ldGFkYXRh6gILQ2FuZGVsYTo6VjFiBnByb3RvMw", [file_candela_types_common, file_candela_types_user]);
+  fileDesc("CiJjYW5kZWxhL3YxL2Rhc2hib2FyZF9zZXJ2aWNlLnByb3RvEgpjYW5kZWxhLnYxIm8KFkdldFVzYWdlU3VtbWFyeVJlcXVlc3QSEgoKcHJvamVjdF9pZBgBIAEoCRIsCgp0aW1lX3JhbmdlGAIgASgLMhguY2FuZGVsYS50eXBlcy5UaW1lUmFuZ2USEwoLZW52aXJvbm1lbnQYAyABKAkixgUKF0dldFVzYWdlU3VtbWFyeVJlc3BvbnNlEhQKDHRvdGFsX3RyYWNlcxgBIAEoAxITCgt0b3RhbF9zcGFucxgCIAEoAxIXCg90b3RhbF9sbG1fY2FsbHMYAyABKAMSGgoSdG90YWxfaW5wdXRfdG9rZW5zGAQgASgDEhsKE3RvdGFsX291dHB1dF90b2tlbnMYBSABKAMSFgoOdG90YWxfY29zdF91c2QYBiABKAESFgoOYXZnX2xhdGVuY3lfbXMYByABKAESEgoKZXJyb3JfcmF0ZRgIIAEoARIfChd0b3RhbF9jYWNoZV9yZWFkX3Rva2VucxgJIAEoAxIjCht0b3RhbF9jYWNoZV9jcmVhdGlvbl90b2tlbnMYCiABKAMSNQoQdHJhY2VzX292ZXJfdGltZRgUIAMoCzIbLmNhbmRlbGEudjEuVGltZVNlcmllc1BvaW50EjMKDmNvc3Rfb3Zlcl90aW1lGBUgAygLMhsuY2FuZGVsYS52MS5UaW1lU2VyaWVzUG9pbnQSNQoQdG9rZW5zX292ZXJfdGltZRgWIAMoCzIbLmNhbmRlbGEudjEuVGltZVNlcmllc1BvaW50EkAKG2NhY2hlX3JlYWRfdG9rZW5zX292ZXJfdGltZRgXIAMoCzIbLmNhbmRlbGEudjEuVGltZVNlcmllc1BvaW50EkQKH2NhY2hlX2NyZWF0aW9uX3Rva2Vuc19vdmVyX3RpbWUYGCADKAsyGy5jYW5kZWxhLnYxLlRpbWVTZXJpZXNQb2ludBI7ChZpbnB1dF90b2tlbnNfb3Zlcl90aW1lGBkgAygLMhsuY2FuZGVsYS52MS5UaW1lU2VyaWVzUG9pbnQSPAoXb3V0cHV0X3Rva2Vuc19vdmVyX3RpbWUYGiADKAsyGy5jYW5kZWxhLnYxLlRpbWVTZXJpZXNQb2ludCIzCg9UaW1lU2VyaWVzUG9pbnQSEQoJdGltZXN0YW1wGAEgASgJEg0KBXZhbHVlGAIgASgBIlwKGEdldE1vZGVsQnJlYWtkb3duUmVxdWVzdBISCgpwcm9qZWN0X2lkGAEgASgJEiwKCnRpbWVfcmFuZ2UYAiABKAsyGC5jYW5kZWxhLnR5cGVzLlRpbWVSYW5nZSJDChlHZXRNb2RlbEJyZWFrZG93blJlc3BvbnNlEiYKBm1vZGVscxgBIAMoCzIWLmNhbmRlbGEudjEuTW9kZWxVc2FnZSLSAQoKTW9kZWxVc2FnZRINCgVtb2RlbBgBIAEoCRIQCghwcm92aWRlchgCIAEoCRISCgpjYWxsX2NvdW50GAMgASgDEhQKDGlucHV0X3Rva2VucxgEIAEoAxIVCg1vdXRwdXRfdG9rZW5zGAUgASgDEhAKCGNvc3RfdXNkGAYgASgBEhYKDmF2Z19sYXRlbmN5X21zGAcgASgBEhkKEWNhY2hlX3JlYWRfdG9rZW5zGAggASgDEh0KFWNhY2hlX2NyZWF0aW9uX3Rva2VucxgJIAEoAyJvChxHZXRMYXRlbmN5UGVyY2VudGlsZXNSZXF1ZXN0EhIKCnByb2plY3RfaWQYASABKAkSLAoKdGltZV9yYW5nZRgCIAEoCzIYLmNhbmRlbGEudHlwZXMuVGltZVJhbmdlEg0KBW1vZGVsGAMgASgJIpcBCh1HZXRMYXRlbmN5UGVyY2VudGlsZXNSZXNwb25zZRIOCgZwNTBfbXMYASABKAESDgoGcDkwX21zGAIgASgBEg4KBnA5NV9tcxgDIAEoARIOCgZwOTlfbXMYBCABKAESNgoRbGF0ZW5jeV9vdmVyX3RpbWUYCiADKAsyGy5jYW5kZWxhLnYxLlRpbWVTZXJpZXNQb2ludCJVChFHZXRNeVVzYWdlUmVxdWVzdBISCgpwcm9qZWN0X2lkGAEgASgJEiwKCnRpbWVfcmFuZ2UYAiABKAsyGC5jYW5kZWxhLnR5cGVzLlRpbWVSYW5nZSL7AgoSR2V0TXlVc2FnZVJlc3BvbnNlEhMKC3RvdGFsX2NhbGxzGAEgASgDEhoKEnRvdGFsX2lucHV0X3Rva2VucxgCIAEoAxIbChN0b3RhbF9vdXRwdXRfdG9rZW5zGAMgASgDEhYKDnRvdGFsX2Nvc3RfdXNkGAQgASgBEhYKDmF2Z19sYXRlbmN5X21zGAUgASgBEh8KF3RvdGFsX2NhY2hlX3JlYWRfdG9rZW5zGAYgASgDEiMKG3RvdGFsX2NhY2hlX2NyZWF0aW9uX3Rva2VucxgHIAEoAxImCgZtb2RlbHMYCiADKAsyFi5jYW5kZWxhLnYxLk1vZGVsVXNhZ2USKQoGYnVkZ2V0GBQgASgLMhkuY2FuZGVsYS50eXBlcy5Vc2VyQnVkZ2V0EhsKE3RvdGFsX3JlbWFpbmluZ191c2QYFSABKAESMQoNYWN0aXZlX2dyYW50cxgWIAMoCzIaLmNhbmRlbGEudHlwZXMuQnVkZ2V0R3JhbnQibAoZR2V0VGVhbUxlYWRlcmJvYXJkUmVxdWVzdBISCgpwcm9qZWN0X2lkGAEgASgJEiwKCnRpbWVfcmFuZ2UYAiABKAsyGC5jYW5kZWxhLnR5cGVzLlRpbWVSYW5nZRINCgVsaW1pdBgDIAEoBSJCChpHZXRUZWFtTGVhZGVyYm9hcmRSZXNwb25zZRIkCgV1c2VycxgBIAMoCzIVLmNhbmRlbGEudjEuVXNlclVzYWdlIqgBCglVc2VyVXNhZ2USDwoHdXNlcl9pZBgBIAEoCRINCgVlbWFpbBgCIAEoCRIUCgxkaXNwbGF5X25hbWUYAyABKAkSEgoKY2FsbF9jb3VudBgEIAEoAxIUCgx0b3RhbF90b2tlbnMYBSABKAMSEAoIY29zdF91c2QYBiABKAESFgoOYXZnX2xhdGVuY3lfbXMYByABKAESEQoJdG9wX21vZGVsGAggASgJImsKGEdldEpvYkxlYWRlcmJvYXJkUmVxdWVzdBISCgpwcm9qZWN0X2lkGAEgASgJEiwKCnRpbWVfcmFuZ2UYAiABKAsyGC5jYW5kZWxhLnR5cGVzLlRpbWVSYW5nZRINCgVsaW1pdBgDIAEoBSI/ChlHZXRKb2JMZWFkZXJib2FyZFJlc3BvbnNlEiIKBGpvYnMYASADKAsyFC5jYW5kZWxhLnYxLkpvYlVzYWdlIoEBCghKb2JVc2FnZRIOCgZqb2JfaWQYASABKAkSEgoKY2FsbF9jb3VudBgCIAEoAxIUCgx0b3RhbF90b2tlbnMYAyABKAMSEAoIY29zdF91c2QYBCABKAESFgoOYXZnX2xhdGVuY3lfbXMYBSABKAESEQoJdG9wX21vZGVsGAYgASgJIogBChdHZXREYXNoYm9hcmREYXRhUmVxdWVzdBISCgpwcm9qZWN0X2lkGAEgASgJEiwKCnRpbWVfcmFuZ2UYAiABKAsyGC5jYW5kZWxhLnR5cGVzLlRpbWVSYW5nZRITCgtlbnZpcm9ubWVudBgDIAEoCRIWCg5pbmNsdWRlX2J1ZGdldBgEIAEoCCLqBgoYR2V0RGFzaGJvYXJkRGF0YVJlc3BvbnNlEhQKDHRvdGFsX3RyYWNlcxgBIAEoAxITCgt0b3RhbF9zcGFucxgCIAEoAxIXCg90b3RhbF9sbG1fY2FsbHMYAyABKAMSGgoSdG90YWxfaW5wdXRfdG9rZW5zGAQgASgDEhsKE3RvdGFsX291dHB1dF90b2tlbnMYBSABKAMSFgoOdG90YWxfY29zdF91c2QYBiABKAESFgoOYXZnX2xhdGVuY3lfbXMYByABKAESEgoKZXJyb3JfcmF0ZRgIIAEoARIfChd0b3RhbF9jYWNoZV9yZWFkX3Rva2VucxgJIAEoAxIjCht0b3RhbF9jYWNoZV9jcmVhdGlvbl90b2tlbnMYCiABKAMSNQoQdHJhY2VzX292ZXJfdGltZRgUIAMoCzIbLmNhbmRlbGEudjEuVGltZVNlcmllc1BvaW50EjMKDmNvc3Rfb3Zlcl90aW1lGBUgAygLMhsuY2FuZGVsYS52MS5UaW1lU2VyaWVzUG9pbnQSNQoQdG9rZW5zX292ZXJfdGltZRgWIAMoCzIbLmNhbmRlbGEudjEuVGltZVNlcmllc1BvaW50EkAKG2NhY2hlX3JlYWRfdG9rZW5zX292ZXJfdGltZRgXIAMoCzIbLmNhbmRlbGEudjEuVGltZVNlcmllc1BvaW50EkQKH2NhY2hlX2NyZWF0aW9uX3Rva2Vuc19vdmVyX3RpbWUYGCADKAsyGy5jYW5kZWxhLnYxLlRpbWVTZXJpZXNQb2ludBI7ChZpbnB1dF90b2tlbnNfb3Zlcl90aW1lGBkgAygLMhsuY2FuZGVsYS52MS5UaW1lU2VyaWVzUG9pbnQSPAoXb3V0cHV0X3Rva2Vuc19vdmVyX3RpbWUYGiADKAsyGy5jYW5kZWxhLnYxLlRpbWVTZXJpZXNQb2ludBImCgZtb2RlbHMYHiADKAsyFi5jYW5kZWxhLnYxLk1vZGVsVXNhZ2USKQoGYnVkZ2V0GCggASgLMhkuY2FuZGVsYS50eXBlcy5Vc2VyQnVkZ2V0EhsKE3RvdGFsX3JlbWFpbmluZ191c2QYKSABKAESMQoNYWN0aXZlX2dyYW50cxgqIAMoCzIaLmNhbmRlbGEudHlwZXMuQnVkZ2V0R3JhbnQywAUKEERhc2hib2FyZFNlcnZpY2USXQoQR2V0RGFzaGJvYXJkRGF0YRIjLmNhbmRlbGEudjEuR2V0RGFzaGJvYXJkRGF0YVJlcXVlc3QaJC5jYW5kZWxhLnYxLkdldERhc2hib2FyZERhdGFSZXNwb25zZRJfCg9HZXRVc2FnZVN1bW1hcnkSIi5jYW5kZWxhLnYxLkdldFVzYWdlU3VtbWFyeVJlcXVlc3QaIy5jYW5kZWxhLnYxLkdldFVzYWdlU3VtbWFyeVJlc3BvbnNlIgOIAgESZQoRR2V0TW9kZWxCcmVha2Rvd24SJC5jYW5kZWxhLnYxLkdldE1vZGVsQnJlYWtkb3duUmVxdWVzdBolLmNhbmRlbGEudjEuR2V0TW9kZWxCcmVha2Rvd25SZXNwb25zZSIDiAIBEmwKFUdldExhdGVuY3lQZXJjZW50aWxlcxIoLmNhbmRlbGEudjEuR2V0TGF0ZW5jeVBlcmNlbnRpbGVzUmVxdWVzdBopLmNhbmRlbGEudjEuR2V0TGF0ZW5jeVBlcmNlbnRpbGVzUmVzcG9uc2USUAoKR2V0TXlVc2FnZRIdLmNhbmRlbGEudjEuR2V0TXlVc2FnZVJlcXVlc3QaHi5jYW5kZWxhLnYxLkdldE15VXNhZ2VSZXNwb25zZSIDiAIBEmMKEkdldFRlYW1MZWFkZXJib2FyZBIlLmNhbmRlbGEudjEuR2V0VGVhbUxlYWRlcmJvYXJkUmVxdWVzdBomLmNhbmRlbGEudjEuR2V0VGVhbUxlYWRlcmJvYXJkUmVzcG9uc2USYAoRR2V0Sm9iTGVhZGVyYm9hcmQSJC5jYW5kZWxhLnYxLkdldEpvYkxlYWRlcmJvYXJkUmVxdWVzdBolLmNhbmRlbGEudjEuR2V0Sm9iTGVhZGVyYm9hcmRSZXNwb25zZUKqAQoOY29tLmNhbmRlbGEudjFCFURhc2hib2FyZFNlcnZpY2VQcm90b1ABWjhnaXRodWIuY29tL2NhbmRlbGFocS9jYW5kZWxhL2dlbi9nby9jYW5kZWxhL3YxO2NhbmRlbGF2MaICA0NYWKoCCkNhbmRlbGEuVjHKAgpDYW5kZWxhXFYx4gIWQ2FuZGVsYVxWMVxHUEJNZXRhZGF0YeoCC0NhbmRlbGE6OlYxYgZwcm90bzM", [file_candela_types_common, file_candela_types_user]);
 
 /**
  * @generated from message candela.v1.GetUsageSummaryRequest
@@ -88,6 +88,9 @@ export type GetUsageSummaryResponse = Message<"candela.v1.GetUsageSummaryRespons
   errorRate: number;
 
   /**
+   * Cache metrics — these fields are subsets of total_input_tokens.
+   * Cache hit rate = cache_read_tokens / input_tokens (excludes output tokens).
+   *
    * @generated from field: int64 total_cache_read_tokens = 9;
    */
   totalCacheReadTokens: bigint;
@@ -113,6 +116,26 @@ export type GetUsageSummaryResponse = Message<"candela.v1.GetUsageSummaryRespons
    * @generated from field: repeated candela.v1.TimeSeriesPoint tokens_over_time = 22;
    */
   tokensOverTime: TimeSeriesPoint[];
+
+  /**
+   * @generated from field: repeated candela.v1.TimeSeriesPoint cache_read_tokens_over_time = 23;
+   */
+  cacheReadTokensOverTime: TimeSeriesPoint[];
+
+  /**
+   * @generated from field: repeated candela.v1.TimeSeriesPoint cache_creation_tokens_over_time = 24;
+   */
+  cacheCreationTokensOverTime: TimeSeriesPoint[];
+
+  /**
+   * @generated from field: repeated candela.v1.TimeSeriesPoint input_tokens_over_time = 25;
+   */
+  inputTokensOverTime: TimeSeriesPoint[];
+
+  /**
+   * @generated from field: repeated candela.v1.TimeSeriesPoint output_tokens_over_time = 26;
+   */
+  outputTokensOverTime: TimeSeriesPoint[];
 };
 
 /**
@@ -223,6 +246,19 @@ export type ModelUsage = Message<"candela.v1.ModelUsage"> & {
    * @generated from field: double avg_latency_ms = 7;
    */
   avgLatencyMs: number;
+
+  /**
+   * Cache metrics per model — subset of input_tokens.
+   * Cache hit rate = cache_read_tokens / input_tokens.
+   *
+   * @generated from field: int64 cache_read_tokens = 8;
+   */
+  cacheReadTokens: bigint;
+
+  /**
+   * @generated from field: int64 cache_creation_tokens = 9;
+   */
+  cacheCreationTokens: bigint;
 };
 
 /**
@@ -348,6 +384,18 @@ export type GetMyUsageResponse = Message<"candela.v1.GetMyUsageResponse"> & {
    * @generated from field: double avg_latency_ms = 5;
    */
   avgLatencyMs: number;
+
+  /**
+   * Cache metrics — subset of total_input_tokens.
+   *
+   * @generated from field: int64 total_cache_read_tokens = 6;
+   */
+  totalCacheReadTokens: bigint;
+
+  /**
+   * @generated from field: int64 total_cache_creation_tokens = 7;
+   */
+  totalCacheCreationTokens: bigint;
 
   /**
    * Per-model breakdown for this user
@@ -570,6 +618,168 @@ export const JobUsageSchema: GenMessage<JobUsage> = /*@__PURE__*/
   messageDesc(file_candela_v1_dashboard_service, 15);
 
 /**
+ * @generated from message candela.v1.GetDashboardDataRequest
+ */
+export type GetDashboardDataRequest = Message<"candela.v1.GetDashboardDataRequest"> & {
+  /**
+   * @generated from field: string project_id = 1;
+   */
+  projectId: string;
+
+  /**
+   * @generated from field: candela.types.TimeRange time_range = 2;
+   */
+  timeRange?: TimeRange | undefined;
+
+  /**
+   * @generated from field: string environment = 3;
+   */
+  environment: string;
+
+  /**
+   * If true, includes per-user budget and grant context (requires auth).
+   * When false or unauthenticated, the budget/grant fields are omitted.
+   *
+   * @generated from field: bool include_budget = 4;
+   */
+  includeBudget: boolean;
+};
+
+/**
+ * Describes the message candela.v1.GetDashboardDataRequest.
+ * Use `create(GetDashboardDataRequestSchema)` to create a new message.
+ */
+export const GetDashboardDataRequestSchema: GenMessage<GetDashboardDataRequest> = /*@__PURE__*/
+  messageDesc(file_candela_v1_dashboard_service, 16);
+
+/**
+ * @generated from message candela.v1.GetDashboardDataResponse
+ */
+export type GetDashboardDataResponse = Message<"candela.v1.GetDashboardDataResponse"> & {
+  /**
+   * ── Aggregate summary ──
+   *
+   * @generated from field: int64 total_traces = 1;
+   */
+  totalTraces: bigint;
+
+  /**
+   * @generated from field: int64 total_spans = 2;
+   */
+  totalSpans: bigint;
+
+  /**
+   * @generated from field: int64 total_llm_calls = 3;
+   */
+  totalLlmCalls: bigint;
+
+  /**
+   * @generated from field: int64 total_input_tokens = 4;
+   */
+  totalInputTokens: bigint;
+
+  /**
+   * @generated from field: int64 total_output_tokens = 5;
+   */
+  totalOutputTokens: bigint;
+
+  /**
+   * @generated from field: double total_cost_usd = 6;
+   */
+  totalCostUsd: number;
+
+  /**
+   * @generated from field: double avg_latency_ms = 7;
+   */
+  avgLatencyMs: number;
+
+  /**
+   * @generated from field: double error_rate = 8;
+   */
+  errorRate: number;
+
+  /**
+   * Cache metrics — subsets of total_input_tokens.
+   *
+   * @generated from field: int64 total_cache_read_tokens = 9;
+   */
+  totalCacheReadTokens: bigint;
+
+  /**
+   * @generated from field: int64 total_cache_creation_tokens = 10;
+   */
+  totalCacheCreationTokens: bigint;
+
+  /**
+   * ── Time series for charts ──
+   *
+   * @generated from field: repeated candela.v1.TimeSeriesPoint traces_over_time = 20;
+   */
+  tracesOverTime: TimeSeriesPoint[];
+
+  /**
+   * @generated from field: repeated candela.v1.TimeSeriesPoint cost_over_time = 21;
+   */
+  costOverTime: TimeSeriesPoint[];
+
+  /**
+   * @generated from field: repeated candela.v1.TimeSeriesPoint tokens_over_time = 22;
+   */
+  tokensOverTime: TimeSeriesPoint[];
+
+  /**
+   * @generated from field: repeated candela.v1.TimeSeriesPoint cache_read_tokens_over_time = 23;
+   */
+  cacheReadTokensOverTime: TimeSeriesPoint[];
+
+  /**
+   * @generated from field: repeated candela.v1.TimeSeriesPoint cache_creation_tokens_over_time = 24;
+   */
+  cacheCreationTokensOverTime: TimeSeriesPoint[];
+
+  /**
+   * @generated from field: repeated candela.v1.TimeSeriesPoint input_tokens_over_time = 25;
+   */
+  inputTokensOverTime: TimeSeriesPoint[];
+
+  /**
+   * @generated from field: repeated candela.v1.TimeSeriesPoint output_tokens_over_time = 26;
+   */
+  outputTokensOverTime: TimeSeriesPoint[];
+
+  /**
+   * ── Per-model breakdown ──
+   *
+   * @generated from field: repeated candela.v1.ModelUsage models = 30;
+   */
+  models: ModelUsage[];
+
+  /**
+   * ── Per-user budget context (populated when include_budget=true + auth) ──
+   *
+   * @generated from field: candela.types.UserBudget budget = 40;
+   */
+  budget?: UserBudget | undefined;
+
+  /**
+   * @generated from field: double total_remaining_usd = 41;
+   */
+  totalRemainingUsd: number;
+
+  /**
+   * @generated from field: repeated candela.types.BudgetGrant active_grants = 42;
+   */
+  activeGrants: BudgetGrant[];
+};
+
+/**
+ * Describes the message candela.v1.GetDashboardDataResponse.
+ * Use `create(GetDashboardDataResponseSchema)` to create a new message.
+ */
+export const GetDashboardDataResponseSchema: GenMessage<GetDashboardDataResponse> = /*@__PURE__*/
+  messageDesc(file_candela_v1_dashboard_service, 17);
+
+/**
  * DashboardService provides aggregated metrics and usage data.
  * Exposed via ConnectRPC for the web UI dashboards.
  *
@@ -577,9 +787,23 @@ export const JobUsageSchema: GenMessage<JobUsage> = /*@__PURE__*/
  */
 export const DashboardService: GenService<{
   /**
-   * GetUsageSummary returns aggregated token usage, cost, and request counts.
+   * GetDashboardData returns a consolidated dashboard view including usage
+   * summary, per-model breakdown, and (if authenticated) per-user budget
+   * context. Replaces the concurrent fan-out of GetUsageSummary +
+   * GetModelBreakdown + GetMyUsage with a single round-trip.
+   *
+   * @generated from rpc candela.v1.DashboardService.GetDashboardData
+   */
+  getDashboardData: {
+    methodKind: "unary";
+    input: typeof GetDashboardDataRequestSchema;
+    output: typeof GetDashboardDataResponseSchema;
+  },
+  /**
+   * Deprecated: use GetDashboardData instead.
    *
    * @generated from rpc candela.v1.DashboardService.GetUsageSummary
+   * @deprecated
    */
   getUsageSummary: {
     methodKind: "unary";
@@ -587,9 +811,10 @@ export const DashboardService: GenService<{
     output: typeof GetUsageSummaryResponseSchema;
   },
   /**
-   * GetModelBreakdown returns usage broken down by model.
+   * Deprecated: use GetDashboardData instead.
    *
    * @generated from rpc candela.v1.DashboardService.GetModelBreakdown
+   * @deprecated
    */
   getModelBreakdown: {
     methodKind: "unary";
@@ -607,10 +832,11 @@ export const DashboardService: GenService<{
     output: typeof GetLatencyPercentilesResponseSchema;
   },
   /**
-   * GetMyUsage returns the calling user's personal usage summary (BigQuery).
+   * Deprecated: use GetDashboardData with include_budget=true instead.
    * For real-time budget/grant progress, see UserService.GetMyBudget.
    *
    * @generated from rpc candela.v1.DashboardService.GetMyUsage
+   * @deprecated
    */
   getMyUsage: {
     methodKind: "unary";


### PR DESCRIPTION
## Summary

Implements the server-side `GetDashboardData` handler that combines usage summary + model breakdown + optional budget/grant context into a single RPC response.

## Changes

### `pkg/connecthandlers/dashboard_handler.go`
- New `GetDashboardData` handler with:
  - `CombinedUsageReader` fast-path for BigQuery (single GROUPING SETS scan)
  - Concurrent fallback for non-BQ backends
  - Non-fatal budget/grant enrichment when `include_budget=true` + authenticated

### `pkg/storage/store.go`
- Added `CombinedUsageReader` optional interface

### `buf.gen.yaml`
- Temporarily points to `candela-protos` feature branch (update to `main` after protos PR merges)

### Generated stubs
- Regenerated Go + TypeScript stubs with new RPC definitions

## Validation

- `go build ./...` ✅
- `go test ./...` ✅ (all packages pass)
- `golangci-lint` ✅
- All 10 pre-commit hooks pass

## Dependencies

- Blocked on: candelahq/candela-protos feat/rpc-consolidation
- After protos merges: update `buf.gen.yaml` branch back to `main`