### PR TITLE
feat: Gemini proxy parity — tests, pricing, config API, direct route

### DIFF
--- a/cmd/candela/config_api_test.go
+++ b/cmd/candela/config_api_test.go
@@ -23,16 +23,19 @@ func TestConfigAPI_GetConfig_NilProxy(t *testing.T) {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
 
-	var resp struct {
-		Caching struct {
-			Anthropic string `json:"anthropic"`
-		} `json:"caching"`
-	}
+	var resp cachingConfigResponse
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode error: %v", err)
 	}
 	if resp.Caching.Anthropic != "off" {
 		t.Errorf("caching.anthropic = %q, want 'off' when cloudProxy is nil", resp.Caching.Anthropic)
+	}
+	// Verify Gemini section is always present.
+	if resp.Caching.Gemini.Mode != "implicit" {
+		t.Errorf("caching.gemini.mode = %q, want 'implicit'", resp.Caching.Gemini.Mode)
+	}
+	if resp.Caching.Gemini.Info == "" {
+		t.Error("caching.gemini.info should not be empty")
 	}
 }
 
@@ -54,17 +57,17 @@ func TestConfigAPI_GetConfig_WithProxy(t *testing.T) {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
 
-	var resp struct {
-		Caching struct {
-			Anthropic string `json:"anthropic"`
-		} `json:"caching"`
-	}
+	var resp cachingConfigResponse
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode error: %v", err)
 	}
 	// Proxy with no providers returns "off".
 	if resp.Caching.Anthropic != "off" {
 		t.Errorf("caching.anthropic = %q, want 'off'", resp.Caching.Anthropic)
+	}
+	// Gemini is always implicit.
+	if resp.Caching.Gemini.Mode != "implicit" {
+		t.Errorf("caching.gemini.mode = %q, want 'implicit'", resp.Caching.Gemini.Mode)
 	}
 }
 
@@ -116,11 +119,7 @@ func TestConfigAPI_SetCaching_ValidModes(t *testing.T) {
 				t.Fatalf("status = %d, want 200", w.Code)
 			}
 
-			var resp struct {
-				Caching struct {
-					Anthropic string `json:"anthropic"`
-				} `json:"caching"`
-			}
+			var resp cachingConfigResponse
 			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 				t.Fatalf("decode error: %v", err)
 			}
@@ -131,6 +130,11 @@ func TestConfigAPI_SetCaching_ValidModes(t *testing.T) {
 			// Verify the mode actually propagated to the translator.
 			if got := ft.GetCachingMode(); string(got) != tt.expected {
 				t.Errorf("translator mode = %q, want %q", got, tt.expected)
+			}
+
+			// Verify Gemini section is always present in response.
+			if resp.Caching.Gemini.Mode != "implicit" {
+				t.Errorf("caching.gemini.mode = %q, want 'implicit'", resp.Caching.Gemini.Mode)
 			}
 		})
 	}

--- a/cmd/candela/local_api.go
+++ b/cmd/candela/local_api.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -149,12 +150,19 @@ func (a *localAPI) buildCachingConfig() cachingProviders {
 		cacheTTL = string(a.cloudProxy.GetCacheTTL())
 	}
 
+	discountStr := "90% (2.5+/3.x), 75% (2.0)"
+	if a.calc != nil {
+		if dc, ok := a.calc.GetCacheDiscount("google"); ok {
+			discountStr = fmt.Sprintf("%.0f%% (runtime override)", dc.ReadDiscount*100)
+		}
+	}
+
 	return cachingProviders{
 		Anthropic: cachingMode,
 		CacheTTL:  cacheTTL,
 		Gemini: geminiCaching{
 			Mode:          "implicit",
-			CacheDiscount: "90% (2.5+/3.x), 75% (2.0)",
+			CacheDiscount: discountStr,
 			Info:          "Gemini caching is automatic. Repeated prefixes are cached server-side with no client-side injection needed.",
 		},
 	}
@@ -210,16 +218,16 @@ func (a *localAPI) handleSetCaching(w http.ResponseWriter, r *http.Request) {
 	// custom rates if they have negotiated pricing.
 	if req.GeminiCacheDiscount != nil && a.calc != nil {
 		disc := *req.GeminiCacheDiscount
-		if disc >= 0 && disc <= 1.0 {
-			a.calc.SetCacheDiscount("google", costcalc.CacheDiscountConfig{
-				ReadDiscount:       disc,
-				CreateMultiplier:   1.0,
-				InputIncludesCache: true,
-			})
-			slog.Info("Gemini cache discount updated at runtime", "discount", disc)
-		} else {
-			slog.Warn("ignoring invalid gemini_cache_discount", "value", disc)
+		if disc < 0 || disc > 1.0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "gemini_cache_discount must be between 0.0 and 1.0"})
+			return
 		}
+		a.calc.SetCacheDiscount("google", costcalc.CacheDiscountConfig{
+			ReadDiscount:       disc,
+			CreateMultiplier:   1.0,
+			InputIncludesCache: true,
+		})
+		slog.Info("Gemini cache discount updated at runtime", "discount", disc)
 	}
 
 	writeJSON(w, http.StatusOK, cachingConfigResponse{

--- a/cmd/candela/local_api.go
+++ b/cmd/candela/local_api.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/candelahq/candela/pkg/costcalc"
 	"github.com/candelahq/candela/pkg/proxy"
 	"github.com/candelahq/candela/pkg/runtime"
 )
@@ -20,15 +21,16 @@ import (
 //	POST /_local/models/pull         — pull/download a model
 //	GET  /_local/backends            — list registered runtime backends
 //	GET  /_local/api/config          — current runtime configuration
-//	POST /_local/api/config/caching  — set Anthropic caching mode at runtime
+//	POST /_local/api/config/caching  — set caching mode at runtime (provider-agnostic)
 type localAPI struct {
 	mgr        *runtime.Manager
 	cloudProxy *proxy.Proxy
+	calc       *costcalc.Calculator // optional: for Gemini cache discount overrides
 }
 
 // registerLocalAPI mounts the /_local/* routes on the mux.
-func registerLocalAPI(mux *http.ServeMux, mgr *runtime.Manager, cloudProxy *proxy.Proxy) {
-	api := &localAPI{mgr: mgr, cloudProxy: cloudProxy}
+func registerLocalAPI(mux *http.ServeMux, mgr *runtime.Manager, cloudProxy *proxy.Proxy, calc *costcalc.Calculator) {
+	api := &localAPI{mgr: mgr, cloudProxy: cloudProxy, calc: calc}
 
 	if mgr != nil {
 		mux.HandleFunc("GET /_local/health", api.handleHealth)
@@ -117,30 +119,68 @@ func (a *localAPI) handleBackends(w http.ResponseWriter, _ *http.Request) {
 	})
 }
 
-// GET /_local/api/config — returns current runtime configuration state.
-func (a *localAPI) handleGetConfig(w http.ResponseWriter, _ *http.Request) {
+// cachingConfigResponse is the canonical config response for GET and POST.
+// Having a shared type ensures the response shape is identical.
+type cachingConfigResponse struct {
+	Caching cachingProviders `json:"caching"`
+}
+
+type cachingProviders struct {
+	Anthropic string        `json:"anthropic"`
+	CacheTTL  string        `json:"cache_ttl"`
+	Gemini    geminiCaching `json:"gemini"`
+}
+
+// geminiCaching surfaces Gemini's caching status. Gemini uses implicit caching
+// (automatic, server-side) — the proxy doesn't inject anything. This section
+// is informational for the desktop/CLI so users understand caching behavior.
+type geminiCaching struct {
+	Mode          string `json:"mode"`           // always "implicit" — automatic server-side caching
+	CacheDiscount string `json:"cache_discount"` // e.g. "90%" (2.5+) or "75%" (2.0)
+	Info          string `json:"info"`           // human-readable explanation
+}
+
+// buildCachingConfig constructs the canonical caching config state.
+func (a *localAPI) buildCachingConfig() cachingProviders {
 	cachingMode := string(proxy.CachingOff)
 	cacheTTL := string(proxy.CacheTTL5m)
 	if a.cloudProxy != nil {
 		cachingMode = string(a.cloudProxy.GetCachingMode())
 		cacheTTL = string(a.cloudProxy.GetCacheTTL())
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
-		"caching": map[string]string{
-			"anthropic": cachingMode,
-			"cache_ttl": cacheTTL,
+
+	return cachingProviders{
+		Anthropic: cachingMode,
+		CacheTTL:  cacheTTL,
+		Gemini: geminiCaching{
+			Mode:          "implicit",
+			CacheDiscount: "90% (2.5+/3.x), 75% (2.0)",
+			Info:          "Gemini caching is automatic. Repeated prefixes are cached server-side with no client-side injection needed.",
 		},
+	}
+}
+
+// GET /_local/api/config — returns current runtime configuration state.
+func (a *localAPI) handleGetConfig(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, cachingConfigResponse{
+		Caching: a.buildCachingConfig(),
 	})
 }
 
 // POST /_local/api/config/caching — set caching mode and TTL at runtime.
-// Body: {"anthropic": "auto", "cache_ttl": "1h"} — anthropic: off, auto, system-only; cache_ttl: 5m, 1h
-// Both fields are optional; omitted fields are left unchanged.
+//
+// Body: {"anthropic": "auto", "cache_ttl": "1h", "gemini_cache_discount": 0.10}
+//   - anthropic: off, auto, system-only
+//   - cache_ttl: 5m, 1h (Anthropic only — Gemini TTL is managed server-side)
+//   - gemini_cache_discount: 0.0–1.0 override for cache read discount (optional)
+//
+// All fields are optional; omitted fields are left unchanged.
 func (a *localAPI) handleSetCaching(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 1024)
 	var req struct {
-		Anthropic *string `json:"anthropic"`
-		CacheTTL  *string `json:"cache_ttl"`
+		Anthropic           *string  `json:"anthropic"`
+		CacheTTL            *string  `json:"cache_ttl"`
+		GeminiCacheDiscount *float64 `json:"gemini_cache_discount"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
@@ -166,11 +206,24 @@ func (a *localAPI) handleSetCaching(w http.ResponseWriter, r *http.Request) {
 		slog.Info("cache TTL updated at runtime", "cache_ttl", string(ttl))
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
-		"caching": map[string]string{
-			"anthropic": string(a.cloudProxy.GetCachingMode()),
-			"cache_ttl": string(a.cloudProxy.GetCacheTTL()),
-		},
+	// Gemini cache discount override — allows enterprise customers to set
+	// custom rates if they have negotiated pricing.
+	if req.GeminiCacheDiscount != nil && a.calc != nil {
+		disc := *req.GeminiCacheDiscount
+		if disc >= 0 && disc <= 1.0 {
+			a.calc.SetCacheDiscount("google", costcalc.CacheDiscountConfig{
+				ReadDiscount:       disc,
+				CreateMultiplier:   1.0,
+				InputIncludesCache: true,
+			})
+			slog.Info("Gemini cache discount updated at runtime", "discount", disc)
+		} else {
+			slog.Warn("ignoring invalid gemini_cache_discount", "value", disc)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, cachingConfigResponse{
+		Caching: a.buildCachingConfig(),
 	})
 }
 

--- a/cmd/candela/local_api_test.go
+++ b/cmd/candela/local_api_test.go
@@ -84,7 +84,7 @@ func setupAPI(t *testing.T) (*http.ServeMux, *apiMockRuntime) {
 	t.Cleanup(func() { _ = mgr.Stop(ctx) })
 
 	mux := http.NewServeMux()
-	registerLocalAPI(mux, mgr, nil)
+	registerLocalAPI(mux, mgr, nil, nil)
 
 	// Poll for the health loop's initial check to complete.
 	for i := 0; i < 10; i++ {

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -715,6 +715,7 @@ func runForeground() {
 	}
 	// Wire the cloud proxy into the config API for runtime caching control.
 	configAPI.cloudProxy = cloudProxy
+	configAPI.calc = cloudCalc
 	// Create a calc for pricing-based model filtering.
 	// Uses the same defaults as the cloud proxy's embedded calc.
 	if len(cloudModels) > 0 {
@@ -1014,6 +1015,13 @@ func buildCloudProxy(cfg Config, submitter *processor.SpanProcessor) (*proxy.Pro
 			// API key via x-api-key or Authorization header. No ADC, no Vertex AI.
 			p.UpstreamURL = "https://api.anthropic.com"
 			// Client manages auth, not ADC.
+		case "gemini-direct":
+			// Native Google Generative Language API passthrough — client provides
+			// its own API key via ?key= parameter. No ADC, no Vertex AI.
+			// Mirrors anthropic-direct for API-key-authenticated Gemini access.
+			p.Name = "google"
+			p.UpstreamURL = "https://generativelanguage.googleapis.com"
+			p.TokenSource = nil // Client manages auth via API key, not ADC.
 		case "anthropic-vertex":
 			// Native Anthropic Messages API routed via Vertex AI rawPredict.
 			// Candela injects GCP ADC auth — no client API key needed.

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -212,6 +212,16 @@ func (c *Calculator) SetCacheDiscount(provider string, cfg CacheDiscountConfig) 
 	c.cacheDiscounts[strings.ToLower(provider)] = cfg
 }
 
+// GetCacheDiscount returns the runtime-overridden cache discount config for a
+// canonical provider, if one has been set via SetCacheDiscount. Returns false
+// if only the default (model-aware) logic is active.
+func (c *Calculator) GetCacheDiscount(provider string) (CacheDiscountConfig, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	cfg, ok := c.cacheDiscounts[strings.ToLower(provider)]
+	return cfg, ok
+}
+
 // NormalizeCachedInput returns cost-equivalent input tokens by applying
 // provider-specific and model-specific cache discounts to raw token counts.
 //

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -424,8 +424,13 @@ func (c *Calculator) key(provider, model string) string {
 func (c *Calculator) loadDefaults() {
 	defaults := []ModelPricing{
 		// ── Google Gemini ─────────────────────────────────────────
-		// Gemini 3.1 (latest)
+		// Gemini 3.1 (latest, May 2026)
 		{Provider: "google", Model: "gemini-3.1-pro", InputPerMillion: 2.00, OutputPerMillion: 12.00},
+		{Provider: "google", Model: "gemini-3.1-flash", InputPerMillion: 0.50, OutputPerMillion: 3.00},
+		{Provider: "google", Model: "gemini-3.1-flash-lite", InputPerMillion: 0.25, OutputPerMillion: 1.50},
+		// Gemini 3.0 (Preview)
+		{Provider: "google", Model: "gemini-3.0-pro", InputPerMillion: 2.00, OutputPerMillion: 12.00},
+		{Provider: "google", Model: "gemini-3.0-flash", InputPerMillion: 0.50, OutputPerMillion: 3.00},
 		// Gemini 2.5
 		{Provider: "google", Model: "gemini-2.5-pro", InputPerMillion: 1.25, OutputPerMillion: 10.00,
 			InputPerMillionHigh: 2.50, OutputPerMillionHigh: 15.00, TierThresholdTokens: 200_000},

--- a/pkg/costcalc/calculator_test.go
+++ b/pkg/costcalc/calculator_test.go
@@ -99,6 +99,51 @@ func TestCalculate(t *testing.T) {
 			wantMax:      0.009,
 		},
 		{
+			name:         "Gemini 3.1 Pro",
+			provider:     "google",
+			model:        "gemini-3.1-pro",
+			inputTokens:  1000,
+			outputTokens: 500,
+			wantMin:      0.007, // 1K×$2.00/M + 500×$12.00/M = $0.002 + $0.006 = $0.008
+			wantMax:      0.009,
+		},
+		{
+			name:         "Gemini 3.1 Flash",
+			provider:     "google",
+			model:        "gemini-3.1-flash",
+			inputTokens:  10000,
+			outputTokens: 2000,
+			wantMin:      0.010, // 10K×$0.50/M + 2K×$3.00/M = $0.005 + $0.006 = $0.011
+			wantMax:      0.012,
+		},
+		{
+			name:         "Gemini 3.1 Flash-Lite",
+			provider:     "google",
+			model:        "gemini-3.1-flash-lite",
+			inputTokens:  10000,
+			outputTokens: 2000,
+			wantMin:      0.005, // 10K×$0.25/M + 2K×$1.50/M = $0.0025 + $0.003 = $0.0055
+			wantMax:      0.006,
+		},
+		{
+			name:         "Gemini 3.0 Flash Preview",
+			provider:     "google",
+			model:        "gemini-3.0-flash",
+			inputTokens:  10000,
+			outputTokens: 2000,
+			wantMin:      0.010,
+			wantMax:      0.012,
+		},
+		{
+			name:         "Gemini 3.0 Pro Preview",
+			provider:     "google",
+			model:        "gemini-3.0-pro",
+			inputTokens:  1000,
+			outputTokens: 500,
+			wantMin:      0.007,
+			wantMax:      0.009,
+		},
+		{
 			name:         "Provider-agnostic fallback",
 			provider:     "gemini-oai",
 			model:        "gemini-2.5-pro",

--- a/pkg/proxy/gemini_test.go
+++ b/pkg/proxy/gemini_test.go
@@ -476,9 +476,8 @@ func TestGeminiParser_MultiPartResponse(t *testing.T) {
 	parser := &googleParser{}
 	content, _, _ := parser.ParseResponse(body)
 
-	// NOTE: The current googleParser only extracts the first text part.
-	// Multi-part concatenation could be a future enhancement.
-	if content != "Part 1. " {
-		t.Errorf("content = %q, want %q (first text part only)", content, "Part 1. ")
+	// googleParser concatenates all text parts from multi-part responses.
+	if content != "Part 1. Part 2." {
+		t.Errorf("content = %q, want %q (concatenated parts)", content, "Part 1. Part 2.")
 	}
 }

--- a/pkg/proxy/gemini_test.go
+++ b/pkg/proxy/gemini_test.go
@@ -1,0 +1,484 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// ── Gemini parser: standard response ────────────────────────────────────────
+
+func TestGeminiParser_ParseResponse_Basic(t *testing.T) {
+	body := []byte(`{
+		"candidates": [{"content": {"parts": [{"text": "Hello, world!"}]}}],
+		"usageMetadata": {
+			"promptTokenCount": 42,
+			"candidatesTokenCount": 10,
+			"totalTokenCount": 52
+		}
+	}`)
+
+	parser := &googleParser{}
+	content, inputTokens, outputTokens := parser.ParseResponse(body)
+
+	if content != "Hello, world!" {
+		t.Errorf("content = %q, want %q", content, "Hello, world!")
+	}
+	if inputTokens != 42 {
+		t.Errorf("inputTokens = %d, want 42", inputTokens)
+	}
+	if outputTokens != 10 {
+		t.Errorf("outputTokens = %d, want 10", outputTokens)
+	}
+}
+
+func TestGeminiParser_ParseResponse_EmptyContent(t *testing.T) {
+	body := []byte(`{
+		"candidates": [],
+		"usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 0}
+	}`)
+
+	parser := &googleParser{}
+	content, inputTokens, outputTokens := parser.ParseResponse(body)
+
+	if content != "" {
+		t.Errorf("content = %q, want empty", content)
+	}
+	if inputTokens != 10 {
+		t.Errorf("inputTokens = %d, want 10", inputTokens)
+	}
+	if outputTokens != 0 {
+		t.Errorf("outputTokens = %d, want 0", outputTokens)
+	}
+}
+
+func TestGeminiParser_ParseResponse_InvalidJSON(t *testing.T) {
+	parser := &googleParser{}
+	content, inputTokens, outputTokens := parser.ParseResponse([]byte("not json"))
+
+	if content != "" || inputTokens != 0 || outputTokens != 0 {
+		t.Error("invalid JSON should return zero values")
+	}
+}
+
+func TestGeminiParser_ParseResponse_MissingUsage(t *testing.T) {
+	body := []byte(`{
+		"candidates": [{"content": {"parts": [{"text": "hi"}]}}]
+	}`)
+
+	parser := &googleParser{}
+	content, inputTokens, outputTokens := parser.ParseResponse(body)
+
+	if content != "hi" {
+		t.Errorf("content = %q, want %q", content, "hi")
+	}
+	if inputTokens != 0 || outputTokens != 0 {
+		t.Errorf("missing usageMetadata should give 0 tokens, got in=%d out=%d",
+			inputTokens, outputTokens)
+	}
+}
+
+// ── Gemini thinking tokens (2.5+ reasoning models) ─────────────────────────
+
+func TestGeminiParser_ThinkingTokens_AddedToOutput(t *testing.T) {
+	body := []byte(`{
+		"candidates": [{"content": {"parts": [{"text": "result"}]}}],
+		"usageMetadata": {
+			"promptTokenCount": 100,
+			"candidatesTokenCount": 200,
+			"thoughtsTokenCount": 3000,
+			"totalTokenCount": 3300
+		}
+	}`)
+
+	parser := &googleParser{}
+	_, inputTokens, outputTokens := parser.ParseResponse(body)
+
+	if inputTokens != 100 {
+		t.Errorf("inputTokens = %d, want 100", inputTokens)
+	}
+	// Output must include thinking: 200 + 3000 = 3200
+	if outputTokens != 3200 {
+		t.Errorf("outputTokens = %d, want 3200 (200 candidates + 3000 thinking)", outputTokens)
+	}
+}
+
+func TestGeminiParser_ThinkingTokens_StreamingAddedToOutput(t *testing.T) {
+	data := []byte(`[
+		{"candidates":[{"content":{"parts":[{"text":"step1"}]}}]},
+		{"candidates":[{"content":{"parts":[{"text":"step2"}]}}],
+		 "usageMetadata":{
+			"promptTokenCount":50,
+			"candidatesTokenCount":100,
+			"thoughtsTokenCount":1500,
+			"totalTokenCount":1650
+		}}
+	]`)
+
+	parser := &googleParser{}
+	content, inputTokens, outputTokens := parser.ParseStreamingResponse(data)
+
+	if content != "step1step2" {
+		t.Errorf("content = %q, want %q", content, "step1step2")
+	}
+	if inputTokens != 50 {
+		t.Errorf("inputTokens = %d, want 50", inputTokens)
+	}
+	if outputTokens != 1600 {
+		t.Errorf("outputTokens = %d, want 1600 (100 + 1500 thinking)", outputTokens)
+	}
+}
+
+// ── Gemini implicit caching (passive — no injection needed) ─────────────────
+
+func TestGeminiParser_ImplicitCaching_ResponseTokens(t *testing.T) {
+	// Gemini 2.5+ automatically caches repeated prefixes (implicit caching).
+	// The proxy doesn't inject anything — it just reads cachedContentTokenCount
+	// from the response and passes it to the cost calculator.
+	body := []byte(`{
+		"candidates": [{"content": {"parts": [{"text": "cached result"}]}}],
+		"modelVersion": "gemini-2.5-flash-preview-05-20",
+		"usageMetadata": {
+			"promptTokenCount": 10000,
+			"cachedContentTokenCount": 8000,
+			"candidatesTokenCount": 200,
+			"totalTokenCount": 10200
+		}
+	}`)
+
+	parser := &googleParser{}
+	_, inputTokens, outputTokens := parser.ParseResponse(body)
+
+	// Parser returns raw promptTokenCount (inclusive of cached tokens).
+	if inputTokens != 10000 {
+		t.Errorf("inputTokens = %d, want 10000 (raw, includes cached)", inputTokens)
+	}
+	if outputTokens != 200 {
+		t.Errorf("outputTokens = %d, want 200", outputTokens)
+	}
+
+	// Verify cache token extraction separately.
+	ct := extractCacheTokens("google", body)
+	if ct.CacheReadTokens != 8000 {
+		t.Errorf("CacheReadTokens = %d, want 8000", ct.CacheReadTokens)
+	}
+	if ct.CacheCreationTokens != 0 {
+		t.Errorf("CacheCreationTokens = %d, want 0 (Google has no creation concept)", ct.CacheCreationTokens)
+	}
+}
+
+func TestGeminiParser_ImplicitCaching_StreamingTokens(t *testing.T) {
+	data := []byte(`[
+		{"candidates":[{"content":{"parts":[{"text":"chunk1"}]}}]},
+		{"candidates":[{"content":{"parts":[{"text":"chunk2"}]}}],
+		 "modelVersion":"gemini-2.5-pro-preview-05-06",
+		 "usageMetadata":{
+			"promptTokenCount":20000,
+			"cachedContentTokenCount":15000,
+			"candidatesTokenCount":500,
+			"thoughtsTokenCount":2000,
+			"totalTokenCount":22500
+		}}
+	]`)
+
+	// Verify streaming cache extraction.
+	ct := extractStreamingCacheTokens("google", data)
+	if ct.CacheReadTokens != 15000 {
+		t.Errorf("streaming CacheReadTokens = %d, want 15000", ct.CacheReadTokens)
+	}
+}
+
+// ── Gemini streaming: format variants ───────────────────────────────────────
+
+func TestGeminiParser_Streaming_JSONArray(t *testing.T) {
+	// Google streaming returns a JSON array of objects.
+	data := []byte(`[
+		{"candidates":[{"content":{"parts":[{"text":"Hello"}]}}]},
+		{"candidates":[{"content":{"parts":[{"text":" world"}]}}],
+		 "usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5}}
+	]`)
+
+	parser := &googleParser{}
+	content, in, out := parser.ParseStreamingResponse(data)
+
+	if content != "Hello world" {
+		t.Errorf("content = %q, want %q", content, "Hello world")
+	}
+	if in != 10 {
+		t.Errorf("inputTokens = %d, want 10", in)
+	}
+	if out != 5 {
+		t.Errorf("outputTokens = %d, want 5", out)
+	}
+}
+
+func TestGeminiParser_Streaming_NDJSON(t *testing.T) {
+	// Fallback: newline-delimited JSON (not a JSON array).
+	data := []byte(`{"candidates":[{"content":{"parts":[{"text":"A"}]}}]}
+{"candidates":[{"content":{"parts":[{"text":"B"}]}}],"usageMetadata":{"promptTokenCount":20,"candidatesTokenCount":8}}
+`)
+
+	parser := &googleParser{}
+	content, in, out := parser.ParseStreamingResponse(data)
+
+	if content != "AB" {
+		t.Errorf("content = %q, want %q", content, "AB")
+	}
+	if in != 20 {
+		t.Errorf("inputTokens = %d, want 20", in)
+	}
+	if out != 8 {
+		t.Errorf("outputTokens = %d, want 8", out)
+	}
+}
+
+func TestGeminiParser_Streaming_EmptyArray(t *testing.T) {
+	parser := &googleParser{}
+	content, in, out := parser.ParseStreamingResponse([]byte(`[]`))
+
+	if content != "" || in != 0 || out != 0 {
+		t.Error("empty array should return zero values")
+	}
+}
+
+// ── Gemini IsStreaming always false (streaming is URL-based) ─────────────────
+
+func TestGeminiParser_IsStreaming_AlwaysFalse(t *testing.T) {
+	parser := &googleParser{}
+
+	// Google uses separate endpoints for streaming, not a body param.
+	bodies := [][]byte{
+		[]byte(`{"contents":[{"parts":[{"text":"hi"}]}]}`),
+		[]byte(`{"contents":[{"parts":[{"text":"hi"}]}],"stream":true}`),
+		[]byte(`{}`),
+	}
+	for _, body := range bodies {
+		if parser.IsStreaming(body) {
+			t.Errorf("IsStreaming should always be false for Google, got true for %s", body)
+		}
+	}
+}
+
+// ── Gemini ParseRequest ─────────────────────────────────────────────────────
+
+func TestGeminiParser_ParseRequest(t *testing.T) {
+	body := []byte(`{
+		"contents": [
+			{"role": "user", "parts": [{"text": "What is the meaning of life?"}]}
+		],
+		"generationConfig": {"temperature": 0.7}
+	}`)
+
+	parser := &googleParser{}
+	model, content := parser.ParseRequest(body)
+
+	// Google doesn't include model in the request body (it's in the URL path).
+	if model != "" {
+		t.Errorf("model = %q, want empty (Google has model in URL, not body)", model)
+	}
+	if content == "" {
+		t.Error("content should not be empty")
+	}
+}
+
+// ── Model version extraction ────────────────────────────────────────────────
+
+func TestGeminiModelVersion_StandardResponse(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantModel string
+	}{
+		{
+			name:      "2.5 Pro preview",
+			body:      `{"modelVersion":"gemini-2.5-pro-preview-05-06","candidates":[]}`,
+			wantModel: "gemini-2.5-pro-preview-05-06",
+		},
+		{
+			name:      "2.5 Flash",
+			body:      `{"modelVersion":"gemini-2.5-flash","candidates":[]}`,
+			wantModel: "gemini-2.5-flash",
+		},
+		{
+			name:      "2.0 Flash Lite",
+			body:      `{"modelVersion":"gemini-2.0-flash-lite-001","candidates":[]}`,
+			wantModel: "gemini-2.0-flash-lite-001",
+		},
+		{
+			name:      "3.0 Flash Preview",
+			body:      `{"modelVersion":"gemini-3-flash-preview","candidates":[]}`,
+			wantModel: "gemini-3-flash-preview",
+		},
+		{
+			name:      "3.0 Pro Preview",
+			body:      `{"modelVersion":"gemini-3-pro-preview","candidates":[]}`,
+			wantModel: "gemini-3-pro-preview",
+		},
+		{
+			name:      "3.1 Pro",
+			body:      `{"modelVersion":"gemini-3.1-pro","candidates":[]}`,
+			wantModel: "gemini-3.1-pro",
+		},
+		{
+			name:      "3.1 Flash",
+			body:      `{"modelVersion":"gemini-3.1-flash","candidates":[]}`,
+			wantModel: "gemini-3.1-flash",
+		},
+		{
+			name:      "missing modelVersion",
+			body:      `{"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}`,
+			wantModel: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractModelFromResponse("google", []byte(tt.body))
+			if got != tt.wantModel {
+				t.Errorf("extractModelFromResponse = %q, want %q", got, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestGeminiModelVersion_StreamingResponse(t *testing.T) {
+	// modelVersion appears in the last chunk of a streaming response.
+	data := []byte(`[
+		{"candidates":[{"content":{"parts":[{"text":"hi"}]}}]},
+		{"candidates":[],
+		 "modelVersion":"gemini-2.5-flash-preview-05-20",
+		 "usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5}}
+	]`)
+
+	model := extractModelFromStreamingResponse("google", data)
+	if model != "gemini-2.5-flash-preview-05-20" {
+		t.Errorf("streaming model = %q, want %q", model, "gemini-2.5-flash-preview-05-20")
+	}
+}
+
+// ── gemini-oai (OpenAI-compat) uses openaiParser ────────────────────────────
+
+func TestGeminiOAI_ParseResponse(t *testing.T) {
+	// Gemini's OpenAI-compat endpoint returns standard OpenAI format.
+	body := []byte(`{
+		"model": "gemini-2.5-flash",
+		"choices": [{"message": {"role": "assistant", "content": "Gemini response"}}],
+		"usage": {
+			"prompt_tokens": 100,
+			"completion_tokens": 50,
+			"total_tokens": 150
+		}
+	}`)
+
+	parser := getParser("gemini-oai")
+	content, inputTokens, outputTokens := parser.ParseResponse(body)
+
+	if content != "Gemini response" {
+		t.Errorf("content = %q, want %q", content, "Gemini response")
+	}
+	if inputTokens != 100 {
+		t.Errorf("inputTokens = %d, want 100", inputTokens)
+	}
+	if outputTokens != 50 {
+		t.Errorf("outputTokens = %d, want 50", outputTokens)
+	}
+}
+
+func TestGeminiOAI_StreamUsageInjection(t *testing.T) {
+	body := []byte(`{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+	result := injectStreamUsageOption("gemini-oai", body)
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	so, ok := parsed["stream_options"].(map[string]interface{})
+	if !ok {
+		t.Fatal("stream_options should be injected for gemini-oai")
+	}
+	if so["include_usage"] != true {
+		t.Errorf("include_usage = %v, want true", so["include_usage"])
+	}
+}
+
+// ── gemini-oai cache tokens via OpenAI format ───────────────────────────────
+
+func TestGeminiOAI_CacheTokens(t *testing.T) {
+	// Gemini OAI-compat reports cached tokens in the OpenAI format.
+	body := []byte(`{
+		"usage": {
+			"prompt_tokens": 5000,
+			"completion_tokens": 100,
+			"prompt_tokens_details": {"cached_tokens": 4000}
+		}
+	}`)
+
+	ct := extractCacheTokens("gemini-oai", body)
+	if ct.CacheReadTokens != 4000 {
+		t.Errorf("CacheReadTokens = %d, want 4000", ct.CacheReadTokens)
+	}
+}
+
+func TestGeminiOAI_StreamingCacheTokens(t *testing.T) {
+	stream := []byte(`data: {"choices":[{"delta":{"content":"hi"}}]}
+data: {"choices":[],"usage":{"prompt_tokens":5000,"completion_tokens":100,"prompt_tokens_details":{"cached_tokens":4000}}}
+data: [DONE]
+`)
+
+	ct := extractStreamingCacheTokens("gemini-oai", stream)
+	if ct.CacheReadTokens != 4000 {
+		t.Errorf("streaming CacheReadTokens = %d, want 4000", ct.CacheReadTokens)
+	}
+}
+
+// ── Gemini: isAnthropicProvider should NOT match ────────────────────────────
+
+func TestGeminiProviders_NotAnthropic(t *testing.T) {
+	for _, name := range []string{"google", "gemini-oai", "gemini-direct"} {
+		if isAnthropicProvider(name) {
+			t.Errorf("isAnthropicProvider(%q) = true, want false", name)
+		}
+	}
+}
+
+// ── Gemini: stream_options injection only for OAI-compat ────────────────────
+
+func TestGeminiNative_NoStreamUsageInjection(t *testing.T) {
+	// Native Google API doesn't use stream_options (it always returns usage).
+	body := []byte(`{"contents":[{"parts":[{"text":"hi"}]}]}`)
+	result := injectStreamUsageOption("google", body)
+
+	// Should be unchanged — injectStreamUsageOption only fires for openai/gemini-oai.
+	if string(result) != string(body) {
+		t.Error("google native body should not be modified by injectStreamUsageOption")
+	}
+}
+
+// ── Multi-part response (multiple text parts) ───────────────────────────────
+
+func TestGeminiParser_MultiPartResponse(t *testing.T) {
+	body := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{"text": "Part 1. "},
+					{"text": "Part 2."}
+				]
+			}
+		}],
+		"usageMetadata": {
+			"promptTokenCount": 30,
+			"candidatesTokenCount": 15,
+			"totalTokenCount": 45
+		}
+	}`)
+
+	parser := &googleParser{}
+	content, _, _ := parser.ParseResponse(body)
+
+	// NOTE: The current googleParser only extracts the first text part.
+	// Multi-part concatenation could be a future enhancement.
+	if content != "Part 1. " {
+		t.Errorf("content = %q, want %q (first text part only)", content, "Part 1. ")
+	}
+}

--- a/pkg/proxy/parsers.go
+++ b/pkg/proxy/parsers.go
@@ -266,10 +266,16 @@ func (p *googleParser) ParseResponse(body []byte) (content string, inputTokens, 
 	if candidates, ok := resp["candidates"].([]interface{}); ok && len(candidates) > 0 {
 		if c, ok := candidates[0].(map[string]interface{}); ok {
 			if cont, ok := c["content"].(map[string]interface{}); ok {
-				if parts, ok := cont["parts"].([]interface{}); ok && len(parts) > 0 {
-					if part, ok := parts[0].(map[string]interface{}); ok {
-						content, _ = part["text"].(string)
+				if parts, ok := cont["parts"].([]interface{}); ok {
+					var b strings.Builder
+					for _, p := range parts {
+						if part, ok := p.(map[string]interface{}); ok {
+							if text, ok := part["text"].(string); ok {
+								b.WriteString(text)
+							}
+						}
 					}
+					content = b.String()
 				}
 			}
 		}
@@ -304,10 +310,12 @@ func (p *googleParser) ParseStreamingResponse(data []byte) (content string, inpu
 			if candidates, ok := chunk["candidates"].([]interface{}); ok && len(candidates) > 0 {
 				if c, ok := candidates[0].(map[string]interface{}); ok {
 					if cont, ok := c["content"].(map[string]interface{}); ok {
-						if parts, ok := cont["parts"].([]interface{}); ok && len(parts) > 0 {
-							if part, ok := parts[0].(map[string]interface{}); ok {
-								if text, ok := part["text"].(string); ok {
-									contentBuilder.WriteString(text)
+						if parts, ok := cont["parts"].([]interface{}); ok {
+							for _, p := range parts {
+								if part, ok := p.(map[string]interface{}); ok {
+									if text, ok := part["text"].(string); ok {
+										contentBuilder.WriteString(text)
+									}
 								}
 							}
 						}
@@ -329,10 +337,12 @@ func (p *googleParser) ParseStreamingResponse(data []byte) (content string, inpu
 			if candidates, ok := chunk["candidates"].([]interface{}); ok && len(candidates) > 0 {
 				if c, ok := candidates[0].(map[string]interface{}); ok {
 					if cont, ok := c["content"].(map[string]interface{}); ok {
-						if parts, ok := cont["parts"].([]interface{}); ok && len(parts) > 0 {
-							if part, ok := parts[0].(map[string]interface{}); ok {
-								if text, ok := part["text"].(string); ok {
-									contentBuilder.WriteString(text)
+						if parts, ok := cont["parts"].([]interface{}); ok {
+							for _, p := range parts {
+								if part, ok := p.(map[string]interface{}); ok {
+									if text, ok := part["text"].(string); ok {
+										contentBuilder.WriteString(text)
+									}
 								}
 							}
 						}

--- a/test/functional/mock/upstream.go
+++ b/test/functional/mock/upstream.go
@@ -13,6 +13,9 @@
 //	POST /v1/messages                                               → Anthropic messages response
 //	POST /v1/projects/*/locations/*/publishers/anthropic/models/*:rawPredict        → Vertex AI response
 //	POST /v1/projects/*/locations/*/publishers/anthropic/models/*:streamRawPredict  → Vertex AI streaming SSE
+//	POST /v1beta/models/*:generateContent                           → Gemini native response
+//	POST /v1beta/models/*:streamGenerateContent                     → Gemini streaming response
+//	POST /v1beta/openai/v1/chat/completions                         → Gemini OAI-compat (reuses OpenAI handler)
 package main
 
 import (
@@ -65,6 +68,18 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	case strings.Contains(path, "/publishers/anthropic/models/") && strings.HasSuffix(path, ":streamRawPredict"):
 		// Vertex AI streamRawPredict (SSE)
 		serveAnthropicStream(w, r)
+
+	case strings.Contains(path, "/models/") && strings.HasSuffix(path, ":generateContent"):
+		// Gemini native generateContent
+		serveGemini(w, r)
+
+	case strings.Contains(path, "/models/") && strings.HasSuffix(path, ":streamGenerateContent"):
+		// Gemini native streaming
+		serveGeminiStream(w, r)
+
+	case strings.Contains(path, "/openai/") && strings.HasSuffix(path, "/chat/completions"):
+		// Gemini OAI-compat (same response format as OpenAI)
+		serveOpenAI(w, r)
 
 	default:
 		http.Error(w, fmt.Sprintf("unknown mock endpoint: %s", path), http.StatusNotFound)
@@ -209,4 +224,89 @@ func serveAnthropicStream(w http.ResponseWriter, r *http.Request) {
 		flusher.Flush()
 		time.Sleep(5 * time.Millisecond)
 	}
+}
+
+// ── Gemini native handlers ──────────────────────────────────────────────────
+
+func serveGemini(w http.ResponseWriter, r *http.Request) {
+	// Extract model from URL path: /v1beta/models/{model}:generateContent
+	path := r.URL.Path
+	modelVersion := "gemini-2.5-flash-preview-05-20"
+	if idx := strings.LastIndex(path, "/models/"); idx != -1 {
+		suffix := path[idx+len("/models/"):]
+		if colonIdx := strings.Index(suffix, ":"); colonIdx != -1 {
+			modelVersion = suffix[:colonIdx]
+		}
+	}
+
+	// Echo whether the internal header leaked.
+	if r.Header.Get("X-Candela-Caching") != "" {
+		w.Header().Set("X-Mock-Candela-Header-Leaked", "true")
+	} else {
+		w.Header().Set("X-Mock-Candela-Header-Leaked", "false")
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"candidates": []map[string]any{
+			{
+				"content": map[string]any{
+					"parts": []map[string]any{
+						{"text": "Hello from the Gemini mock!"},
+					},
+					"role": "model",
+				},
+				"finishReason": "STOP",
+			},
+		},
+		"modelVersion": modelVersion,
+		"usageMetadata": map[string]any{
+			"promptTokenCount":        42,
+			"candidatesTokenCount":    15,
+			"totalTokenCount":         57,
+			"cachedContentTokenCount": 30,
+			"thoughtsTokenCount":      100,
+		},
+	})
+}
+
+func serveGeminiStream(w http.ResponseWriter, r *http.Request) {
+	// Extract model from URL path.
+	path := r.URL.Path
+	modelVersion := "gemini-2.5-flash-preview-05-20"
+	if idx := strings.LastIndex(path, "/models/"); idx != -1 {
+		suffix := path[idx+len("/models/"):]
+		if colonIdx := strings.Index(suffix, ":"); colonIdx != -1 {
+			modelVersion = suffix[:colonIdx]
+		}
+	}
+
+	// Gemini streaming returns a JSON array.
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode([]map[string]any{
+		{
+			"candidates": []map[string]any{
+				{"content": map[string]any{
+					"parts": []map[string]any{{"text": "Hello from "}},
+					"role":  "model",
+				}},
+			},
+		},
+		{
+			"candidates": []map[string]any{
+				{"content": map[string]any{
+					"parts": []map[string]any{{"text": "the Gemini mock!"}},
+					"role":  "model",
+				}},
+			},
+			"modelVersion": modelVersion,
+			"usageMetadata": map[string]any{
+				"promptTokenCount":        42,
+				"candidatesTokenCount":    15,
+				"totalTokenCount":         57,
+				"cachedContentTokenCount": 30,
+				"thoughtsTokenCount":      100,
+			},
+		},
+	})
 }

--- a/test/functional/proxy/proxy_gemini_config.hurl
+++ b/test/functional/proxy/proxy_gemini_config.hurl
@@ -1,0 +1,90 @@
+# GEMINI-CONFIG-01: Gemini section in caching config API
+# Verifies: GET/POST /_local/api/config returns Gemini caching status,
+# and POST accepts gemini_cache_discount override.
+#
+# Run:
+#   hurl --variable CANDELA_URL=http://localhost:8080 test/functional/proxy/proxy_gemini_config.hurl
+
+# ── GET config returns Gemini section ────────────────────────────────────────
+GET {{CANDELA_URL}}/_local/api/config
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+# Anthropic section still present.
+jsonpath "$.caching.anthropic" exists
+jsonpath "$.caching.cache_ttl" exists
+# Gemini section is always present.
+jsonpath "$.caching.gemini" exists
+jsonpath "$.caching.gemini.mode" == "implicit"
+jsonpath "$.caching.gemini.cache_discount" isString
+jsonpath "$.caching.gemini.info" isString
+
+
+# ── POST Anthropic-only update preserves Gemini section ──────────────────────
+POST {{CANDELA_URL}}/_local/api/config/caching
+Content-Type: application/json
+{
+  "anthropic": "auto"
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.caching.anthropic" == "auto"
+# Gemini section must still be present after Anthropic-only update.
+jsonpath "$.caching.gemini.mode" == "implicit"
+jsonpath "$.caching.gemini.cache_discount" isString
+
+
+# ── POST system-only + verify Gemini unaffected ──────────────────────────────
+POST {{CANDELA_URL}}/_local/api/config/caching
+Content-Type: application/json
+{
+  "anthropic": "system-only"
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.caching.anthropic" == "system-only"
+jsonpath "$.caching.gemini.mode" == "implicit"
+
+
+# ── POST gemini_cache_discount override ──────────────────────────────────────
+# Enterprise customers with negotiated pricing can override the cache discount.
+# This only takes effect if the server has a calc instance wired in.
+POST {{CANDELA_URL}}/_local/api/config/caching
+Content-Type: application/json
+{
+  "gemini_cache_discount": 0.15
+}
+
+# Expect 200 (accepted) — the discount is applied if calc is available.
+# Gemini section remains implicit regardless of discount override.
+HTTP 200
+[Asserts]
+jsonpath "$.caching.gemini.mode" == "implicit"
+
+
+# ── POST bad JSON returns 400 ────────────────────────────────────────────────
+POST {{CANDELA_URL}}/_local/api/config/caching
+Content-Type: application/json
+not-valid-json
+
+HTTP 400
+[Asserts]
+jsonpath "$.error" == "invalid JSON"
+
+
+# ── Reset to defaults ────────────────────────────────────────────────────────
+POST {{CANDELA_URL}}/_local/api/config/caching
+Content-Type: application/json
+{
+  "anthropic": "off",
+  "cache_ttl": "5m"
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.caching.anthropic" == "off"
+jsonpath "$.caching.cache_ttl" == "5m"
+jsonpath "$.caching.gemini.mode" == "implicit"

--- a/test/functional/proxy/proxy_gemini_native.hurl
+++ b/test/functional/proxy/proxy_gemini_native.hurl
@@ -1,0 +1,94 @@
+# GEMINI-NATIVE-01: Gemini native generateContent route
+# Verifies:
+#   - Native Google API response format (candidates, usageMetadata)
+#   - Token counting (promptTokenCount, candidatesTokenCount, thoughtsTokenCount)
+#   - Implicit cache tokens (cachedContentTokenCount) surfaced in response
+#   - X-Request-ID generated and returned
+#   - X-Candela-Caching header never leaks to upstream
+#   - modelVersion echoed from upstream
+#
+# Requires mock upstream running:
+#   go run test/functional/mock/upstream.go
+#
+# Run:
+#   hurl --variable CANDELA_URL=http://localhost:8080 test/functional/proxy/proxy_gemini_native.hurl
+
+# ── Standard Gemini native request → Google format response ───────────────────
+POST {{CANDELA_URL}}/proxy/google/v1beta/models/gemini-2.5-flash:generateContent
+Content-Type: application/json
+{
+  "contents": [
+    {"role": "user", "parts": [{"text": "Hello!"}]}
+  ],
+  "generationConfig": {"temperature": 0.7}
+}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+header "X-Request-ID" isString
+# Response is native Google format — NOT OpenAI shape.
+jsonpath "$.candidates" count >= 1
+jsonpath "$.candidates[0].content.parts[0].text" isString
+jsonpath "$.candidates[0].content.role" == "model"
+# Usage metadata present.
+jsonpath "$.usageMetadata.promptTokenCount" isInteger
+jsonpath "$.usageMetadata.candidatesTokenCount" isInteger
+jsonpath "$.usageMetadata.totalTokenCount" isInteger
+# Implicit caching — cachedContentTokenCount present.
+jsonpath "$.usageMetadata.cachedContentTokenCount" isInteger
+# Thinking tokens present (Gemini 2.5+).
+jsonpath "$.usageMetadata.thoughtsTokenCount" isInteger
+# Model version echoed.
+jsonpath "$.modelVersion" isString
+# Must NOT contain OpenAI fields.
+jsonpath "$.choices" not exists
+jsonpath "$.object" not exists
+jsonpath "$.usage" not exists
+
+
+# ── X-Candela-Caching header never leaks to Gemini upstream ──────────────────
+POST {{CANDELA_URL}}/proxy/google/v1beta/models/gemini-2.5-flash:generateContent
+Content-Type: application/json
+X-Candela-Caching: auto
+{
+  "contents": [
+    {"role": "user", "parts": [{"text": "Header leak test"}]}
+  ]
+}
+
+HTTP 200
+[Asserts]
+header "X-Mock-Candela-Header-Leaked" == "false"
+
+
+# ── Streaming endpoint (streamGenerateContent) ───────────────────────────────
+POST {{CANDELA_URL}}/proxy/google/v1beta/models/gemini-2.5-pro:streamGenerateContent
+Content-Type: application/json
+{
+  "contents": [
+    {"role": "user", "parts": [{"text": "Stream test"}]}
+  ]
+}
+
+# Mock returns JSON array for streaming. Expect 200 with content.
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+
+
+# ── Gemini 3.x model routing ─────────────────────────────────────────────────
+# Verify that Gemini 3.x models route through the same handler.
+POST {{CANDELA_URL}}/proxy/google/v1beta/models/gemini-3.1-flash:generateContent
+Content-Type: application/json
+{
+  "contents": [
+    {"role": "user", "parts": [{"text": "Gemini 3.1 test"}]}
+  ]
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.candidates" count >= 1
+jsonpath "$.modelVersion" == "gemini-3.1-flash"
+jsonpath "$.usageMetadata.promptTokenCount" isInteger


### PR DESCRIPTION
## Summary

Establishes full feature parity for Gemini models within the Candela proxy and cost-calculation infrastructure.

### What changed

**1. Gemini Test Suite** (`pkg/proxy/gemini_test.go`) — 23 tests
- Parsing: standard response, empty content, invalid JSON, missing usage metadata
- Thinking tokens: 2.5+ reasoning tokens added to output (body + streaming)
- Implicit caching: cache token extraction from body and streaming responses
- Streaming: JSON array and NDJSON formats
- Model versioning: 2.0, 2.5, 3.0, 3.1 model extraction
- gemini-oai: OAI-compat response parsing, stream usage injection, cache tokens

**2. Gemini 3.x Pricing** (`pkg/costcalc/calculator.go`)
- Added gemini-3.1-pro ($2/$12), gemini-3.1-flash ($0.50/$3), gemini-3.1-flash-lite ($0.25/$1.50), gemini-3.0-pro ($2/$12), gemini-3.0-flash ($0.50/$3) — from Google's May 2026 pricing
- Cache discount: 90% for 2.5+/3.x, 75% for 2.0

**3. Provider-Agnostic Config API** (`cmd/candela/local_api.go`)
- `GET /_local/api/config` now returns a `gemini` section: `mode: "implicit"`, cache discount info
- `POST /_local/api/config/caching` accepts `gemini_cache_discount` (0.0–1.0) for enterprise pricing overrides
- `cloudCalc` wired into `configAPI` so overrides actually apply at runtime

**4. `gemini-direct` Route** (`cmd/candela/main.go`)
- New provider case mirroring `anthropic-direct` for API-key-authenticated native Google API access
- Client passes its own key via `?key=` param; no ADC, no Vertex AI

**5. Hurl Integration Tests**
- Added `serveGemini()` and `serveGeminiStream()` to mock upstream (native Google format with usageMetadata, cache tokens, thinking tokens)
- `proxy_gemini_config.hurl`: 6 assertions on config API Gemini section
- `proxy_gemini_native.hurl`: 4 requests testing generateContent, streaming, header leak, and 3.x model routing

### Design decisions

- **No `GeminiFormatTranslator` needed** — Gemini uses implicit caching (server-side automatic). The proxy reads `cachedContentTokenCount` from response metadata. No request injection required.
- **`gemini-direct` uses `google` parser** — the native Google parser already handles response extraction; no new parser needed.
- **Config API is provider-agnostic** — `caching` response now has per-provider sections instead of being Anthropic-only.

### Testing

- 23 unit tests (Gemini parser)
- 5 pricing tests (Gemini 3.x models)
- Updated config API tests (Gemini section verification)
- 2 Hurl integration test files (config + native route)
- All 9 pre-commit hooks pass (gofmt, go-vet, golangci-lint, go-test)