### PR TITLE
feat(auth): interactive provider selection, config persistence, and proxy restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ For deep observability into agent frameworks (**ADK**, **LangChain**, **CrewAI**
 - **🐳 Production Sidecar**: Minimal `candela-sidecar` binary (<5MB) for container environments — Pub/Sub + OTLP span export with ADC auth.
 - **🔗 W3C Trace Context**: Full `Traceparent` / `Tracestate` propagation for unified trace trees across ADK agents and LLM calls.
 - **📦 Enrichment SDKs**: Lightweight wrappers for **Python**, **TypeScript**, **Go**, **Kotlin**, and **Rust** — propagate tenant and job metadata via W3C Baggage for multitenant cost attribution.
+- **🛡️ eBPF Enforcement**: Kernel-level security ensures all LLM API calls are captured by the proxy — supports transparent iptables redirection with SNI-based routing or Tetragon-based process enforcement for unauthorized egress. [Docs →](https://candelahq.com/governance/ebpf-enforcement/)
 
 ---
 

--- a/cmd/candela/auth.go
+++ b/cmd/candela/auth.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
+	"syscall"
 
 	"github.com/candelahq/candela/pkg/cloudauth"
 )
@@ -39,6 +41,7 @@ func handleAuth(args []string) {
 		_, _ = fmt.Fprintf(os.Stderr, `candela auth — manage cloud credentials
 
 Usage:
+  candela auth login                      Login (auto-detects or prompts for provider)
   candela auth login --provider gcp       Login to GCP via browser
   candela auth login --provider aws       Login to AWS (SSO or validates keys)
   candela auth status                     Show credential status (all providers)
@@ -46,8 +49,8 @@ Usage:
   candela auth token --provider gcp       Print a fresh GCP access token
   candela auth token --provider aws       Print AWS session info
 
-If --provider is omitted for login/token, it is inferred from your config file.
-If your config has only one cloud provider type, that provider is used automatically.
+If --provider is omitted for login, it is inferred from your config file.
+If no config exists, you'll be prompted to choose.
 
 Available providers: %v
 `, cloudauth.Names())
@@ -58,7 +61,7 @@ Available providers: %v
 }
 
 // resolveProvider determines which cloud auth provider to use.
-// Priority: explicit --provider flag > config file inference > error.
+// Priority: explicit --provider flag > config file inference > interactive prompt.
 func resolveProvider(providerName string) cloudauth.Provider {
 	if providerName != "" {
 		p, err := cloudauth.Get(providerName)
@@ -76,10 +79,8 @@ func resolveProvider(providerName string) cloudauth.Provider {
 
 	switch len(inferred) {
 	case 0:
-		_, _ = fmt.Fprintf(os.Stderr, "error: --provider is required (no cloud providers configured)\n")
-		_, _ = fmt.Fprintf(os.Stderr, "  candela auth login --provider gcp\n")
-		_, _ = fmt.Fprintf(os.Stderr, "  candela auth login --provider aws\n")
-		os.Exit(1)
+		// No providers configured — prompt interactively.
+		return promptForProvider()
 	case 1:
 		p, err := cloudauth.Get(inferred[0])
 		if err != nil {
@@ -88,12 +89,60 @@ func resolveProvider(providerName string) cloudauth.Provider {
 		}
 		return p
 	default:
-		_, _ = fmt.Fprintf(os.Stderr, "error: --provider is required (multiple cloud providers in config: %v)\n", inferred)
-		_, _ = fmt.Fprintf(os.Stderr, "  candela auth login --provider gcp\n")
-		_, _ = fmt.Fprintf(os.Stderr, "  candela auth login --provider aws\n")
+		// Multiple providers — prompt to choose.
+		return promptForProviderFrom(inferred)
+	}
+}
+
+// promptForProvider asks the user to select a cloud provider interactively.
+func promptForProvider() cloudauth.Provider {
+	names := cloudauth.Names()
+	return promptForProviderFrom(names)
+}
+
+// promptForProviderFrom presents a numbered list and reads the user's choice.
+func promptForProviderFrom(names []string) cloudauth.Provider {
+	if len(names) == 0 {
+		_, _ = fmt.Fprintf(os.Stderr, "error: no cloud auth providers available\n")
 		os.Exit(1)
 	}
-	return nil // unreachable
+
+	descriptions := map[string]string{
+		"gcp": "Google Cloud Platform",
+		"aws": "Amazon Web Services",
+	}
+
+	fmt.Println("\nSelect a cloud provider to authenticate:")
+	for i, name := range names {
+		desc := descriptions[name]
+		if desc == "" {
+			desc = name
+		}
+		fmt.Printf("  %d. %s — %s\n", i+1, name, desc)
+	}
+
+	fmt.Printf("\nChoice [1]: ")
+	var input string
+	_, _ = fmt.Scanln(&input)
+
+	// Default to first option.
+	choice := 0
+	if input != "" {
+		var n int
+		if _, err := fmt.Sscanf(input, "%d", &n); err == nil && n >= 1 && n <= len(names) {
+			choice = n - 1
+		} else {
+			_, _ = fmt.Fprintf(os.Stderr, "error: invalid choice %q\n", input)
+			os.Exit(1)
+		}
+	}
+
+	p, err := cloudauth.Get(names[choice])
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	return p
 }
 
 // inferAuthProviders reads the config and returns which cloud auth providers
@@ -129,6 +178,67 @@ func cmdAuthLogin(providerName string) {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
+
+	// Offer to save the provider to config and restart if needed.
+	postLoginSetup(provider.Name())
+}
+
+// postLoginSetup persists the provider to config and restarts the proxy if running.
+func postLoginSetup(providerName string) {
+	changed, err := upsertConfigProvider(providerName)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "warning: could not update config: %v\n", err)
+		return
+	}
+
+	if changed {
+		path := configFilePath()
+		fmt.Printf("\n📝 Added provider to %s\n", path)
+	}
+
+	// Check if the proxy is running and offer to restart.
+	if isProxyRunning() {
+		if changed {
+			fmt.Print("\n🔄 Candela proxy is running. Restart to apply new config? [Y/n] ")
+		} else {
+			fmt.Print("\n🔄 Candela proxy is running. Restart to pick up fresh credentials? [Y/n] ")
+		}
+		var input string
+		_, _ = fmt.Scanln(&input)
+		if input == "" || input == "y" || input == "Y" || input == "yes" {
+			restartProxy()
+		}
+	}
+}
+
+// isProxyRunning checks if the candela background proxy is alive via PID file.
+func isProxyRunning() bool {
+	pidPath := pidFilePath()
+	if pidPath == "" {
+		return false
+	}
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		return false
+	}
+	var pid int
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &pid); err != nil || pid == 0 {
+		return false
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// Signal 0 checks if process exists without sending a signal.
+	return process.Signal(syscall.Signal(0)) == nil
+}
+
+// restartProxy stops the running proxy and starts it again.
+func restartProxy() {
+	fmt.Println("Stopping proxy...")
+	cmdStop()
+	fmt.Println("Starting proxy...")
+	cmdStart()
 }
 
 // cmdAuthStatus displays credential status. If providerName is empty,

--- a/cmd/candela/config_writer.go
+++ b/cmd/candela/config_writer.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// configFilePath returns the path to the candela config file.
+// Uses the same search order as loadConfig: CANDELA_CONFIG, then
+// ~/.config/candela/config.yaml.
+func configFilePath() string {
+	if p := os.Getenv("CANDELA_CONFIG"); p != "" {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "candela", "config.yaml")
+}
+
+// upsertConfigProvider ensures the given provider name appears in the
+// config file's `providers:` list. If it already exists, returns false.
+// If the file doesn't exist, creates it with the provider entry.
+//
+// This performs simple text-level insertion to preserve comments and
+// formatting in the existing config file, rather than round-tripping
+// through a YAML parser which would strip comments.
+func upsertConfigProvider(providerName string) (changed bool, err error) {
+	path := configFilePath()
+	if path == "" {
+		return false, fmt.Errorf("cannot determine config file path")
+	}
+
+	// Map cloud auth provider names to config provider names.
+	configName := providerName
+	switch providerName {
+	case "gcp":
+		configName = "google"
+	case "aws":
+		configName = "anthropic-bedrock"
+	}
+
+	// Read existing file (may not exist).
+	data, readErr := os.ReadFile(path)
+	content := ""
+	if readErr == nil {
+		content = string(data)
+	}
+
+	// Check if provider is already configured.
+	if content != "" {
+		lines := strings.Split(content, "\n")
+		inProviders := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "providers:" {
+				inProviders = true
+				continue
+			}
+			// Detect end of providers block: a non-indented, non-empty,
+			// non-comment line means we've hit the next top-level key.
+			isIndented := strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t")
+			if inProviders && !isIndented && trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+				inProviders = false
+			}
+			if inProviders && strings.Contains(trimmed, "name:") {
+				// Extract name value.
+				parts := strings.SplitN(trimmed, ":", 2)
+				if len(parts) == 2 {
+					val := strings.TrimSpace(parts[1])
+					val = strings.Trim(val, `"'`)
+					if val == configName {
+						return false, nil // already present
+					}
+				}
+			}
+		}
+	}
+
+	// Build the entry to add.
+	entry := fmt.Sprintf("  - name: %s\n", configName)
+
+	if content == "" {
+		// Create a new config file.
+		newContent := "providers:\n" + entry
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return false, fmt.Errorf("create config directory: %w", err)
+		}
+		return true, os.WriteFile(path, []byte(newContent), 0o644)
+	}
+
+	// Append to existing providers block, or create one.
+	if strings.Contains(content, "providers:") {
+		// Find the providers: line and insert after it (before the first
+		// non-provider entry).
+		lines := strings.Split(content, "\n")
+		var result []string
+		inserted := false
+		inProviders := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "providers:" {
+				inProviders = true
+				result = append(result, line)
+				continue
+			}
+			// Insert at the end of the providers block.
+			if inProviders && !inserted {
+				isIndented := strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t")
+				if !isIndented && trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+					// We've reached the next top-level key — insert before it.
+					result = append(result, strings.TrimSuffix(entry, "\n"))
+					inserted = true
+					inProviders = false
+				}
+			}
+			result = append(result, line)
+		}
+		// If still in providers block at EOF, append there.
+		if !inserted {
+			result = append(result, strings.TrimSuffix(entry, "\n"))
+		}
+		return true, os.WriteFile(path, []byte(strings.Join(result, "\n")), 0o644)
+	}
+
+	// No providers block exists — append one at the end.
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += "\nproviders:\n" + entry
+	return true, os.WriteFile(path, []byte(content), 0o644)
+}

--- a/cmd/candela/config_writer_test.go
+++ b/cmd/candela/config_writer_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpsertConfigProvider_NewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Override config path via env var.
+	t.Setenv("CANDELA_CONFIG", path)
+
+	changed, err := upsertConfigProvider("gcp")
+	if err != nil {
+		t.Fatalf("upsertConfigProvider: %v", err)
+	}
+	if !changed {
+		t.Error("expected changed=true for new file")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "providers:") {
+		t.Error("expected 'providers:' in config file")
+	}
+	if !strings.Contains(content, "name: google") {
+		t.Error("expected 'name: google' in config file (gcp maps to google)")
+	}
+}
+
+func TestUpsertConfigProvider_ExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Write an existing config.
+	existing := "port: 8181\n\nproviders:\n  - name: anthropic\n\nvertex_ai:\n  project: my-project\n"
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	t.Setenv("CANDELA_CONFIG", path)
+
+	// Add GCP provider.
+	changed, err := upsertConfigProvider("gcp")
+	if err != nil {
+		t.Fatalf("upsertConfigProvider(gcp): %v", err)
+	}
+	if !changed {
+		t.Error("expected changed=true when adding new provider")
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if !strings.Contains(content, "name: google") {
+		t.Error("expected 'name: google' to be added")
+	}
+	// Original content should be preserved.
+	if !strings.Contains(content, "port: 8181") {
+		t.Error("expected original 'port: 8181' to be preserved")
+	}
+	if !strings.Contains(content, "name: anthropic") {
+		t.Error("expected original 'name: anthropic' to be preserved")
+	}
+}
+
+func TestUpsertConfigProvider_AlreadyPresent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	existing := "providers:\n  - name: google\n"
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	t.Setenv("CANDELA_CONFIG", path)
+
+	changed, err := upsertConfigProvider("gcp")
+	if err != nil {
+		t.Fatalf("upsertConfigProvider: %v", err)
+	}
+	if changed {
+		t.Error("expected changed=false when provider already exists")
+	}
+}
+
+func TestUpsertConfigProvider_AWSMapping(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	t.Setenv("CANDELA_CONFIG", path)
+
+	changed, err := upsertConfigProvider("aws")
+	if err != nil {
+		t.Fatalf("upsertConfigProvider(aws): %v", err)
+	}
+	if !changed {
+		t.Error("expected changed=true")
+	}
+
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), "name: anthropic-bedrock") {
+		t.Error("expected 'name: anthropic-bedrock' (aws maps to anthropic-bedrock)")
+	}
+}
+
+func TestIsProxyRunning_NoPidFile(t *testing.T) {
+	// With a non-existent home dir, isProxyRunning should return false.
+	t.Setenv("HOME", t.TempDir())
+	if isProxyRunning() {
+		t.Error("expected isProxyRunning()=false when no PID file exists")
+	}
+}
+
+func TestIsProxyRunning_StalePid(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	// Create .candela dir and write a stale PID.
+	candelaDir := filepath.Join(dir, ".candela")
+	if err := os.MkdirAll(candelaDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// PID 99999999 almost certainly doesn't exist.
+	if err := os.WriteFile(filepath.Join(candelaDir, "candela.pid"), []byte("99999999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if isProxyRunning() {
+		t.Error("expected isProxyRunning()=false for stale PID")
+	}
+}


### PR DESCRIPTION
## Summary

`candela auth login` without `--provider` now prompts interactively instead of erroring when no config exists. After login, the provider is automatically saved to `config.yaml` and if the proxy is running, the CLI offers to restart it.

## Changes

### `auth.go`
- `resolveProvider()` — prompts interactively when no `--provider` flag and no config inference is possible
- `postLoginSetup()` — saves provider to config + detects running proxy via PID file and offers restart via `cmdStop()`/`cmdStart()`
- Multiple configured providers also trigger a selection prompt instead of erroring

### `config_writer.go` (new)
- `upsertConfigProvider()` — adds a provider entry to `config.yaml`, preserving existing comments/formatting via text-level manipulation
- Maps cloud auth names to config names (`gcp→google`, `aws→anthropic-bedrock`)
- Handles new file creation, appending to existing providers block, and deduplication

### `config_writer_test.go` (new)
- 6 tests: new file creation, append to existing config, already-present dedup, AWS name mapping, PID file checks

## Testing
- All Go tests pass (`go test ./cmd/candela/...`)
- Pre-commit hooks pass (gofmt, go-vet, golangci-lint, go-test)