### PR TITLE
feat(desktop): user-scoped observability, models page, and settings refactor

### DIFF
--- a/ui/e2e/app.spec.ts
+++ b/ui/e2e/app.spec.ts
@@ -65,18 +65,21 @@ test.describe("App Shell", () => {
 
 test.describe("Dashboard", () => {
   test("shows stats when backend responds", async ({ page }) => {
-    await mockConnectRPC(page, "/candela.v1.DashboardService/GetUsageSummary", {
-      totalTraces: "42",
-      totalSpans: "128",
-      totalLlmCalls: "42",
-      totalInputTokens: "10000",
-      totalOutputTokens: "5000",
-      totalCostUsd: 3.47,
-      avgLatencyMs: 234.5,
-      errorRate: 0.02,
-      tracesOverTime: [],
-      costOverTime: [],
-      tokensOverTime: [],
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetDashboardData", {
+      summary: {
+        totalTraces: "42",
+        totalSpans: "128",
+        totalLlmCalls: "42",
+        totalInputTokens: "10000",
+        totalOutputTokens: "5000",
+        totalCostUsd: 3.47,
+        avgLatencyMs: 234.5,
+        errorRate: 0.02,
+        tracesOverTime: [],
+        costOverTime: [],
+        tokensOverTime: [],
+      },
+      models: [],
     });
     await mockConnectRPC(page, "/candela.v1.TraceService/ListTraces", {
       traces: [],
@@ -458,17 +461,20 @@ test.describe("Settings", () => {
   });
 
   test("shows connected status when backend responds", async ({ page }) => {
-    await mockConnectRPC(page, "/candela.v1.DashboardService/GetUsageSummary", {
-      totalTraces: "100",
-      totalSpans: "500",
-      totalLlmCalls: "100",
-      totalInputTokens: "0",
-      totalOutputTokens: "0",
-      totalCostUsd: 0,
-      avgLatencyMs: 0,
-      errorRate: 0,
-      costOverTime: [],
-      tokensOverTime: [],
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetDashboardData", {
+      summary: {
+        totalTraces: "100",
+        totalSpans: "500",
+        totalLlmCalls: "100",
+        totalInputTokens: "0",
+        totalOutputTokens: "0",
+        totalCostUsd: 0,
+        avgLatencyMs: 0,
+        errorRate: 0,
+        costOverTime: [],
+        tokensOverTime: [],
+      },
+      models: [],
     });
 
     await page.goto("/settings");
@@ -484,6 +490,26 @@ test.describe("Settings", () => {
   });
 
   test("shows configured providers", async ({ page }) => {
+    await mockConnectRPC(page, "/candela.v1.DashboardService/GetDashboardData", {
+      summary: {
+        totalTraces: "10",
+        totalSpans: "30",
+        totalLlmCalls: "10",
+        totalInputTokens: "0",
+        totalOutputTokens: "0",
+        totalCostUsd: 0,
+        avgLatencyMs: 0,
+        errorRate: 0,
+        costOverTime: [],
+        tokensOverTime: [],
+      },
+      models: [
+        { model: "gpt-4o", provider: "OpenAI", callCount: 5, inputTokens: 0, outputTokens: 0, costUsd: 0, avgLatencyMs: 0 },
+        { model: "gemini-2.5-pro", provider: "Google (Gemini)", callCount: 3, inputTokens: 0, outputTokens: 0, costUsd: 0, avgLatencyMs: 0 },
+        { model: "claude-sonnet-4", provider: "Anthropic", callCount: 2, inputTokens: 0, outputTokens: 0, costUsd: 0, avgLatencyMs: 0 },
+      ],
+    });
+
     await page.goto("/settings");
     await expect(page.locator(".settings-provider-chip").filter({ hasText: "OpenAI" })).toBeVisible();
     await expect(page.locator(".settings-provider-chip").filter({ hasText: "Google (Gemini)" })).toBeVisible();

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
+        "@bufbuild/protovalidate": "^1.1.1",
         "@connectrpc/connect": "^2.1.1",
         "@connectrpc/connect-web": "^2.1.1",
+        "firebase": "^12.12.0",
         "next": "16.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -267,6 +269,27 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bufbuild/cel": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/cel/-/cel-0.4.0.tgz",
+      "integrity": "sha512-CdW/JgiTJCYXqnwuaJRo7NcoYhR37AaF58MMiog0/t8nudn86ZyLXYaA1f2yGhm2U17h8pKGZNksTHVSTcpmAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/cel-spec": "0.4.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.6.2"
+      }
+    },
+    "node_modules/@bufbuild/cel-spec": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/cel-spec/-/cel-spec-0.4.0.tgz",
+      "integrity": "sha512-dUS6f2fNt6KEumsYGE7YFxERZE5ZuyME1hQmGjtO8tkZhR6ow6/ne3v4Gik9cfdb9lSLK3AJ+vDxCdGWmDbWvA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.6.2"
+      }
+    },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
@@ -322,6 +345,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/@bufbuild/protovalidate": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protovalidate/-/protovalidate-1.2.0.tgz",
+      "integrity": "sha512-tD08DwGrHIV88khLz1Kdz9DYUwEo1TsoepaIg7/B/zd//AymaTx67kvCS1jlkcG/+vgQaSOl6f0HCE3sL8vI7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/cel": "0.4.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.8.0"
       }
     },
     "node_modules/@connectrpc/connect": {
@@ -529,6 +564,648 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@firebase/ai": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.12.0.tgz",
+      "integrity": "sha512-b+OL4vdyiSLZL/7dLd67V55CjKJvU9MpNmwnday7eA6GG2+J4iwUEsEHgw0/jKY3A41FfkF0SrnYFvtKbQZ65A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-types": "0.8.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+      "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.12.tgz",
+      "integrity": "sha512-FT+HoNp1NdaZ/N26hCwV3WbxS1m6gTn3p2QRBQ3KH7YqyCQqJx0iT7126RgVk68/Rq+9DeL/zCFnHZ0C4u1nLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.3.tgz",
+      "integrity": "sha512-aJ4DfubWfTO8/2vhEhIAizOoOmiycESTU32e+OUgbWcS/G3PA4Vxlr/9zaiN2wfUG2AptQ7DTvj00tyuFZP5Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.3.tgz",
+      "integrity": "sha512-L3AKIRTJxT9b7cDUH3OyV8gWTnmW3vYkwdzRsukWt4kbPBTct12xalnyvHDkm1lKkr+cQq/4uzBx1bOWsQ2ciw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.3",
+        "@firebase/app-check-types": "0.5.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+      "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.12.tgz",
+      "integrity": "sha512-Pe513OBerK/CIBxz4/za9atd5MsZtd6DzHz4cmqkvkrcDWhQChAoHBpZ3McuZNuSP8YZiKwfX/J1frR07l15/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.12",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.1"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.1.tgz",
+      "integrity": "sha512-/1nkKY/MicI+I9WWcx6R4NKs77AaW9NQ0IwsFdUBomWrW0/cXEmopfM2dtLm2oI1qG6z6vom3CXZDHJIJXoMuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.6.tgz",
+      "integrity": "sha512-KDJ/GAf/rt7galOpn3DRb2buFfGkZCsHTryKjXDG0eeRnok4+2B4nnkMOMdjRnPkElmcJv2Ao0vEA6kp5m98PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.13.1",
+        "@firebase/auth-types": "0.13.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+      "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.0.tgz",
+      "integrity": "sha512-ar9sNOJh5poQCSMSVlnVE8eo8+usTD1POWDCv65omkKUvnFMcdXaQ7J/e7WGKqJzcEMgiezSX/TZiKHZkItMbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-types": "1.0.20",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.5",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.14.1.tgz",
+      "integrity": "sha512-PouS0NJZ3NYOZE/tPDvXa8VUeJ10Ll//7jIdFvMYdhQkd/P3O7nlqhyoTmY0h8Xa9hxg+H0j6gxUytJcoZ9YOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "@firebase/webchannel-wrapper": "1.0.6",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.9.tgz",
+      "integrity": "sha512-NPtBuFr79BbIQJXFWhW4xFC6rBksK8/ewqCTYbbAYfZBDDx0/iHTUj4WpKi5D4d0Pn2Md/3T/e5V9379G5N/Zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/firestore": "4.14.1",
+        "@firebase/firestore-types": "3.0.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+      "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.4.tgz",
+      "integrity": "sha512-oB5rpm2Emxn2+IS1gRelAeT/5tSZMwM/KhqC5LnJsmTNnS1ZDhD7ZMZNgCI8vchTW6PbaXIwEnpUryGuIQsNbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging-interop-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.4.tgz",
+      "integrity": "sha512-Be+MwhseVf/eFAZwGrFJGok6S7cmsLrAPK8MgyM8LjM0MewTsx2n01WOOca9jio1UsCZOJ0aVyQobnINcdNuIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/functions": "0.13.4",
+        "@firebase/functions-types": "0.6.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+      "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-types": "0.5.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+      "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.26",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.26.tgz",
+      "integrity": "sha512-lHVTO9uLofymHVWkYeUtMddIPcmJvSzVbHRB88W6XKfxbcKF+p3QrfqKhDxremSB4NQjUla1Gwn7d9umSMmt/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/messaging-interop-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.26.tgz",
+      "integrity": "sha512-fn0XvWOfK4tsDLSipwJUW9Cp6ahWA6z+iJHxZ0pHp9MzMSUNQx85yuxZAuI7gkGXfqs7+DqEDHyyS7jDGswrmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging": "0.12.26",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.4.tgz",
+      "integrity": "sha512-wrzITQq+xw5LtygX7O0fu43/k9ABQ4x5H9/sR5m1SbNnhIRI5xd3+raSNJaJkYC4BUhM9A4ZNSnyR2sjhxnb2Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+      "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.3.tgz",
+      "integrity": "sha512-ggGKAaLy9YNOvpFoQZgm5p5SiFw3ZFtwti08dojnBQmQicpThTxvG5xZMSpCTYMj2o3gM/yK9CVd2w+kZub8YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.24.tgz",
+      "integrity": "sha512-EWZTt6fJ7YmPHodQNsSxAIDZY2x8P5kRPvXAc5CmzzBm+NyPFhODbfDsNllDXDL8jlzp50bVWjDY+BXepZS9Mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/remote-config": "0.8.3",
+        "@firebase/remote-config-types": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+      "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-types": "0.8.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+      "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+      "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1320,6 +1997,69 @@
         "node": ">=18"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1372,7 +2112,6 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2015,11 +2754,19 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2441,11 +3188,24 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2458,7 +3218,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -2853,7 +3612,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3363,6 +4121,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3404,6 +4174,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.13.0.tgz",
+      "integrity": "sha512-iutR8ejvAqk6qUClnsPz3U3VIjTWp243AX4cD3iifak5t56to1J29xUIQgSDDzaAqKvhshZerzSahwMQj2TlvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.12.0",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-compat": "0.2.28",
+        "@firebase/app": "0.14.12",
+        "@firebase/app-check": "0.11.3",
+        "@firebase/app-check-compat": "0.4.3",
+        "@firebase/app-compat": "0.5.12",
+        "@firebase/app-types": "0.9.5",
+        "@firebase/auth": "1.13.1",
+        "@firebase/auth-compat": "0.6.6",
+        "@firebase/data-connect": "0.7.0",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-compat": "2.1.4",
+        "@firebase/firestore": "4.14.1",
+        "@firebase/firestore-compat": "0.4.9",
+        "@firebase/functions": "0.13.4",
+        "@firebase/functions-compat": "0.4.4",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-compat": "0.2.22",
+        "@firebase/messaging": "0.12.26",
+        "@firebase/messaging-compat": "0.2.26",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-compat": "0.2.25",
+        "@firebase/remote-config": "0.8.3",
+        "@firebase/remote-config-compat": "0.2.24",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-compat": "0.4.3",
+        "@firebase/util": "1.15.1"
       }
     },
     "node_modules/flat-cache": {
@@ -3516,6 +4322,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3755,6 +4570,18 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3989,6 +4816,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -4397,12 +5233,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -4953,6 +5801,30 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
+      "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5056,6 +5928,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -5151,6 +6032,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -5439,6 +6340,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -5550,6 +6471,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -5882,7 +6815,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -5959,6 +6891,35 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/which": {
@@ -6076,12 +7037,65 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -2326,3 +2326,141 @@ tr:hover .model-bar {
   border-radius: 999px;
   transition: width 0.3s ease;
 }
+
+/* ──────────────────────────────────────────
+   Scope Toggle
+   ────────────────────────────────────────── */
+
+.scope-toggle {
+  display: inline-flex;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 100px;
+  padding: 2px;
+  gap: 2px;
+}
+
+.scope-toggle-option {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  border: none;
+  border-radius: 100px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.scope-toggle-option:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.scope-toggle-active {
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.scope-toggle-icon {
+  font-size: 11px;
+}
+
+/* ──────────────────────────────────────────
+   Models Search
+   ────────────────────────────────────────── */
+
+.models-search {
+  margin-bottom: 16px;
+}
+
+.models-search-input {
+  width: 100%;
+  padding: 10px 16px;
+  font-size: 13px;
+  font-family: inherit;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.models-search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.models-search-input:focus {
+  border-color: var(--accent);
+}
+
+/* ──────────────────────────────────────────
+   Budget Bar
+   ────────────────────────────────────────── */
+
+.budget-bar-container {
+  margin-top: 12px;
+}
+
+.budget-bar-track {
+  height: 8px;
+  background: var(--bg-tertiary);
+  border-radius: 100px;
+  overflow: hidden;
+}
+
+.budget-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), #f59e0b);
+  border-radius: 100px;
+  transition: width 0.4s ease;
+}
+
+.budget-bar-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+/* ──────────────────────────────────────────
+   User Account Card (Settings)
+   ────────────────────────────────────────── */
+
+.user-account-card {
+  border-left: 3px solid var(--accent);
+}
+
+.user-account-body {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+  margin-top: 12px;
+}
+
+.user-account-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent) 0%, #ff8c00 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  font-weight: 700;
+  color: #000;
+  flex-shrink: 0;
+}
+
+.user-account-info {
+  flex: 1;
+  min-width: 0;
+}
+

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import { AuthProvider } from "@/components/AuthProvider";
 import { AuthGuard } from "@/components/AuthGuard";
 import { AppShell } from "@/components/AppShell";
+import { UserScopeProvider } from "@/components/UserScopeProvider";
 
 export const metadata: Metadata = {
   title: "Candela — LLM Observability",
@@ -19,7 +20,9 @@ export default function RootLayout({
       <body>
         <AuthProvider>
           <AuthGuard>
-            <AppShell>{children}</AppShell>
+            <UserScopeProvider>
+              <AppShell>{children}</AppShell>
+            </UserScopeProvider>
           </AuthGuard>
         </AuthProvider>
       </body>

--- a/ui/src/app/models/page.tsx
+++ b/ui/src/app/models/page.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useModels, type ModelSortKey } from "@/hooks/useModels";
+import { TimeRangeSelector } from "@/components/TimeRangeSelector";
+import { ScopeToggle } from "@/components/ScopeToggle";
+import { useScope } from "@/components/UserScopeProvider";
+import { ErrorBanner } from "@/components/ErrorBanner";
+import { SkeletonCard } from "@/components/SkeletonCard";
+
+// ──────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return n.toLocaleString();
+}
+
+// ──────────────────────────────────────────
+// Sort header
+// ──────────────────────────────────────────
+
+function SortTh({
+  label,
+  sortKey,
+  currentKey,
+  desc,
+  onSort,
+  align,
+}: {
+  label: string;
+  sortKey: ModelSortKey;
+  currentKey: ModelSortKey;
+  desc: boolean;
+  onSort: (k: ModelSortKey) => void;
+  align?: "right";
+}) {
+  const active = currentKey === sortKey;
+  return (
+    <th
+      onClick={() => onSort(sortKey)}
+      style={{ cursor: "pointer", textAlign: align ?? "left" }}
+    >
+      {label}{" "}
+      {active && (
+        <span style={{ fontSize: 10, opacity: 0.6 }}>
+          {desc ? "▼" : "▲"}
+        </span>
+      )}
+    </th>
+  );
+}
+
+// ──────────────────────────────────────────
+// Page
+// ──────────────────────────────────────────
+
+export default function ModelsPage() {
+  const { includeBudget } = useScope();
+  const {
+    models,
+    totals,
+    loading,
+    error,
+    timeRange,
+    setTimeRange,
+    refresh,
+    sort,
+    toggleSort,
+    search,
+    setSearch,
+    budgetContext,
+  } = useModels({ includeBudget });
+
+  return (
+    <>
+      <header className="main-header">
+        <h1>Models</h1>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <ScopeToggle />
+          <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          <button className="btn" onClick={refresh}>🔄</button>
+        </div>
+      </header>
+
+      <div className="main-body">
+        {error && <ErrorBanner title="Models Error">{error}</ErrorBanner>}
+
+        {/* Summary cards */}
+        {loading && models.length === 0 ? (
+          <div className="stats-grid animate-in">
+            <SkeletonCard />
+            <SkeletonCard />
+            <SkeletonCard />
+            <SkeletonCard />
+          </div>
+        ) : (
+          <div className="stats-grid animate-in">
+            <div className="card">
+              <div className="card-title">Models Used</div>
+              <div className="card-value">{models.length}</div>
+              <div className="card-subtitle">Unique models</div>
+            </div>
+            <div className="card">
+              <div className="card-title">Total Calls</div>
+              <div className="card-value">{totals.totalCalls.toLocaleString()}</div>
+              <div className="card-subtitle">Across all models</div>
+            </div>
+            <div className="card">
+              <div className="card-title">Total Tokens</div>
+              <div className="card-value">
+                {fmtTokens(totals.totalInputTokens + totals.totalOutputTokens)}
+              </div>
+              <div className="card-subtitle">
+                {fmtTokens(totals.totalInputTokens)} in / {fmtTokens(totals.totalOutputTokens)} out
+              </div>
+            </div>
+            <div className="card">
+              <div className="card-title">Total Cost</div>
+              <div className="card-value">${totals.totalCost.toFixed(2)}</div>
+              <div className="card-subtitle">
+                {budgetContext?.budget
+                  ? `$${budgetContext.totalRemainingUsd.toFixed(2)} remaining`
+                  : "Estimated USD"}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Budget bar (if available) */}
+        {budgetContext?.budget && (
+          <div className="card animate-in" style={{ marginBottom: 16, animationDelay: "0.03s" }}>
+            <div className="card-title">Budget</div>
+            <div className="budget-bar-container">
+              <div className="budget-bar-track">
+                <div
+                  className="budget-bar-fill"
+                  style={{
+                    width: `${Math.min(100, ((totals.totalCost) / (totals.totalCost + budgetContext.totalRemainingUsd)) * 100)}%`,
+                  }}
+                />
+              </div>
+              <div className="budget-bar-labels">
+                <span>${totals.totalCost.toFixed(2)} spent</span>
+                <span>${budgetContext.totalRemainingUsd.toFixed(2)} remaining</span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Search */}
+        <div className="models-search animate-in" style={{ animationDelay: "0.05s" }}>
+          <input
+            type="text"
+            className="models-search-input"
+            placeholder="Search models or providers…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+
+        {/* Models table */}
+        <div className="table-container animate-in" style={{ animationDelay: "0.08s" }}>
+          <div className="table-header">
+            <span className="table-title">Model Breakdown</span>
+            <span style={{ fontSize: 12, color: "var(--text-muted)" }}>
+              {models.length} model{models.length !== 1 ? "s" : ""}
+            </span>
+          </div>
+          {models.length === 0 ? (
+            <div className="empty-state" style={{ minHeight: 200 }}>
+              <div className="empty-state-icon">🤖</div>
+              <div className="empty-state-title">
+                {search ? "No matching models" : "No model data"}
+              </div>
+              <div className="empty-state-desc">
+                {search
+                  ? "Try a different search term."
+                  : "Send requests through Candela to see model usage analytics."}
+              </div>
+            </div>
+          ) : (
+            <table>
+              <thead>
+                <tr>
+                  <SortTh label="Model" sortKey="model" {...sort} currentKey={sort.key} onSort={toggleSort} />
+                  <SortTh label="Provider" sortKey="provider" {...sort} currentKey={sort.key} onSort={toggleSort} />
+                  <SortTh label="Calls" sortKey="callCount" {...sort} currentKey={sort.key} onSort={toggleSort} align="right" />
+                  <SortTh label="Input Tokens" sortKey="inputTokens" {...sort} currentKey={sort.key} onSort={toggleSort} align="right" />
+                  <SortTh label="Output Tokens" sortKey="outputTokens" {...sort} currentKey={sort.key} onSort={toggleSort} align="right" />
+                  <SortTh label="Cost" sortKey="costUsd" {...sort} currentKey={sort.key} onSort={toggleSort} align="right" />
+                  <SortTh label="Avg Latency" sortKey="avgLatencyMs" {...sort} currentKey={sort.key} onSort={toggleSort} align="right" />
+                  <th style={{ textAlign: "right" }}>Cost %</th>
+                </tr>
+              </thead>
+              <tbody>
+                {models.map((m) => {
+                  const pct = totals.totalCost > 0 ? (m.costUsd / totals.totalCost) * 100 : 0;
+                  return (
+                    <tr key={`${m.model}-${m.provider}`}>
+                      <td>
+                        <span className="mono" style={{ fontSize: 12 }}>{m.model}</span>
+                      </td>
+                      <td>
+                        <span className="badge badge-info">{m.provider}</span>
+                      </td>
+                      <td style={{ textAlign: "right" }}>{m.callCount.toLocaleString()}</td>
+                      <td style={{ textAlign: "right" }}>{fmtTokens(m.inputTokens)}</td>
+                      <td style={{ textAlign: "right" }}>{fmtTokens(m.outputTokens)}</td>
+                      <td style={{ textAlign: "right" }}>${m.costUsd.toFixed(4)}</td>
+                      <td style={{ textAlign: "right" }}>{m.avgLatencyMs.toFixed(0)}ms</td>
+                      <td style={{ textAlign: "right" }}>
+                        <div style={{ display: "flex", alignItems: "center", gap: 8, justifyContent: "flex-end" }}>
+                          <div style={{ width: 60, height: 4, background: "var(--bg-tertiary)", borderRadius: 2 }}>
+                            <div
+                              style={{
+                                height: "100%",
+                                width: `${Math.min(100, pct)}%`,
+                                background: "var(--accent)",
+                                borderRadius: 2,
+                              }}
+                            />
+                          </div>
+                          <span style={{ fontSize: 11, color: "var(--text-muted)", minWidth: 32 }}>
+                            {pct.toFixed(1)}%
+                          </span>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* Cache stats */}
+        {(totals.totalCacheRead > 0 || totals.totalCacheCreation > 0) && (
+          <div className="card animate-in" style={{ marginTop: 16, animationDelay: "0.12s" }}>
+            <div className="card-title">Cache Performance</div>
+            <div className="settings-grid">
+              <div className="settings-row">
+                <span className="settings-label">Cache Read Tokens</span>
+                <span className="settings-value">{fmtTokens(totals.totalCacheRead)}</span>
+              </div>
+              <div className="settings-row">
+                <span className="settings-label">Cache Creation Tokens</span>
+                <span className="settings-value">{fmtTokens(totals.totalCacheCreation)}</span>
+              </div>
+              <div className="settings-row">
+                <span className="settings-label">Effective Hit Rate</span>
+                <span className="settings-value">
+                  {totals.totalInputTokens > 0
+                    ? `${((totals.totalCacheRead / totals.totalInputTokens) * 100).toFixed(1)}%`
+                    : "—"}
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/ui/src/app/models/page.tsx
+++ b/ui/src/app/models/page.tsx
@@ -137,7 +137,7 @@ export default function ModelsPage() {
                 <div
                   className="budget-bar-fill"
                   style={{
-                    width: `${Math.min(100, ((totals.totalCost) / (totals.totalCost + budgetContext.totalRemainingUsd)) * 100)}%`,
+                    width: `${(totals.totalCost + budgetContext.totalRemainingUsd) > 0 ? Math.min(100, (totals.totalCost / (totals.totalCost + budgetContext.totalRemainingUsd)) * 100) : 0}%`,
                   }}
                 />
               </div>

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { useDashboard } from "@/hooks/useDashboard";
 import { AreaChart } from "@/components/chart";
 import { TimeRangeSelector } from "@/components/TimeRangeSelector";
+import { ScopeToggle } from "@/components/ScopeToggle";
+import { useScope } from "@/components/UserScopeProvider";
 import { ErrorBanner } from "@/components/ErrorBanner";
 import { SkeletonCard } from "@/components/SkeletonCard";
 import { SpanStatus } from "@/gen/candela/types/trace_pb";
@@ -22,6 +24,7 @@ const statusLabel = (s: number) => {
 // ──────────────────────────────────────────
 
 export default function DashboardPage() {
+  const { includeBudget } = useScope();
   const {
     summary,
     recentTraces,
@@ -30,7 +33,7 @@ export default function DashboardPage() {
     timeRange,
     setTimeRange,
     refresh,
-  } = useDashboard();
+  } = useDashboard({ includeBudget });
 
   const totalTokens = summary
     ? (summary.totalInputTokens + summary.totalOutputTokens).toLocaleString()
@@ -41,6 +44,7 @@ export default function DashboardPage() {
       <header className="main-header">
         <h1>Dashboard</h1>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <ScopeToggle />
           <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
           <button className="btn" onClick={refresh}>
             🔄

--- a/ui/src/app/settings/page.tsx
+++ b/ui/src/app/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useReducer } from "react";
 import { dashboardClient } from "@/lib/api";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { API_BASE_URL } from "@/lib/constants";
 
@@ -15,13 +16,23 @@ interface SettingsState {
   health: HealthStatus;
   backendVersion: string;
   traceCount: number | null;
+  llmCalls: number | null;
+  totalCost: number | null;
+  modelCount: number | null;
   storageBackend: string;
   providers: string[];
 }
 
 type Action =
   | { type: "checking" }
-  | { type: "connected"; traceCount: number }
+  | {
+      type: "connected";
+      traceCount: number;
+      llmCalls: number;
+      totalCost: number;
+      providers: string[];
+      modelCount: number;
+    }
   | { type: "offline" };
 
 function reducer(state: SettingsState, action: Action): SettingsState {
@@ -29,7 +40,15 @@ function reducer(state: SettingsState, action: Action): SettingsState {
     case "checking":
       return { ...state, health: "checking" };
     case "connected":
-      return { ...state, health: "connected", traceCount: action.traceCount };
+      return {
+        ...state,
+        health: "connected",
+        traceCount: action.traceCount,
+        llmCalls: action.llmCalls,
+        totalCost: action.totalCost,
+        providers: action.providers,
+        modelCount: action.modelCount,
+      };
     case "offline":
       return { ...state, health: "offline" };
   }
@@ -40,12 +59,17 @@ function reducer(state: SettingsState, action: Action): SettingsState {
 // ──────────────────────────────────────────
 
 export default function SettingsPage() {
+  const { user, isAdmin, isLoading: userLoading } = useCurrentUser();
+
   const [state, dispatch] = useReducer(reducer, {
     health: "checking",
     backendVersion: process.env.NEXT_PUBLIC_APP_VERSION ?? "v0.1.0-dev",
     traceCount: null,
+    llmCalls: null,
+    totalCost: null,
+    modelCount: null,
     storageBackend: "DuckDB",
-    providers: ["OpenAI", "Google (Gemini)", "Anthropic"],
+    providers: [],
   });
 
   useEffect(() => {
@@ -55,14 +79,25 @@ export default function SettingsPage() {
     const start = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
 
     dashboardClient
-      .getUsageSummary({
+      .getDashboardData({
         timeRange: {
           start: timestampFromDate(start),
           end: timestampFromDate(now),
         },
+        includeBudget: true,
       })
       .then((res) => {
-        dispatch({ type: "connected", traceCount: Number(res.totalTraces) });
+        const uniqueProviders = [
+          ...new Set((res.models || []).map((m) => m.provider).filter(Boolean)),
+        ];
+        dispatch({
+          type: "connected",
+          traceCount: Number(res.summary?.totalTraces ?? 0),
+          llmCalls: Number(res.summary?.totalLlmCalls ?? 0),
+          totalCost: res.summary?.totalCostUsd ?? 0,
+          providers: uniqueProviders.length > 0 ? uniqueProviders : ["OpenAI", "Google (Gemini)", "Anthropic"],
+          modelCount: (res.models || []).length,
+        });
       })
       .catch(() => {
         dispatch({ type: "offline" });
@@ -90,17 +125,48 @@ export default function SettingsPage() {
       </header>
 
       <div className="main-body">
+        {/* User Account Card */}
+        {!userLoading && user && (
+          <div className="card animate-in user-account-card" style={{ marginBottom: 16 }}>
+            <div className="card-title">Your Account</div>
+            <div className="user-account-body">
+              <div className="user-account-avatar">
+                {user.email.charAt(0).toUpperCase()}
+              </div>
+              <div className="user-account-info">
+                <div className="settings-grid">
+                  <div className="settings-row">
+                    <span className="settings-label">Email</span>
+                    <span className="settings-value mono">{user.email}</span>
+                  </div>
+                  <div className="settings-row">
+                    <span className="settings-label">Display Name</span>
+                    <span className="settings-value">
+                      {user.displayName || user.email.split("@")[0]}
+                    </span>
+                  </div>
+                  <div className="settings-row">
+                    <span className="settings-label">Role</span>
+                    <span className="settings-value">
+                      <span className={`badge ${isAdmin ? "badge-warning" : "badge-info"}`}>
+                        {isAdmin ? "Admin" : "Developer"}
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* Backend Connection */}
-        <div className="card animate-in" style={{ marginBottom: 16 }}>
+        <div className="card animate-in" style={{ marginBottom: 16, animationDelay: "0.05s" }}>
           <div className="card-title">Backend Connection</div>
           <div className="settings-grid">
             <div className="settings-row">
               <span className="settings-label">Status</span>
               <span className="settings-value">
-                <span
-                  className="health-dot"
-                  style={{ background: healthDot }}
-                />
+                <span className="health-dot" style={{ background: healthDot }} />
                 {healthLabel}
               </span>
             </div>
@@ -116,11 +182,42 @@ export default function SettingsPage() {
               <span className="settings-label">Version</span>
               <span className="settings-value mono">{state.backendVersion}</span>
             </div>
+          </div>
+        </div>
+
+        {/* System Overview (live data) */}
+        <div className="card animate-in" style={{ marginBottom: 16, animationDelay: "0.08s" }}>
+          <div className="card-title">System Overview (30 days)</div>
+          <div className="settings-grid">
             {state.traceCount !== null && (
               <div className="settings-row">
-                <span className="settings-label">Total Traces (30d)</span>
+                <span className="settings-label">Total Traces</span>
                 <span className="settings-value">
                   {state.traceCount.toLocaleString()}
+                </span>
+              </div>
+            )}
+            {state.llmCalls !== null && (
+              <div className="settings-row">
+                <span className="settings-label">LLM Calls</span>
+                <span className="settings-value">
+                  {state.llmCalls.toLocaleString()}
+                </span>
+              </div>
+            )}
+            {state.totalCost !== null && (
+              <div className="settings-row">
+                <span className="settings-label">Total Cost</span>
+                <span className="settings-value">
+                  ${state.totalCost.toFixed(2)}
+                </span>
+              </div>
+            )}
+            {state.modelCount !== null && (
+              <div className="settings-row">
+                <span className="settings-label">Active Models</span>
+                <span className="settings-value">
+                  {state.modelCount}
                 </span>
               </div>
             )}
@@ -128,10 +225,7 @@ export default function SettingsPage() {
         </div>
 
         {/* Storage */}
-        <div
-          className="card animate-in"
-          style={{ marginBottom: 16, animationDelay: "0.05s" }}
-        >
+        <div className="card animate-in" style={{ marginBottom: 16, animationDelay: "0.1s" }}>
           <div className="card-title">Storage Backend</div>
           <div className="settings-grid">
             <div className="settings-row">
@@ -148,10 +242,7 @@ export default function SettingsPage() {
         </div>
 
         {/* Configured Providers */}
-        <div
-          className="card animate-in"
-          style={{ animationDelay: "0.1s" }}
-        >
+        <div className="card animate-in" style={{ animationDelay: "0.12s" }}>
           <div className="card-title">Configured Providers</div>
           <div className="settings-providers">
             {state.providers.map((p) => (

--- a/ui/src/app/traces/page.tsx
+++ b/ui/src/app/traces/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTraces } from "@/hooks/useTraces";
+import { ScopeToggle } from "@/components/ScopeToggle";
 import { ErrorBanner } from "@/components/ErrorBanner";
 import type { TraceFilters } from "@/types/traces";
 
@@ -42,6 +43,7 @@ export default function TracesPage() {
       <header className="main-header">
         <h1>Traces</h1>
         <div style={{ display: "flex", gap: 8 }}>
+          <ScopeToggle />
           <button className="btn" onClick={refresh}>
             🔄 Refresh
           </button>

--- a/ui/src/components/ScopeToggle.tsx
+++ b/ui/src/components/ScopeToggle.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useScope, type ScopeMode } from "@/components/UserScopeProvider";
+
+/**
+ * Pill toggle for switching between "My Data" and "All Data" views.
+ * Designed to sit in page headers alongside TimeRangeSelector.
+ */
+export function ScopeToggle() {
+  const { mode, setMode } = useScope();
+
+  const options: { value: ScopeMode; label: string; icon: string }[] = [
+    { value: "personal", label: "My Data", icon: "👤" },
+    { value: "global", label: "All Data", icon: "🌐" },
+  ];
+
+  return (
+    <div className="scope-toggle" role="radiogroup" aria-label="Data scope">
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          role="radio"
+          aria-checked={mode === opt.value}
+          className={`scope-toggle-option ${mode === opt.value ? "scope-toggle-active" : ""}`}
+          onClick={() => setMode(opt.value)}
+        >
+          <span className="scope-toggle-icon">{opt.icon}</span>
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/components/UserScopeProvider.tsx
+++ b/ui/src/components/UserScopeProvider.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
+
+// ──────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────
+
+export type ScopeMode = "personal" | "global";
+
+export interface UserScopeContextValue {
+  /** Current data scope — "personal" shows only the current user's data */
+  mode: ScopeMode;
+  /** Toggle between personal and global views */
+  setMode: (mode: ScopeMode) => void;
+  /** Whether the GetDashboardData RPC should set include_budget=true */
+  includeBudget: boolean;
+  /** Whether the user is viewing their own data */
+  isPersonalScope: boolean;
+}
+
+const STORAGE_KEY = "candela-scope-mode";
+
+function getInitialMode(): ScopeMode {
+  if (typeof window === "undefined") return "personal";
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === "global" || stored === "personal") return stored;
+  return "personal"; // Default: desktop users see their own data
+}
+
+// ──────────────────────────────────────────
+// Context
+// ──────────────────────────────────────────
+
+const UserScopeContext = createContext<UserScopeContextValue | undefined>(undefined);
+
+export function UserScopeProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setModeRaw] = useState<ScopeMode>(getInitialMode);
+
+  const setMode = useCallback((m: ScopeMode) => {
+    setModeRaw(m);
+    try { localStorage.setItem(STORAGE_KEY, m); } catch { /* SSR / privacy */ }
+  }, []);
+
+  const value = useMemo<UserScopeContextValue>(
+    () => ({
+      mode,
+      setMode,
+      includeBudget: mode === "personal",
+      isPersonalScope: mode === "personal",
+    }),
+    [mode, setMode]
+  );
+
+  return (
+    <UserScopeContext.Provider value={value}>
+      {children}
+    </UserScopeContext.Provider>
+  );
+}
+
+/**
+ * Read the current data scope.
+ * Must be used inside <UserScopeProvider>.
+ */
+export function useScope(): UserScopeContextValue {
+  const ctx = useContext(UserScopeContext);
+  if (!ctx) {
+    throw new Error("useScope must be used within <UserScopeProvider>");
+  }
+  return ctx;
+}

--- a/ui/src/components/sidebar.tsx
+++ b/ui/src/components/sidebar.tsx
@@ -19,6 +19,7 @@ const navItems = [
   {
     section: "Manage",
     items: [
+      { href: "/models", label: "Models", icon: "🤖" },
       { href: "/projects", label: "Projects", icon: "📁" },
       { href: "/settings", label: "Settings", icon: "⚙️" },
     ],

--- a/ui/src/hooks/useDashboard.ts
+++ b/ui/src/hooks/useDashboard.ts
@@ -5,7 +5,30 @@ import { dashboardClient, traceClient } from "@/lib/api";
 import { DEFAULT_PROJECT_ID } from "@/lib/constants";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import type { DataPoint } from "@/components/chart";
-import type { GetJobLeaderboardResponse, JobUsage } from "@/gen/candela/v1/dashboard_service_pb";
+import type { GetJobLeaderboardResponse, JobUsage, ModelUsage } from "@/gen/candela/v1/dashboard_service_pb";
+import type { UserBudget, BudgetGrant } from "@/gen/candela/types/user_pb";
+
+// ──────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────
+
+export interface ModelUsageRow {
+  model: string;
+  provider: string;
+  callCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  avgLatencyMs: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+}
+
+export interface BudgetContext {
+  budget: UserBudget | null;
+  totalRemainingUsd: number;
+  activeGrants: BudgetGrant[];
+}
 
 export interface DashboardSummary {
   totalTraces: number;
@@ -47,6 +70,8 @@ export type TimeRange = "24h" | "7d" | "30d";
 type State = {
   summary: DashboardSummary | null;
   recentTraces: RecentTrace[];
+  models: ModelUsageRow[];
+  budgetContext: BudgetContext | null;
   loading: boolean;
   error: string | null;
   timeRange: TimeRange;
@@ -55,7 +80,13 @@ type State = {
 
 type Action =
   | { type: "fetch" }
-  | { type: "success"; summary: DashboardSummary; recentTraces: RecentTrace[] }
+  | {
+      type: "success";
+      summary: DashboardSummary;
+      recentTraces: RecentTrace[];
+      models: ModelUsageRow[];
+      budgetContext: BudgetContext | null;
+    }
   | { type: "error"; message: string }
   | { type: "refresh" }
   | { type: "setTimeRange"; range: TimeRange };
@@ -65,7 +96,14 @@ function reducer(state: State, action: Action): State {
     case "fetch":
       return { ...state, loading: true, error: null };
     case "success":
-      return { ...state, loading: false, summary: action.summary, recentTraces: action.recentTraces };
+      return {
+        ...state,
+        loading: false,
+        summary: action.summary,
+        recentTraces: action.recentTraces,
+        models: action.models,
+        budgetContext: action.budgetContext,
+      };
     case "error":
       return { ...state, loading: false, error: action.message };
     case "refresh":
@@ -74,6 +112,10 @@ function reducer(state: State, action: Action): State {
       return { ...state, timeRange: action.range, fetchCount: state.fetchCount + 1 };
   }
 }
+
+// ──────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────
 
 function timeRangeToMs(range: TimeRange): number {
   switch (range) {
@@ -98,14 +140,41 @@ function toDataPoints(pts: Array<{ timestamp: string; value: number }> | undefin
   }));
 }
 
+function mapModelUsage(m: ModelUsage): ModelUsageRow {
+  return {
+    model: m.model,
+    provider: m.provider,
+    callCount: Number(m.callCount),
+    inputTokens: Number(m.inputTokens),
+    outputTokens: Number(m.outputTokens),
+    costUsd: m.costUsd,
+    avgLatencyMs: m.avgLatencyMs,
+    cacheReadTokens: Number(m.cacheReadTokens),
+    cacheCreationTokens: Number(m.cacheCreationTokens),
+  };
+}
+
+// ──────────────────────────────────────────
+// Hook
+// ──────────────────────────────────────────
+
 /**
- * Hook for fetching the dashboard usage summary with time-series data
- * and recent traces. Supports time range filtering.
+ * Hook for fetching the consolidated dashboard data via GetDashboardData RPC.
+ *
+ * This replaces the previous fan-out of GetUsageSummary + GetModelBreakdown + GetMyUsage
+ * with a single round-trip. When `includeBudget` is true (the default when authenticated),
+ * the response includes per-user budget/grant context.
+ *
+ * Recent traces are still fetched separately via ListTraces.
  */
-export function useDashboard() {
+export function useDashboard(options?: { includeBudget?: boolean }) {
+  const includeBudget = options?.includeBudget ?? true;
+
   const [state, dispatch] = useReducer(reducer, {
     summary: null,
     recentTraces: [],
+    models: [],
+    budgetContext: null,
     loading: true,
     error: null,
     timeRange: "24h",
@@ -118,50 +187,66 @@ export function useDashboard() {
 
     const now = new Date();
     const start = new Date(now.getTime() - timeRangeToMs(state.timeRange));
+    const timeRange = {
+      start: timestampFromDate(start),
+      end: timestampFromDate(now),
+    };
 
-    const summaryPromise = dashboardClient.getUsageSummary({
-      projectId: DEFAULT_PROJECT_ID, // FIXME: Hardcoded - see constants.ts for evolution plan
-      timeRange: {
-        start: timestampFromDate(start),
-        end: timestampFromDate(now),
-      },
+    // ── Primary RPC: GetDashboardData (replaces GetUsageSummary + GetModelBreakdown) ──
+    const dashboardPromise = dashboardClient.getDashboardData({
+      projectId: DEFAULT_PROJECT_ID,
+      timeRange,
+      includeBudget,
     });
 
+    // ── Recent traces (still separate — no equivalent in GetDashboardData) ──
     const tracesPromise = traceClient.listTraces({
-      projectId: DEFAULT_PROJECT_ID, // FIXME: Hardcoded - see constants.ts for evolution plan
+      projectId: DEFAULT_PROJECT_ID,
       orderBy: "start_time",
       descending: true,
       pagination: { pageSize: 5 },
     });
 
+    // ── Job leaderboard (still separate) ──
     const jobLeaderboardPromise = dashboardClient.getJobLeaderboard({
       projectId: DEFAULT_PROJECT_ID,
-      timeRange: {
-        start: timestampFromDate(start),
-        end: timestampFromDate(now),
-      },
+      timeRange,
       limit: 10,
     }).catch(() => ({ jobs: [] })); // Degrade gracefully if job_id column missing
 
-    Promise.all([summaryPromise, tracesPromise, jobLeaderboardPromise])
-      .then(([res, tracesRes, jobRes]) => {
+    Promise.all([dashboardPromise, tracesPromise, jobLeaderboardPromise])
+      .then(([dashRes, tracesRes, jobRes]) => {
         if (cancelled) return;
+
+        const res = dashRes.summary;
+        const models = (dashRes.models || []).map(mapModelUsage);
+
+        // Map budget context from the consolidated response
+        let budgetCtx: BudgetContext | null = null;
+        if (dashRes.budgetContext) {
+          budgetCtx = {
+            budget: dashRes.budgetContext.budget ?? null,
+            totalRemainingUsd: dashRes.budgetContext.totalRemainingUsd,
+            activeGrants: dashRes.budgetContext.activeGrants,
+          };
+        }
+
         dispatch({
           type: "success",
           summary: {
-            totalTraces: Number(res.totalTraces),
-            totalSpans: Number(res.totalSpans),
-            totalLlmCalls: Number(res.totalLlmCalls),
-            totalInputTokens: Number(res.totalInputTokens),
-            totalOutputTokens: Number(res.totalOutputTokens),
-            totalCostUsd: res.totalCostUsd,
-            avgLatencyMs: res.avgLatencyMs,
-            errorRate: res.errorRate,
-            totalCacheReadTokens: Number(res.totalCacheReadTokens ?? 0),
-            totalCacheCreationTokens: Number(res.totalCacheCreationTokens ?? 0),
-            tracesOverTime: toDataPoints(res.tracesOverTime, state.timeRange),
-            costOverTime: toDataPoints(res.costOverTime, state.timeRange),
-            tokensOverTime: toDataPoints(res.tokensOverTime, state.timeRange),
+            totalTraces: Number(res?.totalTraces ?? 0),
+            totalSpans: Number(res?.totalSpans ?? 0),
+            totalLlmCalls: Number(res?.totalLlmCalls ?? 0),
+            totalInputTokens: Number(res?.totalInputTokens ?? 0),
+            totalOutputTokens: Number(res?.totalOutputTokens ?? 0),
+            totalCostUsd: res?.totalCostUsd ?? 0,
+            avgLatencyMs: res?.avgLatencyMs ?? 0,
+            errorRate: res?.errorRate ?? 0,
+            totalCacheReadTokens: Number(res?.totalCacheReadTokens ?? 0),
+            totalCacheCreationTokens: Number(res?.totalCacheCreationTokens ?? 0),
+            tracesOverTime: toDataPoints(res?.tracesOverTime, state.timeRange),
+            costOverTime: toDataPoints(res?.costOverTime, state.timeRange),
+            tokensOverTime: toDataPoints(res?.tokensOverTime, state.timeRange),
             jobLeaderboard: (jobRes as Pick<GetJobLeaderboardResponse, "jobs">).jobs.map((j: JobUsage) => ({
               jobId: j.jobId,
               callCount: Number(j.callCount),
@@ -189,6 +274,8 @@ export function useDashboard() {
                 : "—",
             };
           }),
+          models,
+          budgetContext: budgetCtx,
         });
       })
       .catch((err) => {
@@ -196,7 +283,7 @@ export function useDashboard() {
       });
 
     return () => { cancelled = true; };
-  }, [state.fetchCount, state.timeRange]);
+  }, [state.fetchCount, state.timeRange, includeBudget]);
 
   const refresh = useCallback(() => dispatch({ type: "refresh" }), []);
   const setTimeRange = useCallback(
@@ -207,6 +294,8 @@ export function useDashboard() {
   return {
     summary: state.summary,
     recentTraces: state.recentTraces,
+    models: state.models,
+    budgetContext: state.budgetContext,
     loading: state.loading,
     error: state.error,
     timeRange: state.timeRange,

--- a/ui/src/hooks/useModels.ts
+++ b/ui/src/hooks/useModels.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useDashboard, type ModelUsageRow } from "@/hooks/useDashboard";
+
+// ──────────────────────────────────────────
+// Sort logic
+// ──────────────────────────────────────────
+
+export type ModelSortKey = keyof Pick<
+  ModelUsageRow,
+  "model" | "provider" | "callCount" | "inputTokens" | "outputTokens" | "costUsd" | "avgLatencyMs"
+>;
+
+interface SortState {
+  key: ModelSortKey;
+  desc: boolean;
+}
+
+function compare(a: ModelUsageRow, b: ModelUsageRow, key: ModelSortKey): number {
+  const va = a[key];
+  const vb = b[key];
+  if (typeof va === "string" && typeof vb === "string") {
+    return va.localeCompare(vb);
+  }
+  return (va as number) - (vb as number);
+}
+
+// ──────────────────────────────────────────
+// Hook
+// ──────────────────────────────────────────
+
+/**
+ * Hook for the Models page.
+ *
+ * Re-uses useDashboard() to get model breakdown from GetDashboardData,
+ * and adds client-side sort + search.
+ */
+export function useModels(options?: { includeBudget?: boolean }) {
+  const dashboard = useDashboard(options);
+  const [sort, setSort] = useState<SortState>({ key: "costUsd", desc: true });
+  const [search, setSearch] = useState("");
+
+  const toggleSort = useCallback((key: ModelSortKey) => {
+    setSort((prev) =>
+      prev.key === key ? { key, desc: !prev.desc } : { key, desc: true }
+    );
+  }, []);
+
+  const filtered = useMemo(() => {
+    let rows = [...dashboard.models];
+    if (search) {
+      const q = search.toLowerCase();
+      rows = rows.filter(
+        (r) =>
+          r.model.toLowerCase().includes(q) ||
+          r.provider.toLowerCase().includes(q)
+      );
+    }
+    rows.sort((a, b) => {
+      const c = compare(a, b, sort.key);
+      return sort.desc ? -c : c;
+    });
+    return rows;
+  }, [dashboard.models, sort, search]);
+
+  // Aggregate totals
+  const totals = useMemo(() => {
+    const t = {
+      totalCalls: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCost: 0,
+      totalCacheRead: 0,
+      totalCacheCreation: 0,
+    };
+    for (const r of dashboard.models) {
+      t.totalCalls += r.callCount;
+      t.totalInputTokens += r.inputTokens;
+      t.totalOutputTokens += r.outputTokens;
+      t.totalCost += r.costUsd;
+      t.totalCacheRead += r.cacheReadTokens;
+      t.totalCacheCreation += r.cacheCreationTokens;
+    }
+    return t;
+  }, [dashboard.models]);
+
+  return {
+    models: filtered,
+    totals,
+    loading: dashboard.loading,
+    error: dashboard.error,
+    timeRange: dashboard.timeRange,
+    setTimeRange: dashboard.setTimeRange,
+    refresh: dashboard.refresh,
+    sort,
+    toggleSort,
+    search,
+    setSearch,
+    budgetContext: dashboard.budgetContext,
+  };
+}

--- a/ui/src/hooks/useTraces.ts
+++ b/ui/src/hooks/useTraces.ts
@@ -171,8 +171,7 @@ export function useTraces() {
       prevModeRef.current = mode;
       fetchTraces(state.filters);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode]);
+  }, [mode, fetchTraces, state.filters]);
 
   return {
     traces: state.traces,

--- a/ui/src/hooks/useTraces.ts
+++ b/ui/src/hooks/useTraces.ts
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useReducer, useRef } from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 import { traceClient } from "@/lib/api";
 import { DEFAULT_PROJECT_ID } from "@/lib/constants";
 import type { TraceSummaryRow, TraceFilters } from "@/types/traces";
 import { DEFAULT_FILTERS } from "@/types/traces";
+import { useScope } from "@/components/UserScopeProvider";
 
 type State = {
   traces: TraceSummaryRow[];
@@ -79,8 +80,15 @@ function mapTrace(t: {
 /**
  * Hook for fetching and filtering traces.
  * Encapsulates the ListTraces RPC, debounced search, and filter state.
+ *
+ * Scope-aware: In "personal" mode the backend already scopes by the
+ * authenticated user's Firebase token.  We pass `include_budget=true`
+ * as a hint header so the backend knows this is a personal-scope request.
+ * Re-fetches automatically when the scope mode changes.
  */
 export function useTraces() {
+  const { isPersonalScope, mode } = useScope();
+
   const [state, dispatch] = useReducer(reducer, {
     traces: [],
     loading: true,
@@ -88,12 +96,21 @@ export function useTraces() {
     filters: DEFAULT_FILTERS,
   });
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Track the previous scope mode so we can detect changes
+  const prevModeRef = useRef(mode);
 
   const fetchTraces = useCallback((f: TraceFilters) => {
     dispatch({ type: "fetch", filters: f });
+
+    // Build headers — the backend interprets the auth token + this hint
+    // to decide whether to filter to the authenticated user's traces.
+    const headers: Record<string, string> = {};
+    if (f.jobId) headers["X-Candela-Job-Id"] = f.jobId;
+    if (isPersonalScope) headers["X-Candela-Scope"] = "personal";
+
     traceClient
       .listTraces({
-        projectId: DEFAULT_PROJECT_ID, // FIXME: Hardcoded - see constants.ts for evolution plan
+        projectId: DEFAULT_PROJECT_ID,
         pagination: { pageSize: 100 },
         search: f.search,
         model: f.model,
@@ -102,7 +119,7 @@ export function useTraces() {
         orderBy: f.orderBy,
         descending: f.descending,
       }, {
-        headers: f.jobId ? { "X-Candela-Job-Id": f.jobId } : {},
+        headers,
       })
       .then((res) => {
         dispatch({
@@ -111,7 +128,7 @@ export function useTraces() {
         });
       })
       .catch((err) => dispatch({ type: "error", message: err.message }));
-  }, []);
+  }, [isPersonalScope]);
 
   const updateFilters = useCallback(
     (patch: Partial<TraceFilters>) => {
@@ -147,6 +164,15 @@ export function useTraces() {
     () => fetchTraces(state.filters),
     [state.filters, fetchTraces]
   );
+
+  // Re-fetch when scope mode changes
+  useEffect(() => {
+    if (prevModeRef.current !== mode) {
+      prevModeRef.current = mode;
+      fetchTraces(state.filters);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode]);
 
   return {
     traces: state.traces,


### PR DESCRIPTION
## Summary

Modernizes the Candela desktop UI with user-scoped observability, a new Models dashboard, and a live Settings page.

### Changes

**User Scope Infrastructure**
- `UserScopeProvider` + `ScopeToggle` — Personal/Global data view toggle (persisted in localStorage)
- Integrated into Dashboard, Traces, and Models pages

**Dashboard RPC Consolidation**
- Refactored `useDashboard` to use single `GetDashboardData` RPC (replaces fan-out of GetUsageSummary + GetModelBreakdown)
- Returns model breakdown + budget context in one round-trip

**Traces Scope Integration**
- `useTraces` now sends `X-Candela-Scope: personal` header in personal mode
- Auto re-fetches when scope mode changes

**New Models Page**
- Sortable, searchable model breakdown table
- Aggregate stats (models used, total calls, tokens, cost)
- Budget progress bar + cache performance section

**Settings Page Refactor**
- Live data from `useCurrentUser()` + `useDashboard()`
- User account card (email, role, budget context)

### Files Changed (13)
- 4 new: `UserScopeProvider.tsx`, `ScopeToggle.tsx`, `useModels.ts`, `models/page.tsx`
- 9 modified: hooks, pages, sidebar, layout, CSS

### Verification
- ✅ `next build` — TypeScript clean
- ✅ `eslint` — 0 errors (warnings only in generated proto files)
- ✅ All pre-commit hooks pass