### PR TITLE
feat(ui): model pricing columns and cache efficiency badges

### DIFF
--- a/ui/src/app/models/page.tsx
+++ b/ui/src/app/models/page.tsx
@@ -210,10 +210,10 @@ export default function ModelsPage() {
                         <span className="badge badge-info">{m.provider}</span>
                       </td>
                       <td style={{ textAlign: "right", fontFamily: "monospace", fontSize: 11, color: "var(--text-secondary)" }}>
-                        {m.inputPricePerMillion != null ? `$${m.inputPricePerMillion.toFixed(2)}` : "—"}
+                        {m.inputPricePerMillion != null ? `$${m.inputPricePerMillion.toFixed(3)}` : "—"}
                       </td>
                       <td style={{ textAlign: "right", fontFamily: "monospace", fontSize: 11, color: "var(--text-secondary)" }}>
-                        {m.outputPricePerMillion != null ? `$${m.outputPricePerMillion.toFixed(2)}` : "—"}
+                        {m.outputPricePerMillion != null ? `$${m.outputPricePerMillion.toFixed(3)}` : "—"}
                       </td>
                       <td style={{ textAlign: "right" }}>{m.callCount.toLocaleString()}</td>
                       <td style={{ textAlign: "right" }}>{fmtTokens(m.inputTokens)}</td>
@@ -285,14 +285,8 @@ export default function ModelsPage() {
 // Cache badge inline component
 // ──────────────────────────────────────────
 
-const tierColors: Record<CacheEfficiency["tier"], string> = {
-  excellent: "#4ade80",
-  good: "var(--accent)",
-  low: "var(--warning, #f59e0b)",
-};
-
 function CacheBadge({ eff }: { eff: CacheEfficiency }) {
-  const color = tierColors[eff.tier];
+  const color = eff.color;
   return (
     <span
       style={{

--- a/ui/src/app/models/page.tsx
+++ b/ui/src/app/models/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useModels, type ModelSortKey } from "@/hooks/useModels";
+import { useModels, type ModelSortKey, type EnrichedModelRow } from "@/hooks/useModels";
+import { type CacheEfficiency } from "@/lib/modelPricing";
 import { TimeRangeSelector } from "@/components/TimeRangeSelector";
 import { ScopeToggle } from "@/components/ScopeToggle";
 import { useScope } from "@/components/UserScopeProvider";
@@ -186,11 +187,14 @@ export default function ModelsPage() {
                 <tr>
                   <SortTh label="Model" sortKey="model" {...sort} currentKey={sort.key} onSort={toggleSort} />
                   <SortTh label="Provider" sortKey="provider" {...sort} currentKey={sort.key} onSort={toggleSort} />
+                  <SortTh label="In $/M" sortKey="inputPrice" {...sort} currentKey={sort.key} onSort={toggleSort} align="right" />
+                  <SortTh label="Out $/M" sortKey="outputPrice" {...sort} currentKey={sort.key} onSort={toggleSort} align="right" />
                   <SortTh label="Calls" sortKey="callCount" {...sort} currentKey={sort.key} onSort={toggleSort} align="right" />
                   <SortTh label="Input Tokens" sortKey="inputTokens" {...sort} currentKey={sort.key} onSort={toggleSort} align="right" />
                   <SortTh label="Output Tokens" sortKey="outputTokens" {...sort} currentKey={sort.key} onSort={toggleSort} align="right" />
                   <SortTh label="Cost" sortKey="costUsd" {...sort} currentKey={sort.key} onSort={toggleSort} align="right" />
                   <SortTh label="Avg Latency" sortKey="avgLatencyMs" {...sort} currentKey={sort.key} onSort={toggleSort} align="right" />
+                  <th style={{ textAlign: "center" }}>Cache</th>
                   <th style={{ textAlign: "right" }}>Cost %</th>
                 </tr>
               </thead>
@@ -205,11 +209,24 @@ export default function ModelsPage() {
                       <td>
                         <span className="badge badge-info">{m.provider}</span>
                       </td>
+                      <td style={{ textAlign: "right", fontFamily: "monospace", fontSize: 11, color: "var(--text-secondary)" }}>
+                        {m.inputPricePerMillion != null ? `$${m.inputPricePerMillion.toFixed(2)}` : "—"}
+                      </td>
+                      <td style={{ textAlign: "right", fontFamily: "monospace", fontSize: 11, color: "var(--text-secondary)" }}>
+                        {m.outputPricePerMillion != null ? `$${m.outputPricePerMillion.toFixed(2)}` : "—"}
+                      </td>
                       <td style={{ textAlign: "right" }}>{m.callCount.toLocaleString()}</td>
                       <td style={{ textAlign: "right" }}>{fmtTokens(m.inputTokens)}</td>
                       <td style={{ textAlign: "right" }}>{fmtTokens(m.outputTokens)}</td>
                       <td style={{ textAlign: "right" }}>${m.costUsd.toFixed(4)}</td>
                       <td style={{ textAlign: "right" }}>{m.avgLatencyMs.toFixed(0)}ms</td>
+                      <td style={{ textAlign: "center" }}>
+                        {m.cacheEfficiency ? (
+                          <CacheBadge eff={m.cacheEfficiency} />
+                        ) : (
+                          <span style={{ color: "var(--text-muted)", fontSize: 11 }}>—</span>
+                        )}
+                      </td>
                       <td style={{ textAlign: "right" }}>
                         <div style={{ display: "flex", alignItems: "center", gap: 8, justifyContent: "flex-end" }}>
                           <div style={{ width: 60, height: 4, background: "var(--bg-tertiary)", borderRadius: 2 }}>
@@ -261,5 +278,36 @@ export default function ModelsPage() {
         )}
       </div>
     </>
+  );
+}
+
+// ──────────────────────────────────────────
+// Cache badge inline component
+// ──────────────────────────────────────────
+
+const tierColors: Record<CacheEfficiency["tier"], string> = {
+  excellent: "#4ade80",
+  good: "var(--accent)",
+  low: "var(--warning, #f59e0b)",
+};
+
+function CacheBadge({ eff }: { eff: CacheEfficiency }) {
+  const color = tierColors[eff.tier];
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        padding: "2px 8px",
+        fontSize: 10,
+        fontWeight: 700,
+        fontFamily: "monospace",
+        color,
+        background: `color-mix(in srgb, ${color} 12%, transparent)`,
+        border: `1px solid color-mix(in srgb, ${color} 30%, transparent)`,
+        borderRadius: 6,
+      }}
+    >
+      {eff.label} {(eff.rate * 100).toFixed(0)}%
+    </span>
   );
 }

--- a/ui/src/hooks/useModels.ts
+++ b/ui/src/hooks/useModels.ts
@@ -2,22 +2,34 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { useDashboard, type ModelUsageRow } from "@/hooks/useDashboard";
+import { getModelPricing, getCacheEfficiency, type CacheEfficiency } from "@/lib/modelPricing";
 
 // ──────────────────────────────────────────
 // Sort logic
 // ──────────────────────────────────────────
 
-export type ModelSortKey = keyof Pick<
-  ModelUsageRow,
-  "model" | "provider" | "callCount" | "inputTokens" | "outputTokens" | "costUsd" | "avgLatencyMs"
->;
+export type ModelSortKey =
+  | keyof Pick<
+      ModelUsageRow,
+      "model" | "provider" | "callCount" | "inputTokens" | "outputTokens" | "costUsd" | "avgLatencyMs"
+    >
+  | "inputPrice"
+  | "outputPrice";
+
+export interface EnrichedModelRow extends ModelUsageRow {
+  inputPricePerMillion: number | null;
+  outputPricePerMillion: number | null;
+  cacheEfficiency: CacheEfficiency | null;
+}
 
 interface SortState {
   key: ModelSortKey;
   desc: boolean;
 }
 
-function compare(a: ModelUsageRow, b: ModelUsageRow, key: ModelSortKey): number {
+function compare(a: EnrichedModelRow, b: EnrichedModelRow, key: ModelSortKey): number {
+  if (key === "inputPrice") return (a.inputPricePerMillion ?? 0) - (b.inputPricePerMillion ?? 0);
+  if (key === "outputPrice") return (a.outputPricePerMillion ?? 0) - (b.outputPricePerMillion ?? 0);
   const va = a[key];
   const vb = b[key];
   if (typeof va === "string" && typeof vb === "string") {
@@ -47,8 +59,21 @@ export function useModels(options?: { includeBudget?: boolean }) {
     );
   }, []);
 
+  // Enrich rows with static pricing and cache efficiency
+  const enriched: EnrichedModelRow[] = useMemo(() => {
+    return dashboard.models.map((m) => {
+      const pricing = getModelPricing(m.model);
+      return {
+        ...m,
+        inputPricePerMillion: pricing?.inputPerMillion ?? null,
+        outputPricePerMillion: pricing?.outputPerMillion ?? null,
+        cacheEfficiency: getCacheEfficiency(m.cacheReadTokens, m.inputTokens),
+      };
+    });
+  }, [dashboard.models]);
+
   const filtered = useMemo(() => {
-    let rows = [...dashboard.models];
+    let rows = [...enriched];
     if (search) {
       const q = search.toLowerCase();
       rows = rows.filter(
@@ -62,7 +87,7 @@ export function useModels(options?: { includeBudget?: boolean }) {
       return sort.desc ? -c : c;
     });
     return rows;
-  }, [dashboard.models, sort, search]);
+  }, [enriched, sort, search]);
 
   // Aggregate totals
   const totals = useMemo(() => {

--- a/ui/src/hooks/useModels.ts
+++ b/ui/src/hooks/useModels.ts
@@ -30,8 +30,8 @@ interface SortState {
 function compare(a: EnrichedModelRow, b: EnrichedModelRow, key: ModelSortKey): number {
   if (key === "inputPrice") return (a.inputPricePerMillion ?? 0) - (b.inputPricePerMillion ?? 0);
   if (key === "outputPrice") return (a.outputPricePerMillion ?? 0) - (b.outputPricePerMillion ?? 0);
-  const va = a[key];
-  const vb = b[key];
+  const va = a[key as keyof ModelUsageRow];
+  const vb = b[key as keyof ModelUsageRow];
   if (typeof va === "string" && typeof vb === "string") {
     return va.localeCompare(vb);
   }

--- a/ui/src/lib/modelPricing.ts
+++ b/ui/src/lib/modelPricing.ts
@@ -1,0 +1,100 @@
+/**
+ * Static per-model pricing registry.
+ *
+ * SOURCE OF TRUTH: pkg/costcalc/calculator.go → loadDefaults()
+ * Keep this file in sync whenever model pricing is added or changed.
+ *
+ * Prices are list prices in USD per 1 million tokens.
+ */
+
+export interface ModelPricing {
+  inputPerMillion: number;
+  outputPerMillion: number;
+}
+
+export interface CacheEfficiency {
+  /** Hit rate 0.0–1.0 */
+  rate: number;
+  label: string;
+  /** CSS-friendly color */
+  color: string;
+  /** CSS class suffix: "excellent" | "good" | "low" */
+  tier: "excellent" | "good" | "low";
+}
+
+// ── Registry ──────────────────────────────────────────────────────
+// Keys are lowercase model names (provider-agnostic, matching the
+// fallback behavior in calculator.go).
+
+const PRICING_MAP: Record<string, ModelPricing> = {
+  // Google Gemini
+  "gemini-3.5-flash":        { inputPerMillion: 1.50,  outputPerMillion: 9.00 },
+  "gemini-3.1-pro":          { inputPerMillion: 2.00,  outputPerMillion: 12.00 },
+  "gemini-3.1-flash":        { inputPerMillion: 0.50,  outputPerMillion: 3.00 },
+  "gemini-3.1-flash-lite":   { inputPerMillion: 0.25,  outputPerMillion: 1.50 },
+  "gemini-3.0-pro":          { inputPerMillion: 2.00,  outputPerMillion: 12.00 },
+  "gemini-3.0-flash":        { inputPerMillion: 0.50,  outputPerMillion: 3.00 },
+  "gemini-2.5-pro":          { inputPerMillion: 1.25,  outputPerMillion: 10.00 },
+  "gemini-2.5-flash":        { inputPerMillion: 0.30,  outputPerMillion: 2.50 },
+  "gemini-2.5-flash-lite":   { inputPerMillion: 0.10,  outputPerMillion: 0.40 },
+  "gemini-2.0-flash":        { inputPerMillion: 0.10,  outputPerMillion: 0.40 },
+  "gemini-2.0-pro":          { inputPerMillion: 1.25,  outputPerMillion: 10.00 },
+  "gemini-1.5-flash":        { inputPerMillion: 0.075, outputPerMillion: 0.30 },
+  "gemini-1.5-pro":          { inputPerMillion: 1.25,  outputPerMillion: 5.00 },
+
+  // OpenAI
+  "gpt-5.4-pro":     { inputPerMillion: 30.00, outputPerMillion: 180.00 },
+  "gpt-5.4":         { inputPerMillion: 2.50,  outputPerMillion: 15.00 },
+  "gpt-5.4-mini":    { inputPerMillion: 0.75,  outputPerMillion: 4.50 },
+  "gpt-5.4-nano":    { inputPerMillion: 0.20,  outputPerMillion: 1.25 },
+  "gpt-4o":          { inputPerMillion: 2.50,  outputPerMillion: 10.00 },
+  "gpt-4o-mini":     { inputPerMillion: 0.15,  outputPerMillion: 0.60 },
+  "gpt-4-turbo":     { inputPerMillion: 10.00, outputPerMillion: 30.00 },
+  "gpt-3.5-turbo":   { inputPerMillion: 0.50,  outputPerMillion: 1.50 },
+  "o3":              { inputPerMillion: 10.00, outputPerMillion: 40.00 },
+  "o3-mini":         { inputPerMillion: 1.10,  outputPerMillion: 4.40 },
+  "o1":              { inputPerMillion: 15.00, outputPerMillion: 60.00 },
+  "o1-mini":         { inputPerMillion: 3.00,  outputPerMillion: 12.00 },
+
+  // Anthropic
+  "claude-opus-4.7":              { inputPerMillion: 5.00,  outputPerMillion: 25.00 },
+  "claude-opus-4.6":              { inputPerMillion: 5.00,  outputPerMillion: 25.00 },
+  "claude-sonnet-4.6":            { inputPerMillion: 3.00,  outputPerMillion: 15.00 },
+  "claude-haiku-4.5":             { inputPerMillion: 1.00,  outputPerMillion: 5.00 },
+  "claude-sonnet-4":              { inputPerMillion: 3.00,  outputPerMillion: 15.00 },
+  "claude-opus-4":                { inputPerMillion: 5.00,  outputPerMillion: 25.00 },
+  "claude-sonnet-4-20250514":     { inputPerMillion: 3.00,  outputPerMillion: 15.00 },
+  "claude-opus-4-20250514":       { inputPerMillion: 5.00,  outputPerMillion: 25.00 },
+  "claude-3-5-sonnet-20241022":   { inputPerMillion: 3.00,  outputPerMillion: 15.00 },
+  "claude-haiku-3-5-20241022":    { inputPerMillion: 0.80,  outputPerMillion: 4.00 },
+  "claude-3-opus-20240229":       { inputPerMillion: 15.00, outputPerMillion: 75.00 },
+};
+
+/**
+ * Look up static list pricing for a model.
+ * Returns null for models without a known price (e.g. local/custom).
+ */
+export function getModelPricing(model: string): ModelPricing | null {
+  return PRICING_MAP[model.toLowerCase()] ?? null;
+}
+
+/**
+ * Compute cache efficiency from per-model token counts.
+ * Returns null when there are no cache read tokens.
+ */
+export function getCacheEfficiency(
+  cacheReadTokens: number,
+  inputTokens: number
+): CacheEfficiency | null {
+  if (inputTokens <= 0 || cacheReadTokens <= 0) return null;
+
+  const rate = Math.min(1, cacheReadTokens / inputTokens);
+
+  if (rate >= 0.5) {
+    return { rate, label: "Excellent", color: "var(--success, #4ade80)", tier: "excellent" };
+  }
+  if (rate >= 0.2) {
+    return { rate, label: "Good", color: "var(--accent, #60a5fa)", tier: "good" };
+  }
+  return { rate, label: "Low", color: "var(--warning, #fbbf24)", tier: "low" };
+}


### PR DESCRIPTION
## Summary

Surfaces per-model list pricing and cache-efficiency badges in the Web UI models table.

### Changes
- **`ui/src/lib/modelPricing.ts`** — Static pricing registry mirroring `calculator.go` + cache efficiency helpers
- **`ui/src/hooks/useModels.ts`** — Enriches model rows with pricing data; adds `inputPrice`/`outputPrice` sort keys
- **`ui/src/app/models/page.tsx`** — Adds sortable In $/M and Out $/M columns, per-row cache efficiency badges with tier coloring

### Cache Efficiency Tiers
| Hit Rate | Label | Color |
|----------|-------|-------|
| ≥ 50% | Excellent | Green |
| ≥ 20% | Good | Accent blue |
| > 0% | Low | Amber |

### Notes
- Pricing is static client-side to avoid new RPCs; source of truth remains `pkg/costcalc/calculator.go`
- Build verified: `npm run build` passes cleanly
- Companion desktop PR: candelahq/candela-desktop (feat/model-pricing-ui)