### PR TITLE
refactor: harden Tetragon gRPC audit pipeline error handling and observability

### DIFF
--- a/cmd/candela-sidecar/main.go
+++ b/cmd/candela-sidecar/main.go
@@ -297,7 +297,9 @@ func main() {
 				slog.Info("📋 Tetragon gRPC audit pipeline started", "addr", tetragonGRPCAddr)
 				stream, err := tetragonaudit.NewGRPCEventStreamAdapter(ctx, grpcSrc.Conn())
 				if err != nil {
-					slog.Error("Tetragon gRPC audit pipeline error during stream initialization", "error", err)
+					if ctx.Err() == nil {
+						slog.Error("Tetragon gRPC audit pipeline error during stream initialization", "error", err)
+					}
 					return
 				}
 				if err := grpcSrc.StreamEvents(ctx, stream, pipeline); err != nil && ctx.Err() == nil {

--- a/cmd/candela-sidecar/main.go
+++ b/cmd/candela-sidecar/main.go
@@ -295,7 +295,11 @@ func main() {
 
 			go func() {
 				slog.Info("📋 Tetragon gRPC audit pipeline started", "addr", tetragonGRPCAddr)
-				stream := tetragonaudit.NewGRPCEventStreamAdapter(grpcSrc.Conn())
+				stream, err := tetragonaudit.NewGRPCEventStreamAdapter(ctx, grpcSrc.Conn())
+				if err != nil {
+					slog.Error("Tetragon gRPC audit pipeline error during stream initialization", "error", err)
+					return
+				}
 				if err := grpcSrc.StreamEvents(ctx, stream, pipeline); err != nil && ctx.Err() == nil {
 					slog.Error("Tetragon gRPC audit pipeline error", "error", err)
 				}

--- a/pkg/tetragonaudit/grpc_source.go
+++ b/pkg/tetragonaudit/grpc_source.go
@@ -104,21 +104,17 @@ type GRPCEventStreamAdapter struct {
 // NewGRPCEventStreamAdapter creates a TetragonEventStream from a gRPC connection.
 // It initiates a server-streaming RPC on the Tetragon FineGuidanceSensors/GetEvents
 // endpoint and returns an adapter that reads raw event bytes.
-func NewGRPCEventStreamAdapter(conn *grpc.ClientConn) *GRPCEventStreamAdapter {
-	// Use a background context — the caller controls cancellation via
-	// StreamEvents' context parameter.
-	ctx := context.Background()
+func NewGRPCEventStreamAdapter(ctx context.Context, conn *grpc.ClientConn) (*GRPCEventStreamAdapter, error) {
 	desc := &grpc.StreamDesc{ServerStreams: true}
 	stream, err := conn.NewStream(ctx, desc, "/tetragon.FineGuidanceSensors/GetEvents")
 	if err != nil {
-		slog.Error("tetragonaudit: failed to create gRPC stream", "error", err)
-		return &GRPCEventStreamAdapter{}
+		return nil, fmt.Errorf("tetragonaudit: failed to create gRPC stream: %w", err)
 	}
 	// Send empty request to initiate streaming.
 	if err := stream.SendMsg([]byte("{}")); err != nil {
-		slog.Error("tetragonaudit: failed to send GetEvents request", "error", err)
+		return nil, fmt.Errorf("tetragonaudit: failed to send GetEvents request: %w", err)
 	}
-	return &GRPCEventStreamAdapter{stream: stream}
+	return &GRPCEventStreamAdapter{stream: stream}, nil
 }
 
 // Recv blocks until the next event is available from the gRPC stream.

--- a/pkg/tetragonaudit/grpc_source.go
+++ b/pkg/tetragonaudit/grpc_source.go
@@ -114,6 +114,10 @@ func NewGRPCEventStreamAdapter(ctx context.Context, conn *grpc.ClientConn) (*GRP
 	if err := stream.SendMsg([]byte("{}")); err != nil {
 		return nil, fmt.Errorf("tetragonaudit: failed to send GetEvents request: %w", err)
 	}
+	// Signal that the client is done sending (server-streaming RPC best practice).
+	if err := stream.CloseSend(); err != nil {
+		return nil, fmt.Errorf("tetragonaudit: failed to close send stream: %w", err)
+	}
 	return &GRPCEventStreamAdapter{stream: stream}, nil
 }
 

--- a/pkg/tetragonaudit/grpc_source_test.go
+++ b/pkg/tetragonaudit/grpc_source_test.go
@@ -7,6 +7,9 @@ import (
 	"io"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // mockStream implements TetragonEventStream for testing.
@@ -196,5 +199,21 @@ func TestGRPCSource_Conn(t *testing.T) {
 
 	if src.Conn() == nil {
 		t.Error("Conn() should not be nil")
+	}
+}
+
+func TestNewGRPCEventStreamAdapter_Error(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel the context to force NewStream to return an error.
+
+	conn, err := grpc.NewClient("localhost:12345", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	_, err = NewGRPCEventStreamAdapter(ctx, conn)
+	if err == nil {
+		t.Error("expected error when context is canceled, got nil")
 	}
 }

--- a/pkg/tetragonaudit/multi_sink_test.go
+++ b/pkg/tetragonaudit/multi_sink_test.go
@@ -1,0 +1,86 @@
+package tetragonaudit
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// erringSink always returns an error from Emit.
+type erringSink struct {
+	err error
+}
+
+func (s *erringSink) Emit(_ context.Context, _ AuditRecord) error {
+	return s.err
+}
+
+func TestMultiSink_FanOut(t *testing.T) {
+	sink1 := &CollectorSink{}
+	sink2 := &CollectorSink{}
+
+	ms := &MultiSink{Sinks: []Sink{sink1, sink2}}
+	record := AuditRecord{Binary: "/bin/test", Severity: "INFO"}
+
+	if err := ms.Emit(context.Background(), record); err != nil {
+		t.Fatalf("Emit returned unexpected error: %v", err)
+	}
+
+	if got := len(sink1.GetRecords()); got != 1 {
+		t.Errorf("sink1 got %d records, want 1", got)
+	}
+	if got := len(sink2.GetRecords()); got != 1 {
+		t.Errorf("sink2 got %d records, want 1", got)
+	}
+}
+
+func TestMultiSink_ErrorDoesNotShortCircuit(t *testing.T) {
+	// First sink errors, second should still receive the record.
+	errSink := &erringSink{err: errors.New("sink1 failed")}
+	sink2 := &CollectorSink{}
+
+	ms := &MultiSink{Sinks: []Sink{errSink, sink2}}
+	record := AuditRecord{Binary: "/bin/test"}
+
+	err := ms.Emit(context.Background(), record)
+	if err == nil {
+		t.Fatal("expected error from MultiSink.Emit, got nil")
+	}
+	if err.Error() != "sink1 failed" {
+		t.Errorf("got error %q, want %q", err.Error(), "sink1 failed")
+	}
+
+	// Verify second sink was called despite first error.
+	if got := len(sink2.GetRecords()); got != 1 {
+		t.Errorf("sink2 got %d records, want 1 (should not short-circuit)", got)
+	}
+}
+
+func TestMultiSink_ReturnsFirstError(t *testing.T) {
+	// Both sinks error; should get the first one.
+	err1 := errors.New("first")
+	err2 := errors.New("second")
+	ms := &MultiSink{Sinks: []Sink{
+		&erringSink{err: err1},
+		&erringSink{err: err2},
+	}}
+
+	err := ms.Emit(context.Background(), AuditRecord{})
+	if !errors.Is(err, err1) {
+		t.Errorf("got error %v, want %v", err, err1)
+	}
+}
+
+func TestMultiSink_Empty(t *testing.T) {
+	ms := &MultiSink{Sinks: nil}
+	if err := ms.Emit(context.Background(), AuditRecord{}); err != nil {
+		t.Fatalf("empty MultiSink should not error, got: %v", err)
+	}
+}
+
+func TestMultiSink_NilSinks(t *testing.T) {
+	ms := &MultiSink{}
+	if err := ms.Emit(context.Background(), AuditRecord{}); err != nil {
+		t.Fatalf("nil-sinks MultiSink should not error, got: %v", err)
+	}
+}

--- a/pkg/tetragonaudit/pipeline.go
+++ b/pkg/tetragonaudit/pipeline.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 )
@@ -299,7 +300,7 @@ func (p *Pipeline) normalize(event Event) AuditRecord {
 		record.PolicyName = kp.PolicyName
 
 		// SIGKILL actions are critical security events.
-		if kp.Action == "SIGKILL" || kp.Action == "Sigkill" {
+		if strings.EqualFold(kp.Action, "SIGKILL") {
 			record.Severity = "CRITICAL"
 		}
 
@@ -372,7 +373,7 @@ func EnforcementOnly() EventFilter {
 			return false
 		}
 		action := e.ProcessKprobe.Action
-		return action == "SIGKILL" || action == "Sigkill"
+		return strings.EqualFold(action, "SIGKILL")
 	}
 }
 

--- a/pkg/tetragonaudit/pipeline_extra_test.go
+++ b/pkg/tetragonaudit/pipeline_extra_test.go
@@ -99,3 +99,42 @@ func TestPipelineStatsSnapshot(t *testing.T) {
 		t.Errorf("errors = %d, want 1", errors)
 	}
 }
+
+func TestSIGKILLCaseInsensitive(t *testing.T) {
+	// Regression: kernel/Tetragon may emit SIGKILL in different casing.
+	cases := []string{"SIGKILL", "Sigkill", "sigkill", "SigKill"}
+
+	for _, action := range cases {
+		t.Run("normalize_"+action, func(t *testing.T) {
+			sink := &CollectorSink{}
+			p := NewPipeline(PipelineConfig{Sink: sink})
+			event := Event{
+				NodeName: "n1",
+				ProcessKprobe: &ProcessKprobe{
+					Process:      &Process{Binary: "/bin/kill"},
+					FunctionName: "security_task_kill",
+					Action:       action,
+					PolicyName:   "enforce",
+				},
+			}
+			_ = p.ProcessEvent(context.Background(), event)
+			records := sink.GetRecords()
+			if len(records) != 1 {
+				t.Fatalf("got %d records, want 1", len(records))
+			}
+			if records[0].Severity != "CRITICAL" {
+				t.Errorf("action=%q: severity=%q, want CRITICAL", action, records[0].Severity)
+			}
+		})
+
+		t.Run("enforcementFilter_"+action, func(t *testing.T) {
+			filter := EnforcementOnly()
+			event := Event{
+				ProcessKprobe: &ProcessKprobe{Action: action},
+			}
+			if !filter(event) {
+				t.Errorf("EnforcementOnly() rejected action=%q, want accepted", action)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Refactor the Tetragon gRPC audit pipeline to improve error handling, address Gemini code review feedback, and expand test coverage.

## Changes

### `pkg/tetragonaudit/grpc_source.go`
- Changed `NewGRPCEventStreamAdapter` signature to accept `context.Context` and return `(*GRPCEventStreamAdapter, error)`
- Returns wrapped errors from `NewStream`/`SendMsg` instead of logging internally
- **Added `stream.CloseSend()`** after `SendMsg` — gRPC best practice for server-streaming RPCs (Gemini review)

### `cmd/candela-sidecar/main.go`
- Updated call site to handle the returned error
- **Guarded init error log** behind `ctx.Err() == nil` to silence noise during graceful shutdown (Gemini review)

### `pkg/tetragonaudit/pipeline.go`
- **Replaced fragile SIGKILL casing** (`== "SIGKILL" || == "Sigkill"`) with `strings.EqualFold` in both `normalize()` and `EnforcementOnly()`

### `pkg/tetragonaudit/multi_sink_test.go` (NEW)
- 5 unit tests for `MultiSink`: fan-out delivery, no short-circuit on error, first-error return, empty/nil edge cases

### `pkg/tetragonaudit/pipeline_extra_test.go`
- **SIGKILL case-insensitivity regression test** — table-driven across 4 casing variants, verifying both severity classification and enforcement filter

### `pkg/tetragonaudit/grpc_source_test.go`
- Added `TestNewGRPCEventStreamAdapter_Error` covering the cancelled-context error path

## Testing
- All pre-commit hooks pass (gofmt, go-vet, golangci-lint 0 issues, go-test)
- Full `go test ./...` passes across all packages
- `go build ./cmd/candela-sidecar` compiles cleanly