### PR TITLE
feat(ui): Agent DAG graph visualization for trace detail view

### DIFF
--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -2464,3 +2464,118 @@ tr:hover .model-bar {
   min-width: 0;
 }
 
+/* ──────────────────────────────────────────
+   View Toggle (Waterfall / Graph)
+   ────────────────────────────────────────── */
+
+.view-toggle {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-primary);
+  border-radius: var(--radius-md);
+  padding: 2px;
+  border: 1px solid var(--border-subtle);
+}
+
+.view-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.view-toggle-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.view-toggle-active {
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+/* ──────────────────────────────────────────
+   Agent DAG Graph
+   ────────────────────────────────────────── */
+
+.dag-container {
+  flex: 1;
+  overflow: auto;
+  padding: 24px;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(240, 160, 48, 0.03) 0%, transparent 70%),
+    var(--bg-primary);
+  background-size: 100% 100%;
+  min-height: 400px;
+}
+
+.dag-svg {
+  display: block;
+}
+
+/* Edges */
+.dag-edge {
+  stroke: var(--border);
+  stroke-width: 1.5;
+  opacity: 0.5;
+  transition: opacity 0.2s ease, stroke 0.2s ease;
+}
+
+.dag-edges:hover .dag-edge {
+  opacity: 0.3;
+}
+
+/* Nodes */
+.dag-node-group {
+  transition: filter 0.2s ease;
+}
+
+.dag-node-group:hover {
+  filter: brightness(1.15);
+}
+
+.dag-node-group:hover .dag-node-bg {
+  stroke: var(--text-muted);
+}
+
+.dag-node-bg {
+  transition: stroke 0.15s ease, filter 0.15s ease;
+}
+
+.dag-node-glow {
+  animation: dagGlow 2s ease-in-out infinite alternate;
+}
+
+@keyframes dagGlow {
+  from { opacity: 0.4; }
+  to { opacity: 0.8; }
+}
+
+.dag-node-kind {
+  font-family: 'Inter', sans-serif;
+  letter-spacing: 0.04em;
+}
+
+.dag-node-name {
+  font-family: 'Inter', sans-serif;
+}
+
+.dag-node-metric {
+  letter-spacing: -0.01em;
+}
+
+/* Selected node: also brighten connected edges */
+.dag-node-selected .dag-node-bg {
+  filter: drop-shadow(0 0 8px rgba(240, 160, 48, 0.3));
+}
+

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -2464,6 +2464,11 @@ tr:hover .model-bar {
   min-width: 0;
 }
 
+.btn-xs {
+  padding: 3px 8px;
+  font-size: 11px;
+}
+
 /* ──────────────────────────────────────────
    View Toggle (Waterfall / Graph)
    ────────────────────────────────────────── */

--- a/ui/src/app/traces/[id]/page.tsx
+++ b/ui/src/app/traces/[id]/page.tsx
@@ -395,14 +395,14 @@ export default function TraceDetailPage() {
                     {viewMode === "waterfall" && (
                       <>
                         <button
-                          className="btn" style={{ padding: "3px 8px", fontSize: 11 }}
+                          className="btn btn-xs"
                           onClick={collapseAll}
                           title="Collapse all"
                         >
                           ⊟ Collapse
                         </button>
                         <button
-                          className="btn" style={{ padding: "3px 8px", fontSize: 11 }}
+                          className="btn btn-xs"
                           onClick={expandAll}
                           title="Expand all"
                         >

--- a/ui/src/app/traces/[id]/page.tsx
+++ b/ui/src/app/traces/[id]/page.tsx
@@ -6,7 +6,10 @@ import { useParams, useRouter } from "next/navigation";
 import { useTrace, kindLabel, kindColor } from "@/hooks/useTrace";
 import type { SpanNode } from "@/hooks/useTrace";
 import { ErrorBanner } from "@/components/ErrorBanner";
+import { AgentDAG } from "@/components/AgentDAG";
 import { SpanStatus } from "@/gen/candela/types/trace_pb";
+
+type ViewMode = "waterfall" | "graph";
 
 
 function ExpandablePre({ content, label }: { content: string; label: string }) {
@@ -296,6 +299,7 @@ export default function TraceDetailPage() {
   const params = useParams();
   const router = useRouter();
   const traceId = params.id as string;
+  const [viewMode, setViewMode] = useState<ViewMode>("waterfall");
 
   const { trace, loading, error, selectedSpanId, selectedNode, toggleSpan,
     visibleSpans, collapsedIds, toggleCollapse, collapseAll, expandAll } =
@@ -368,61 +372,90 @@ export default function TraceDetailPage() {
               </div>
             </div>
 
-            {/* Waterfall + Detail split */}
+            {/* View toggle + content */}
             <div className="waterfall-split">
               <div className="waterfall-panel animate-in">
                 <div className="waterfall-header">
-                  <span className="table-title">Span Waterfall</span>
+                  {/* View mode toggle */}
+                  <div className="view-toggle">
+                    <button
+                      className={`view-toggle-btn ${viewMode === "waterfall" ? "view-toggle-active" : ""}`}
+                      onClick={() => setViewMode("waterfall")}
+                    >
+                      ☰ Waterfall
+                    </button>
+                    <button
+                      className={`view-toggle-btn ${viewMode === "graph" ? "view-toggle-active" : ""}`}
+                      onClick={() => setViewMode("graph")}
+                    >
+                      🔀 Agent Graph
+                    </button>
+                  </div>
                   <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                    <button
-                      className="btn" style={{ padding: "3px 8px", fontSize: 11 }}
-                      onClick={collapseAll}
-                      title="Collapse all"
-                    >
-                      ⊟ Collapse
-                    </button>
-                    <button
-                      className="btn" style={{ padding: "3px 8px", fontSize: 11 }}
-                      onClick={expandAll}
-                      title="Expand all"
-                    >
-                      ⊞ Expand
-                    </button>
+                    {viewMode === "waterfall" && (
+                      <>
+                        <button
+                          className="btn" style={{ padding: "3px 8px", fontSize: 11 }}
+                          onClick={collapseAll}
+                          title="Collapse all"
+                        >
+                          ⊟ Collapse
+                        </button>
+                        <button
+                          className="btn" style={{ padding: "3px 8px", fontSize: 11 }}
+                          onClick={expandAll}
+                          title="Expand all"
+                        >
+                          ⊞ Expand
+                        </button>
+                      </>
+                    )}
                     <span style={{ fontSize: 12, color: "var(--text-muted)" }}>
                       {trace.totalDurationMs.toFixed(0)}ms total
                     </span>
                   </div>
                 </div>
-                {/* Time ruler */}
-                <div className="waterfall-ruler">
-                  <div className="waterfall-ruler-label" style={{ left: 0 }}>0ms</div>
-                  <div className="waterfall-ruler-label" style={{ left: "25%" }}>
-                    {(trace.totalDurationMs * 0.25).toFixed(0)}ms
-                  </div>
-                  <div className="waterfall-ruler-label" style={{ left: "50%" }}>
-                    {(trace.totalDurationMs * 0.5).toFixed(0)}ms
-                  </div>
-                  <div className="waterfall-ruler-label" style={{ left: "75%" }}>
-                    {(trace.totalDurationMs * 0.75).toFixed(0)}ms
-                  </div>
-                  <div className="waterfall-ruler-label" style={{ right: 0 }}>
-                    {trace.totalDurationMs.toFixed(0)}ms
-                  </div>
-                </div>
-                {/* Span rows */}
-                <div className="waterfall-body">
-                  {visibleSpans.map((node) => (
-                    <SpanRow
-                      key={node.span.spanId}
-                      node={node}
-                      totalDurationMs={trace.totalDurationMs}
-                      selected={node.span.spanId === selectedSpanId}
-                      collapsed={collapsedIds.has(node.span.spanId)}
-                      onClick={() => toggleSpan(node.span.spanId)}
-                      onToggleCollapse={() => toggleCollapse(node.span.spanId)}
-                    />
-                  ))}
-                </div>
+
+                {viewMode === "waterfall" ? (
+                  <>
+                    {/* Time ruler */}
+                    <div className="waterfall-ruler">
+                      <div className="waterfall-ruler-label" style={{ left: 0 }}>0ms</div>
+                      <div className="waterfall-ruler-label" style={{ left: "25%" }}>
+                        {(trace.totalDurationMs * 0.25).toFixed(0)}ms
+                      </div>
+                      <div className="waterfall-ruler-label" style={{ left: "50%" }}>
+                        {(trace.totalDurationMs * 0.5).toFixed(0)}ms
+                      </div>
+                      <div className="waterfall-ruler-label" style={{ left: "75%" }}>
+                        {(trace.totalDurationMs * 0.75).toFixed(0)}ms
+                      </div>
+                      <div className="waterfall-ruler-label" style={{ right: 0 }}>
+                        {trace.totalDurationMs.toFixed(0)}ms
+                      </div>
+                    </div>
+                    {/* Span rows */}
+                    <div className="waterfall-body">
+                      {visibleSpans.map((node) => (
+                        <SpanRow
+                          key={node.span.spanId}
+                          node={node}
+                          totalDurationMs={trace.totalDurationMs}
+                          selected={node.span.spanId === selectedSpanId}
+                          collapsed={collapsedIds.has(node.span.spanId)}
+                          onClick={() => toggleSpan(node.span.spanId)}
+                          onToggleCollapse={() => toggleCollapse(node.span.spanId)}
+                        />
+                      ))}
+                    </div>
+                  </>
+                ) : (
+                  <AgentDAG
+                    tree={trace.tree}
+                    selectedSpanId={selectedSpanId}
+                    onSelectSpan={toggleSpan}
+                  />
+                )}
               </div>
 
               {/* Detail panel */}

--- a/ui/src/components/AgentDAG.tsx
+++ b/ui/src/components/AgentDAG.tsx
@@ -14,6 +14,17 @@ const NODE_H = 72;
 const H_GAP = 40; // horizontal gap between siblings
 const V_GAP = 80; // vertical gap between levels
 
+// Node rendering constants
+const BADGE_CHAR_WIDTH = 7.5;
+const BADGE_PADDING = 10;
+const BADGE_HEIGHT = 18;
+const BADGE_Y = 10;
+const BADGE_X = 14;
+const ERR_BADGE_WIDTH = 28;
+const ERR_BADGE_OFFSET = 38;
+const SPAN_NAME_MAX_LEN = 30;
+const SPAN_NAME_TRUNC_LEN = 28;
+
 // ──────────────────────────────────────────
 // Layout types
 // ──────────────────────────────────────────
@@ -113,6 +124,7 @@ function DAGEdge({
       stroke="var(--border)"
       strokeWidth={1.5}
       fill="none"
+      markerEnd="url(#dag-arrow)"
     />
   );
 }
@@ -186,16 +198,16 @@ function DAGNode({
 
       {/* Kind badge */}
       <rect
-        x={14}
-        y={10}
-        width={label.length * 7.5 + 10}
-        height={18}
+        x={BADGE_X}
+        y={BADGE_Y}
+        width={label.length * BADGE_CHAR_WIDTH + BADGE_PADDING}
+        height={BADGE_HEIGHT}
         rx={4}
         fill={color}
         opacity={0.15}
       />
       <text
-        x={14 + (label.length * 7.5 + 10) / 2}
+        x={BADGE_X + (label.length * BADGE_CHAR_WIDTH + BADGE_PADDING) / 2}
         y={22}
         textAnchor="middle"
         className="dag-node-kind"
@@ -210,16 +222,16 @@ function DAGNode({
       {isError && (
         <>
           <rect
-            x={NODE_W - 38}
-            y={10}
-            width={28}
-            height={18}
+            x={NODE_W - ERR_BADGE_OFFSET}
+            y={BADGE_Y}
+            width={ERR_BADGE_WIDTH}
+            height={BADGE_HEIGHT}
             rx={4}
             fill="var(--error)"
             opacity={0.15}
           />
           <text
-            x={NODE_W - 24}
+            x={NODE_W - ERR_BADGE_OFFSET + ERR_BADGE_WIDTH / 2}
             y={22}
             textAnchor="middle"
             fill="var(--error)"
@@ -240,8 +252,8 @@ function DAGNode({
         fontSize={12}
         fontWeight={500}
       >
-        {node.span.name.length > 30
-          ? node.span.name.slice(0, 28) + "…"
+        {node.span.name.length > SPAN_NAME_MAX_LEN
+          ? node.span.name.slice(0, SPAN_NAME_TRUNC_LEN) + "…"
           : node.span.name}
       </text>
 
@@ -329,8 +341,8 @@ export function AgentDAG({
 
         {/* Edges */}
         <g className="dag-edges">
-          {edges.map((edge, i) => (
-            <DAGEdge key={i} from={edge.from} to={edge.to} />
+          {edges.map((edge) => (
+            <DAGEdge key={`${edge.from.node.span.spanId}-${edge.to.node.span.spanId}`} from={edge.from} to={edge.to} />
           ))}
         </g>
 

--- a/ui/src/components/AgentDAG.tsx
+++ b/ui/src/components/AgentDAG.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useMemo, useCallback } from "react";
+import type { SpanNode } from "@/hooks/useTrace";
+import { kindLabel, kindColor } from "@/hooks/useTrace";
+import { SpanStatus } from "@/gen/candela/types/trace_pb";
+
+// ──────────────────────────────────────────
+// Layout constants
+// ──────────────────────────────────────────
+
+const NODE_W = 260;
+const NODE_H = 72;
+const H_GAP = 40; // horizontal gap between siblings
+const V_GAP = 80; // vertical gap between levels
+
+// ──────────────────────────────────────────
+// Layout types
+// ──────────────────────────────────────────
+
+interface LayoutNode {
+  node: SpanNode;
+  x: number;
+  y: number;
+  width: number;
+  children: LayoutNode[];
+}
+
+// ──────────────────────────────────────────
+// Tree layout algorithm
+// ──────────────────────────────────────────
+
+/** Compute the subtree width for a node (sum of children widths or self) */
+function subtreeWidth(node: SpanNode): number {
+  if (node.children.length === 0) return NODE_W;
+  const childWidths = node.children.map(subtreeWidth);
+  return childWidths.reduce((a, b) => a + b, 0) + (node.children.length - 1) * H_GAP;
+}
+
+/** Recursively lay out nodes in a top-down tree */
+function layoutTree(
+  nodes: SpanNode[],
+  startX: number,
+  startY: number
+): LayoutNode[] {
+  const result: LayoutNode[] = [];
+  let cursor = startX;
+
+  for (const node of nodes) {
+    const w = subtreeWidth(node);
+    const x = cursor + w / 2 - NODE_W / 2;
+    const y = startY;
+
+    const children = layoutTree(node.children, cursor, y + NODE_H + V_GAP);
+    result.push({ node, x, y, width: w, children });
+
+    cursor += w + H_GAP;
+  }
+
+  return result;
+}
+
+/** Flatten layout tree for rendering */
+function flattenLayout(nodes: LayoutNode[]): LayoutNode[] {
+  const result: LayoutNode[] = [];
+  function walk(n: LayoutNode) {
+    result.push(n);
+    n.children.forEach(walk);
+  }
+  nodes.forEach(walk);
+  return result;
+}
+
+/** Collect edges from layout tree */
+function collectEdges(
+  nodes: LayoutNode[]
+): { from: LayoutNode; to: LayoutNode }[] {
+  const edges: { from: LayoutNode; to: LayoutNode }[] = [];
+  function walk(n: LayoutNode) {
+    for (const child of n.children) {
+      edges.push({ from: n, to: child });
+      walk(child);
+    }
+  }
+  nodes.forEach(walk);
+  return edges;
+}
+
+// ──────────────────────────────────────────
+// SVG edge component
+// ──────────────────────────────────────────
+
+function DAGEdge({
+  from,
+  to,
+}: {
+  from: LayoutNode;
+  to: LayoutNode;
+}) {
+  const x1 = from.x + NODE_W / 2;
+  const y1 = from.y + NODE_H;
+  const x2 = to.x + NODE_W / 2;
+  const y2 = to.y;
+
+  const midY = (y1 + y2) / 2;
+
+  const d = `M ${x1} ${y1} C ${x1} ${midY}, ${x2} ${midY}, ${x2} ${y2}`;
+
+  return (
+    <path
+      d={d}
+      className="dag-edge"
+      stroke="var(--border)"
+      strokeWidth={1.5}
+      fill="none"
+    />
+  );
+}
+
+// ──────────────────────────────────────────
+// DAG node component
+// ──────────────────────────────────────────
+
+function DAGNode({
+  layout,
+  selected,
+  onClick,
+}: {
+  layout: LayoutNode;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  const { node } = layout;
+  const color = kindColor(node.span.kind);
+  const isError = node.span.status === SpanStatus.ERROR;
+  const label = kindLabel(node.span.kind);
+  const costUsd = node.subtreeCostUsd;
+  const tokens = node.subtreeTokens;
+
+  return (
+    <g
+      transform={`translate(${layout.x}, ${layout.y})`}
+      className={`dag-node-group ${selected ? "dag-node-selected" : ""}`}
+      onClick={onClick}
+      style={{ cursor: "pointer" }}
+    >
+      {/* Glow effect for selected */}
+      {selected && (
+        <rect
+          x={-4}
+          y={-4}
+          width={NODE_W + 8}
+          height={NODE_H + 8}
+          rx={16}
+          ry={16}
+          className="dag-node-glow"
+          fill="none"
+          stroke="var(--accent)"
+          strokeWidth={2}
+          opacity={0.6}
+        />
+      )}
+
+      {/* Main card */}
+      <rect
+        width={NODE_W}
+        height={NODE_H}
+        rx={12}
+        ry={12}
+        className="dag-node-bg"
+        fill="var(--bg-elevated)"
+        stroke={isError ? "var(--error)" : selected ? "var(--accent)" : "var(--border)"}
+        strokeWidth={isError ? 1.5 : 1}
+      />
+
+      {/* Left color accent bar */}
+      <rect
+        x={0}
+        y={0}
+        width={4}
+        height={NODE_H}
+        rx={2}
+        fill={color}
+        opacity={0.8}
+      />
+
+      {/* Kind badge */}
+      <rect
+        x={14}
+        y={10}
+        width={label.length * 7.5 + 10}
+        height={18}
+        rx={4}
+        fill={color}
+        opacity={0.15}
+      />
+      <text
+        x={14 + (label.length * 7.5 + 10) / 2}
+        y={22}
+        textAnchor="middle"
+        className="dag-node-kind"
+        fill={color}
+        fontSize={10}
+        fontWeight={600}
+      >
+        {label.toUpperCase()}
+      </text>
+
+      {/* Error badge */}
+      {isError && (
+        <>
+          <rect
+            x={NODE_W - 38}
+            y={10}
+            width={28}
+            height={18}
+            rx={4}
+            fill="var(--error)"
+            opacity={0.15}
+          />
+          <text
+            x={NODE_W - 24}
+            y={22}
+            textAnchor="middle"
+            fill="var(--error)"
+            fontSize={9}
+            fontWeight={600}
+          >
+            ERR
+          </text>
+        </>
+      )}
+
+      {/* Span name */}
+      <text
+        x={14}
+        y={44}
+        className="dag-node-name"
+        fill="var(--text-primary)"
+        fontSize={12}
+        fontWeight={500}
+      >
+        {node.span.name.length > 30
+          ? node.span.name.slice(0, 28) + "…"
+          : node.span.name}
+      </text>
+
+      {/* Bottom metrics row */}
+      <text
+        x={14}
+        y={62}
+        className="dag-node-metric"
+        fill="var(--text-muted)"
+        fontSize={10}
+        fontFamily="'SF Mono', monospace"
+      >
+        {node.durationMs.toFixed(0)}ms
+        {tokens > 0 ? ` · ${tokens.toLocaleString()} tok` : ""}
+        {costUsd > 0 ? ` · $${costUsd.toFixed(4)}` : ""}
+      </text>
+    </g>
+  );
+}
+
+// ──────────────────────────────────────────
+// Main AgentDAG component
+// ──────────────────────────────────────────
+
+export function AgentDAG({
+  tree,
+  selectedSpanId,
+  onSelectSpan,
+}: {
+  tree: SpanNode[];
+  selectedSpanId: string | null;
+  onSelectSpan: (spanId: string) => void;
+}) {
+  const layout = useMemo(() => layoutTree(tree, 40, 40), [tree]);
+  const allNodes = useMemo(() => flattenLayout(layout), [layout]);
+  const edges = useMemo(() => collectEdges(layout), [layout]);
+
+  // Compute SVG viewBox dimensions
+  const { svgW, svgH } = useMemo(() => {
+    let maxX = 0;
+    let maxY = 0;
+    for (const n of allNodes) {
+      maxX = Math.max(maxX, n.x + NODE_W);
+      maxY = Math.max(maxY, n.y + NODE_H);
+    }
+    return { svgW: maxX + 80, svgH: maxY + 80 };
+  }, [allNodes]);
+
+  const handleClick = useCallback(
+    (spanId: string) => () => onSelectSpan(spanId),
+    [onSelectSpan]
+  );
+
+  if (tree.length === 0) {
+    return (
+      <div className="empty-state">
+        <div className="empty-state-icon">🌳</div>
+        <div className="empty-state-title">No spans to visualize</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="dag-container">
+      <svg
+        width={svgW}
+        height={svgH}
+        viewBox={`0 0 ${svgW} ${svgH}`}
+        className="dag-svg"
+      >
+        <defs>
+          {/* Arrow marker for edges */}
+          <marker
+            id="dag-arrow"
+            viewBox="0 0 10 10"
+            refX={10}
+            refY={5}
+            markerWidth={6}
+            markerHeight={6}
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--text-muted)" opacity={0.5} />
+          </marker>
+        </defs>
+
+        {/* Edges */}
+        <g className="dag-edges">
+          {edges.map((edge, i) => (
+            <DAGEdge key={i} from={edge.from} to={edge.to} />
+          ))}
+        </g>
+
+        {/* Nodes */}
+        <g className="dag-nodes">
+          {allNodes.map((ln) => (
+            <DAGNode
+              key={ln.node.span.spanId}
+              layout={ln}
+              selected={ln.node.span.spanId === selectedSpanId}
+              onClick={handleClick(ln.node.span.spanId)}
+            />
+          ))}
+        </g>
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds an interactive **Agent Graph** view to the trace detail page, providing a visual DAG representation of agent execution flows alongside the existing waterfall view.

### New Component: `AgentDAG.tsx`
- Pure React/SVG renderer — **zero external dependencies**
- Recursive tree layout algorithm with computed subtree widths
- Color-coded kind badges (LLM, Agent, Tool, RAG, etc.)
- Per-node metrics: duration, tokens, cost
- Bezier curve edges between parent/child spans
- Selection glow animation + hover effects

### Integration
- **View toggle** (☰ Waterfall | 🔀 Agent Graph) pill-style button group in trace header
- Collapse/Expand buttons hidden in graph mode
- Shared `SpanDetail` panel works with both views

### Styling
- View toggle segmented control
- Subtle radial gradient background for graph canvas
- Node hover brightness, edge fade animations
- Pulsing glow on selected node (`@keyframes dagGlow`)

### Verification
- `npx next build` — TypeScript clean, all 16 routes built ✅
- Pre-commit hooks passed (lefthook) ✅
- Zero new dependencies ✅