### PR TITLE
feat(tetragonaudit): production-grade gRPC reconnect, health endpoint & graceful drain

### DIFF
--- a/cmd/candela-sidecar/main.go
+++ b/cmd/candela-sidecar/main.go
@@ -256,6 +256,7 @@ func main() {
 	}
 
 	// ── Tetragon audit pipeline (optional) ──
+	var auditPipeline *tetragonaudit.Pipeline
 	if tetragonAudit != "" || tetragonGRPCAddr != "" {
 		var auditSink tetragonaudit.Sink
 
@@ -277,8 +278,20 @@ func main() {
 			auditSink = &tetragonaudit.LogSink{}
 		}
 
-		pipeline := tetragonaudit.NewPipeline(tetragonaudit.PipelineConfig{
+		auditPipeline = tetragonaudit.NewPipeline(tetragonaudit.PipelineConfig{
 			Sink: auditSink,
+		})
+
+		// Register health endpoint.
+		mux.HandleFunc("/debug/tetragon/health", func(w http.ResponseWriter, r *http.Request) {
+			h := auditPipeline.Health()
+			w.Header().Set("Content-Type", "application/json")
+			if !h.Healthy {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			}
+			_, _ = fmt.Fprintf(w,
+				`{"healthy":%t,"connected":%t,"last_event_at":"%s","processed":%d,"dropped":%d,"errors":%d}`+"\n",
+				h.Healthy, h.Connected, h.LastEventAt.Format(time.RFC3339), h.Processed, h.Dropped, h.Errors)
 		})
 
 		// Prefer gRPC source over file source.
@@ -295,17 +308,13 @@ func main() {
 
 			go func() {
 				slog.Info("📋 Tetragon gRPC audit pipeline started", "addr", tetragonGRPCAddr)
-				stream, err := tetragonaudit.NewGRPCEventStreamAdapter(ctx, grpcSrc.Conn())
-				if err != nil {
-					if ctx.Err() == nil {
-						slog.Error("Tetragon gRPC audit pipeline error during stream initialization", "error", err)
-					}
-					return
-				}
-				if err := grpcSrc.StreamEvents(ctx, stream, pipeline); err != nil && ctx.Err() == nil {
+				auditPipeline.SetConnected(true)
+				err := grpcSrc.StreamEventsWithRetry(ctx, auditPipeline, tetragonaudit.RetryConfig{})
+				auditPipeline.SetConnected(false)
+				if ctx.Err() == nil && err != nil {
 					slog.Error("Tetragon gRPC audit pipeline error", "error", err)
 				}
-				p, d, e := pipeline.Stats().Snapshot()
+				p, d, e := auditPipeline.Stats().Snapshot()
 				slog.Info("Tetragon gRPC audit pipeline stopped",
 					"processed", p, "dropped", d, "errors", e)
 			}()
@@ -318,11 +327,13 @@ func main() {
 				}
 				defer func() { _ = f.Close() }()
 
+				auditPipeline.SetConnected(true)
 				slog.Info("📋 Tetragon audit pipeline started", "source", tetragonAudit)
-				if err := pipeline.ProcessJSONStream(ctx, f); err != nil && ctx.Err() == nil {
+				if err := auditPipeline.ProcessJSONStream(ctx, f); err != nil && ctx.Err() == nil {
 					slog.Error("Tetragon audit pipeline error", "error", err)
 				}
-				p, d, e := pipeline.Stats().Snapshot()
+				auditPipeline.SetConnected(false)
+				p, d, e := auditPipeline.Stats().Snapshot()
 				slog.Info("Tetragon audit pipeline stopped",
 					"processed", p, "dropped", d, "errors", e)
 			}()
@@ -334,6 +345,13 @@ func main() {
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
+	// Drain audit pipeline first (flush any buffered OTel logs).
+	if auditPipeline != nil {
+		if err := auditPipeline.Drain(shutdownCtx); err != nil {
+			slog.Warn("audit pipeline drain error", "error", err)
+		}
+	}
 
 	// Close sinks first (flush pending spans), then server.
 	proc.Stop()

--- a/cmd/candela-sidecar/main.go
+++ b/cmd/candela-sidecar/main.go
@@ -308,9 +308,7 @@ func main() {
 
 			go func() {
 				slog.Info("📋 Tetragon gRPC audit pipeline started", "addr", tetragonGRPCAddr)
-				auditPipeline.SetConnected(true)
 				err := grpcSrc.StreamEventsWithRetry(ctx, auditPipeline, tetragonaudit.RetryConfig{})
-				auditPipeline.SetConnected(false)
 				if ctx.Err() == nil && err != nil {
 					slog.Error("Tetragon gRPC audit pipeline error", "error", err)
 				}

--- a/pkg/tetragonaudit/grpc_source.go
+++ b/pkg/tetragonaudit/grpc_source.go
@@ -136,6 +136,7 @@ func (s *GRPCSource) StreamEventsWithRetry(ctx context.Context, pipeline *Pipeli
 
 		stream, err := NewGRPCEventStreamAdapter(ctx, s.conn)
 		if err != nil {
+			pipeline.SetConnected(false)
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
@@ -152,16 +153,24 @@ func (s *GRPCSource) StreamEventsWithRetry(ctx context.Context, pipeline *Pipeli
 		}
 
 		slog.Info("tetragonaudit: gRPC stream connected", "addr", s.addr, "attempt", attempt+1)
+		pipeline.SetConnected(true)
 		attempt = 0 // Reset on successful connection.
 
 		err = s.StreamEvents(ctx, stream, pipeline)
+		pipeline.SetConnected(false)
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 		if err == nil {
-			// Clean EOF — server shut the stream. Reconnect.
+			// Clean EOF — server shut the stream. Reconnect after a small delay
+			// to avoid a tight loop during rolling updates or config mismatches.
 			slog.Info("tetragonaudit: gRPC stream ended, reconnecting", "addr", s.addr)
-			continue
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(rc.InitialDelay):
+				continue
+			}
 		}
 
 		delay := backoff(attempt, rc)

--- a/pkg/tetragonaudit/grpc_source.go
+++ b/pkg/tetragonaudit/grpc_source.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
+	"math/rand/v2"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -85,6 +88,105 @@ func (s *GRPCSource) Close() error {
 	return nil
 }
 
+// Addr returns the configured gRPC address.
+func (s *GRPCSource) Addr() string {
+	return s.addr
+}
+
+// RetryConfig controls the reconnect backoff behavior.
+type RetryConfig struct {
+	// InitialDelay is the first backoff duration (default: 1s).
+	InitialDelay time.Duration
+	// MaxDelay is the backoff ceiling (default: 30s).
+	MaxDelay time.Duration
+	// Multiplier is the backoff factor (default: 2.0).
+	Multiplier float64
+}
+
+func (rc RetryConfig) withDefaults() RetryConfig {
+	if rc.InitialDelay <= 0 {
+		rc.InitialDelay = time.Second
+	}
+	if rc.MaxDelay <= 0 {
+		rc.MaxDelay = 30 * time.Second
+	}
+	if rc.Multiplier <= 0 {
+		rc.Multiplier = 2.0
+	}
+	return rc
+}
+
+// StreamEventsWithRetry streams events from the Tetragon gRPC API with
+// automatic reconnection on failure using exponential backoff.
+//
+// On each connection failure, the method sleeps for an exponentially-growing
+// duration (with ±25% jitter) before retrying. On successful reconnection
+// the backoff resets to InitialDelay.
+//
+// The loop exits cleanly when ctx is cancelled (graceful shutdown).
+func (s *GRPCSource) StreamEventsWithRetry(ctx context.Context, pipeline *Pipeline, rc RetryConfig) error {
+	rc = rc.withDefaults()
+	attempt := 0
+
+	for {
+		// Check for cancellation before each attempt.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		stream, err := NewGRPCEventStreamAdapter(ctx, s.conn)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			delay := backoff(attempt, rc)
+			slog.Warn("tetragonaudit: gRPC stream creation failed, retrying",
+				"error", err, "attempt", attempt+1, "backoff", delay)
+			attempt++
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+				continue
+			}
+		}
+
+		slog.Info("tetragonaudit: gRPC stream connected", "addr", s.addr, "attempt", attempt+1)
+		attempt = 0 // Reset on successful connection.
+
+		err = s.StreamEvents(ctx, stream, pipeline)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err == nil {
+			// Clean EOF — server shut the stream. Reconnect.
+			slog.Info("tetragonaudit: gRPC stream ended, reconnecting", "addr", s.addr)
+			continue
+		}
+
+		delay := backoff(attempt, rc)
+		slog.Warn("tetragonaudit: gRPC stream error, reconnecting",
+			"error", err, "attempt", attempt+1, "backoff", delay)
+		attempt++
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
+
+// backoff computes the delay for a given attempt with ±25% jitter.
+func backoff(attempt int, rc RetryConfig) time.Duration {
+	d := float64(rc.InitialDelay) * math.Pow(rc.Multiplier, float64(attempt))
+	if d > float64(rc.MaxDelay) {
+		d = float64(rc.MaxDelay)
+	}
+	// Add ±25% jitter.
+	jitter := d * 0.25 * (2*rand.Float64() - 1) //nolint:gosec
+	return time.Duration(d + jitter)
+}
+
 // Conn returns the underlying gRPC connection for advanced usage
 // (e.g. creating Tetragon-specific clients).
 func (s *GRPCSource) Conn() *grpc.ClientConn {
@@ -105,6 +207,9 @@ type GRPCEventStreamAdapter struct {
 // It initiates a server-streaming RPC on the Tetragon FineGuidanceSensors/GetEvents
 // endpoint and returns an adapter that reads raw event bytes.
 func NewGRPCEventStreamAdapter(ctx context.Context, conn *grpc.ClientConn) (*GRPCEventStreamAdapter, error) {
+	if conn == nil {
+		return nil, fmt.Errorf("tetragonaudit: gRPC connection is nil")
+	}
 	desc := &grpc.StreamDesc{ServerStreams: true}
 	stream, err := conn.NewStream(ctx, desc, "/tetragon.FineGuidanceSensors/GetEvents")
 	if err != nil {

--- a/pkg/tetragonaudit/health_test.go
+++ b/pkg/tetragonaudit/health_test.go
@@ -1,0 +1,208 @@
+package tetragonaudit
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPipeline_Health_InitialState(t *testing.T) {
+	sink := &CollectorSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+
+	h := p.Health()
+	if h.Healthy {
+		t.Error("expected Healthy=false initially (not connected)")
+	}
+	if h.Connected {
+		t.Error("expected Connected=false initially")
+	}
+	if h.Processed != 0 || h.Dropped != 0 || h.Errors != 0 {
+		t.Errorf("expected zero stats, got processed=%d dropped=%d errors=%d",
+			h.Processed, h.Dropped, h.Errors)
+	}
+}
+
+func TestPipeline_Health_ConnectedNoEvents(t *testing.T) {
+	sink := &CollectorSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+
+	p.SetConnected(true)
+	h := p.Health()
+
+	if !h.Healthy {
+		t.Error("expected Healthy=true when connected with no prior events")
+	}
+	if !h.Connected {
+		t.Error("expected Connected=true")
+	}
+}
+
+func TestPipeline_Health_AfterProcessing(t *testing.T) {
+	sink := &CollectorSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+	p.SetConnected(true)
+
+	// Process an event.
+	event := Event{
+		ProcessKprobe: &ProcessKprobe{
+			Action:       "post",
+			FunctionName: "tcp_connect",
+			Process:      &Process{Binary: "/usr/bin/curl"},
+		},
+	}
+	if err := p.ProcessEvent(context.Background(), event); err != nil {
+		t.Fatal(err)
+	}
+
+	h := p.Health()
+	if !h.Healthy {
+		t.Error("expected Healthy=true after processing")
+	}
+	if h.Processed != 1 {
+		t.Errorf("expected Processed=1, got %d", h.Processed)
+	}
+	if h.LastEventAt.IsZero() {
+		t.Error("expected LastEventAt to be set")
+	}
+}
+
+func TestPipeline_Health_Disconnected(t *testing.T) {
+	sink := &CollectorSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+
+	p.SetConnected(true)
+	p.SetConnected(false)
+
+	h := p.Health()
+	if h.Healthy {
+		t.Error("expected Healthy=false when disconnected")
+	}
+	if h.Connected {
+		t.Error("expected Connected=false")
+	}
+}
+
+// mockFlushSink records whether Flush was called.
+type mockFlushSink struct {
+	emitCount  atomic.Int32
+	flushed    atomic.Bool
+	flushError error
+}
+
+func (s *mockFlushSink) Emit(_ context.Context, _ AuditRecord) error {
+	s.emitCount.Add(1)
+	return nil
+}
+
+func (s *mockFlushSink) Flush(_ context.Context) error {
+	s.flushed.Store(true)
+	return s.flushError
+}
+
+// Verify mockFlushSink implements both interfaces.
+var _ Sink = (*mockFlushSink)(nil)
+var _ Flusher = (*mockFlushSink)(nil)
+
+func TestPipeline_Drain_CallsFlush(t *testing.T) {
+	sink := &mockFlushSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+
+	err := p.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sink.flushed.Load() {
+		t.Error("expected Flush to be called on sink")
+	}
+}
+
+func TestPipeline_Drain_PropagatesFlushError(t *testing.T) {
+	wantErr := errors.New("flush failed")
+	sink := &mockFlushSink{flushError: wantErr}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+
+	err := p.Drain(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+}
+
+func TestPipeline_Drain_NonFlushSinkNoError(t *testing.T) {
+	// CollectorSink does NOT implement Flusher.
+	sink := &CollectorSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+
+	err := p.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error for non-Flusher sink, got: %v", err)
+	}
+}
+
+func TestPipeline_Drain_MultiSinkFlushes(t *testing.T) {
+	flushable := &mockFlushSink{}
+	nonFlushable := &CollectorSink{}
+
+	multi := &MultiSink{Sinks: []Sink{flushable, nonFlushable}}
+	p := NewPipeline(PipelineConfig{Sink: multi})
+
+	err := p.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !flushable.flushed.Load() {
+		t.Error("expected Flush to be called on the flushable child of MultiSink")
+	}
+}
+
+func TestPipeline_Drain_MultiSinkFirstFlushError(t *testing.T) {
+	wantErr := errors.New("first flush failed")
+	flushable1 := &mockFlushSink{flushError: wantErr}
+	flushable2 := &mockFlushSink{}
+
+	multi := &MultiSink{Sinks: []Sink{flushable1, flushable2}}
+	p := NewPipeline(PipelineConfig{Sink: multi})
+
+	err := p.Drain(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+	// Second sink should still have been flushed.
+	if !flushable2.flushed.Load() {
+		t.Error("expected second sink to be flushed even after first error")
+	}
+}
+
+func TestOTelSink_ImplementsFlusher(t *testing.T) {
+	sink, err := NewOTelSink(OTelSinkConfig{Endpoint: "http://localhost:4318"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var f Flusher = sink
+	if err := f.Flush(context.Background()); err != nil {
+		t.Fatalf("unexpected flush error: %v", err)
+	}
+}
+
+func TestPipeline_LastEventTracking(t *testing.T) {
+	sink := &CollectorSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+	p.SetConnected(true)
+
+	before := time.Now()
+	event := Event{
+		ProcessKprobe: &ProcessKprobe{
+			Action:  "post",
+			Process: &Process{Binary: "/bin/test"},
+		},
+	}
+	_ = p.ProcessEvent(context.Background(), event)
+	after := time.Now()
+
+	h := p.Health()
+	if h.LastEventAt.Before(before) || h.LastEventAt.After(after) {
+		t.Errorf("LastEventAt=%v not in [%v, %v]", h.LastEventAt, before, after)
+	}
+}

--- a/pkg/tetragonaudit/otel_sink.go
+++ b/pkg/tetragonaudit/otel_sink.go
@@ -15,6 +15,7 @@ import (
 )
 
 var _ Sink = (*OTelSink)(nil)
+var _ Flusher = (*OTelSink)(nil)
 
 // OTelSinkConfig holds configuration for the OTel log exporter.
 type OTelSinkConfig struct {
@@ -175,5 +176,13 @@ func (s *OTelSink) exportLogs(ctx context.Context, logs plog.Logs) error {
 		"endpoint", url,
 	)
 
+	return nil
+}
+
+// Flush closes idle HTTP connections to ensure a clean shutdown.
+// The OTelSink exports synchronously per-event, so there's no pending
+// batch to flush — but closing idle connections ensures transport cleanup.
+func (s *OTelSink) Flush(_ context.Context) error {
+	s.client.CloseIdleConnections()
 	return nil
 }

--- a/pkg/tetragonaudit/pipeline.go
+++ b/pkg/tetragonaudit/pipeline.go
@@ -152,12 +152,22 @@ type Sink interface {
 	Emit(ctx context.Context, record AuditRecord) error
 }
 
+// Flusher is an optional interface for sinks that buffer data and need
+// an explicit flush before shutdown.
+type Flusher interface {
+	Flush(ctx context.Context) error
+}
+
 // Pipeline reads Tetragon events from a source and forwards them to a Sink
 // as normalized AuditRecords.
 type Pipeline struct {
 	sink    Sink
 	stats   PipelineStats
 	filters []EventFilter
+
+	mu        sync.Mutex
+	lastEvent time.Time
+	connected bool
 }
 
 // EventFilter returns true if the event should be processed.
@@ -196,6 +206,71 @@ func NewPipeline(cfg PipelineConfig) *Pipeline {
 // Stats returns the pipeline's processing statistics.
 func (p *Pipeline) Stats() *PipelineStats {
 	return &p.stats
+}
+
+// PipelineHealth reports the current health of the audit pipeline.
+type PipelineHealth struct {
+	Healthy     bool      `json:"healthy"`
+	Connected   bool      `json:"connected"`
+	LastEventAt time.Time `json:"last_event_at,omitempty"`
+	Processed   int64     `json:"processed"`
+	Dropped     int64     `json:"dropped"`
+	Errors      int64     `json:"errors"`
+}
+
+// Health returns a snapshot of the pipeline's health status.
+// Healthy is true when the pipeline is connected and has received
+// at least one event within the last 5 minutes.
+func (p *Pipeline) Health() PipelineHealth {
+	processed, dropped, errors := p.stats.Snapshot()
+
+	p.mu.Lock()
+	lastEvent := p.lastEvent
+	connected := p.connected
+	p.mu.Unlock()
+
+	healthy := connected
+	if !lastEvent.IsZero() {
+		// If we've seen events before, consider unhealthy if stale > 5m.
+		healthy = connected && time.Since(lastEvent) < 5*time.Minute
+	}
+
+	return PipelineHealth{
+		Healthy:     healthy,
+		Connected:   connected,
+		LastEventAt: lastEvent,
+		Processed:   processed,
+		Dropped:     dropped,
+		Errors:      errors,
+	}
+}
+
+// SetConnected updates the pipeline's connection status.
+func (p *Pipeline) SetConnected(connected bool) {
+	p.mu.Lock()
+	p.connected = connected
+	p.mu.Unlock()
+}
+
+// Drain flushes any buffered data in the sink and returns.
+// If the sink implements Flusher, it is called with the given context.
+func (p *Pipeline) Drain(ctx context.Context) error {
+	if f, ok := p.sink.(Flusher); ok {
+		return f.Flush(ctx)
+	}
+	// MultiSink: check if any child implements Flusher.
+	if ms, ok := p.sink.(*MultiSink); ok {
+		var firstErr error
+		for _, s := range ms.Sinks {
+			if f, ok := s.(Flusher); ok {
+				if err := f.Flush(ctx); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+		return firstErr
+	}
+	return nil
 }
 
 // ProcessJSONStream reads newline-delimited JSON Tetragon events from
@@ -273,6 +348,11 @@ func (p *Pipeline) ProcessEvent(ctx context.Context, event Event) error {
 	p.stats.mu.Lock()
 	p.stats.Processed++
 	p.stats.mu.Unlock()
+
+	p.mu.Lock()
+	p.lastEvent = time.Now()
+	p.mu.Unlock()
+
 	return nil
 }
 

--- a/pkg/tetragonaudit/retry_test.go
+++ b/pkg/tetragonaudit/retry_test.go
@@ -1,0 +1,100 @@
+package tetragonaudit
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestStreamEventsWithRetry_ReconnectsAfterFailure(t *testing.T) {
+	src := &GRPCSource{addr: "test://localhost:54321"}
+
+	sink := &CollectorSink{}
+	pipeline := NewPipeline(PipelineConfig{Sink: sink})
+
+	// Cancel after a short delay to let the retry loop attempt at least once.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	// With nil conn, NewGRPCEventStreamAdapter will fail, triggering retry.
+	// The retry should back off and eventually exit on context deadline.
+	err := src.StreamEventsWithRetry(ctx, pipeline, RetryConfig{
+		InitialDelay: 10 * time.Millisecond,
+		MaxDelay:     50 * time.Millisecond,
+	})
+	// Should exit with context error (either deadline or cancel).
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context error, got: %v", err)
+	}
+}
+
+func TestStreamEventsWithRetry_CancelledImmediately(t *testing.T) {
+	src := &GRPCSource{addr: "test://localhost:54321"}
+	sink := &CollectorSink{}
+	pipeline := NewPipeline(PipelineConfig{Sink: sink})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	start := time.Now()
+	err := src.StreamEventsWithRetry(ctx, pipeline, RetryConfig{
+		InitialDelay: time.Second,
+	})
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("took too long to exit: %v (should be near-instant)", elapsed)
+	}
+}
+
+func TestBackoff_ExponentialWithCap(t *testing.T) {
+	rc := RetryConfig{
+		InitialDelay: 100 * time.Millisecond,
+		MaxDelay:     2 * time.Second,
+		Multiplier:   2.0,
+	}
+
+	tests := []struct {
+		attempt  int
+		minDelay time.Duration
+		maxDelay time.Duration
+	}{
+		// attempt 0: 100ms base ± 25% = [75ms, 125ms]
+		{0, 75 * time.Millisecond, 125 * time.Millisecond},
+		// attempt 1: 200ms ± 25% = [150ms, 250ms]
+		{1, 150 * time.Millisecond, 250 * time.Millisecond},
+		// attempt 2: 400ms ± 25% = [300ms, 500ms]
+		{2, 300 * time.Millisecond, 500 * time.Millisecond},
+		// attempt 10: capped at 2s ± 25% = [1.5s, 2.5s]
+		{10, 1500 * time.Millisecond, 2500 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		// Run each sub-test multiple times to verify jitter range.
+		for range 20 {
+			d := backoff(tt.attempt, rc)
+			if d < tt.minDelay || d > tt.maxDelay {
+				t.Errorf("attempt %d: backoff=%v, want [%v, %v]",
+					tt.attempt, d, tt.minDelay, tt.maxDelay)
+			}
+		}
+	}
+}
+
+func TestBackoff_DefaultConfig(t *testing.T) {
+	rc := RetryConfig{}.withDefaults()
+
+	if rc.InitialDelay != time.Second {
+		t.Errorf("InitialDelay=%v, want 1s", rc.InitialDelay)
+	}
+	if rc.MaxDelay != 30*time.Second {
+		t.Errorf("MaxDelay=%v, want 30s", rc.MaxDelay)
+	}
+	if rc.Multiplier != 2.0 {
+		t.Errorf("Multiplier=%v, want 2.0", rc.Multiplier)
+	}
+}

--- a/pkg/tetragonaudit/retry_test.go
+++ b/pkg/tetragonaudit/retry_test.go
@@ -27,6 +27,15 @@ func TestStreamEventsWithRetry_ReconnectsAfterFailure(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context error, got: %v", err)
 	}
+
+	// After retry loop exits, health should report disconnected.
+	h := pipeline.Health()
+	if h.Connected {
+		t.Error("expected Connected=false after retry loop exits")
+	}
+	if h.Healthy {
+		t.Error("expected Healthy=false after retry loop exits")
+	}
 }
 
 func TestStreamEventsWithRetry_CancelledImmediately(t *testing.T) {


### PR DESCRIPTION
## Summary

Hardens the Tetragon audit pipeline for production readiness with three key capabilities:

### 1. gRPC Stream Reconnection with Exponential Backoff
- `StreamEventsWithRetry()` automatically reconnects on transient Tetragon gRPC failures
- Exponential backoff from 1s → 30s cap with ±25% jitter to prevent thundering herd
- Backoff resets on successful reconnection
- Nil conn guard in `NewGRPCEventStreamAdapter` to prevent panics

### 2. Pipeline Health Endpoint
- New `PipelineHealth` struct tracking connection state, liveness, counters, and last event timestamp
- `GET /debug/tetragon/health` returns JSON with HTTP 200 (healthy) or 503 (unhealthy)
- 5-minute staleness threshold for liveness detection

### 3. Graceful Shutdown Drain
- `Flusher` interface with `Flush(ctx) error`
- `OTelSink.Flush()` cleans up idle HTTP transport connections
- `Pipeline.Drain()` walks `MultiSink` children, flushing all Flusher-capable sinks
- Wired into sidecar shutdown sequence before closing sinks and server

## Test Coverage (15 new tests)

| Area | Tests |
|------|-------|
| Backoff math | Exponential growth, jitter bounds, max cap, defaults |
| Retry loop | Context deadline exit, immediate cancellation |
| Health state | Initial state, connected, after processing, disconnected |
| Drain/Flush | Direct flush, error propagation, non-Flusher skip, MultiSink fan-out |
| Interface | OTelSink implements Flusher, LastEvent timestamp tracking |

## Verification
- 54 tests pass across `pkg/tetragonaudit/...`
- Full workspace build clean (`go build ./...`)
- All 9 pre-commit hooks pass