### PR TITLE
feat(tetragonaudit): add bytesCodec and e2e gRPC test harness

### DIFF
--- a/cmd/candela-sidecar/main.go
+++ b/cmd/candela-sidecar/main.go
@@ -256,6 +256,7 @@ func main() {
 	}
 
 	// ── Tetragon audit pipeline (optional) ──
+	var auditPipeline *tetragonaudit.Pipeline
 	if tetragonAudit != "" || tetragonGRPCAddr != "" {
 		var auditSink tetragonaudit.Sink
 
@@ -277,8 +278,20 @@ func main() {
 			auditSink = &tetragonaudit.LogSink{}
 		}
 
-		pipeline := tetragonaudit.NewPipeline(tetragonaudit.PipelineConfig{
+		auditPipeline = tetragonaudit.NewPipeline(tetragonaudit.PipelineConfig{
 			Sink: auditSink,
+		})
+
+		// Register health endpoint.
+		mux.HandleFunc("/debug/tetragon/health", func(w http.ResponseWriter, r *http.Request) {
+			h := auditPipeline.Health()
+			w.Header().Set("Content-Type", "application/json")
+			if !h.Healthy {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			}
+			_, _ = fmt.Fprintf(w,
+				`{"healthy":%t,"connected":%t,"last_event_at":"%s","processed":%d,"dropped":%d,"errors":%d}`+"\n",
+				h.Healthy, h.Connected, h.LastEventAt.Format(time.RFC3339), h.Processed, h.Dropped, h.Errors)
 		})
 
 		// Prefer gRPC source over file source.
@@ -295,17 +308,11 @@ func main() {
 
 			go func() {
 				slog.Info("📋 Tetragon gRPC audit pipeline started", "addr", tetragonGRPCAddr)
-				stream, err := tetragonaudit.NewGRPCEventStreamAdapter(ctx, grpcSrc.Conn())
-				if err != nil {
-					if ctx.Err() == nil {
-						slog.Error("Tetragon gRPC audit pipeline error during stream initialization", "error", err)
-					}
-					return
-				}
-				if err := grpcSrc.StreamEvents(ctx, stream, pipeline); err != nil && ctx.Err() == nil {
+				err := grpcSrc.StreamEventsWithRetry(ctx, auditPipeline, tetragonaudit.RetryConfig{})
+				if ctx.Err() == nil && err != nil {
 					slog.Error("Tetragon gRPC audit pipeline error", "error", err)
 				}
-				p, d, e := pipeline.Stats().Snapshot()
+				p, d, e := auditPipeline.Stats().Snapshot()
 				slog.Info("Tetragon gRPC audit pipeline stopped",
 					"processed", p, "dropped", d, "errors", e)
 			}()
@@ -318,11 +325,13 @@ func main() {
 				}
 				defer func() { _ = f.Close() }()
 
+				auditPipeline.SetConnected(true)
 				slog.Info("📋 Tetragon audit pipeline started", "source", tetragonAudit)
-				if err := pipeline.ProcessJSONStream(ctx, f); err != nil && ctx.Err() == nil {
+				if err := auditPipeline.ProcessJSONStream(ctx, f); err != nil && ctx.Err() == nil {
 					slog.Error("Tetragon audit pipeline error", "error", err)
 				}
-				p, d, e := pipeline.Stats().Snapshot()
+				auditPipeline.SetConnected(false)
+				p, d, e := auditPipeline.Stats().Snapshot()
 				slog.Info("Tetragon audit pipeline stopped",
 					"processed", p, "dropped", d, "errors", e)
 			}()
@@ -334,6 +343,13 @@ func main() {
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
+	// Drain audit pipeline first (flush any buffered OTel logs).
+	if auditPipeline != nil {
+		if err := auditPipeline.Drain(shutdownCtx); err != nil {
+			slog.Warn("audit pipeline drain error", "error", err)
+		}
+	}
 
 	// Close sinks first (flush pending spans), then server.
 	proc.Stop()

--- a/pkg/tetragonaudit/grpc_e2e_test.go
+++ b/pkg/tetragonaudit/grpc_e2e_test.go
@@ -1,0 +1,614 @@
+package tetragonaudit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// ─── Mock Tetragon gRPC Server ───────────────────────────────────────────────
+//
+// mockTetragonServer implements a minimal gRPC server that serves
+// /tetragon.FineGuidanceSensors/GetEvents with configurable behavior per
+// connection attempt. This enables full lifecycle testing of
+// StreamEventsWithRetry without any Tetragon proto dependency.
+
+// streamBehavior defines what the mock server does on each connection.
+type streamBehavior struct {
+	// Events to send before closing. Each is JSON-serialized.
+	Events []Event
+	// Err to return after sending all events. nil = clean EOF.
+	Err error
+}
+
+type mockTetragonServer struct {
+	mu         sync.Mutex
+	behaviors  []streamBehavior
+	attempt    int
+	connectCh  chan struct{} // signaled on each new stream
+	totalConns atomic.Int64
+}
+
+func newMockTetragonServer(behaviors ...streamBehavior) *mockTetragonServer {
+	return &mockTetragonServer{
+		behaviors: behaviors,
+		connectCh: make(chan struct{}, 100),
+	}
+}
+
+// serve starts the mock gRPC server and returns the listener address.
+// The returned cleanup function stops the server.
+func (m *mockTetragonServer) serve(t *testing.T) (addr string, cleanup func()) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("mock server listen: %v", err)
+	}
+
+	srv := grpc.NewServer()
+
+	// Register a raw service handler for the Tetragon export RPC path.
+	// This avoids importing Tetragon protobufs while testing the real gRPC layer.
+	handler := func(srv any, stream grpc.ServerStream) error {
+		return m.handleGetEvents(srv, stream)
+	}
+	sd := grpc.ServiceDesc{
+		ServiceName: "tetragon.FineGuidanceSensors",
+		HandlerType: (*mockTetragonService)(nil),
+		Streams: []grpc.StreamDesc{
+			{
+				StreamName:    "GetEvents",
+				Handler:       handler,
+				ServerStreams: true,
+				ClientStreams: false,
+			},
+		},
+		Metadata: "tetragon/sensors.proto",
+	}
+	// The second argument must be a non-nil value that implements HandlerType.
+	srv.RegisterService(&sd, &mockTetragonServiceImpl{})
+
+	go func() {
+		_ = srv.Serve(lis) // errors expected on GracefulStop
+	}()
+
+	return lis.Addr().String(), func() { srv.GracefulStop() }
+}
+
+// mockTetragonService is the interface type for RegisterService's HandlerType.
+type mockTetragonService interface{}
+
+// mockTetragonServiceImpl satisfies the interface.
+type mockTetragonServiceImpl struct{}
+
+// handleGetEvents is the gRPC stream handler for GetEvents.
+func (m *mockTetragonServer) handleGetEvents(_ any, stream grpc.ServerStream) error {
+	// Read the client's request (we don't care about its content).
+	var req json.RawMessage
+	if err := stream.RecvMsg(&req); err != nil {
+		return err
+	}
+
+	m.totalConns.Add(1)
+
+	m.mu.Lock()
+	behavior := streamBehavior{} // default: immediate EOF
+	if m.attempt < len(m.behaviors) {
+		behavior = m.behaviors[m.attempt]
+	} else if len(m.behaviors) > 0 {
+		// After exhausting the list, repeat the last behavior.
+		behavior = m.behaviors[len(m.behaviors)-1]
+	}
+	m.attempt++
+	m.mu.Unlock()
+
+	// Signal that a new connection arrived.
+	select {
+	case m.connectCh <- struct{}{}:
+	default:
+	}
+
+	// Stream events.
+	for _, ev := range behavior.Events {
+		b, err := json.Marshal(ev)
+		if err != nil {
+			return fmt.Errorf("mock server: marshal: %w", err)
+		}
+		if err := stream.SendMsg(json.RawMessage(b)); err != nil {
+			return err
+		}
+	}
+
+	// Return the configured error (nil = clean EOF).
+	return behavior.Err
+}
+
+// waitForConnections blocks until n connections have been received or timeout.
+func (m *mockTetragonServer) waitForConnections(t *testing.T, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for range n {
+		select {
+		case <-m.connectCh:
+		case <-deadline:
+			t.Fatalf("timed out waiting for connection %d/%d (got %d total)",
+				n, n, m.totalConns.Load())
+		}
+	}
+}
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+func testEvent(binary string) Event {
+	return Event{
+		Time:     time.Now().UTC(),
+		NodeName: "e2e-node",
+		ProcessKprobe: &ProcessKprobe{
+			Process:      &Process{Binary: binary, UID: 1000},
+			FunctionName: "tcp_connect",
+			Action:       "post",
+			PolicyName:   "e2e-test",
+		},
+	}
+}
+
+// ─── E2E Tests ───────────────────────────────────────────────────────────────
+
+// TestE2E_StreamAndProcess verifies the full happy path: connect to a real
+// gRPC server, stream events, receive them through the pipeline, and verify
+// health + stats.
+func TestE2E_StreamAndProcess(t *testing.T) {
+	mock := newMockTetragonServer(streamBehavior{
+		Events: []Event{testEvent("/usr/bin/curl"), testEvent("/usr/bin/python3")},
+	})
+	addr, cleanup := mock.serve(t)
+	defer cleanup()
+
+	src, err := NewGRPCSource(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("NewGRPCSource: %v", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	sink := &CollectorSink{}
+	pipeline := NewPipeline(PipelineConfig{Sink: sink})
+
+	// The server sends 2 events then EOF. StreamEventsWithRetry will reconnect
+	// after EOF, so we cancel after the first batch is received.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	// Run in background so we can inspect results.
+	done := make(chan error, 1)
+	go func() {
+		done <- src.StreamEventsWithRetry(ctx, pipeline, RetryConfig{
+			InitialDelay: 50 * time.Millisecond,
+			MaxDelay:     200 * time.Millisecond,
+		})
+	}()
+
+	// Wait for the first connection to be served.
+	mock.waitForConnections(t, 1, 2*time.Second)
+
+	// Give the pipeline a moment to process.
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify events were processed.
+	records := sink.GetRecords()
+	if len(records) < 2 {
+		t.Fatalf("expected ≥2 records, got %d", len(records))
+	}
+	if records[0].Binary != "/usr/bin/curl" {
+		t.Errorf("records[0].Binary = %q, want /usr/bin/curl", records[0].Binary)
+	}
+	if records[1].Binary != "/usr/bin/python3" {
+		t.Errorf("records[1].Binary = %q, want /usr/bin/python3", records[1].Binary)
+	}
+
+	// Health should show connected (or reconnecting after EOF).
+	h := pipeline.Health()
+	if h.Processed < 2 {
+		t.Errorf("health.Processed = %d, want ≥2", h.Processed)
+	}
+
+	// Stats should reflect processed events.
+	p, d, e := pipeline.Stats().Snapshot()
+	if p < 2 {
+		t.Errorf("processed = %d, want ≥2", p)
+	}
+	if d != 0 {
+		t.Errorf("dropped = %d, want 0", d)
+	}
+	if e != 0 {
+		t.Errorf("errors = %d, want 0", e)
+	}
+
+	cancel()
+	<-done
+}
+
+// TestE2E_ReconnectAfterError verifies that StreamEventsWithRetry reconnects
+// after the server returns a transient error, and successfully processes
+// events on the subsequent connection.
+func TestE2E_ReconnectAfterError(t *testing.T) {
+	mock := newMockTetragonServer(
+		// Attempt 1: sends 1 event then returns an error.
+		streamBehavior{
+			Events: []Event{testEvent("/bin/first")},
+			Err:    fmt.Errorf("mock transient error"),
+		},
+		// Attempt 2: sends 1 event then clean EOF.
+		streamBehavior{
+			Events: []Event{testEvent("/bin/second")},
+		},
+	)
+	addr, cleanup := mock.serve(t)
+	defer cleanup()
+
+	src, err := NewGRPCSource(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("NewGRPCSource: %v", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	sink := &CollectorSink{}
+	pipeline := NewPipeline(PipelineConfig{Sink: sink})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- src.StreamEventsWithRetry(ctx, pipeline, RetryConfig{
+			InitialDelay: 50 * time.Millisecond,
+			MaxDelay:     100 * time.Millisecond,
+		})
+	}()
+
+	// Wait for both connections.
+	mock.waitForConnections(t, 2, 3*time.Second)
+	time.Sleep(150 * time.Millisecond)
+
+	records := sink.GetRecords()
+	if len(records) < 2 {
+		t.Fatalf("expected ≥2 records across reconnect, got %d", len(records))
+	}
+
+	// Both events from both connections should be present.
+	binaries := make(map[string]bool)
+	for _, r := range records {
+		binaries[r.Binary] = true
+	}
+	if !binaries["/bin/first"] {
+		t.Error("missing /bin/first from attempt 1")
+	}
+	if !binaries["/bin/second"] {
+		t.Error("missing /bin/second from attempt 2")
+	}
+
+	cancel()
+	<-done
+}
+
+// TestE2E_HealthToggles verifies that the pipeline health accurately
+// reflects connected/disconnected states during the retry lifecycle.
+func TestE2E_HealthToggles(t *testing.T) {
+	mock := newMockTetragonServer(
+		// Attempt 1: send 1 event, then error → triggers backoff.
+		streamBehavior{
+			Events: []Event{testEvent("/bin/health-check")},
+			Err:    fmt.Errorf("mock error for health toggle test"),
+		},
+		// Attempt 2: send 1 event, clean EOF → triggers InitialDelay.
+		streamBehavior{
+			Events: []Event{testEvent("/bin/health-check-2")},
+		},
+	)
+	addr, cleanup := mock.serve(t)
+	defer cleanup()
+
+	src, err := NewGRPCSource(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("NewGRPCSource: %v", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	sink := &CollectorSink{}
+	pipeline := NewPipeline(PipelineConfig{Sink: sink})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- src.StreamEventsWithRetry(ctx, pipeline, RetryConfig{
+			// Use longer delays so we can observe the disconnected state.
+			InitialDelay: 500 * time.Millisecond,
+			MaxDelay:     1 * time.Second,
+		})
+	}()
+
+	// Wait for first connection.
+	mock.waitForConnections(t, 1, 2*time.Second)
+	time.Sleep(100 * time.Millisecond)
+
+	// After the first stream errors, pipeline should be disconnected during backoff.
+	// The 500ms backoff gives us time to observe.
+	h := pipeline.Health()
+	if h.Connected {
+		// This is expected — the stream just errored, so we should be in backoff.
+		// (It's possible we catch it during the brief reconnect window, so we
+		// just log rather than fail.)
+		t.Log("note: caught pipeline in connected state during expected backoff — timing dependent")
+	}
+
+	// Wait for second connection.
+	mock.waitForConnections(t, 1, 3*time.Second)
+	time.Sleep(50 * time.Millisecond)
+
+	// After second connection succeeds, health should show connected.
+	h = pipeline.Health()
+	if !h.Connected {
+		// The stream may have already ended (clean EOF), so this is also timing dependent.
+		t.Log("note: pipeline not connected — stream may have already ended")
+	}
+
+	cancel()
+	<-done
+
+	// After cancellation, pipeline should be disconnected.
+	h = pipeline.Health()
+	if h.Connected {
+		t.Error("expected Connected=false after context cancellation")
+	}
+}
+
+// TestE2E_CleanEOFBackoff verifies that a clean EOF (server closes stream
+// without error) does NOT cause a tight reconnect loop — there must be a
+// delay between the first and second connections.
+func TestE2E_CleanEOFBackoff(t *testing.T) {
+	mock := newMockTetragonServer(
+		// Both attempts: clean EOF immediately.
+		streamBehavior{Events: []Event{testEvent("/bin/eof1")}},
+		streamBehavior{Events: []Event{testEvent("/bin/eof2")}},
+	)
+	addr, cleanup := mock.serve(t)
+	defer cleanup()
+
+	src, err := NewGRPCSource(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("NewGRPCSource: %v", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	sink := &CollectorSink{}
+	pipeline := NewPipeline(PipelineConfig{Sink: sink})
+
+	initialDelay := 300 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	start := time.Now()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- src.StreamEventsWithRetry(ctx, pipeline, RetryConfig{
+			InitialDelay: initialDelay,
+			MaxDelay:     1 * time.Second,
+		})
+	}()
+
+	// Wait for both connections.
+	mock.waitForConnections(t, 2, 2*time.Second)
+	elapsed := time.Since(start)
+
+	// The second connection should have been delayed by at least InitialDelay.
+	// We check for 80% of the delay to account for scheduling jitter.
+	minExpected := time.Duration(float64(initialDelay) * 0.8)
+	if elapsed < minExpected {
+		t.Errorf("reconnect after clean EOF was too fast: %v (expected ≥%v)",
+			elapsed, minExpected)
+	}
+
+	cancel()
+	<-done
+}
+
+// TestE2E_MultipleReconnects verifies that the retry loop handles multiple
+// consecutive failures followed by a successful connection.
+func TestE2E_MultipleReconnects(t *testing.T) {
+	mock := newMockTetragonServer(
+		streamBehavior{Err: fmt.Errorf("fail-1")},
+		streamBehavior{Err: fmt.Errorf("fail-2")},
+		streamBehavior{Err: fmt.Errorf("fail-3")},
+		// 4th attempt succeeds.
+		streamBehavior{Events: []Event{testEvent("/bin/success")}},
+	)
+	addr, cleanup := mock.serve(t)
+	defer cleanup()
+
+	src, err := NewGRPCSource(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("NewGRPCSource: %v", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	sink := &CollectorSink{}
+	pipeline := NewPipeline(PipelineConfig{Sink: sink})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- src.StreamEventsWithRetry(ctx, pipeline, RetryConfig{
+			InitialDelay: 20 * time.Millisecond,
+			MaxDelay:     100 * time.Millisecond,
+		})
+	}()
+
+	// Wait for all 4 connections.
+	mock.waitForConnections(t, 4, 4*time.Second)
+	time.Sleep(100 * time.Millisecond)
+
+	// The event from the 4th connection should be processed.
+	records := sink.GetRecords()
+	if len(records) < 1 {
+		t.Fatalf("expected ≥1 record after 3 failures + 1 success, got %d", len(records))
+	}
+
+	found := false
+	for _, r := range records {
+		if r.Binary == "/bin/success" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("missing /bin/success event after reconnect")
+	}
+
+	// Total connections should be ≥4.
+	if mock.totalConns.Load() < 4 {
+		t.Errorf("expected ≥4 connections, got %d", mock.totalConns.Load())
+	}
+
+	cancel()
+	<-done
+}
+
+// TestE2E_GracefulShutdownDuringStream verifies that cancelling the context
+// during active streaming exits cleanly without hanging.
+func TestE2E_GracefulShutdownDuringStream(t *testing.T) {
+	// Server that streams events slowly (one every 100ms).
+	slowEvents := make([]Event, 50)
+	for i := range slowEvents {
+		slowEvents[i] = testEvent(fmt.Sprintf("/bin/slow-%d", i))
+	}
+
+	mock := newMockTetragonServer(streamBehavior{Events: slowEvents})
+	addr, cleanup := mock.serve(t)
+	defer cleanup()
+
+	src, err := NewGRPCSource(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("NewGRPCSource: %v", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	sink := &CollectorSink{}
+	pipeline := NewPipeline(PipelineConfig{Sink: sink})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- src.StreamEventsWithRetry(ctx, pipeline, RetryConfig{
+			InitialDelay: 50 * time.Millisecond,
+		})
+	}()
+
+	// Let some events flow, then cancel.
+	mock.waitForConnections(t, 1, 2*time.Second)
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	// Must exit within 1 second.
+	select {
+	case err := <-done:
+		if err != nil && err != context.Canceled {
+			t.Errorf("expected context.Canceled or nil, got: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("StreamEventsWithRetry did not exit within 2s after cancel")
+	}
+
+	// Health should show disconnected.
+	h := pipeline.Health()
+	if h.Connected {
+		t.Error("expected Connected=false after graceful shutdown")
+	}
+
+	// Should have processed at least some events.
+	if h.Processed == 0 {
+		t.Error("expected some events to be processed before shutdown")
+	}
+}
+
+// TestE2E_DrainAfterShutdown verifies that Drain() can flush the pipeline
+// after the streaming goroutine has exited.
+func TestE2E_DrainAfterShutdown(t *testing.T) {
+	var flushed atomic.Bool
+	flushSink := &flushRecordingSink{flushed: &flushed}
+
+	mock := newMockTetragonServer(streamBehavior{
+		Events: []Event{testEvent("/bin/drain-test")},
+	})
+	addr, cleanup := mock.serve(t)
+	defer cleanup()
+
+	src, err := NewGRPCSource(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("NewGRPCSource: %v", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	pipeline := NewPipeline(PipelineConfig{Sink: flushSink})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- src.StreamEventsWithRetry(ctx, pipeline, RetryConfig{
+			InitialDelay: 50 * time.Millisecond,
+		})
+	}()
+
+	mock.waitForConnections(t, 1, 2*time.Second)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	// Drain should call Flush.
+	if err := pipeline.Drain(context.Background()); err != nil {
+		t.Fatalf("Drain: %v", err)
+	}
+	if !flushed.Load() {
+		t.Error("expected Flush to be called during Drain")
+	}
+}
+
+// flushRecordingSink records whether Flush was called.
+type flushRecordingSink struct {
+	mu      sync.Mutex
+	records []AuditRecord
+	flushed *atomic.Bool
+}
+
+func (s *flushRecordingSink) Emit(_ context.Context, r AuditRecord) error {
+	s.mu.Lock()
+	s.records = append(s.records, r)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *flushRecordingSink) Flush(_ context.Context) error {
+	s.flushed.Store(true)
+	return nil
+}
+
+// Compile-time check that flushRecordingSink implements both interfaces.
+var (
+	_ Sink    = (*flushRecordingSink)(nil)
+	_ Flusher = (*flushRecordingSink)(nil)
+)

--- a/pkg/tetragonaudit/grpc_source.go
+++ b/pkg/tetragonaudit/grpc_source.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
+	"math/rand/v2"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -85,6 +88,114 @@ func (s *GRPCSource) Close() error {
 	return nil
 }
 
+// Addr returns the configured gRPC address.
+func (s *GRPCSource) Addr() string {
+	return s.addr
+}
+
+// RetryConfig controls the reconnect backoff behavior.
+type RetryConfig struct {
+	// InitialDelay is the first backoff duration (default: 1s).
+	InitialDelay time.Duration
+	// MaxDelay is the backoff ceiling (default: 30s).
+	MaxDelay time.Duration
+	// Multiplier is the backoff factor (default: 2.0).
+	Multiplier float64
+}
+
+func (rc RetryConfig) withDefaults() RetryConfig {
+	if rc.InitialDelay <= 0 {
+		rc.InitialDelay = time.Second
+	}
+	if rc.MaxDelay <= 0 {
+		rc.MaxDelay = 30 * time.Second
+	}
+	if rc.Multiplier <= 0 {
+		rc.Multiplier = 2.0
+	}
+	return rc
+}
+
+// StreamEventsWithRetry streams events from the Tetragon gRPC API with
+// automatic reconnection on failure using exponential backoff.
+//
+// On each connection failure, the method sleeps for an exponentially-growing
+// duration (with ±25% jitter) before retrying. On successful reconnection
+// the backoff resets to InitialDelay.
+//
+// The loop exits cleanly when ctx is cancelled (graceful shutdown).
+func (s *GRPCSource) StreamEventsWithRetry(ctx context.Context, pipeline *Pipeline, rc RetryConfig) error {
+	rc = rc.withDefaults()
+	attempt := 0
+
+	for {
+		// Check for cancellation before each attempt.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		stream, err := NewGRPCEventStreamAdapter(ctx, s.conn)
+		if err != nil {
+			pipeline.SetConnected(false)
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			delay := backoff(attempt, rc)
+			slog.Warn("tetragonaudit: gRPC stream creation failed, retrying",
+				"error", err, "attempt", attempt+1, "backoff", delay)
+			attempt++
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+				continue
+			}
+		}
+
+		slog.Info("tetragonaudit: gRPC stream connected", "addr", s.addr, "attempt", attempt+1)
+		pipeline.SetConnected(true)
+		attempt = 0 // Reset on successful connection.
+
+		err = s.StreamEvents(ctx, stream, pipeline)
+		pipeline.SetConnected(false)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err == nil {
+			// Clean EOF — server shut the stream. Reconnect after a small delay
+			// to avoid a tight loop during rolling updates or config mismatches.
+			slog.Info("tetragonaudit: gRPC stream ended, reconnecting", "addr", s.addr)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(rc.InitialDelay):
+				continue
+			}
+		}
+
+		delay := backoff(attempt, rc)
+		slog.Warn("tetragonaudit: gRPC stream error, reconnecting",
+			"error", err, "attempt", attempt+1, "backoff", delay)
+		attempt++
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
+
+// backoff computes the delay for a given attempt with ±25% jitter.
+func backoff(attempt int, rc RetryConfig) time.Duration {
+	d := float64(rc.InitialDelay) * math.Pow(rc.Multiplier, float64(attempt))
+	if d > float64(rc.MaxDelay) {
+		d = float64(rc.MaxDelay)
+	}
+	// Add ±25% jitter.
+	jitter := d * 0.25 * (2*rand.Float64() - 1) //nolint:gosec
+	return time.Duration(d + jitter)
+}
+
 // Conn returns the underlying gRPC connection for advanced usage
 // (e.g. creating Tetragon-specific clients).
 func (s *GRPCSource) Conn() *grpc.ClientConn {
@@ -105,6 +216,9 @@ type GRPCEventStreamAdapter struct {
 // It initiates a server-streaming RPC on the Tetragon FineGuidanceSensors/GetEvents
 // endpoint and returns an adapter that reads raw event bytes.
 func NewGRPCEventStreamAdapter(ctx context.Context, conn *grpc.ClientConn) (*GRPCEventStreamAdapter, error) {
+	if conn == nil {
+		return nil, fmt.Errorf("tetragonaudit: gRPC connection is nil")
+	}
 	desc := &grpc.StreamDesc{ServerStreams: true}
 	stream, err := conn.NewStream(ctx, desc, "/tetragon.FineGuidanceSensors/GetEvents")
 	if err != nil {

--- a/pkg/tetragonaudit/grpc_source.go
+++ b/pkg/tetragonaudit/grpc_source.go
@@ -12,7 +12,46 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/encoding"
 )
+
+func init() {
+	// Register the bytes codec so both client (via ForceCodec) and server
+	// (via content-subtype discovery) can use raw byte transport without
+	// requiring protobuf message types.
+	encoding.RegisterCodec(bytesCodec{})
+}
+
+// bytesCodec is a gRPC codec for raw byte transfer without protobuf.
+// This enables the Tetragon adapter to communicate using JSON-encoded
+// bytes without importing the full Tetragon protobuf dependency.
+type bytesCodec struct{}
+
+func (bytesCodec) Marshal(v any) ([]byte, error) {
+	switch m := v.(type) {
+	case []byte:
+		return m, nil
+	case json.RawMessage:
+		return []byte(m), nil
+	default:
+		return nil, fmt.Errorf("bytesCodec: unsupported type %T", v)
+	}
+}
+
+func (bytesCodec) Unmarshal(data []byte, v any) error {
+	switch m := v.(type) {
+	case *[]byte:
+		*m = append((*m)[:0], data...)
+		return nil
+	case *json.RawMessage:
+		*m = append((*m)[:0], data...)
+		return nil
+	default:
+		return fmt.Errorf("bytesCodec: unsupported type %T", v)
+	}
+}
+
+func (bytesCodec) Name() string { return "bytes" }
 
 // GRPCSource streams Tetragon events from the Tetragon gRPC export API.
 // This is the production event source for in-cluster deployments where
@@ -220,7 +259,8 @@ func NewGRPCEventStreamAdapter(ctx context.Context, conn *grpc.ClientConn) (*GRP
 		return nil, fmt.Errorf("tetragonaudit: gRPC connection is nil")
 	}
 	desc := &grpc.StreamDesc{ServerStreams: true}
-	stream, err := conn.NewStream(ctx, desc, "/tetragon.FineGuidanceSensors/GetEvents")
+	stream, err := conn.NewStream(ctx, desc, "/tetragon.FineGuidanceSensors/GetEvents",
+		grpc.ForceCodec(bytesCodec{}))
 	if err != nil {
 		return nil, fmt.Errorf("tetragonaudit: failed to create gRPC stream: %w", err)
 	}

--- a/pkg/tetragonaudit/health_test.go
+++ b/pkg/tetragonaudit/health_test.go
@@ -1,0 +1,208 @@
+package tetragonaudit
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPipeline_Health_InitialState(t *testing.T) {
+	sink := &CollectorSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+
+	h := p.Health()
+	if h.Healthy {
+		t.Error("expected Healthy=false initially (not connected)")
+	}
+	if h.Connected {
+		t.Error("expected Connected=false initially")
+	}
+	if h.Processed != 0 || h.Dropped != 0 || h.Errors != 0 {
+		t.Errorf("expected zero stats, got processed=%d dropped=%d errors=%d",
+			h.Processed, h.Dropped, h.Errors)
+	}
+}
+
+func TestPipeline_Health_ConnectedNoEvents(t *testing.T) {
+	sink := &CollectorSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+
+	p.SetConnected(true)
+	h := p.Health()
+
+	if !h.Healthy {
+		t.Error("expected Healthy=true when connected with no prior events")
+	}
+	if !h.Connected {
+		t.Error("expected Connected=true")
+	}
+}
+
+func TestPipeline_Health_AfterProcessing(t *testing.T) {
+	sink := &CollectorSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+	p.SetConnected(true)
+
+	// Process an event.
+	event := Event{
+		ProcessKprobe: &ProcessKprobe{
+			Action:       "post",
+			FunctionName: "tcp_connect",
+			Process:      &Process{Binary: "/usr/bin/curl"},
+		},
+	}
+	if err := p.ProcessEvent(context.Background(), event); err != nil {
+		t.Fatal(err)
+	}
+
+	h := p.Health()
+	if !h.Healthy {
+		t.Error("expected Healthy=true after processing")
+	}
+	if h.Processed != 1 {
+		t.Errorf("expected Processed=1, got %d", h.Processed)
+	}
+	if h.LastEventAt.IsZero() {
+		t.Error("expected LastEventAt to be set")
+	}
+}
+
+func TestPipeline_Health_Disconnected(t *testing.T) {
+	sink := &CollectorSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+
+	p.SetConnected(true)
+	p.SetConnected(false)
+
+	h := p.Health()
+	if h.Healthy {
+		t.Error("expected Healthy=false when disconnected")
+	}
+	if h.Connected {
+		t.Error("expected Connected=false")
+	}
+}
+
+// mockFlushSink records whether Flush was called.
+type mockFlushSink struct {
+	emitCount  atomic.Int32
+	flushed    atomic.Bool
+	flushError error
+}
+
+func (s *mockFlushSink) Emit(_ context.Context, _ AuditRecord) error {
+	s.emitCount.Add(1)
+	return nil
+}
+
+func (s *mockFlushSink) Flush(_ context.Context) error {
+	s.flushed.Store(true)
+	return s.flushError
+}
+
+// Verify mockFlushSink implements both interfaces.
+var _ Sink = (*mockFlushSink)(nil)
+var _ Flusher = (*mockFlushSink)(nil)
+
+func TestPipeline_Drain_CallsFlush(t *testing.T) {
+	sink := &mockFlushSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+
+	err := p.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sink.flushed.Load() {
+		t.Error("expected Flush to be called on sink")
+	}
+}
+
+func TestPipeline_Drain_PropagatesFlushError(t *testing.T) {
+	wantErr := errors.New("flush failed")
+	sink := &mockFlushSink{flushError: wantErr}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+
+	err := p.Drain(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+}
+
+func TestPipeline_Drain_NonFlushSinkNoError(t *testing.T) {
+	// CollectorSink does NOT implement Flusher.
+	sink := &CollectorSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+
+	err := p.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error for non-Flusher sink, got: %v", err)
+	}
+}
+
+func TestPipeline_Drain_MultiSinkFlushes(t *testing.T) {
+	flushable := &mockFlushSink{}
+	nonFlushable := &CollectorSink{}
+
+	multi := &MultiSink{Sinks: []Sink{flushable, nonFlushable}}
+	p := NewPipeline(PipelineConfig{Sink: multi})
+
+	err := p.Drain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !flushable.flushed.Load() {
+		t.Error("expected Flush to be called on the flushable child of MultiSink")
+	}
+}
+
+func TestPipeline_Drain_MultiSinkFirstFlushError(t *testing.T) {
+	wantErr := errors.New("first flush failed")
+	flushable1 := &mockFlushSink{flushError: wantErr}
+	flushable2 := &mockFlushSink{}
+
+	multi := &MultiSink{Sinks: []Sink{flushable1, flushable2}}
+	p := NewPipeline(PipelineConfig{Sink: multi})
+
+	err := p.Drain(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+	// Second sink should still have been flushed.
+	if !flushable2.flushed.Load() {
+		t.Error("expected second sink to be flushed even after first error")
+	}
+}
+
+func TestOTelSink_ImplementsFlusher(t *testing.T) {
+	sink, err := NewOTelSink(OTelSinkConfig{Endpoint: "http://localhost:4318"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var f Flusher = sink
+	if err := f.Flush(context.Background()); err != nil {
+		t.Fatalf("unexpected flush error: %v", err)
+	}
+}
+
+func TestPipeline_LastEventTracking(t *testing.T) {
+	sink := &CollectorSink{}
+	p := NewPipeline(PipelineConfig{Sink: sink})
+	p.SetConnected(true)
+
+	before := time.Now()
+	event := Event{
+		ProcessKprobe: &ProcessKprobe{
+			Action:  "post",
+			Process: &Process{Binary: "/bin/test"},
+		},
+	}
+	_ = p.ProcessEvent(context.Background(), event)
+	after := time.Now()
+
+	h := p.Health()
+	if h.LastEventAt.Before(before) || h.LastEventAt.After(after) {
+		t.Errorf("LastEventAt=%v not in [%v, %v]", h.LastEventAt, before, after)
+	}
+}

--- a/pkg/tetragonaudit/otel_sink.go
+++ b/pkg/tetragonaudit/otel_sink.go
@@ -15,6 +15,7 @@ import (
 )
 
 var _ Sink = (*OTelSink)(nil)
+var _ Flusher = (*OTelSink)(nil)
 
 // OTelSinkConfig holds configuration for the OTel log exporter.
 type OTelSinkConfig struct {
@@ -175,5 +176,13 @@ func (s *OTelSink) exportLogs(ctx context.Context, logs plog.Logs) error {
 		"endpoint", url,
 	)
 
+	return nil
+}
+
+// Flush closes idle HTTP connections to ensure a clean shutdown.
+// The OTelSink exports synchronously per-event, so there's no pending
+// batch to flush — but closing idle connections ensures transport cleanup.
+func (s *OTelSink) Flush(_ context.Context) error {
+	s.client.CloseIdleConnections()
 	return nil
 }

--- a/pkg/tetragonaudit/pipeline.go
+++ b/pkg/tetragonaudit/pipeline.go
@@ -152,12 +152,22 @@ type Sink interface {
 	Emit(ctx context.Context, record AuditRecord) error
 }
 
+// Flusher is an optional interface for sinks that buffer data and need
+// an explicit flush before shutdown.
+type Flusher interface {
+	Flush(ctx context.Context) error
+}
+
 // Pipeline reads Tetragon events from a source and forwards them to a Sink
 // as normalized AuditRecords.
 type Pipeline struct {
 	sink    Sink
 	stats   PipelineStats
 	filters []EventFilter
+
+	mu        sync.Mutex
+	lastEvent time.Time
+	connected bool
 }
 
 // EventFilter returns true if the event should be processed.
@@ -196,6 +206,71 @@ func NewPipeline(cfg PipelineConfig) *Pipeline {
 // Stats returns the pipeline's processing statistics.
 func (p *Pipeline) Stats() *PipelineStats {
 	return &p.stats
+}
+
+// PipelineHealth reports the current health of the audit pipeline.
+type PipelineHealth struct {
+	Healthy     bool      `json:"healthy"`
+	Connected   bool      `json:"connected"`
+	LastEventAt time.Time `json:"last_event_at,omitempty"`
+	Processed   int64     `json:"processed"`
+	Dropped     int64     `json:"dropped"`
+	Errors      int64     `json:"errors"`
+}
+
+// Health returns a snapshot of the pipeline's health status.
+// Healthy is true when the pipeline is connected and has received
+// at least one event within the last 5 minutes.
+func (p *Pipeline) Health() PipelineHealth {
+	processed, dropped, errors := p.stats.Snapshot()
+
+	p.mu.Lock()
+	lastEvent := p.lastEvent
+	connected := p.connected
+	p.mu.Unlock()
+
+	healthy := connected
+	if !lastEvent.IsZero() {
+		// If we've seen events before, consider unhealthy if stale > 5m.
+		healthy = connected && time.Since(lastEvent) < 5*time.Minute
+	}
+
+	return PipelineHealth{
+		Healthy:     healthy,
+		Connected:   connected,
+		LastEventAt: lastEvent,
+		Processed:   processed,
+		Dropped:     dropped,
+		Errors:      errors,
+	}
+}
+
+// SetConnected updates the pipeline's connection status.
+func (p *Pipeline) SetConnected(connected bool) {
+	p.mu.Lock()
+	p.connected = connected
+	p.mu.Unlock()
+}
+
+// Drain flushes any buffered data in the sink and returns.
+// If the sink implements Flusher, it is called with the given context.
+func (p *Pipeline) Drain(ctx context.Context) error {
+	if f, ok := p.sink.(Flusher); ok {
+		return f.Flush(ctx)
+	}
+	// MultiSink: check if any child implements Flusher.
+	if ms, ok := p.sink.(*MultiSink); ok {
+		var firstErr error
+		for _, s := range ms.Sinks {
+			if f, ok := s.(Flusher); ok {
+				if err := f.Flush(ctx); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+		return firstErr
+	}
+	return nil
 }
 
 // ProcessJSONStream reads newline-delimited JSON Tetragon events from
@@ -273,6 +348,11 @@ func (p *Pipeline) ProcessEvent(ctx context.Context, event Event) error {
 	p.stats.mu.Lock()
 	p.stats.Processed++
 	p.stats.mu.Unlock()
+
+	p.mu.Lock()
+	p.lastEvent = time.Now()
+	p.mu.Unlock()
+
 	return nil
 }
 

--- a/pkg/tetragonaudit/retry_test.go
+++ b/pkg/tetragonaudit/retry_test.go
@@ -1,0 +1,109 @@
+package tetragonaudit
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestStreamEventsWithRetry_ReconnectsAfterFailure(t *testing.T) {
+	src := &GRPCSource{addr: "test://localhost:54321"}
+
+	sink := &CollectorSink{}
+	pipeline := NewPipeline(PipelineConfig{Sink: sink})
+
+	// Cancel after a short delay to let the retry loop attempt at least once.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	// With nil conn, NewGRPCEventStreamAdapter will fail, triggering retry.
+	// The retry should back off and eventually exit on context deadline.
+	err := src.StreamEventsWithRetry(ctx, pipeline, RetryConfig{
+		InitialDelay: 10 * time.Millisecond,
+		MaxDelay:     50 * time.Millisecond,
+	})
+	// Should exit with context error (either deadline or cancel).
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context error, got: %v", err)
+	}
+
+	// After retry loop exits, health should report disconnected.
+	h := pipeline.Health()
+	if h.Connected {
+		t.Error("expected Connected=false after retry loop exits")
+	}
+	if h.Healthy {
+		t.Error("expected Healthy=false after retry loop exits")
+	}
+}
+
+func TestStreamEventsWithRetry_CancelledImmediately(t *testing.T) {
+	src := &GRPCSource{addr: "test://localhost:54321"}
+	sink := &CollectorSink{}
+	pipeline := NewPipeline(PipelineConfig{Sink: sink})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	start := time.Now()
+	err := src.StreamEventsWithRetry(ctx, pipeline, RetryConfig{
+		InitialDelay: time.Second,
+	})
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("took too long to exit: %v (should be near-instant)", elapsed)
+	}
+}
+
+func TestBackoff_ExponentialWithCap(t *testing.T) {
+	rc := RetryConfig{
+		InitialDelay: 100 * time.Millisecond,
+		MaxDelay:     2 * time.Second,
+		Multiplier:   2.0,
+	}
+
+	tests := []struct {
+		attempt  int
+		minDelay time.Duration
+		maxDelay time.Duration
+	}{
+		// attempt 0: 100ms base ± 25% = [75ms, 125ms]
+		{0, 75 * time.Millisecond, 125 * time.Millisecond},
+		// attempt 1: 200ms ± 25% = [150ms, 250ms]
+		{1, 150 * time.Millisecond, 250 * time.Millisecond},
+		// attempt 2: 400ms ± 25% = [300ms, 500ms]
+		{2, 300 * time.Millisecond, 500 * time.Millisecond},
+		// attempt 10: capped at 2s ± 25% = [1.5s, 2.5s]
+		{10, 1500 * time.Millisecond, 2500 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		// Run each sub-test multiple times to verify jitter range.
+		for range 20 {
+			d := backoff(tt.attempt, rc)
+			if d < tt.minDelay || d > tt.maxDelay {
+				t.Errorf("attempt %d: backoff=%v, want [%v, %v]",
+					tt.attempt, d, tt.minDelay, tt.maxDelay)
+			}
+		}
+	}
+}
+
+func TestBackoff_DefaultConfig(t *testing.T) {
+	rc := RetryConfig{}.withDefaults()
+
+	if rc.InitialDelay != time.Second {
+		t.Errorf("InitialDelay=%v, want 1s", rc.InitialDelay)
+	}
+	if rc.MaxDelay != 30*time.Second {
+		t.Errorf("MaxDelay=%v, want 30s", rc.MaxDelay)
+	}
+	if rc.Multiplier != 2.0 {
+		t.Errorf("Multiplier=%v, want 2.0", rc.Multiplier)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a custom `bytesCodec` for raw byte gRPC transport and a comprehensive e2e test suite for the Tetragon audit pipeline.

### bytesCodec

The Tetragon adapter communicates using JSON-encoded bytes over gRPC without importing the full Tetragon protobuf dependency. Previously, `SendMsg([]byte("..."))` failed against real gRPC servers because the default proto codec expects `proto.Message`. The new `bytesCodec`:

- Handles `[]byte` and `json.RawMessage` transparently
- Is registered globally via `encoding.RegisterCodec` so both client (`ForceCodec`) and server (content-subtype discovery) use it
- Enables true end-to-end testing through the real gRPC transport layer

### E2E Test Suite (`grpc_e2e_test.go`)

7 tests exercise the full connect-stream-reconnect lifecycle using an in-process mock gRPC server:

| Test | What it validates |
|------|------------------|
| `TestE2E_StreamAndProcess` | Happy-path: connect → stream 2 events → verify pipeline stats |
| `TestE2E_ReconnectAfterError` | Transient error recovery across reconnect |
| `TestE2E_HealthToggles` | Connected/disconnected state transitions during retry |
| `TestE2E_CleanEOFBackoff` | Anti-tight-loop: InitialDelay enforced on clean EOF |
| `TestE2E_MultipleReconnects` | 3 consecutive failures → successful 4th attempt |
| `TestE2E_GracefulShutdownDuringStream` | Context cancellation exits cleanly |
| `TestE2E_DrainAfterShutdown` | Flush/Drain lifecycle after stream exit |

### Design

The mock server uses a raw `grpc.ServiceDesc` with custom handler to serve `/tetragon.FineGuidanceSensors/GetEvents` — no Tetragon proto imports needed. The `mockTetragonServer` accepts configurable `streamBehavior` per connection attempt, making it trivially extensible for future Tier 2 sources (Hubble, etc).

### Test Results

All 57 tests pass (50 unit + 7 e2e). All pre-commit hooks green (gofmt, go-vet, golangci-lint, go-test).

Refs: #254