### PR TITLE
fix: wire ADC TokenSource into gemini-oai and google providers

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -239,7 +239,7 @@ func main() {
 			for i, p := range allProviders {
 				if p.Name == "gemini-oai" || p.Name == "google" {
 					allProviders[i].TokenSource = tokenSource
-					slog.Info("🔐 Gemini provider configured with ADC",
+					slog.Info("🔐 GCP-backed provider configured with ADC",
 						"provider", p.Name, "upstream", p.UpstreamURL)
 				}
 			}

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -222,20 +222,35 @@ func main() {
 	if cfg.Proxy.Enabled {
 		allProviders := proxy.DefaultProviders()
 
+		// Get ADC token source for automatic GCP auth.
+		// Used by Anthropic (Vertex AI), Gemini, and Google providers so the
+		// Cloud Run service account authenticates to upstream APIs on behalf
+		// of users — individual user tokens never reach the upstream provider.
+		tokenSource, adcErr := google.DefaultTokenSource(context.Background(),
+			"https://www.googleapis.com/auth/cloud-platform")
+		if adcErr != nil {
+			slog.Warn("failed to get GCP ADC — GCP-backed providers will require manual auth",
+				"error", adcErr)
+		}
+
+		// Attach ADC to Gemini / Google providers.
+		// These use the Generative Language API directly (no Vertex AI project needed).
+		if tokenSource != nil {
+			for i, p := range allProviders {
+				if p.Name == "gemini-oai" || p.Name == "google" {
+					allProviders[i].TokenSource = tokenSource
+					slog.Info("🔐 Gemini provider configured with ADC",
+						"provider", p.Name, "upstream", p.UpstreamURL)
+				}
+			}
+		}
+
 		// Attach FormatTranslator + PathRewriter + ADC to the Anthropic provider
 		// if Vertex AI is configured.
 		if cfg.Proxy.VertexAI.ProjectID != "" {
 			region := cfg.Proxy.VertexAI.Region
 			if region == "" {
 				region = "us-central1"
-			}
-
-			// Get ADC token source for automatic GCP auth.
-			tokenSource, adcErr := google.DefaultTokenSource(context.Background(),
-				"https://www.googleapis.com/auth/cloud-platform")
-			if adcErr != nil {
-				slog.Warn("failed to get GCP ADC — Anthropic proxy will require manual auth",
-					"error", adcErr)
 			}
 
 			for i, p := range allProviders {


### PR DESCRIPTION
## Problem

The server was only attaching the Cloud Run service account's ADC credentials to `anthropic` and `anthropic-vertex` providers. The `gemini-oai` and `google` providers were left without server-side auth injection, causing:

- **401 UNAUTHENTICATED** on `gemini-oai` — missing credential entirely
- **403 PERMISSION_DENIED** on `google` — user's Cloud Run auth token forwarded to Generative Language API, which rejected it as insufficient scope

Team members hitting these routes got errors even though they were properly authenticated to Cloud Run.

## Fix

Moved the ADC `TokenSource` acquisition **outside** the Vertex AI config gate (Gemini routes don't need a Vertex project) and wired it into `gemini-oai` and `google` providers. This follows the same pattern already working for Anthropic:

1. User authenticates to Cloud Run (Firebase Auth)
2. Server authenticates to upstream API using its own service account ADC
3. User identity tracked internally for cost attribution/observability

## Test Plan

- `go build ./cmd/candela-server/...` ✅
- `go test ./pkg/proxy/...` ✅
- All pre-commit hooks pass ✅
- After deploy: re-run curl tests against `/proxy/gemini-oai/` and `/proxy/google/`