### PR TITLE
fix: route Gemini through Vertex AI for server-side ADC auth

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -279,38 +279,29 @@ func main() {
 						"format_translation", p.Name == "anthropic",
 						"caching_mode", cfg.Proxy.VertexAI.CachingMode)
 
-				case "gemini-oai":
-					// Route through Vertex AI's OpenAI-compatible endpoint.
-					// Path: /v1/projects/{P}/locations/{R}/endpoints/openapi/chat/completions
-					// Model prefix "google/" is injected by proxy body enrichment.
+				case "gemini-oai", "google":
+					// Route through Vertex AI endpoints for ADC auth support.
 					allProviders[i].UpstreamURL = fmt.Sprintf(
 						"https://%s-aiplatform.googleapis.com", region)
-					allProviders[i].PathRewriter = &proxy.VertexAIGeminiOAIPathRewriter{
-						ProjectID: cfg.Proxy.VertexAI.ProjectID,
-						Region:    region,
+					if p.Name == "gemini-oai" {
+						allProviders[i].PathRewriter = &proxy.VertexAIGeminiOAIPathRewriter{
+							ProjectID: cfg.Proxy.VertexAI.ProjectID,
+							Region:    region,
+						}
+					} else {
+						allProviders[i].PathRewriter = &proxy.VertexAIGooglePathRewriter{
+							ProjectID: cfg.Proxy.VertexAI.ProjectID,
+							Region:    region,
+						}
 					}
 					if tokenSource != nil {
 						allProviders[i].TokenSource = tokenSource
 					}
-					slog.Info("🔐 Gemini-OAI via Vertex AI configured",
-						"provider", p.Name,
-						"project", cfg.Proxy.VertexAI.ProjectID,
-						"region", region,
-						"adc", tokenSource != nil)
-
-				case "google":
-					// Route through Vertex AI's native Gemini publisher endpoint.
-					// Path: /v1/projects/{P}/locations/{R}/publishers/google/models/{M}:{method}
-					allProviders[i].UpstreamURL = fmt.Sprintf(
-						"https://%s-aiplatform.googleapis.com", region)
-					allProviders[i].PathRewriter = &proxy.VertexAIGooglePathRewriter{
-						ProjectID: cfg.Proxy.VertexAI.ProjectID,
-						Region:    region,
+					msg := "🔐 Gemini-OAI via Vertex AI configured"
+					if p.Name == "google" {
+						msg = "🔐 Google native via Vertex AI configured"
 					}
-					if tokenSource != nil {
-						allProviders[i].TokenSource = tokenSource
-					}
-					slog.Info("🔐 Google native via Vertex AI configured",
+					slog.Info(msg,
 						"provider", p.Name,
 						"project", cfg.Proxy.VertexAI.ProjectID,
 						"region", region,

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -233,20 +233,17 @@ func main() {
 				"error", adcErr)
 		}
 
-		// Attach ADC to Gemini / Google providers.
-		// These use the Generative Language API directly (no Vertex AI project needed).
-		if tokenSource != nil {
-			for i, p := range allProviders {
-				if p.Name == "gemini-oai" || p.Name == "google" {
-					allProviders[i].TokenSource = tokenSource
-					slog.Info("🔐 GCP-backed provider configured with ADC",
-						"provider", p.Name, "upstream", p.UpstreamURL)
-				}
-			}
-		}
+		// NOTE: Gemini/Google ADC is NOT configured here for the Generative
+		// Language API (generativelanguage.googleapis.com) because that endpoint
+		// does NOT accept OAuth2 ADC tokens — it requires API keys. Instead,
+		// when Vertex AI is configured below, Gemini routes are redirected to
+		// the Vertex AI endpoint which natively accepts ADC tokens.
 
-		// Attach FormatTranslator + PathRewriter + ADC to the Anthropic provider
-		// if Vertex AI is configured.
+		// Attach FormatTranslator + PathRewriter + ADC to providers when
+		// Vertex AI is configured. This handles:
+		//   - anthropic / anthropic-vertex → Vertex AI rawPredict
+		//   - gemini-oai → Vertex AI OpenAI-compat endpoint
+		//   - google → Vertex AI native Gemini publisher endpoint
 		if cfg.Proxy.VertexAI.ProjectID != "" {
 			region := cfg.Proxy.VertexAI.Region
 			if region == "" {
@@ -254,7 +251,8 @@ func main() {
 			}
 
 			for i, p := range allProviders {
-				if p.Name == "anthropic" || p.Name == "anthropic-vertex" {
+				switch p.Name {
+				case "anthropic", "anthropic-vertex":
 					allProviders[i].UpstreamURL = fmt.Sprintf(
 						"https://%s-aiplatform.googleapis.com", region)
 					allProviders[i].PathRewriter = &proxy.VertexAIPathRewriter{
@@ -280,6 +278,43 @@ func main() {
 						"adc", tokenSource != nil,
 						"format_translation", p.Name == "anthropic",
 						"caching_mode", cfg.Proxy.VertexAI.CachingMode)
+
+				case "gemini-oai":
+					// Route through Vertex AI's OpenAI-compatible endpoint.
+					// Path: /v1/projects/{P}/locations/{R}/endpoints/openapi/chat/completions
+					// Model prefix "google/" is injected by proxy body enrichment.
+					allProviders[i].UpstreamURL = fmt.Sprintf(
+						"https://%s-aiplatform.googleapis.com", region)
+					allProviders[i].PathRewriter = &proxy.VertexAIGeminiOAIPathRewriter{
+						ProjectID: cfg.Proxy.VertexAI.ProjectID,
+						Region:    region,
+					}
+					if tokenSource != nil {
+						allProviders[i].TokenSource = tokenSource
+					}
+					slog.Info("🔐 Gemini-OAI via Vertex AI configured",
+						"provider", p.Name,
+						"project", cfg.Proxy.VertexAI.ProjectID,
+						"region", region,
+						"adc", tokenSource != nil)
+
+				case "google":
+					// Route through Vertex AI's native Gemini publisher endpoint.
+					// Path: /v1/projects/{P}/locations/{R}/publishers/google/models/{M}:{method}
+					allProviders[i].UpstreamURL = fmt.Sprintf(
+						"https://%s-aiplatform.googleapis.com", region)
+					allProviders[i].PathRewriter = &proxy.VertexAIGooglePathRewriter{
+						ProjectID: cfg.Proxy.VertexAI.ProjectID,
+						Region:    region,
+					}
+					if tokenSource != nil {
+						allProviders[i].TokenSource = tokenSource
+					}
+					slog.Info("🔐 Google native via Vertex AI configured",
+						"provider", p.Name,
+						"project", cfg.Proxy.VertexAI.ProjectID,
+						"region", region,
+						"adc", tokenSource != nil)
 				}
 			}
 		}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -756,7 +756,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 			"streaming", isStreaming)
 	}
 
-	// --- Vertex AI body enrichment for native passthrough ---
+	// --- Vertex AI body enrichment for native Anthropic passthrough ---
 	// When there's no FormatTranslator (e.g. anthropic-vertex), the body is
 	// forwarded as-is. But Vertex AI rawPredict requires:
 	//   1. `anthropic_version` in the body (Claude Code sends it as a header)
@@ -765,7 +765,10 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// or model stripping — Bedrock accepts the model in the URL and ignores
 	// extra body fields. Use RequestSigner to distinguish: Bedrock uses SigV4
 	// signing, Vertex uses Bearer tokens.
-	if provider.FormatTranslator == nil && provider.PathRewriter != nil && provider.RequestSigner == nil {
+	// NOTE: This block is scoped to Anthropic providers — Gemini providers with
+	// PathRewriter have different body requirements (model prefix, no stripping).
+	isAnthropicPassthrough := providerName == "anthropic-vertex" || providerName == "anthropic-direct"
+	if provider.FormatTranslator == nil && provider.PathRewriter != nil && provider.RequestSigner == nil && isAnthropicPassthrough {
 		var bodyMap map[string]interface{}
 		if json.Unmarshal(upstreamBody, &bodyMap) == nil && bodyMap != nil {
 			modified := false
@@ -816,6 +819,22 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 					"anthropic_version", bodyMap["anthropic_version"],
 					"system_snippet", systemSnippet,
 					"body_len", len(upstreamBody))
+			}
+		}
+	}
+
+	// --- Vertex AI Gemini model prefix injection ---
+	// Vertex AI's OpenAI-compat endpoint requires model names to include the
+	// publisher prefix (e.g. "google/gemini-2.5-flash"). Transparently inject
+	// the "google/" prefix so clients can send bare model names.
+	if providerName == "gemini-oai" && provider.PathRewriter != nil {
+		var bodyMap map[string]interface{}
+		if json.Unmarshal(upstreamBody, &bodyMap) == nil && bodyMap != nil {
+			if model, ok := bodyMap["model"].(string); ok && !strings.HasPrefix(model, "google/") {
+				bodyMap["model"] = "google/" + model
+				if prefixed, err := json.Marshal(bodyMap); err == nil {
+					upstreamBody = prefixed
+				}
 			}
 		}
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -670,26 +670,32 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// Check if this is a streaming request (check BEFORE translation).
 	isStreaming := isStreamingRequest(providerName, reqBody)
 
+	// Extract model from request once — reused for pricing gate, body
+	// enrichment, and path rewriting. For most providers the model is in
+	// the request body; for "google" it's in the URL path
+	// (e.g. /v1beta/models/gemini-2.5-flash:generateContent).
+	requestModel, _ := extractRequestInfo(providerName, reqBody)
+	if requestModel == "" {
+		requestModel = extractModelFromURLPath(upstreamPath)
+	}
+
 	// ── Pricing gate (#6) — blocks unpriced cloud models universally ──
 	// This runs for ALL requests (solo, team, local) to prevent untracked
 	// API calls that would show $0 cost. Only "local" provider is exempt.
-	{
-		model, _ := extractRequestInfo(providerName, reqBody)
-		if model != "" && strings.ToLower(providerName) != "local" && !p.calc.HasPricing(providerName, model) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusPaymentRequired)
-			errBody, _ := json.Marshal(map[string]any{
-				"error": map[string]any{
-					"message": "no pricing configured for model " + model + " — contact your admin",
-					"type":    "pricing_not_configured",
-					"code":    402,
-				},
-			})
-			_, _ = w.Write(errBody)
-			slog.Warn("blocked request: no pricing for model",
-				"user_id", effectiveUserID, "provider", providerName, "model", model)
-			return
-		}
+	if requestModel != "" && strings.ToLower(providerName) != "local" && !p.calc.HasPricing(providerName, requestModel) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired)
+		errBody, _ := json.Marshal(map[string]any{
+			"error": map[string]any{
+				"message": "no pricing configured for model " + requestModel + " — contact your admin",
+				"type":    "pricing_not_configured",
+				"code":    402,
+			},
+		})
+		_, _ = w.Write(errBody)
+		slog.Warn("blocked request: no pricing for model",
+			"user_id", effectiveUserID, "provider", providerName, "model", requestModel)
+		return
 	}
 
 	// ── Budget pre-flight with model-aware floor (#7) ──
@@ -767,7 +773,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// signing, Vertex uses Bearer tokens.
 	// NOTE: This block is scoped to Anthropic providers — Gemini providers with
 	// PathRewriter have different body requirements (model prefix, no stripping).
-	isAnthropicPassthrough := providerName == "anthropic-vertex" || providerName == "anthropic-direct"
+	isAnthropicPassthrough := providerName == "anthropic-vertex"
 	if provider.FormatTranslator == nil && provider.PathRewriter != nil && provider.RequestSigner == nil && isAnthropicPassthrough {
 		var bodyMap map[string]interface{}
 		if json.Unmarshal(upstreamBody, &bodyMap) == nil && bodyMap != nil {
@@ -827,14 +833,13 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// Vertex AI's OpenAI-compat endpoint requires model names to include the
 	// publisher prefix (e.g. "google/gemini-2.5-flash"). Transparently inject
 	// the "google/" prefix so clients can send bare model names.
-	if providerName == "gemini-oai" && provider.PathRewriter != nil {
+	// Uses requestModel (extracted once above) to avoid redundant JSON parsing.
+	if providerName == "gemini-oai" && provider.PathRewriter != nil && requestModel != "" && !strings.HasPrefix(requestModel, "google/") {
 		var bodyMap map[string]interface{}
 		if json.Unmarshal(upstreamBody, &bodyMap) == nil && bodyMap != nil {
-			if model, ok := bodyMap["model"].(string); ok && !strings.HasPrefix(model, "google/") {
-				bodyMap["model"] = "google/" + model
-				if prefixed, err := json.Marshal(bodyMap); err == nil {
-					upstreamBody = prefixed
-				}
+			bodyMap["model"] = "google/" + requestModel
+			if prefixed, err := json.Marshal(bodyMap); err == nil {
+				upstreamBody = prefixed
 			}
 		}
 	}
@@ -842,11 +847,11 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// --- Path rewriting ---
 	// If the provider has a PathRewriter, rewrite the upstream URL path
 	// (e.g. Vertex AI project-scoped model endpoints).
-	// When FormatTranslator is nil (e.g. anthropic-vertex), the model comes
-	// from the request body rather than from translation.
+	// Uses translatedModel (from FormatTranslator) or requestModel
+	// (extracted once above from body or URL path).
 	modelForPath := translatedModel
-	if modelForPath == "" && provider.PathRewriter != nil {
-		modelForPath, _ = extractRequestInfo(providerName, reqBody)
+	if modelForPath == "" {
+		modelForPath = requestModel
 	}
 	if provider.PathRewriter != nil && modelForPath != "" {
 		upstreamPath = provider.PathRewriter.RewritePath(modelForPath, isStreaming)
@@ -1629,4 +1634,23 @@ func isUtilityEndpoint(path string) bool {
 		strings.HasSuffix(path, "/tokenize") ||
 		strings.HasSuffix(path, "/models") ||
 		path == "/v1/models"
+}
+
+// extractModelFromURLPath extracts a model name from a Google API URL path.
+// Supports patterns like:
+//
+//	/v1beta/models/gemini-2.5-flash:generateContent → gemini-2.5-flash
+//	/v1/models/gemini-2.5-pro:streamGenerateContent → gemini-2.5-pro
+func extractModelFromURLPath(path string) string {
+	const marker = "/models/"
+	idx := strings.LastIndex(path, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := path[idx+len(marker):]
+	// Strip the method suffix (e.g. ":generateContent").
+	if colon := strings.Index(rest, ":"); colon > 0 {
+		rest = rest[:colon]
+	}
+	return rest
 }

--- a/pkg/proxy/translate.go
+++ b/pkg/proxy/translate.go
@@ -570,6 +570,44 @@ func (r *VertexAIPathRewriter) RewritePath(model string, streaming bool) string 
 }
 
 // ====================================================================
+// VertexAIGeminiOAIPathRewriter — implements PathRewriter
+// ====================================================================
+
+// VertexAIGeminiOAIPathRewriter rewrites URL paths for Vertex AI's OpenAI-compatible
+// Gemini endpoint. The model name is in the request body (not the URL), so this
+// returns a static path to the OpenAI-compat endpoint.
+type VertexAIGeminiOAIPathRewriter struct {
+	ProjectID string // GCP project ID
+	Region    string // GCP region (e.g. "us-central1")
+}
+
+func (r *VertexAIGeminiOAIPathRewriter) RewritePath(model string, streaming bool) string {
+	// Vertex AI's OpenAI-compat endpoint uses a fixed path — model is in the body.
+	return fmt.Sprintf("/v1/projects/%s/locations/%s/endpoints/openapi/chat/completions",
+		r.ProjectID, r.Region)
+}
+
+// ====================================================================
+// VertexAIGooglePathRewriter — implements PathRewriter
+// ====================================================================
+
+// VertexAIGooglePathRewriter rewrites URL paths for Vertex AI's native Gemini
+// publisher endpoint (e.g. publishers/google/models/{model}:generateContent).
+type VertexAIGooglePathRewriter struct {
+	ProjectID string // GCP project ID
+	Region    string // GCP region (e.g. "us-central1")
+}
+
+func (r *VertexAIGooglePathRewriter) RewritePath(model string, streaming bool) string {
+	method := "generateContent"
+	if streaming {
+		method = "streamGenerateContent"
+	}
+	return fmt.Sprintf("/v1/projects/%s/locations/%s/publishers/google/models/%s:%s",
+		r.ProjectID, r.Region, model, method)
+}
+
+// ====================================================================
 // Shared types for OpenAI ↔ Anthropic translation
 // ====================================================================
 


### PR DESCRIPTION
## Problem

The Generative Language API (`generativelanguage.googleapis.com`) does NOT accept OAuth2 ADC tokens — it requires API keys. This means PR #261's ADC injection for `gemini-oai` and `google` providers was insufficient: the Cloud Run service account's ADC credentials were being injected but rejected by the upstream endpoint.

## Solution

When Vertex AI is configured (`ProjectID` set), redirect Gemini providers to the Vertex AI endpoint which natively accepts ADC tokens:

### `gemini-oai` (OpenAI-compatible)
- **Upstream**: `https://{region}-aiplatform.googleapis.com`
- **Path**: `/v1/projects/{P}/locations/{R}/endpoints/openapi/chat/completions`
- **Body**: Transparently injects `google/` model prefix (Vertex requirement)

### `google` (native API)
- **Upstream**: `https://{region}-aiplatform.googleapis.com`
- **Path**: `/v1/projects/{P}/locations/{R}/publishers/google/models/{M}:{method}`
- **Method**: Maps streaming to `streamGenerateContent`, non-streaming to `generateContent`

### Scoping fix
- Gates the Anthropic body enrichment block (anthropic_version injection + model stripping) to only Anthropic providers, preventing it from interfering with Gemini routes that also have PathRewriter set.

## Files Changed
- `pkg/proxy/translate.go`: Add `VertexAIGeminiOAIPathRewriter` and `VertexAIGooglePathRewriter`
- `pkg/proxy/proxy.go`: Scope Anthropic enrichment + add Gemini model prefix injection
- `cmd/candela-server/main.go`: Wire both Gemini providers through Vertex AI

## Testing
- All proxy tests pass
- Verified Vertex AI OpenAI-compat endpoint accepts ADC + `google/` prefixed models via curl