### PR TITLE
fix(server): route Gemini via generativelanguage.googleapis.com

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -237,11 +237,9 @@ func main() {
 		// (generativelanguage.googleapis.com) which accepts ADC OAuth2 tokens,
 		// avoiding regional model availability issues entirely.
 
-		// Attach FormatTranslator + PathRewriter + ADC to providers when
-		// Vertex AI is configured. This handles:
-		//   - anthropic / anthropic-vertex → Vertex AI rawPredict (regional)
-		//   - gemini-oai → Generative Language API (OpenAI-compat)
-		//   - google → Generative Language API (native)
+		// Attach FormatTranslator + PathRewriter + ADC to Anthropic providers
+		// when Vertex AI is configured. Anthropic routes through regional
+		// Vertex AI publisher endpoints (rawPredict/streamRawPredict).
 		if cfg.Proxy.VertexAI.ProjectID != "" {
 			region := cfg.Proxy.VertexAI.Region
 			if region == "" {
@@ -275,30 +273,38 @@ func main() {
 						"adc", tokenSource != nil,
 						"format_translation", p.Name == "anthropic",
 						"caching_mode", cfg.Proxy.VertexAI.CachingMode)
-
-				case "gemini-oai":
-					// Route through Google Generative Language API (OpenAI-compat).
-					// No Vertex AI, no region — avoids regional model availability issues.
-					// ADC OAuth tokens work with generativelanguage.googleapis.com.
-					allProviders[i].UpstreamURL = "https://generativelanguage.googleapis.com/v1beta/openai"
-					if tokenSource != nil {
-						allProviders[i].TokenSource = tokenSource
-					}
-					slog.Info("🔐 Gemini-OAI via Generative Language API configured",
-						"provider", p.Name,
-						"adc", tokenSource != nil)
-
-				case "google":
-					// Route through Google Generative Language API (native).
-					// No Vertex AI, no region — avoids regional model availability issues.
-					allProviders[i].UpstreamURL = "https://generativelanguage.googleapis.com"
-					if tokenSource != nil {
-						allProviders[i].TokenSource = tokenSource
-					}
-					slog.Info("🔐 Google native via Generative Language API configured",
-						"provider", p.Name,
-						"adc", tokenSource != nil)
 				}
+			}
+		}
+
+		// Configure Gemini providers — these route through the Google
+		// Generative Language API (generativelanguage.googleapis.com), which
+		// accepts ADC OAuth2 tokens and avoids regional model availability issues.
+		// No Vertex AI ProjectID required.
+		for i, p := range allProviders {
+			switch p.Name {
+			case "gemini-oai":
+				// OpenAI-compatible endpoint. The PathRewriter strips /v1 so
+				// clients sending /v1/chat/completions hit the correct upstream
+				// path at /v1beta/openai/chat/completions.
+				allProviders[i].UpstreamURL = "https://generativelanguage.googleapis.com/v1beta/openai"
+				allProviders[i].PathRewriter = &proxy.GenLangOAIPathRewriter{}
+				if tokenSource != nil {
+					allProviders[i].TokenSource = tokenSource
+				}
+				slog.Info("🔐 Gemini-OAI via Generative Language API configured",
+					"provider", p.Name,
+					"adc", tokenSource != nil)
+
+			case "google":
+				// Native Gemini endpoint — path is forwarded as-is from client.
+				allProviders[i].UpstreamURL = "https://generativelanguage.googleapis.com"
+				if tokenSource != nil {
+					allProviders[i].TokenSource = tokenSource
+				}
+				slog.Info("🔐 Google native via Generative Language API configured",
+					"provider", p.Name,
+					"adc", tokenSource != nil)
 			}
 		}
 

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -233,26 +233,20 @@ func main() {
 				"error", adcErr)
 		}
 
-		// NOTE: Gemini/Google ADC is NOT configured here for the Generative
-		// Language API (generativelanguage.googleapis.com) because that endpoint
-		// does NOT accept OAuth2 ADC tokens — it requires API keys. Instead,
-		// when Vertex AI is configured below, Gemini routes are redirected to
-		// the Vertex AI endpoint which natively accepts ADC tokens.
+		// NOTE: Gemini/Google providers use the Generative Language API
+		// (generativelanguage.googleapis.com) which accepts ADC OAuth2 tokens,
+		// avoiding regional model availability issues entirely.
 
 		// Attach FormatTranslator + PathRewriter + ADC to providers when
 		// Vertex AI is configured. This handles:
-		//   - anthropic / anthropic-vertex → Vertex AI rawPredict
-		//   - gemini-oai → Vertex AI OpenAI-compat endpoint
-		//   - google → Vertex AI native Gemini publisher endpoint
+		//   - anthropic / anthropic-vertex → Vertex AI rawPredict (regional)
+		//   - gemini-oai → Generative Language API (OpenAI-compat)
+		//   - google → Generative Language API (native)
 		if cfg.Proxy.VertexAI.ProjectID != "" {
 			region := cfg.Proxy.VertexAI.Region
 			if region == "" {
 				region = "us-central1"
 			}
-
-			// Gemini 3.x models are only available on the global endpoint.
-			// Anthropic models require a regional endpoint.
-			geminiRegion := "global"
 
 			for i, p := range allProviders {
 				switch p.Name {
@@ -283,38 +277,26 @@ func main() {
 						"caching_mode", cfg.Proxy.VertexAI.CachingMode)
 
 				case "gemini-oai":
-					// Route through Vertex AI's OpenAI-compatible endpoint.
-					// Path: /v1/projects/{P}/locations/{R}/endpoints/openapi/chat/completions
-					// Model prefix "google/" is injected by proxy body enrichment.
-					allProviders[i].UpstreamURL = proxy.VertexAIUpstreamURL(geminiRegion)
-					allProviders[i].PathRewriter = &proxy.VertexAIGeminiOAIPathRewriter{
-						ProjectID: cfg.Proxy.VertexAI.ProjectID,
-						Region:    geminiRegion,
-					}
+					// Route through Google Generative Language API (OpenAI-compat).
+					// No Vertex AI, no region — avoids regional model availability issues.
+					// ADC OAuth tokens work with generativelanguage.googleapis.com.
+					allProviders[i].UpstreamURL = "https://generativelanguage.googleapis.com/v1beta/openai"
 					if tokenSource != nil {
 						allProviders[i].TokenSource = tokenSource
 					}
-					slog.Info("🔐 Gemini-OAI via Vertex AI configured",
+					slog.Info("🔐 Gemini-OAI via Generative Language API configured",
 						"provider", p.Name,
-						"project", cfg.Proxy.VertexAI.ProjectID,
-						"region", geminiRegion,
 						"adc", tokenSource != nil)
 
 				case "google":
-					// Route through Vertex AI's native Gemini publisher endpoint.
-					// Path: /v1/projects/{P}/locations/{R}/publishers/google/models/{M}:{method}
-					allProviders[i].UpstreamURL = proxy.VertexAIUpstreamURL(geminiRegion)
-					allProviders[i].PathRewriter = &proxy.VertexAIGooglePathRewriter{
-						ProjectID: cfg.Proxy.VertexAI.ProjectID,
-						Region:    geminiRegion,
-					}
+					// Route through Google Generative Language API (native).
+					// No Vertex AI, no region — avoids regional model availability issues.
+					allProviders[i].UpstreamURL = "https://generativelanguage.googleapis.com"
 					if tokenSource != nil {
 						allProviders[i].TokenSource = tokenSource
 					}
-					slog.Info("🔐 Google native via Vertex AI configured",
+					slog.Info("🔐 Google native via Generative Language API configured",
 						"provider", p.Name,
-						"project", cfg.Proxy.VertexAI.ProjectID,
-						"region", geminiRegion,
 						"adc", tokenSource != nil)
 				}
 			}

--- a/pkg/proxy/translate.go
+++ b/pkg/proxy/translate.go
@@ -618,6 +618,24 @@ func (r *VertexAIGooglePathRewriter) RewritePath(model string, streaming bool) s
 }
 
 // ====================================================================
+// GenLangOAIPathRewriter — implements PathRewriter
+// ====================================================================
+
+// GenLangOAIPathRewriter rewrites URL paths for the Google Generative Language
+// API's OpenAI-compatible endpoint. OpenAI SDK clients send paths like
+// /v1/chat/completions, but the GenLang upstream is already mounted at
+// /v1beta/openai, so we strip the /v1 prefix to produce the correct path
+// (e.g. /chat/completions).
+type GenLangOAIPathRewriter struct{}
+
+func (r *GenLangOAIPathRewriter) RewritePath(_ string, _ bool) string {
+	// The GenLang OpenAI-compat endpoint uses a static path; model is in the body.
+	// Stripping /v1 from /v1/chat/completions → /chat/completions, which the
+	// proxy appends to UpstreamURL (https://generativelanguage.googleapis.com/v1beta/openai).
+	return "/chat/completions"
+}
+
+// ====================================================================
 // Shared types for OpenAI ↔ Anthropic translation
 // ====================================================================
 


### PR DESCRIPTION
## What

Route Gemini providers (`gemini-oai`, `google`) through the **Generative Language API** (`generativelanguage.googleapis.com`) instead of Vertex AI publisher endpoints.

## Why

Gemini 3.x models return 404s on regional Vertex AI endpoints and even the `global` endpoint is unreliable. The Generative Language API:
- Has **no region dependency** — eliminates the entire class of regional availability errors
- Accepts **ADC OAuth2 tokens** — no API key management needed
- Matches the routing strategy already used by the **local CLI** (`cmd/candela/main.go`)

## What Changed

- `gemini-oai`: upstream → `https://generativelanguage.googleapis.com/v1beta/openai` (no PathRewriter)
- `google`: upstream → `https://generativelanguage.googleapis.com` (no PathRewriter)
- Removed `geminiRegion` variable — no longer needed
- Updated comments to reflect the new routing architecture
- **Anthropic providers unchanged** — still use Vertex AI regional endpoints

## Testing

All pre-commit hooks pass (gofmt, go-vet, golangci-lint, go-test).