### PR TITLE
fix(proxy): switch Gemini from GenLang API to Vertex AI global endpoint

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -233,9 +233,9 @@ func main() {
 				"error", adcErr)
 		}
 
-		// NOTE: Gemini/Google providers use the Generative Language API
-		// (generativelanguage.googleapis.com) which accepts ADC OAuth2 tokens,
-		// avoiding regional model availability issues entirely.
+		// NOTE: Gemini/Google providers are configured below to use the Vertex AI
+		// global endpoint. This avoids regional model availability issues
+		// and natively accepts ADC OAuth2 tokens.
 
 		// Attach FormatTranslator + PathRewriter + ADC to Anthropic providers
 		// when Vertex AI is configured. Anthropic routes through regional
@@ -320,7 +320,16 @@ func main() {
 				}
 			}
 		} else {
-			slog.Warn("⚠️ Gemini providers require vertex_ai.project_id — gemini-oai and google providers will not be available")
+			// Without a project ID, Gemini providers can't route to Vertex AI.
+			// Remove them from allProviders to prevent broken defaults.
+			slog.Warn("⚠️ Gemini providers require vertex_ai.project_id — gemini-oai and google providers will be disabled")
+			var filtered []proxy.Provider
+			for _, p := range allProviders {
+				if p.Name != "gemini-oai" && p.Name != "google" {
+					filtered = append(filtered, p)
+				}
+			}
+			allProviders = filtered
 		}
 
 		var activeProviders []proxy.Provider

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -277,35 +277,50 @@ func main() {
 			}
 		}
 
-		// Configure Gemini providers — these route through the Google
-		// Generative Language API (generativelanguage.googleapis.com), which
-		// accepts ADC OAuth2 tokens and avoids regional model availability issues.
-		// No Vertex AI ProjectID required.
-		for i, p := range allProviders {
-			switch p.Name {
-			case "gemini-oai":
-				// OpenAI-compatible endpoint. The PathRewriter strips /v1 so
-				// clients sending /v1/chat/completions hit the correct upstream
-				// path at /v1beta/openai/chat/completions.
-				allProviders[i].UpstreamURL = "https://generativelanguage.googleapis.com/v1beta/openai"
-				allProviders[i].PathRewriter = &proxy.GenLangOAIPathRewriter{}
-				if tokenSource != nil {
-					allProviders[i].TokenSource = tokenSource
-				}
-				slog.Info("🔐 Gemini-OAI via Generative Language API configured",
-					"provider", p.Name,
-					"adc", tokenSource != nil)
+		// Configure Gemini providers — these route through Vertex AI's
+		// global OpenAI-compatible endpoint (aiplatform.googleapis.com with
+		// locations/global). This accepts ADC OAuth2 tokens and avoids
+		// regional model availability issues.
+		// Requires a ProjectID for the endpoint path.
+		geminiProjectID := cfg.Proxy.VertexAI.ProjectID
+		if geminiProjectID != "" {
+			for i, p := range allProviders {
+				switch p.Name {
+				case "gemini-oai":
+					// OpenAI-compatible endpoint via Vertex AI global.
+					// Path: /v1/projects/{project}/locations/global/endpoints/openapi/chat/completions
+					// Model names require "google/" prefix (injected by handleProxy).
+					allProviders[i].UpstreamURL = proxy.VertexAIUpstreamURL("global")
+					allProviders[i].PathRewriter = &proxy.VertexAIGeminiOAIPathRewriter{
+						ProjectID: geminiProjectID,
+						Region:    "global",
+					}
+					if tokenSource != nil {
+						allProviders[i].TokenSource = tokenSource
+					}
+					slog.Info("🔐 Gemini-OAI via Vertex AI global endpoint configured",
+						"provider", p.Name,
+						"project", geminiProjectID,
+						"adc", tokenSource != nil)
 
-			case "google":
-				// Native Gemini endpoint — path is forwarded as-is from client.
-				allProviders[i].UpstreamURL = "https://generativelanguage.googleapis.com"
-				if tokenSource != nil {
-					allProviders[i].TokenSource = tokenSource
+				case "google":
+					// Native Gemini endpoint via Vertex AI global.
+					allProviders[i].UpstreamURL = proxy.VertexAIUpstreamURL("global")
+					allProviders[i].PathRewriter = &proxy.VertexAIGooglePathRewriter{
+						ProjectID: geminiProjectID,
+						Region:    "global",
+					}
+					if tokenSource != nil {
+						allProviders[i].TokenSource = tokenSource
+					}
+					slog.Info("🔐 Google native via Vertex AI global endpoint configured",
+						"provider", p.Name,
+						"project", geminiProjectID,
+						"adc", tokenSource != nil)
 				}
-				slog.Info("🔐 Google native via Generative Language API configured",
-					"provider", p.Name,
-					"adc", tokenSource != nil)
 			}
+		} else {
+			slog.Warn("⚠️ Gemini providers require vertex_ai.project_id — gemini-oai and google providers will not be available")
 		}
 
 		var activeProviders []proxy.Provider

--- a/pkg/proxy/translate.go
+++ b/pkg/proxy/translate.go
@@ -618,24 +618,6 @@ func (r *VertexAIGooglePathRewriter) RewritePath(model string, streaming bool) s
 }
 
 // ====================================================================
-// GenLangOAIPathRewriter — implements PathRewriter
-// ====================================================================
-
-// GenLangOAIPathRewriter rewrites URL paths for the Google Generative Language
-// API's OpenAI-compatible endpoint. OpenAI SDK clients send paths like
-// /v1/chat/completions, but the GenLang upstream is already mounted at
-// /v1beta/openai, so we strip the /v1 prefix to produce the correct path
-// (e.g. /chat/completions).
-type GenLangOAIPathRewriter struct{}
-
-func (r *GenLangOAIPathRewriter) RewritePath(_ string, _ bool) string {
-	// The GenLang OpenAI-compat endpoint uses a static path; model is in the body.
-	// Stripping /v1 from /v1/chat/completions → /chat/completions, which the
-	// proxy appends to UpstreamURL (https://generativelanguage.googleapis.com/v1beta/openai).
-	return "/chat/completions"
-}
-
-// ====================================================================
 // Shared types for OpenAI ↔ Anthropic translation
 // ====================================================================
 


### PR DESCRIPTION
## Problem

The `generativelanguage.googleapis.com` API rejects standard ADC OAuth2 Bearer tokens with `401 UNAUTHENTICATED` on its OpenAI-compatible REST path (`/v1beta/openai/chat/completions`).

The Go client library for GenLang works because it uses **gRPC with auto-injected quota project headers** — but our raw HTTP proxy cannot replicate that transport-level auth.

### Reproduction

```bash
# GenLang API — FAILS
curl -X POST https://generativelanguage.googleapis.com/v1beta/openai/chat/completions \
  -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
  -H "Content-Type: application/json" \
  -d '{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"hi"}]}'
# → 401 UNAUTHENTICATED

# Vertex AI global — WORKS
curl -X POST https://aiplatform.googleapis.com/v1/projects/PROJECT/locations/global/endpoints/openapi/chat/completions \
  -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
  -H "Content-Type: application/json" \
  -d '{"model":"google/gemini-2.5-flash","messages":[{"role":"user","content":"hi"}]}'
# → 200 OK
```

## Solution

Switch both `gemini-oai` and `google` providers from `generativelanguage.googleapis.com` to `aiplatform.googleapis.com` with `locations/global`.

### Why Vertex AI global?
- ✅ Accepts standard ADC Bearer tokens (OAuth2 `cloud-platform` scope)
- ✅ All models available globally (no regional 404s like `us-east5`)
- ✅ Project context embedded in URL path (no extra headers needed)
- ✅ Reuses existing `VertexAIGeminiOAIPathRewriter` and `VertexAIUpstreamURL()` helpers

### What changed
- **`cmd/candela-server/main.go`**: Switched Gemini provider config to use Vertex AI global endpoint with `cfg.Proxy.VertexAI.ProjectID` (already set via `CANDELA_VERTEX_PROJECT` on Cloud Run).

### Deployment
No env var changes needed — `CANDELA_VERTEX_PROJECT=your-gcp-project` is already configured on the Cloud Run service.