### PR TITLE
feat(phase5): OTel span instrumentation for MITM + Helm trust injection

### DIFF
--- a/deploy/helm/candela-sidecar/README.md
+++ b/deploy/helm/candela-sidecar/README.md
@@ -90,6 +90,67 @@ This single config generates:
 
 > ⚠️ **Tetragon and transparent proxy are mutually exclusive.** Tetragon kprobes fire at the syscall level *before* iptables NAT, so they would kill the app process before the proxy can intercept. The Helm chart will fail if both are enabled.
 
+## MITM TLS Termination
+
+When `mitm.enabled=true`, the sidecar generates an ephemeral CA at startup and performs TLS termination on intercepted LLM traffic. This enables **request-level observability** (model, tokens, cost) without requiring SDK modifications.
+
+### How It Works
+
+```
+App Container                Sidecar Container
+┌──────────┐   TLS (ephemeral cert)   ┌──────────────────┐   plaintext   ┌────────┐   TLS   ┌──────────┐
+│ curl/SDK │ ────────────────────────► │ Transparent      │ ────────────► │ HTTP   │ ──────► │ Upstream │
+│          │                           │ Listener :15001  │               │ Proxy  │         │ LLM API  │
+└──────────┘                           └──────────────────┘               │ :8080  │         └──────────┘
+     ▲                                        │                           └────────┘
+     │ trusts CA via SSL_CERT_FILE            │ writes CA PEM
+     └────────────────────────────────────────┘
+              /var/run/candela/ca.pem (emptyDir volume)
+```
+
+### Enable MITM
+
+```bash
+helm install candela-sidecar deploy/helm/candela-sidecar/ \
+  --set transparent.enabled=true \
+  --set iptables.enabled=true \
+  --set mitm.enabled=true \
+  --set gcpProject=my-project
+```
+
+The Helm chart generates a `ConfigMap` with sidecar container spec fragments
+and trust injection env vars. Merge these into your Deployment:
+
+1. **Add the sidecar container** (from `sidecar.yaml` in the ConfigMap)
+2. **Add the `candela-ca` emptyDir volume** to the pod spec
+3. **Mount the volume** in the application container (read-only)
+4. **Set trust env vars** (`SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`)
+
+### Provider Opt-Out
+
+Providers with certificate pinning can opt out of MITM while still being
+intercepted for connection-level metrics:
+
+```yaml
+providers:
+  - name: openai
+    host: api.openai.com
+    intercept: true
+    mitm: true    # default
+  - name: pinned-service
+    host: pinned.example.com
+    intercept: true
+    mitm: false   # tunnel passthrough, no TLS termination
+```
+
+### W3C Trace Context
+
+The MITM layer is protocol-transparent — it performs byte-level
+`copy_bidirectional` between the decrypted TLS stream and the proxy.
+W3C `traceparent` headers in the client's HTTP request propagate
+naturally to the proxy handler, which already parses them for span
+correlation. No header injection is needed.
+
 ## Monitoring
 
 The transparent proxy exposes stats via:

--- a/deploy/helm/candela-sidecar/templates/mitm-configmap.yaml
+++ b/deploy/helm/candela-sidecar/templates/mitm-configmap.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.mitm.enabled }}
+# MITM TLS termination sidecar resources.
+# This ConfigMap provides a Pod mutating template for injecting the
+# Candela sidecar with MITM capabilities into application deployments.
+#
+# Usage: Mount these volumes and env vars alongside the sidecar container.
+# See the README for integration patterns.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "candela-sidecar.fullname" . }}-mitm
+  labels:
+    {{- include "candela-sidecar.labels" . | nindent 4 }}
+data:
+  # Sidecar container spec fragment (JSON Patch compatible).
+  # Operators can reference this to build mutating webhook patches
+  # or manually merge into Deployment specs.
+  sidecar.yaml: |
+    # ── Sidecar container ──
+    containers:
+      - name: candela-sidecar
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+          - name: proxy
+            containerPort: 8080
+            protocol: TCP
+          {{- if .Values.transparent.enabled }}
+          - name: transparent
+            containerPort: {{ .Values.transparent.port }}
+            protocol: TCP
+          {{- end }}
+        env:
+          - name: PORT
+            value: "8080"
+          {{- if .Values.gcpProject }}
+          - name: GCP_PROJECT
+            value: {{ .Values.gcpProject | quote }}
+          {{- end }}
+          {{- if .Values.candelaProjectId }}
+          - name: CANDELA_PROJECT_ID
+            value: {{ .Values.candelaProjectId | quote }}
+          {{- end }}
+          {{- if .Values.transparent.enabled }}
+          - name: TRANSPARENT_PORT
+            value: {{ .Values.transparent.port | quote }}
+          {{- end }}
+          - name: MITM_CA_ENABLED
+            value: "true"
+          - name: MITM_CA_PEM_PATH
+            value: {{ .Values.mitm.caPemPath | quote }}
+          {{- if .Values.pubsub.topic }}
+          - name: PUBSUB_TOPIC
+            value: {{ .Values.pubsub.topic | quote }}
+          - name: SPAN_FORMAT
+            value: {{ .Values.pubsub.format | quote }}
+          {{- end }}
+          {{- if .Values.otlp.endpoint }}
+          - name: OTLP_ENDPOINT
+            value: {{ .Values.otlp.endpoint | quote }}
+          {{- end }}
+          {{- if .Values.otlp.headers }}
+          - name: OTLP_HEADERS
+            value: {{ .Values.otlp.headers | quote }}
+          {{- end }}
+          - name: CORS_ORIGINS
+            value: {{ .Values.cors.origins | quote }}
+          - name: PROVIDERS
+            value: {{ include "candela-sidecar.providerNames" . | quote }}
+        volumeMounts:
+          - name: {{ .Values.mitm.caVolume.name }}
+            mountPath: {{ .Values.mitm.caVolume.mountPath }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+
+    # ── Volume definition (add to pod spec) ──
+    volumes:
+      - name: {{ .Values.mitm.caVolume.name }}
+        emptyDir:
+          sizeLimit: 1Mi
+
+  # Application container env vars for CA trust injection.
+  # Add these to the application container's env section.
+  trust-env.yaml: |
+    env:
+    {{- range $key, $value := .Values.mitm.trustEnv }}
+    {{- if $value }}
+      - name: {{ $key }}
+        value: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+
+  # Application container volumeMount for CA PEM access.
+  trust-volume.yaml: |
+    volumeMounts:
+      - name: {{ .Values.mitm.caVolume.name }}
+        mountPath: {{ .Values.mitm.caVolume.mountPath }}
+        readOnly: true
+{{- end }}

--- a/deploy/helm/candela-sidecar/values.yaml
+++ b/deploy/helm/candela-sidecar/values.yaml
@@ -50,6 +50,27 @@ transparent:
   enabled: false
   port: 15001
 
+# ── MITM TLS termination ──
+# When enabled, the sidecar generates an ephemeral CA at startup and
+# terminates TLS for intercepted LLM traffic, forwarding decrypted
+# bytes to the HTTP proxy for request-level observability.
+mitm:
+  enabled: false
+  # Path where the sidecar writes the ephemeral CA PEM.
+  caPemPath: "/var/run/candela/ca.pem"
+  # Shared volume for CA PEM trust injection (emptyDir).
+  # The sidecar writes the CA cert here; the application reads it via
+  # SSL_CERT_FILE / REQUESTS_CA_BUNDLE / NODE_EXTRA_CA_CERTS.
+  caVolume:
+    name: candela-ca
+    mountPath: "/var/run/candela"
+  # Environment variables injected into the application container
+  # to trust the ephemeral CA. Set to empty string to disable.
+  trustEnv:
+    SSL_CERT_FILE: "/var/run/candela/ca.pem"
+    REQUESTS_CA_BUNDLE: "/var/run/candela/ca.pem"
+    NODE_EXTRA_CA_CERTS: "/var/run/candela/ca.pem"
+
 # ── iptables init container ──
 iptables:
   enabled: false

--- a/rust/crates/candela-transparent/src/mitm.rs
+++ b/rust/crates/candela-transparent/src/mitm.rs
@@ -67,8 +67,22 @@ pub async fn mitm_intercept(
     async {
         let start = Instant::now();
 
+        // Helper: record duration_ms on the current span regardless of
+        // which exit path we take. This ensures OTLP exporters always
+        // see the total MITM attempt duration.
+        let record_duration = || {
+            tracing::Span::current()
+                .record("duration_ms", start.elapsed().as_millis() as u64);
+        };
+
         // 1. Get the TLS ServerConfig for this hostname.
-        let server_config = ca.server_config_for(sni)?;
+        let server_config = ca.server_config_for(sni).map_err(|e| {
+            let current = tracing::Span::current();
+            current.record("handshake_ok", false);
+            current.record("duration_ms", start.elapsed().as_millis() as u64);
+            debug!(sni = %sni, error = %e, "MITM cert generation failed");
+            e
+        })?;
         let acceptor = TlsAcceptor::from(server_config);
 
         // 2. Replay the peeked ClientHello.
@@ -78,7 +92,9 @@ pub async fn mitm_intercept(
 
         // 3. Accept TLS handshake.
         let tls_stream = acceptor.accept(replay).await.map_err(|e| {
-            tracing::Span::current().record("handshake_ok", false);
+            let current = tracing::Span::current();
+            current.record("handshake_ok", false);
+            current.record("duration_ms", start.elapsed().as_millis() as u64);
             debug!(sni = %sni, error = %e, "MITM TLS handshake failed");
             anyhow::anyhow!("TLS handshake failed for {sni}: {e}")
         })?;
@@ -93,7 +109,13 @@ pub async fn mitm_intercept(
         let mut proxy_stream =
             tokio::time::timeout(PROXY_DIAL_TIMEOUT, TcpStream::connect(proxy_addr))
                 .await
-                .map_err(|_| anyhow::anyhow!("proxy dial timeout to {proxy_addr}"))??;
+                .map_err(|_| {
+                    record_duration();
+                    anyhow::anyhow!("proxy dial timeout to {proxy_addr}")
+                })?
+                .inspect_err(|_| {
+                    record_duration();
+                })?;
 
         // 5. Bidirectional copy: decrypted client ↔ plaintext proxy.
         //    copy_bidirectional drains both directions fully before closing,
@@ -110,13 +132,13 @@ pub async fn mitm_intercept(
                     sni = %sni,
                     client_to_proxy,
                     proxy_to_client,
-                    duration_ms = %start.elapsed().as_millis(),
+                    duration_ms = start.elapsed().as_millis() as u64,
                     "MITM bidirectional copy completed"
                 );
             }
             Err(e) => {
-                tracing::Span::current().record("duration_ms", start.elapsed().as_millis() as u64);
-                debug!(sni = %sni, error = %e, "MITM bidirectional copy error");
+                record_duration();
+                debug!(sni = %sni, error = %e, duration_ms = start.elapsed().as_millis() as u64, "MITM bidirectional copy error");
             }
         }
 
@@ -357,6 +379,142 @@ mod tests {
             stats.mitm.load(Ordering::Relaxed),
             1,
             "MITM counter should be 1"
+        );
+    }
+
+    /// Verifies that mitm_intercept returns an error and does NOT increment
+    /// stats when the proxy address is unreachable (exercises the proxy dial
+    /// timeout error path, which should record duration_ms on the span).
+    #[tokio::test]
+    async fn mitm_intercept_proxy_unreachable_returns_error() {
+        install_crypto_provider();
+        use std::sync::Arc;
+        use tokio::net::TcpListener;
+
+        let ca = Arc::new(EphemeralCA::generate().unwrap());
+        let stats = Arc::new(Stats::default());
+
+        // Bind a listener for the MITM side, but point proxy_addr at a
+        // port nothing is listening on.
+        let mitm_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mitm_addr = mitm_listener.local_addr().unwrap();
+
+        // Use a port that will refuse connections.
+        let bad_proxy_addr = "127.0.0.1:1"; // port 1 — almost certainly refused
+
+        let ca_clone = Arc::clone(&ca);
+        let stats_clone = Arc::clone(&stats);
+        let proxy_str = bad_proxy_addr.to_string();
+
+        let mitm_handle = tokio::spawn(async move {
+            let (stream, _) = mitm_listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 16384];
+            let n = stream.peek(&mut buf).await.unwrap();
+            let peeked = buf[..n].to_vec();
+            let mut stream2 = stream;
+            let mut discard = vec![0u8; n];
+            stream2.read_exact(&mut discard).await.unwrap();
+
+            mitm_intercept(
+                stream2,
+                &peeked,
+                "unreachable.example.com",
+                &ca_clone,
+                &proxy_str,
+                &stats_clone,
+            )
+            .await
+        });
+
+        // Connect a TLS client.
+        let mut root_store = rustls::RootCertStore::empty();
+        root_store.add(ca.ca_cert_der.clone()).unwrap();
+        let client_cfg = Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(root_store)
+                .with_no_client_auth(),
+        );
+        let connector = tokio_rustls::TlsConnector::from(client_cfg);
+        let server_name = rustls::pki_types::ServerName::try_from("unreachable.example.com")
+            .unwrap()
+            .to_owned();
+
+        let tcp = TcpStream::connect(mitm_addr).await.unwrap();
+        // The TLS handshake should succeed (the MITM accepts it), but then
+        // the proxy dial should fail.
+        let tls_result = connector.connect(server_name, tcp).await;
+        // The handshake may succeed or fail depending on timing. Either way,
+        // the MITM handler should complete with an error.
+        drop(tls_result);
+
+        let result = tokio::time::timeout(Duration::from_secs(10), mitm_handle)
+            .await
+            .expect("MITM handler should complete");
+        let inner = result.expect("task should not panic");
+        assert!(inner.is_err(), "should error on unreachable proxy");
+
+        // Stats should NOT be incremented on failure.
+        assert_eq!(
+            stats.mitm.load(Ordering::Relaxed),
+            0,
+            "MITM counter should remain 0 on error"
+        );
+    }
+
+    /// Verifies that sending non-TLS garbage data results in a handshake
+    /// failure error (exercises the handshake_ok=false span recording path).
+    #[tokio::test]
+    async fn mitm_intercept_non_tls_data_returns_error() {
+        install_crypto_provider();
+        use std::sync::Arc;
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+
+        let ca = Arc::new(EphemeralCA::generate().unwrap());
+        let stats = Arc::new(Stats::default());
+
+        let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let echo_addr = echo_listener.local_addr().unwrap();
+
+        let mitm_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mitm_addr = mitm_listener.local_addr().unwrap();
+
+        let ca_clone = Arc::clone(&ca);
+        let stats_clone = Arc::clone(&stats);
+        let proxy_addr_str = echo_addr.to_string();
+
+        let mitm_handle = tokio::spawn(async move {
+            let (stream, _) = mitm_listener.accept().await.unwrap();
+            // Simulate peeking some garbage "ClientHello".
+            let garbage = b"NOT A TLS CLIENT HELLO";
+            mitm_intercept(
+                stream,
+                garbage,
+                "garbage.example.com",
+                &ca_clone,
+                &proxy_addr_str,
+                &stats_clone,
+            )
+            .await
+        });
+
+        // Connect and send garbage (non-TLS) data.
+        let mut tcp = TcpStream::connect(mitm_addr).await.unwrap();
+        tcp.write_all(b"GET / HTTP/1.1\r\nHost: garbage.example.com\r\n\r\n")
+            .await
+            .unwrap();
+
+        let result = tokio::time::timeout(Duration::from_secs(5), mitm_handle)
+            .await
+            .expect("MITM handler should complete");
+        let inner = result.expect("task should not panic");
+        assert!(inner.is_err(), "should error on non-TLS handshake");
+
+        // Stats should NOT be incremented on failure.
+        assert_eq!(
+            stats.mitm.load(Ordering::Relaxed),
+            0,
+            "MITM counter should remain 0 on handshake failure"
         );
     }
 }

--- a/rust/crates/candela-transparent/src/mitm.rs
+++ b/rust/crates/candela-transparent/src/mitm.rs
@@ -4,15 +4,23 @@
 //! then forwards the decrypted bytes to the Candela HTTP proxy via a
 //! plaintext TCP connection. The interceptor is fully protocol-transparent:
 //! it performs byte-level `copy_bidirectional` without parsing HTTP.
+//!
+//! **Trace context propagation:** The MITM layer does NOT inject or modify
+//! HTTP headers — it operates at the byte level. W3C `traceparent` headers
+//! propagate naturally: the client's HTTP request (including trace headers)
+//! flows through the decrypted TLS stream → plaintext to the proxy handler,
+//! which already parses `traceparent` (see `handler.rs`). The `#[instrument]`
+//! spans here provide sidecar-internal observability for the MITM lifecycle
+//! itself (handshake timing, byte counts, errors).
 
 use std::io::Cursor;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::io::{self, AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
 use tokio_rustls::TlsAcceptor;
-use tracing::debug;
+use tracing::{Instrument, debug, info_span};
 
 use crate::ca::EphemeralCA;
 use crate::listener::Stats;
@@ -28,6 +36,11 @@ const PROXY_DIAL_TIMEOUT: Duration = Duration::from_secs(5);
 /// 4. Bidirectionally copies bytes between the decrypted TLS stream and
 ///    the proxy connection.
 ///
+/// The function is instrumented with a `tracing` span (`mitm.tls_termination`)
+/// that records SNI, proxy address, handshake success, and byte counts.
+/// When the sidecar exports to an OTLP collector, these spans provide
+/// visibility into the MITM lifecycle alongside the proxy's LLM spans.
+///
 /// # Errors
 ///
 /// Returns an error if any step fails (cert generation, TLS handshake,
@@ -40,49 +53,78 @@ pub async fn mitm_intercept(
     proxy_addr: &str,
     stats: &Stats,
 ) -> anyhow::Result<()> {
-    // 1. Get the TLS ServerConfig for this hostname.
-    let server_config = ca.server_config_for(sni)?;
-    let acceptor = TlsAcceptor::from(server_config);
+    let span = info_span!(
+        "mitm.tls_termination",
+        sni = %sni,
+        proxy_addr = %proxy_addr,
+        handshake_ok = tracing::field::Empty,
+        handshake_ms = tracing::field::Empty,
+        bytes_client_to_proxy = tracing::field::Empty,
+        bytes_proxy_to_client = tracing::field::Empty,
+        duration_ms = tracing::field::Empty,
+    );
 
-    // 2. Replay the peeked ClientHello.
-    //    We already consumed these bytes from the socket; we need to
-    //    prepend them so the TLS acceptor sees the full handshake.
-    let replay = ReplayStream::new(peeked, client);
+    async {
+        let start = Instant::now();
 
-    // 3. Accept TLS handshake.
-    let tls_stream = acceptor.accept(replay).await.map_err(|e| {
-        debug!(sni = %sni, error = %e, "MITM TLS handshake failed");
-        anyhow::anyhow!("TLS handshake failed for {sni}: {e}")
-    })?;
+        // 1. Get the TLS ServerConfig for this hostname.
+        let server_config = ca.server_config_for(sni)?;
+        let acceptor = TlsAcceptor::from(server_config);
 
-    debug!(sni = %sni, "MITM TLS handshake succeeded");
+        // 2. Replay the peeked ClientHello.
+        //    We already consumed these bytes from the socket; we need to
+        //    prepend them so the TLS acceptor sees the full handshake.
+        let replay = ReplayStream::new(peeked, client);
 
-    // 4. Open plaintext connection to the Candela proxy.
-    let mut proxy_stream = tokio::time::timeout(PROXY_DIAL_TIMEOUT, TcpStream::connect(proxy_addr))
-        .await
-        .map_err(|_| anyhow::anyhow!("proxy dial timeout to {proxy_addr}"))??;
+        // 3. Accept TLS handshake.
+        let tls_stream = acceptor.accept(replay).await.map_err(|e| {
+            tracing::Span::current().record("handshake_ok", false);
+            debug!(sni = %sni, error = %e, "MITM TLS handshake failed");
+            anyhow::anyhow!("TLS handshake failed for {sni}: {e}")
+        })?;
 
-    // 5. Bidirectional copy: decrypted client ↔ plaintext proxy.
-    //    copy_bidirectional drains both directions fully before closing,
-    //    avoiding response truncation when the client finishes sending
-    //    before the proxy finishes responding.
-    let mut tls_stream = tls_stream;
-    match io::copy_bidirectional(&mut tls_stream, &mut proxy_stream).await {
-        Ok((client_to_proxy, proxy_to_client)) => {
-            debug!(
-                sni = %sni,
-                client_to_proxy,
-                proxy_to_client,
-                "MITM bidirectional copy completed"
-            );
+        let handshake_elapsed = start.elapsed();
+        let current_span = tracing::Span::current();
+        current_span.record("handshake_ok", true);
+        current_span.record("handshake_ms", handshake_elapsed.as_millis() as u64);
+        debug!(sni = %sni, handshake_ms = handshake_elapsed.as_millis(), "MITM TLS handshake succeeded");
+
+        // 4. Open plaintext connection to the Candela proxy.
+        let mut proxy_stream =
+            tokio::time::timeout(PROXY_DIAL_TIMEOUT, TcpStream::connect(proxy_addr))
+                .await
+                .map_err(|_| anyhow::anyhow!("proxy dial timeout to {proxy_addr}"))??;
+
+        // 5. Bidirectional copy: decrypted client ↔ plaintext proxy.
+        //    copy_bidirectional drains both directions fully before closing,
+        //    avoiding response truncation when the client finishes sending
+        //    before the proxy finishes responding.
+        let mut tls_stream = tls_stream;
+        match io::copy_bidirectional(&mut tls_stream, &mut proxy_stream).await {
+            Ok((client_to_proxy, proxy_to_client)) => {
+                let current = tracing::Span::current();
+                current.record("bytes_client_to_proxy", client_to_proxy);
+                current.record("bytes_proxy_to_client", proxy_to_client);
+                current.record("duration_ms", start.elapsed().as_millis() as u64);
+                debug!(
+                    sni = %sni,
+                    client_to_proxy,
+                    proxy_to_client,
+                    duration_ms = %start.elapsed().as_millis(),
+                    "MITM bidirectional copy completed"
+                );
+            }
+            Err(e) => {
+                tracing::Span::current().record("duration_ms", start.elapsed().as_millis() as u64);
+                debug!(sni = %sni, error = %e, "MITM bidirectional copy error");
+            }
         }
-        Err(e) => {
-            debug!(sni = %sni, error = %e, "MITM bidirectional copy error");
-        }
+
+        stats.mitm.fetch_add(1, Ordering::Relaxed);
+        Ok(())
     }
-
-    stats.mitm.fetch_add(1, Ordering::Relaxed);
-    Ok(())
+    .instrument(span)
+    .await
 }
 
 /// A stream that replays `peeked` bytes before reading from the inner stream.


### PR DESCRIPTION
## Summary

Adds sidecar-internal OTel observability to the MITM TLS termination path and Helm chart support for ephemeral CA trust injection.

### Changes

**`mitm.rs` — OTel span instrumentation**
- Wraps `mitm_intercept` in `info_span!("mitm.tls_termination")` recording:
  - `sni`, `proxy_addr`, `handshake_ok`, `handshake_ms`
  - `bytes_client_to_proxy`, `bytes_proxy_to_client`, `duration_ms`
- W3C `traceparent` propagates naturally through the byte-level bridge — the proxy handler already parses it from decrypted HTTP. No header injection needed.

**`values.yaml` — MITM config block**
- `mitm.enabled`, `mitm.caPemPath`, `mitm.caVolume` (emptyDir)
- `mitm.trustEnv`: `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`

**`mitm-configmap.yaml` — New Helm template**
- ConfigMap with sidecar container spec fragments and trust injection env vars
- Operators merge these into Deployment specs for automated CA trust

**`README.md` — Documentation**
- MITM architecture diagram
- Enable flow, provider opt-out, W3C trace context explanation

### Testing
- 241 tests pass (including MITM e2e)
- Helm lint clean
- All pre-commit hooks green (cargo-fmt, cargo-clippy, cargo-test, check-yaml)