### PR TITLE
fix(auth): update SA denial message to recommend candela auth login

### DIFF
--- a/pkg/auth/firebase.go
+++ b/pkg/auth/firebase.go
@@ -137,7 +137,8 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 						slog.Warn("service account not in allowlist — access denied",
 							"email", user.Email, "path", r.URL.Path)
 						writeError(w, http.StatusForbidden,
-							"service account not authorized — use personal credentials (gcloud auth application-default login) or contact your admin to allowlist this SA")
+							"service account not authorized — use personal credentials (candela auth login) or contact your admin to allowlist this SA. "+
+								"Check your identity: a service account may be unintentionally used from your environment (ADC, GOOGLE_APPLICATION_CREDENTIALS, etc.)")
 						return
 					}
 					slog.Debug("service account authenticated (allowlisted)",
@@ -166,7 +167,8 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 					slog.Warn("service account not in allowlist — access denied (OAuth2)",
 						"email", user.Email, "path", r.URL.Path)
 					writeError(w, http.StatusForbidden,
-						"service account not authorized — use personal credentials (gcloud auth application-default login) or contact your admin to allowlist this SA")
+						"service account not authorized — use personal credentials (candela auth login) or contact your admin to allowlist this SA. "+
+							"Check your identity: a service account may be unintentionally used from your environment (ADC, GOOGLE_APPLICATION_CREDENTIALS, etc.)")
 					return
 				}
 				slog.Debug("service account authenticated via OAuth2 (allowlisted)",

--- a/pkg/auth/firebase.go
+++ b/pkg/auth/firebase.go
@@ -19,6 +19,11 @@ import (
 // is treated as a transient failure and results in a 500 instead of 403.
 var ErrNotRegistered = errors.New("user not registered")
 
+// errServiceAccountDenied is the user-facing message returned when a service
+// account attempts to authenticate but is not on the allowlist.
+const errServiceAccountDenied = "service account not authorized — use personal credentials (candela auth login) or contact your admin to allowlist this SA. " +
+	"Check your identity: a service account may be unintentionally used from your environment (ADC, GOOGLE_APPLICATION_CREDENTIALS, etc.)"
+
 // UserAuthorizer checks if an email belongs to a registered user.
 // Returns nil if the user exists.
 // Returns ErrNotRegistered (or a wrapped form) if the user does not exist.
@@ -136,9 +141,7 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 					if !saAllowlist.IsAllowed(user.Email) {
 						slog.Warn("service account not in allowlist — access denied",
 							"email", user.Email, "path", r.URL.Path)
-						writeError(w, http.StatusForbidden,
-							"service account not authorized — use personal credentials (candela auth login) or contact your admin to allowlist this SA. "+
-								"Check your identity: a service account may be unintentionally used from your environment (ADC, GOOGLE_APPLICATION_CREDENTIALS, etc.)")
+						writeError(w, http.StatusForbidden, errServiceAccountDenied)
 						return
 					}
 					slog.Debug("service account authenticated (allowlisted)",
@@ -166,9 +169,7 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 				if !saAllowlist.IsAllowed(user.Email) {
 					slog.Warn("service account not in allowlist — access denied (OAuth2)",
 						"email", user.Email, "path", r.URL.Path)
-					writeError(w, http.StatusForbidden,
-						"service account not authorized — use personal credentials (candela auth login) or contact your admin to allowlist this SA. "+
-							"Check your identity: a service account may be unintentionally used from your environment (ADC, GOOGLE_APPLICATION_CREDENTIALS, etc.)")
+					writeError(w, http.StatusForbidden, errServiceAccountDenied)
 					return
 				}
 				slog.Debug("service account authenticated via OAuth2 (allowlisted)",


### PR DESCRIPTION
The error message for denied service accounts previously pointed users to `gcloud auth application-default login`. Now that `candela auth login` is the recommended auth flow, this updates the message accordingly.

Also adds a hint that a service account may be unintentionally picked up from the environment (ADC, GOOGLE_APPLICATION_CREDENTIALS, etc.), which is the most common cause of this error.

**Before:**
```
service account not authorized — use personal credentials (gcloud auth application-default login) or contact your admin to allowlist this SA
```

**After:**
```
service account not authorized — use personal credentials (candela auth login) or contact your admin to allowlist this SA. Check your identity: a service account may be unintentionally used from your environment (ADC, GOOGLE_APPLICATION_CREDENTIALS, etc.)
```