### PR TITLE
feat(cache): surface cache token analytics in all storage backends and handlers

### DIFF
--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -94,13 +94,15 @@ func (h *DashboardHandler) GetModelBreakdown(
 	var pbModels []*v1.ModelUsage
 	for _, m := range models {
 		pbModels = append(pbModels, &v1.ModelUsage{
-			Model:        m.Model,
-			Provider:     m.Provider,
-			CallCount:    m.CallCount,
-			InputTokens:  m.InputTokens,
-			OutputTokens: m.OutputTokens,
-			CostUsd:      m.CostUSD,
-			AvgLatencyMs: m.AvgLatencyMs,
+			Model:               m.Model,
+			Provider:            m.Provider,
+			CallCount:           m.CallCount,
+			InputTokens:         m.InputTokens,
+			OutputTokens:        m.OutputTokens,
+			CostUsd:             m.CostUSD,
+			AvgLatencyMs:        m.AvgLatencyMs,
+			CacheReadTokens:     m.CacheReadTokens,
+			CacheCreationTokens: m.CacheCreationTokens,
 		})
 	}
 
@@ -227,16 +229,20 @@ func (h *DashboardHandler) GetMyUsage(
 		resp.TotalOutputTokens = summary.TotalOutputTokens
 		resp.TotalCostUsd = summary.TotalCostUSD
 		resp.AvgLatencyMs = summary.AvgLatencyMs
+		resp.TotalCacheReadTokens = summary.TotalCacheReadTokens
+		resp.TotalCacheCreationTokens = summary.TotalCacheCreationTokens
 	}
 	for _, m := range models {
 		resp.Models = append(resp.Models, &v1.ModelUsage{
-			Model:        m.Model,
-			Provider:     m.Provider,
-			CallCount:    m.CallCount,
-			InputTokens:  m.InputTokens,
-			OutputTokens: m.OutputTokens,
-			CostUsd:      m.CostUSD,
-			AvgLatencyMs: m.AvgLatencyMs,
+			Model:               m.Model,
+			Provider:            m.Provider,
+			CallCount:           m.CallCount,
+			InputTokens:         m.InputTokens,
+			OutputTokens:        m.OutputTokens,
+			CostUsd:             m.CostUSD,
+			AvgLatencyMs:        m.AvgLatencyMs,
+			CacheReadTokens:     m.CacheReadTokens,
+			CacheCreationTokens: m.CacheCreationTokens,
 		})
 	}
 	return connect.NewResponse(resp), nil

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -708,7 +708,9 @@ func (s *Store) GetModelBreakdown(ctx context.Context, uq storage.UsageQuery) ([
 			COALESCE(SUM(gen_ai_output_tokens), 0) AS output_tokens,
 			COALESCE(SUM(gen_ai_total_tokens), 0) AS total_tokens,
 			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
-			COALESCE(AVG(duration_ns), 0) AS avg_duration_ns
+			COALESCE(AVG(duration_ns), 0) AS avg_duration_ns,
+			COALESCE(SUM(gen_ai_cache_read_tokens), 0) AS cache_read_tokens,
+			COALESCE(SUM(gen_ai_cache_creation_tokens), 0) AS cache_creation_tokens
 		FROM %s
 		WHERE (@projectID = '' OR project_id = @projectID)
 		  AND start_time >= @startTime
@@ -737,14 +739,16 @@ func (s *Store) GetModelBreakdown(ctx context.Context, uq storage.UsageQuery) ([
 	var models []storage.ModelUsage
 	for {
 		var row struct {
-			Model         string  `bigquery:"model"`
-			Provider      string  `bigquery:"provider"`
-			CallCount     int64   `bigquery:"call_count"`
-			InputTokens   int64   `bigquery:"input_tokens"`
-			OutputTokens  int64   `bigquery:"output_tokens"`
-			TotalTokens   int64   `bigquery:"total_tokens"`
-			TotalCostUSD  float64 `bigquery:"total_cost_usd"`
-			AvgDurationNs float64 `bigquery:"avg_duration_ns"`
+			Model               string  `bigquery:"model"`
+			Provider            string  `bigquery:"provider"`
+			CallCount           int64   `bigquery:"call_count"`
+			InputTokens         int64   `bigquery:"input_tokens"`
+			OutputTokens        int64   `bigquery:"output_tokens"`
+			TotalTokens         int64   `bigquery:"total_tokens"`
+			TotalCostUSD        float64 `bigquery:"total_cost_usd"`
+			AvgDurationNs       float64 `bigquery:"avg_duration_ns"`
+			CacheReadTokens     int64   `bigquery:"cache_read_tokens"`
+			CacheCreationTokens int64   `bigquery:"cache_creation_tokens"`
 		}
 		err := it.Next(&row)
 		if err == iterator.Done {
@@ -754,13 +758,15 @@ func (s *Store) GetModelBreakdown(ctx context.Context, uq storage.UsageQuery) ([
 			return nil, fmt.Errorf("iterating model breakdown: %w", err)
 		}
 		models = append(models, storage.ModelUsage{
-			Model:        row.Model,
-			Provider:     row.Provider,
-			CallCount:    row.CallCount,
-			InputTokens:  row.InputTokens,
-			OutputTokens: row.OutputTokens,
-			CostUSD:      row.TotalCostUSD,
-			AvgLatencyMs: float64(row.AvgDurationNs) / 1e6,
+			Model:               row.Model,
+			Provider:            row.Provider,
+			CallCount:           row.CallCount,
+			InputTokens:         row.InputTokens,
+			OutputTokens:        row.OutputTokens,
+			CostUSD:             row.TotalCostUSD,
+			AvgLatencyMs:        float64(row.AvgDurationNs) / 1e6,
+			CacheReadTokens:     row.CacheReadTokens,
+			CacheCreationTokens: row.CacheCreationTokens,
 		})
 	}
 

--- a/pkg/storage/duckdb/duckdb.go
+++ b/pkg/storage/duckdb/duckdb.go
@@ -396,7 +396,9 @@ func (s *Store) GetModelBreakdown(ctx context.Context, q storage.UsageQuery) ([]
 			COALESCE(SUM(gen_ai_input_tokens), 0)::BIGINT,
 			COALESCE(SUM(gen_ai_output_tokens), 0)::BIGINT,
 			COALESCE(SUM(gen_ai_cost_usd), 0)::DOUBLE,
-			COALESCE(AVG(duration_ns), 0)::DOUBLE / 1000000.0
+			COALESCE(AVG(duration_ns), 0)::DOUBLE / 1000000.0,
+			COALESCE(SUM(gen_ai_cache_read_tokens), 0)::BIGINT,
+			COALESCE(SUM(gen_ai_cache_creation_tokens), 0)::BIGINT
 		FROM spans
 		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
 			AND gen_ai_model != ''
@@ -413,7 +415,8 @@ func (s *Store) GetModelBreakdown(ctx context.Context, q storage.UsageQuery) ([]
 	for rows.Next() {
 		var m storage.ModelUsage
 		err := rows.Scan(&m.Model, &m.Provider, &m.CallCount,
-			&m.InputTokens, &m.OutputTokens, &m.CostUSD, &m.AvgLatencyMs)
+			&m.InputTokens, &m.OutputTokens, &m.CostUSD, &m.AvgLatencyMs,
+			&m.CacheReadTokens, &m.CacheCreationTokens)
 		if err != nil {
 			return nil, fmt.Errorf("scanning model: %w", err)
 		}

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -426,7 +426,9 @@ func (s *Store) GetModelBreakdown(ctx context.Context, q storage.UsageQuery) ([]
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT gen_ai_model, gen_ai_provider,
 			COUNT(*), SUM(gen_ai_input_tokens), SUM(gen_ai_output_tokens),
-			SUM(gen_ai_cost_usd), AVG(duration_ns) / 1000000.0
+			SUM(gen_ai_cost_usd), AVG(duration_ns) / 1000000.0,
+			COALESCE(SUM(gen_ai_cache_read_tokens), 0),
+			COALESCE(SUM(gen_ai_cache_creation_tokens), 0)
 		FROM spans
 		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
 			AND gen_ai_model != ''
@@ -444,7 +446,8 @@ func (s *Store) GetModelBreakdown(ctx context.Context, q storage.UsageQuery) ([]
 	for rows.Next() {
 		var m storage.ModelUsage
 		err := rows.Scan(&m.Model, &m.Provider, &m.CallCount,
-			&m.InputTokens, &m.OutputTokens, &m.CostUSD, &m.AvgLatencyMs)
+			&m.InputTokens, &m.OutputTokens, &m.CostUSD, &m.AvgLatencyMs,
+			&m.CacheReadTokens, &m.CacheCreationTokens)
 		if err != nil {
 			return nil, fmt.Errorf("scanning model: %w", err)
 		}


### PR DESCRIPTION
## Summary

Surfaces cache token analytics (read + creation) through all storage backends and handler responses, enabling the frontend to render per-model cache utilization.

### Problem
Cache token data was already captured and stored in dedicated columns (`gen_ai_cache_read_tokens`, `gen_ai_cache_creation_tokens`) across all backends. The combined `GROUPING SETS` query (`GetUsageWithModelBreakdown`) already returned them. However:
- The standalone `GetModelBreakdown` query was missing these columns
- The `GetMyUsage` handler wasn't populating cache fields in the response
- The `GetModelBreakdown` handler wasn't mapping cache fields to the proto

### Changes
| Component | Fix |
|-----------|-----|
| **BigQuery** `GetModelBreakdown` | Added `SUM(gen_ai_cache_read_tokens)` + `SUM(gen_ai_cache_creation_tokens)` |
| **DuckDB** `GetModelBreakdown` | Same |
| **SQLite** `GetModelBreakdown` | Same |
| **`GetModelBreakdown` handler** | Map `CacheReadTokens`/`CacheCreationTokens` → proto |
| **`GetMyUsage` handler** | Populate cache tokens in summary + per-model rows |

### Data flow (before → after)
```
Before: BQ column → ModelUsage (zeroed) → proto (zeroed) → frontend (invisible)
After:  BQ column → ModelUsage (populated) → proto (populated) → frontend (visible)
```

### Testing
Full pre-commit suite passes: gofmt, go vet, golangci-lint (0 issues), go test ./...