### PR TITLE
feat: IAP support via service account impersonation

### DIFF
--- a/cmd/candela/iap_token.go
+++ b/cmd/candela/iap_token.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// iapImpersonatingTokenSource generates IAP-compatible OIDC ID tokens by
+// impersonating a service account via the IAM Credentials API.
+//
+// When candela-local runs with user ADC credentials (from `candela auth login`
+// or `gcloud auth application-default login`), those credentials produce OAuth2
+// access tokens — which IAP rejects. IAP requires an OIDC ID token with the
+// IAP client ID as the audience.
+//
+// This token source solves the problem by using the user's access token to call
+// IAM's generateIdToken endpoint, which returns an ID token scoped to the IAP
+// audience. The user needs `roles/iam.serviceAccountTokenCreator` on the target
+// service account (project owners/editors have this by default).
+//
+// Flow:
+//
+//	User ADC → access_token → IAM generateIdToken(SA, audience) → id_token → IAP ✅
+type iapImpersonatingTokenSource struct {
+	base           oauth2.TokenSource
+	serviceAccount string
+	audience       string
+}
+
+func (s *iapImpersonatingTokenSource) Token() (*oauth2.Token, error) {
+	// Get the user's access token from ADC.
+	baseToken, err := s.base.Token()
+	if err != nil {
+		return nil, fmt.Errorf("IAP: failed to get base credentials: %w", err)
+	}
+
+	// Call IAM Credentials API to generate an ID token with the IAP audience.
+	url := fmt.Sprintf(
+		"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateIdToken",
+		s.serviceAccount,
+	)
+	body := fmt.Sprintf(`{"audience":%q,"includeEmail":true}`, s.audience)
+
+	req, err := http.NewRequest("POST", url, strings.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("IAP: failed to build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+baseToken.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("IAP: generateIdToken request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("IAP: generateIdToken returned %d: %s\n"+
+			"Ensure you have roles/iam.serviceAccountTokenCreator on %s",
+			resp.StatusCode, respBody, s.serviceAccount)
+	}
+
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("IAP: failed to decode generateIdToken response: %w", err)
+	}
+
+	// Return the ID token as AccessToken so the Director sends it as Bearer.
+	return &oauth2.Token{
+		AccessToken: result.Token,
+		TokenType:   "Bearer",
+		Expiry:      time.Now().Add(3500 * time.Second), // ID tokens valid ~1 hour
+	}, nil
+}

--- a/cmd/candela/iap_token.go
+++ b/cmd/candela/iap_token.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -45,23 +45,34 @@ func (s *iapImpersonatingTokenSource) Token() (*oauth2.Token, error) {
 		"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateIdToken",
 		s.serviceAccount,
 	)
-	body := fmt.Sprintf(`{"audience":%q,"includeEmail":true}`, s.audience)
+	reqPayload := struct {
+		Audience     string `json:"audience"`
+		IncludeEmail bool   `json:"includeEmail"`
+	}{
+		Audience:     s.audience,
+		IncludeEmail: true,
+	}
+	bodyBytes, err := json.Marshal(reqPayload)
+	if err != nil {
+		return nil, fmt.Errorf("IAP: failed to marshal request body: %w", err)
+	}
 
-	req, err := http.NewRequest("POST", url, strings.NewReader(body))
+	req, err := http.NewRequest("POST", url, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("IAP: failed to build request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+baseToken.AccessToken)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("IAP: generateIdToken request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, fmt.Errorf("IAP: generateIdToken returned %d: %s\n"+
 			"Ensure you have roles/iam.serviceAccountTokenCreator on %s",
 			resp.StatusCode, respBody, s.serviceAccount)

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -65,12 +65,13 @@ var uiFS embed.FS
 
 // Config holds the candela-local configuration.
 type Config struct {
-	Remote        string `yaml:"remote"`         // Remote Candela server URL
-	Audience      string `yaml:"audience"`       // IAP OAuth Client ID (OIDC audience)
-	Port          int    `yaml:"port"`           // Local port to listen on
-	LMStudioPort  int    `yaml:"lmstudio_port"`  // LM Studio compat listener port (default: 1234)
-	LocalUpstream string `yaml:"local_upstream"` // Local runtime URL (e.g. http://127.0.0.1:11434)
-	StateDBPath   string `yaml:"state_db_path"`  // Path to SQLite state DB (default: ~/.candela/state.db)
+	Remote            string `yaml:"remote"`              // Remote Candela server URL
+	Audience          string `yaml:"audience"`            // IAP OAuth Client ID (OIDC audience)
+	IAPServiceAccount string `yaml:"iap_service_account"` // SA to impersonate for IAP ID tokens
+	Port              int    `yaml:"port"`                // Local port to listen on
+	LMStudioPort      int    `yaml:"lmstudio_port"`       // LM Studio compat listener port (default: 1234)
+	LocalUpstream     string `yaml:"local_upstream"`      // Local runtime URL (e.g. http://127.0.0.1:11434)
+	StateDBPath       string `yaml:"state_db_path"`       // Path to SQLite state DB (default: ~/.candela/state.db)
 
 	// Runtime management configuration.
 	RuntimeBackend string                `yaml:"runtime_backend"` // "ollama", "vllm", "lmstudio"
@@ -446,9 +447,29 @@ func runForeground() {
 
 		ts, err := idtoken.NewTokenSource(ctx, cfg.Audience)
 		if err == nil {
+			// Strategy 1: Service account credentials → audience-scoped OIDC ID token.
 			slog.Info("using service account ID token source")
 			tokenSource = ts
+		} else if cfg.IAPServiceAccount != "" {
+			// Strategy 1.5: User credentials + SA impersonation → IAP OIDC ID token.
+			// Uses IAM Credentials API to generate an ID token with the IAP audience.
+			slog.Debug("idtoken.NewTokenSource unavailable, trying IAP impersonation", "reason", err)
+			baseTSr, err2 := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+			if err2 != nil {
+				slog.Error("failed to get credentials — run 'candela auth login' first",
+					"error", err2)
+				os.Exit(1)
+			}
+			tokenSource = oauth2.ReuseTokenSource(nil, &iapImpersonatingTokenSource{
+				base:           baseTSr,
+				serviceAccount: cfg.IAPServiceAccount,
+				audience:       cfg.Audience,
+			})
+			slog.Info("using IAP via service account impersonation",
+				"sa", cfg.IAPServiceAccount)
 		} else {
+			// Strategy 2: User credentials → OAuth2 access token.
+			// Works when the server validates via userinfo (no IAP).
 			slog.Debug("idtoken.NewTokenSource unavailable (user credentials fallback)", "reason", err)
 			ts2, err2 := google.DefaultTokenSource(ctx, "openid", "email")
 			if err2 != nil {


### PR DESCRIPTION
## Summary

When `iap_service_account` is set in config, candela-local uses the IAM
Credentials API (`generateIdToken`) to produce OIDC ID tokens with the
IAP client ID as the audience. This lets user ADC credentials work with
IAP-protected servers.

## Changes

- **`cmd/candela/iap_token.go`** — new file: IAP token source via SA impersonation
- **`cmd/candela/main.go`** — add `iap_service_account` config field + Strategy 1.5

## Config

```yaml
iap_service_account: candela-server@project.iam.gserviceaccount.com
```

## Testing

- ✅ All pre-commit hooks pass (gofmt, golangci-lint, go-vet, go-test)
- ✅ Live tested: healthz through IAP → `{"status": "ok"}`