### PR TITLE
docs: IAP auth documentation + sync example terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,14 +509,16 @@ Connect to a shared Candela server for **budget enforcement, RBAC, and team-wide
 ```yaml
 # ~/.config/candela/config.yaml
 runtime_backend: ollama
-remote: https://candela-xxx.a.run.app
-audience: "12345678.apps.googleusercontent.com"
+remote: https://candela.example.com
+audience: "12345678.apps.googleusercontent.com"        # IAP OAuth Client ID
+iap_service_account: candela-server@project.iam.gserviceaccount.com  # SA to impersonate for IAP
 ```
 
 - Local + cloud models merged into `/v1/models`
 - Smart routing: local models stay local, cloud models route through Candela server
-- OIDC auth injected automatically (uses credentials from `candela auth login`)
+- OIDC auth injected automatically via SA impersonation (IAP-compatible ID token)
 - Team-wide cost tracking, budget enforcement, and centralized governance
+- Prerequisites: `candela auth login --provider gcp`
 
 > [!TIP]
 > See [docs/candela.md](docs/candela.md) for the full setup guide.

--- a/docs/candela.md
+++ b/docs/candela.md
@@ -112,6 +112,7 @@ runtime_backend: ollama
 
 remote: https://candela-xxx.a.run.app
 audience: "12345678.apps.googleusercontent.com"
+iap_service_account: candela-server@project.iam.gserviceaccount.com
 ```
 
 **What you get**:
@@ -121,6 +122,12 @@ audience: "12345678.apps.googleusercontent.com"
   Candela server (with automatic OIDC auth injection via ADC)
 - Team-wide cost tracking, budget enforcement, and traces on the cloud dashboard
 - Cloud-hosted observability for remote model calls
+
+> [!NOTE]
+> `iap_service_account` is required when the Candela server is behind
+> [Cloud IAP](https://cloud.google.com/iap). When set, `candela` uses
+> SA impersonation to obtain an IAP-targeted ID token instead of using
+> the user's own ADC token directly.
 
 **Architecture**:
 ```
@@ -194,6 +201,7 @@ vertex_ai:
 # ── Optional: Team Mode (omit for Solo) ──
 remote: https://candela-xxx.run.app # Candela server URL
 audience: "12345678.apps..."        # IAP audience for OIDC auth
+iap_service_account: "sa@..."       # SA to impersonate for IAP ID tokens
 
 # ── Optional: Advanced ──
 local_upstream: http://localhost:11434  # explicit local runtime URL

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -77,8 +77,9 @@ Next.js rewrites:
 
 ```yaml
 # ~/.config/candela/config.yaml
-remote: https://candela-xxx.run.app
-audience: https://candela-xxx.run.app
+remote: https://candela.example.com
+audience: "288865965866-xxx.apps.googleusercontent.com"
+iap_service_account: candela-server@project.iam.gserviceaccount.com
 port: 8181
 ```
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -201,13 +201,66 @@ Token acquisition flow:
 2. Uses `google.DefaultTokenSource()` to get an ADC token
 3. Injects `Authorization: Bearer <token>` on every proxied request
 
+**Strategy 1.5 — IAP Service Account Impersonation**
+
+When `iap_service_account` is set in config, `candela` uses **SA impersonation**
+instead of the user's own ADC token:
+
+```
+IDE → candela (:1234)
+         │
+         └── Cloud model ──┐
+                           ▼
+              IAM generateIdToken API
+              (impersonate iap_service_account)
+                           │
+              Authorization: Bearer <iap-id-token>
+                           ▼
+              IAP ──▶ Candela Server
+```
+
+Token acquisition flow:
+1. `candela` reads `iap_service_account` and `audience` from config
+2. Uses the user's ADC to call the IAM `generateIdToken` API, impersonating the configured service account
+3. The IAM API returns an ID token scoped to the IAP `audience`
+4. `candela` injects `Authorization: Bearer <iap-id-token>` on every proxied request
+
 ---
 
-## IAP Authentication (Legacy)
+## IAP Authentication
 
-The `IAPMiddleware` (`pkg/auth/iap.go`) validates Cloud IAP JWT assertions from the `x-goog-iap-jwt-assertion` header. This is the **original** auth path when Candela ran behind Cloud IAP.
+The `IAPMiddleware` (`pkg/auth/iap.go`) validates Cloud IAP JWT assertions from the `x-goog-iap-jwt-assertion` header. This is used when Candela is deployed behind [Cloud IAP](https://cloud.google.com/iap).
 
 The current production setup uses `FirebaseAuthMiddleware` instead, which provides more flexible multi-strategy auth. The IAP middleware remains available for deployments behind Cloud IAP.
+
+### IAP Auth Flow with SA Impersonation
+
+When `iap_service_account` is configured, `candela` (the local CLI) authenticates
+to an IAP-protected server using **service account impersonation**:
+
+1. The user's ADC calls the IAM `generateIdToken` API on the configured `iap_service_account`
+2. The IAM API returns an OIDC ID token with `audience` set to the IAP client ID
+3. `candela` sends this token in the `Authorization: Bearer` header
+4. Cloud IAP validates the token and forwards the request to the Candela server
+
+### Custom IAP Role — `iapIdTokenCreator`
+
+To restrict what impersonating users can do, Candela defines a custom IAM role
+`iapIdTokenCreator` that grants **only** the `iam.serviceAccounts.getOpenIdToken`
+permission:
+
+```yaml
+# Custom role (Terraform)
+title: IAP ID Token Creator
+permissions:
+  - iam.serviceAccounts.getOpenIdToken
+```
+
+This is intentionally narrower than the built-in `roles/iam.serviceAccountTokenCreator`,
+which also grants `getAccessToken`. By omitting `getAccessToken`, users **cannot**
+obtain an access token for the service account — they can only generate ID tokens
+for IAP authentication. This prevents users from bypassing the IAP proxy to call
+LLM APIs (Vertex AI, OpenAI) directly using the server's service account credentials.
 
 ---
 

--- a/examples/terraform/cloud_run.tf
+++ b/examples/terraform/cloud_run.tf
@@ -17,7 +17,7 @@ resource "google_cloud_run_v2_service" "candela" {
 
   deletion_protection = false
 
-  ingress = var.iap_oauth_client_id != "" ? "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER" : "INGRESS_TRAFFIC_ALL"
+  ingress = (var.custom_domain != "" && var.iap_oauth_client_id != "") ? "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER" : "INGRESS_TRAFFIC_ALL"
 
   template {
     service_account = google_service_account.candela.email
@@ -104,6 +104,7 @@ resource "google_cloud_run_v2_service" "candela" {
 # When IAP is enabled, Cloud Run needs allUsers invoker because ingress is
 # restricted to the Internal Load Balancer. IAP handles the access gate.
 resource "google_cloud_run_v2_service_iam_member" "allow_unauthenticated" {
+  count    = (var.custom_domain != "" && var.iap_oauth_client_id != "") ? 1 : 0
   project  = google_cloud_run_v2_service.candela.project
   location = google_cloud_run_v2_service.candela.location
   name     = google_cloud_run_v2_service.candela.name

--- a/examples/terraform/cloud_run.tf
+++ b/examples/terraform/cloud_run.tf
@@ -1,6 +1,7 @@
 # ──────────────────────────────────────────────────
 # Cloud Run — Candela server (API + proxy)
-# Protected by run.invoker IAM (no IAP).
+# Protected by run.invoker IAM, or by IAP when a
+# custom domain + OAuth credentials are provided.
 # Programmatic access via ID tokens from candela-local.
 # ──────────────────────────────────────────────────
 
@@ -15,6 +16,8 @@ resource "google_cloud_run_v2_service" "candela" {
   location = var.region
 
   deletion_protection = false
+
+  ingress = var.iap_oauth_client_id != "" ? "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER" : "INGRESS_TRAFFIC_ALL"
 
   template {
     service_account = google_service_account.candela.email
@@ -97,6 +100,16 @@ resource "google_cloud_run_v2_service" "candela" {
 # 1. A valid Google ID token (audience = Cloud Run service URL)
 # 2. The caller must have roles/run.invoker on the service
 # candela-local injects ID tokens automatically for developer tools.
+
+# When IAP is enabled, Cloud Run needs allUsers invoker because ingress is
+# restricted to the Internal Load Balancer. IAP handles the access gate.
+resource "google_cloud_run_v2_service_iam_member" "allow_unauthenticated" {
+  project  = google_cloud_run_v2_service.candela.project
+  location = google_cloud_run_v2_service.candela.location
+  name     = google_cloud_run_v2_service.candela.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
 
 resource "google_cloud_run_v2_service_iam_member" "group_invoker" {
   project  = var.project_id

--- a/examples/terraform/iam.tf
+++ b/examples/terraform/iam.tf
@@ -47,3 +47,22 @@ resource "google_service_account_iam_member" "candela_self_token_creator" {
   role               = "roles/iam.serviceAccountTokenCreator"
   member             = "serviceAccount:${google_service_account.candela.email}"
 }
+
+# ── IAP ID Token Creator (custom role) ──
+# Narrow role that only allows generating OIDC ID tokens (getOpenIdToken).
+# This lets candela-local users authenticate through IAP via SA impersonation
+# WITHOUT being able to generate access tokens (which could call LLM APIs directly).
+
+resource "google_project_iam_custom_role" "iap_id_token_creator" {
+  role_id     = "iapIdTokenCreator"
+  title       = "IAP ID Token Creator"
+  description = "Allows generating OIDC ID tokens only (for IAP auth). Cannot generate access tokens."
+  permissions = ["iam.serviceAccounts.getOpenIdToken"]
+  stage       = "GA"
+}
+
+resource "google_service_account_iam_member" "candela_users_iap_token" {
+  service_account_id = google_service_account.candela.name
+  role               = google_project_iam_custom_role.iap_id_token_creator.id
+  member             = "group:${var.invoker_google_group}"
+}

--- a/examples/terraform/load_balancer.tf
+++ b/examples/terraform/load_balancer.tf
@@ -1,0 +1,167 @@
+# ──────────────────────────────────────────────────
+# Load Balancer + IAP — Custom domain with zero-trust access
+# ──────────────────────────────────────────────────
+#
+# Provisions a Global HTTPS Load Balancer in front of Cloud Run
+# with Identity-Aware Proxy (IAP) for access control.
+#
+# Traffic flow:
+#   Browser/candela-local → GLB (IAP enforced) → Cloud Run (internal only)
+#
+# Only members of var.invoker_google_group can access.
+
+locals {
+  has_custom_domain = var.custom_domain != ""
+}
+
+# ── Static IP ──
+
+resource "google_compute_global_address" "candela" {
+  count = local.has_custom_domain ? 1 : 0
+  name  = "${var.service_name}-lb-ip"
+}
+
+# ── SSL Certificate ──
+
+resource "google_compute_managed_ssl_certificate" "candela" {
+  count = local.has_custom_domain ? 1 : 0
+  name  = "${var.service_name}-ssl-cert"
+
+  managed {
+    domains = [var.custom_domain]
+  }
+}
+
+# ── Serverless NEG (Cloud Run backend) ──
+
+resource "google_compute_region_network_endpoint_group" "candela" {
+  count                 = local.has_custom_domain ? 1 : 0
+  name                  = "${var.service_name}-serverless-neg"
+  region                = var.region
+  network_endpoint_type = "SERVERLESS"
+
+  cloud_run {
+    service = google_cloud_run_v2_service.candela.name
+  }
+}
+
+# ── Backend Service (with IAP) ──
+
+resource "google_compute_backend_service" "candela" {
+  count                 = local.has_custom_domain ? 1 : 0
+  name                  = "${var.service_name}-backend"
+  protocol              = "HTTPS"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  timeout_sec           = 30
+
+  backend {
+    group           = google_compute_region_network_endpoint_group.candela[0].id
+    balancing_mode  = "UTILIZATION"
+    capacity_scaler = 1
+  }
+
+  # Enable IAP when OAuth credentials are provided.
+  # Phase 1: Apply without IAP (set up infra).
+  # Phase 2: Create OAuth client, set vars, apply again to enable IAP.
+  dynamic "iap" {
+    for_each = var.iap_oauth_client_id != "" ? [1] : []
+    content {
+      enabled              = true
+      oauth2_client_id     = var.iap_oauth_client_id
+      oauth2_client_secret = var.iap_oauth_client_secret
+    }
+  }
+
+  log_config {
+    enable      = true
+    sample_rate = 0.1
+  }
+}
+
+# ── URL Maps ──
+
+resource "google_compute_url_map" "candela" {
+  count           = local.has_custom_domain ? 1 : 0
+  name            = "${var.service_name}-url-map"
+  default_service = google_compute_backend_service.candela[0].id
+}
+
+# HTTP → HTTPS redirect.
+resource "google_compute_url_map" "candela_redirect" {
+  count = local.has_custom_domain ? 1 : 0
+  name  = "${var.service_name}-http-redirect"
+
+  default_url_redirect {
+    https_redirect         = true
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    strip_query            = false
+  }
+}
+
+# ── Proxies ──
+
+resource "google_compute_target_https_proxy" "candela" {
+  count            = local.has_custom_domain ? 1 : 0
+  name             = "${var.service_name}-https-proxy"
+  url_map          = google_compute_url_map.candela[0].id
+  ssl_certificates = [google_compute_managed_ssl_certificate.candela[0].id]
+}
+
+resource "google_compute_target_http_proxy" "candela_redirect" {
+  count   = local.has_custom_domain ? 1 : 0
+  name    = "${var.service_name}-http-proxy"
+  url_map = google_compute_url_map.candela_redirect[0].id
+}
+
+# ── Forwarding Rules ──
+
+resource "google_compute_global_forwarding_rule" "candela_https" {
+  count                 = local.has_custom_domain ? 1 : 0
+  name                  = "${var.service_name}-https-rule"
+  ip_address            = google_compute_global_address.candela[0].address
+  ip_protocol           = "TCP"
+  port_range            = "443"
+  target                = google_compute_target_https_proxy.candela[0].id
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_global_forwarding_rule" "candela_http" {
+  count                 = local.has_custom_domain ? 1 : 0
+  name                  = "${var.service_name}-http-rule"
+  ip_address            = google_compute_global_address.candela[0].address
+  ip_protocol           = "TCP"
+  port_range            = "80"
+  target                = google_compute_target_http_proxy.candela_redirect[0].id
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+# ── IAP (Identity-Aware Proxy) ──
+# Zero-trust access: only members of the invoker Google Group can reach
+# Candela through the load balancer. No allUsers needed.
+#
+# Prerequisites (one-time manual setup):
+#   1. Go to GCP Console → APIs & Services → OAuth consent screen
+#   2. Configure the consent screen (Internal)
+#   3. Go to Credentials → Create OAuth client ID → Web application
+#   4. Set the client ID and secret in terraform.tfvars:
+#        iap_oauth_client_id     = "xxx.apps.googleusercontent.com"
+#        iap_oauth_client_secret = "GOCSPX-xxx"
+
+# Grant the Google Group access through IAP.
+resource "google_iap_web_backend_service_iam_member" "candela_users" {
+  web_backend_service = google_compute_backend_service.candela[0].name
+  role                = "roles/iap.httpsResourceAccessor"
+  member              = "group:${var.invoker_google_group}"
+}
+
+# ── Outputs ──
+
+output "load_balancer_ip" {
+  description = "Static IP for DNS A record"
+  value       = local.has_custom_domain ? google_compute_global_address.candela[0].address : null
+}
+
+output "custom_domain_url" {
+  description = "Custom domain URL"
+  value       = local.has_custom_domain ? "https://${var.custom_domain}" : null
+}

--- a/examples/terraform/load_balancer.tf
+++ b/examples/terraform/load_balancer.tf
@@ -50,14 +50,12 @@ resource "google_compute_region_network_endpoint_group" "candela" {
 resource "google_compute_backend_service" "candela" {
   count                 = local.has_custom_domain ? 1 : 0
   name                  = "${var.service_name}-backend"
-  protocol              = "HTTPS"
+  protocol              = "HTTP"
   load_balancing_scheme = "EXTERNAL_MANAGED"
   timeout_sec           = 30
 
   backend {
     group           = google_compute_region_network_endpoint_group.candela[0].id
-    balancing_mode  = "UTILIZATION"
-    capacity_scaler = 1
   }
 
   # Enable IAP when OAuth credentials are provided.
@@ -149,6 +147,7 @@ resource "google_compute_global_forwarding_rule" "candela_http" {
 
 # Grant the Google Group access through IAP.
 resource "google_iap_web_backend_service_iam_member" "candela_users" {
+  count               = (local.has_custom_domain && var.iap_oauth_client_id != "") ? 1 : 0
   web_backend_service = google_compute_backend_service.candela[0].name
   role                = "roles/iap.httpsResourceAccessor"
   member              = "group:${var.invoker_google_group}"

--- a/examples/terraform/main.tf
+++ b/examples/terraform/main.tf
@@ -51,6 +51,7 @@ resource "google_project_service" "apis" {
     "cloudresourcemanager.googleapis.com",
     "firebase.googleapis.com",
     "identitytoolkit.googleapis.com",
+    "iap.googleapis.com",
   ])
 
   service            = each.value

--- a/examples/terraform/outputs.tf
+++ b/examples/terraform/outputs.tf
@@ -26,8 +26,8 @@ output "candela_local_config" {
   description = "Template for ~/.config/candela/config.yaml"
   value       = <<-EOT
     # ~/.config/candela/config.yaml
-    remote: https://${var.custom_domain}
-    audience: ${var.iap_oauth_client_id}
+    remote: ${var.custom_domain != "" ? "https://${var.custom_domain}" : google_cloud_run_v2_service.candela.uri}
+    audience: ${var.iap_oauth_client_id != "" ? var.iap_oauth_client_id : google_cloud_run_v2_service.candela.uri}
     iap_service_account: ${google_service_account.candela.email}
     port: 8181
   EOT

--- a/examples/terraform/outputs.tf
+++ b/examples/terraform/outputs.tf
@@ -23,11 +23,12 @@ output "service_account_email" {
 }
 
 output "candela_local_config" {
-  description = "Template for ~/.candela.yaml"
+  description = "Template for ~/.config/candela/config.yaml"
   value       = <<-EOT
-    # ~/.candela.yaml
-    remote: ${google_cloud_run_v2_service.candela.uri}
-    audience: ${google_cloud_run_v2_service.candela.uri}
+    # ~/.config/candela/config.yaml
+    remote: https://${var.custom_domain}
+    audience: ${var.iap_oauth_client_id}
+    iap_service_account: ${google_service_account.candela.email}
     port: 8181
   EOT
 }

--- a/examples/terraform/terraform.tfvars.example
+++ b/examples/terraform/terraform.tfvars.example
@@ -27,3 +27,7 @@ invoker_google_group   = "devs@company.com"
 
 # Custom Domain (optional)
 # custom_domain = "candela.company.com"
+
+# ── IAP (optional — enables zero-trust access) ──
+# iap_oauth_client_id     = "YOUR_CLIENT_ID.apps.googleusercontent.com"
+# iap_oauth_client_secret = "GOCSPX-YOUR_SECRET"

--- a/examples/terraform/variables.tf
+++ b/examples/terraform/variables.tf
@@ -121,3 +121,16 @@ variable "custom_domain" {
   type        = string
   default     = ""
 }
+
+variable "iap_oauth_client_id" {
+  description = "OAuth Client ID for IAP (from GCP Console > APIs & Services > Credentials)"
+  type        = string
+  default     = ""
+}
+
+variable "iap_oauth_client_secret" {
+  description = "OAuth Client Secret for IAP"
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Updates documentation and example terraform to reflect IAP service account impersonation.

### Documentation (11 files, 294 insertions)
- **README.md**: Team Mode with `iap_service_account` config
- **docs/candela.md**: Config examples + note about IAP requirement
- **docs/security.md**: Strategy 1.5 (SA impersonation) + custom role docs
- **docs/deployment.md**: IAP + custom domain config

### Example Terraform
- **iam.tf**: `iapIdTokenCreator` custom role + group binding
- **cloud_run.tf**: Conditional IAP ingress + `allUsers` invoker
- **load_balancer.tf**: NEW — full GLB + IAP infrastructure
- **variables.tf**: IAP OAuth variables
- **outputs.tf**: `candela_local_config` with `iap_service_account`
- **terraform.tfvars.example**: IAP placeholders
- **main.tf**: Enable `iap.googleapis.com` API