### PR TITLE
fix(auth): dual-token IAP auth + /v1/models endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,9 +516,24 @@ iap_service_account: candela-server@project.iam.gserviceaccount.com  # SA to imp
 
 - Local + cloud models merged into `/v1/models`
 - Smart routing: local models stay local, cloud models route through Candela server
-- OIDC auth injected automatically via SA impersonation (IAP-compatible ID token)
+- **Dual-token IAP auth** when `iap_service_account` is configured (see below)
 - Team-wide cost tracking, budget enforcement, and centralized governance
 - Prerequisites: `candela auth login --provider gcp`
+
+#### Dual-Token Authentication (IAP)
+
+When `iap_service_account` is configured, the CLI uses a **dual-token strategy** to authenticate through Identity-Aware Proxy:
+
+| Header | Token | Consumed By |
+|--------|-------|-------------|
+| `Authorization` / `Proxy-Authorization` | IAP ID token (OIDC token from impersonated SA) | IAP at the load balancer |
+| `X-Candela-Auth` | User's ADC OAuth2 access token | `candela-server` (identifies the actual user) |
+
+This is necessary because **IAP replaces the `Authorization` header** with its own JWT before forwarding requests to the backend — the original user identity would be lost without the second token.
+
+**Server-side resolution order:**
+1. `X-Candela-Auth` header → CLI traffic behind IAP (the typical team mode flow)
+2. `Authorization` header → browser or direct traffic (no IAP in the path)
 
 > [!TIP]
 > See [docs/candela.md](docs/candela.md) for the full setup guide.

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -360,6 +360,48 @@ func main() {
 
 			llmProxy.RegisterRoutes(mux)
 
+			// Build compat model list from the cost calculator's pricing table.
+			// Map pricing provider names → OpenAI-compatible proxy route names.
+			// Only include models whose compat provider is active.
+			pricingToCompat := map[string]string{
+				"google":    "gemini-oai", // Gemini via OpenAI-compat endpoint
+				"anthropic": "anthropic",  // Anthropic with FormatTranslator (OpenAI→Messages)
+				"openai":    "openai",     // Native OpenAI passthrough
+			}
+
+			// Build set of active provider names for quick lookup.
+			activeSet := make(map[string]bool, len(activeProviders))
+			for _, p := range activeProviders {
+				activeSet[p.Name] = true
+			}
+
+			// Deduplicate models: the pricing table may have both short names
+			// (e.g. "claude-sonnet-4") and dated variants ("claude-sonnet-4-20250514")
+			// that resolve to the same underlying model. Keep all of them — the
+			// compat layer's prefix-based alias resolution handles short→long mapping.
+			seen := make(map[string]bool)
+			var compatModels []proxy.CompatModel
+			for _, m := range calc.Models() {
+				compatProvider, ok := pricingToCompat[m.Provider]
+				if !ok || !activeSet[compatProvider] {
+					continue
+				}
+				key := compatProvider + "/" + m.Model
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				compatModels = append(compatModels, proxy.CompatModel{
+					ID:       m.Model,
+					Provider: compatProvider,
+				})
+			}
+
+			if len(compatModels) > 0 {
+				llmProxy.RegisterCompatRoutes(mux, compatModels)
+				slog.Info("📋 /v1/models endpoint registered", "models", len(compatModels))
+			}
+
 			var names []string
 			for _, p := range activeProviders {
 				names = append(names, "/proxy/"+p.Name+"/")

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -444,6 +444,7 @@ func runForeground() {
 		// a generic OIDC token without the required audience claim, which the
 		// server rejects.
 		var tokenSource oauth2.TokenSource
+		var userTokenSource oauth2.TokenSource // User's ADC token for server-side identity validation.
 
 		ts, err := idtoken.NewTokenSource(ctx, cfg.Audience)
 		if err == nil {
@@ -451,8 +452,9 @@ func runForeground() {
 			slog.Info("using service account ID token source")
 			tokenSource = ts
 		} else if cfg.IAPServiceAccount != "" {
-			// Strategy 1.5: User credentials + SA impersonation → IAP OIDC ID token.
-			// Uses IAM Credentials API to generate an ID token with the IAP audience.
+			// Strategy 1.5: User credentials + SA impersonation → dual token.
+			// - IAP token: OIDC ID token (via SA impersonation) for Proxy-Authorization
+			// - User token: ADC OAuth2 access token for Authorization (server validates via userinfo)
 			slog.Debug("idtoken.NewTokenSource unavailable, trying IAP impersonation", "reason", err)
 			baseTSr, err2 := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
 			if err2 != nil {
@@ -465,6 +467,14 @@ func runForeground() {
 				serviceAccount: cfg.IAPServiceAccount,
 				audience:       cfg.Audience,
 			})
+			// Keep the user's ADC token source for server-side auth.
+			// The server validates this via Google's userinfo endpoint.
+			userTSr, err3 := google.DefaultTokenSource(ctx, "openid", "email")
+			if err3 != nil {
+				slog.Warn("failed to get user ADC token source — server auth may fail", "error", err3)
+			} else {
+				userTokenSource = userTSr
+			}
 			slog.Info("using IAP via service account impersonation",
 				"sa", cfg.IAPServiceAccount)
 		} else {
@@ -489,21 +499,34 @@ func runForeground() {
 				req.URL.Host = remoteURL.Host
 				req.Host = remoteURL.Host
 
-				// Inject auth token for the remote server.
-				// For service accounts, AccessToken is the audience-scoped OIDC ID token.
-				// For user credentials, AccessToken is the OAuth2 access token which
-				// the server validates via Google's userinfo endpoint.
+				// Inject auth tokens for IAP + backend server.
 				token, err := tokenSource.Token()
 				if err != nil {
 					slog.Error("failed to get auth token", "error", err)
 					return
 				}
-				// Set Proxy-Authorization so Google Cloud IAP consumes it and allows the
-				// Authorization header to flow through to the backend (where FirebaseAuthMiddleware expects it).
+
+				// Proxy-Authorization: consumed by IAP at the load balancer.
 				req.Header.Set("Proxy-Authorization", "Bearer "+token.AccessToken)
-				req.Header.Set("Authorization", "Bearer "+token.AccessToken)
-				// Set custom header as a fallback in case IAP still strips Authorization
-				req.Header.Set("X-Candela-Auth", "Bearer "+token.AccessToken)
+
+				if userTokenSource != nil {
+					// Dual-token mode (IAP impersonation):
+					// - Authorization gets the IAP ID token (IAP validates this
+					//   and replaces it with its own JWT before forwarding)
+					// - X-Candela-Auth gets the user's ADC OAuth2 access token
+					//   (the server checks this first for user identity)
+					req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+					userToken, err := userTokenSource.Token()
+					if err != nil {
+						slog.Error("failed to get user auth token", "error", err)
+						return
+					}
+					req.Header.Set("X-Candela-Auth", "Bearer "+userToken.AccessToken)
+				} else {
+					// Single-token mode: same token for IAP and server.
+					req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+					req.Header.Set("X-Candela-Auth", "Bearer "+token.AccessToken)
+				}
 
 				// Preserve the original path.
 				if _, ok := req.Header["User-Agent"]; !ok {

--- a/deploy/entrypoint-server.sh
+++ b/deploy/entrypoint-server.sh
@@ -43,6 +43,8 @@ cors:
 
 auth:
   dev_mode: ${CANDELA_DEV_MODE:-false}
+  allowed_service_accounts:
+    - "${CANDELA_SERVICE_ACCOUNT:-}"
 
 firestore:
   enabled: true

--- a/pkg/auth/firebase.go
+++ b/pkg/auth/firebase.go
@@ -251,11 +251,15 @@ func validateAccessToken(ctx context.Context, accessToken string) (*User, error)
 	}, nil
 }
 
-// extractBearerToken pulls the token from "Authorization: Bearer <token>".
+// extractBearerToken pulls the token from request headers.
+// Checks X-Candela-Auth first (set by candela-local behind IAP, carries the
+// user's ADC token), then falls back to Authorization (browser/Firebase clients).
+// When behind IAP, Authorization is replaced by IAP's own JWT — so we prefer
+// X-Candela-Auth which carries the original user identity token.
 func extractBearerToken(r *http.Request) string {
-	auth := r.Header.Get("Authorization")
+	auth := r.Header.Get("X-Candela-Auth")
 	if auth == "" {
-		auth = r.Header.Get("X-Candela-Auth")
+		auth = r.Header.Get("Authorization")
 		if auth == "" {
 			return ""
 		}

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -7,6 +7,7 @@ package costcalc
 import (
 	"log/slog"
 	"math"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -328,6 +329,40 @@ func (c *Calculator) SetGlobalDiscount(discount float64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.globalDiscount = clampDiscount(discount)
+}
+
+// Models returns all known model pricing entries (defaults merged with overrides).
+// Overrides take priority over defaults on key conflicts. The returned slice is
+// sorted by provider, then model name. This is used to populate the /v1/models
+// endpoint so clients can discover available models.
+func (c *Calculator) Models() []ModelPricing {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// Merge defaults and overrides into a single map (overrides win).
+	merged := make(map[string]ModelPricing, len(c.defaults)+len(c.overrides))
+	for k, v := range c.defaults {
+		merged[k] = v
+	}
+	for k, v := range c.overrides {
+		merged[k] = v
+	}
+
+	// Collect into a slice.
+	models := make([]ModelPricing, 0, len(merged))
+	for _, m := range merged {
+		models = append(models, m)
+	}
+
+	// Sort by provider, then model.
+	sort.Slice(models, func(i, j int) bool {
+		if models[i].Provider != models[j].Provider {
+			return models[i].Provider < models[j].Provider
+		}
+		return models[i].Model < models[j].Model
+	})
+
+	return models
 }
 
 // clampDiscount ensures a discount is within [0.0, 1.0].


### PR DESCRIPTION
## Summary

### CLI (candela-local)
- Dual-token mode for IAP impersonation: IAP ID token in `Authorization` (consumed by IAP), user's ADC OAuth2 token in `X-Candela-Auth` (for server-side identity validation via userinfo)
- Separate `userTokenSource` for server auth, independent of IAP token

### Server (candela-server)
- `extractBearerToken` now checks `X-Candela-Auth` first (CLI traffic behind IAP), then falls back to `Authorization` (browser/Firebase clients)
- Added `/v1/models` endpoint via `RegisterCompatRoutes` with models auto-derived from the cost calculator's pricing table
- Added `/v1/chat/completions` model-based routing (free with compat routes)
- Added `Calculator.Models()` method to expose all known model pricing

## Fixes
- 401 auth errors on proxy endpoints when using IAP impersonation
- "no models available" in team mode
- OpenCode / LM Studio can now discover models via `/v1/models`

## Testing
- All pre-commit hooks pass (golangci-lint, go-vet, gofmt)
- All 30+ test packages pass
- Manually verified: DashboardService → 200, Claude proxy → 200 with response