### PR TITLE
ci: auto-build and push candela-server to GHCR on merge

### DIFF
--- a/.github/workflows/server-image.yml
+++ b/.github/workflows/server-image.yml
@@ -1,0 +1,61 @@
+name: Build & Push Server Image
+
+# Builds candela-server and pushes to GHCR on every merge to main
+# and on version tags. GitLab CI then retags from GHCR → Artifact Registry.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cmd/candela-server/**'
+      - 'pkg/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'deploy/Dockerfile'
+      - 'deploy/entrypoint-server.sh'
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/candela-server
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds a GitHub Actions workflow that:

- Triggers on pushes to `main` that touch server code (`cmd/candela-server/`, `pkg/`, `go.mod`, `deploy/Dockerfile`)
- Builds with Docker Buildx + GHA cache
- Pushes to `ghcr.io/candelahq/candela-server` with tags: SHA, branch, latest
- GitLab CI then retags from GHCR → Artifact Registry for Cloud Run deployment

This replaces the manual `docker build && docker push` workflow.