### PR TITLE
feat(proxy): per-request cost caps (#277) and per-model daily spend limits (#278)

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -64,10 +64,12 @@ type Config struct {
 		} `yaml:"bigquery"`
 	} `yaml:"storage"`
 	Proxy struct {
-		Enabled   bool     `yaml:"enabled"`
-		ProjectID string   `yaml:"project_id"`
-		Providers []string `yaml:"providers"` // e.g. ["openai", "google", "anthropic", "anthropic-direct", "gemini-oai"]
-		VertexAI  struct {
+		Enabled        bool                     `yaml:"enabled"`
+		ProjectID      string                   `yaml:"project_id"`
+		Providers      []string                 `yaml:"providers"`            // e.g. ["openai", "google", "anthropic", "anthropic-direct", "gemini-oai"]
+		MaxRequestCost float64                  `yaml:"max_request_cost_usd"` // Per-request cost cap (0 = disabled)
+		DailyLimits    []proxy.SpendLimitConfig `yaml:"daily_limits"`         // Per-model daily spend limits
+		VertexAI       struct {
 			ProjectID   string `yaml:"project_id"`   // GCP project for Vertex AI
 			Region      string `yaml:"region"`       // e.g. "us-central1"
 			CachingMode string `yaml:"caching_mode"` // off|auto|system-only (default: auto)
@@ -396,8 +398,10 @@ func main() {
 
 		if len(activeProviders) > 0 {
 			llmProxy = proxy.New(proxy.Config{
-				Providers: activeProviders,
-				ProjectID: cfg.Proxy.ProjectID,
+				Providers:      activeProviders,
+				ProjectID:      cfg.Proxy.ProjectID,
+				MaxRequestCost: cfg.Proxy.MaxRequestCost,
+				DailyLimits:    cfg.Proxy.DailyLimits,
 			}, proc, calc)
 
 			// Wire team-mode features if Firestore is available.

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -79,9 +79,11 @@ type Config struct {
 	RuntimeManage  runtime.ManagerConfig `yaml:"runtime_manage"`  // Auto-start, auto-pull, models
 
 	// Direct cloud providers (solo mode — call Gemini/Claude without a server).
-	Providers []LocalProvider `yaml:"providers"`
-	VertexAI  VertexAIConfig  `yaml:"vertex_ai"`
-	AWS       AWSConfig       `yaml:"aws"`
+	Providers      []LocalProvider          `yaml:"providers"`
+	VertexAI       VertexAIConfig           `yaml:"vertex_ai"`
+	AWS            AWSConfig                `yaml:"aws"`
+	MaxRequestCost float64                  `yaml:"max_request_cost_usd"` // Per-request cost cap (0 = disabled)
+	DailyLimits    []proxy.SpendLimitConfig `yaml:"daily_limits"`         // Per-model daily spend limits
 }
 
 // LocalProvider configures a direct cloud provider for solo mode.
@@ -1117,8 +1119,10 @@ func buildCloudProxy(cfg Config, submitter *processor.SpanProcessor) (*proxy.Pro
 
 	calc := costcalc.New()
 	cloudProxy := proxy.New(proxy.Config{
-		Providers: providers,
-		ProjectID: "local",
+		Providers:      providers,
+		ProjectID:      "local",
+		MaxRequestCost: cfg.MaxRequestCost,
+		DailyLimits:    cfg.DailyLimits,
 	}, submitter, calc)
 
 	var names []string

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -71,6 +71,21 @@ proxy:
   # only available in the local CLI (`candela`), not in candela-server.
   # See ~/.config/candela/config.yaml for local LM Studio compat settings.
 
+  # Per-request cost cap (#277) — reject single requests estimated to exceed
+  # this amount. Uses a conservative estimate from input body size × model pricing.
+  # Set to 0 or omit to disable.
+  # max_request_cost_usd: 5.00
+
+  # Per-model daily spend limits (#278) — prevent a single expensive model
+  # from consuming the entire budget in one day. Model names are matched by
+  # prefix (e.g. "claude-opus-4" matches "claude-opus-4-20250514").
+  # Limits are per-user and reset at UTC midnight.
+  # daily_limits:
+  #   - model: "claude-opus-4"
+  #     max_daily_usd: 50.00
+  #   - model: "gpt-4.1"
+  #     max_daily_usd: 25.00
+
 # Pricing overrides.
 # Built-in defaults cover all cloud models at list prices.
 # Use this section for negotiated rates or enterprise discounts.

--- a/pkg/proxy/cost_gate.go
+++ b/pkg/proxy/cost_gate.go
@@ -1,0 +1,141 @@
+// Package proxy — cost_gate.go implements per-request cost caps (#277) and
+// per-model daily spend limits (#278). These are in-memory pre-flight gates
+// that reject requests before they reach upstream providers.
+package proxy
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/candelahq/candela/pkg/costcalc"
+)
+
+// SpendLimitConfig defines a per-model daily spend ceiling.
+// Model is matched by prefix: "claude-opus-4" matches "claude-opus-4",
+// "claude-opus-4-20250514", "claude-opus-4.6", etc.
+type SpendLimitConfig struct {
+	Model       string  `yaml:"model" json:"model"`                 // Model prefix (e.g. "claude-opus-4")
+	MaxDailyUSD float64 `yaml:"max_daily_usd" json:"max_daily_usd"` // Daily spend cap per user
+}
+
+// spendEntry tracks a single user+model_prefix daily spend total.
+type spendEntry struct {
+	spent float64
+	date  string // "2026-06-07" — resets on new UTC day
+}
+
+// SpendTracker is a thread-safe in-memory tracker for per-user per-model
+// daily spend. Counters auto-reset when the UTC date changes.
+type SpendTracker struct {
+	mu      sync.Mutex
+	entries map[string]*spendEntry // key: "user\x00model_prefix"
+}
+
+// NewSpendTracker creates a new SpendTracker.
+func NewSpendTracker() *SpendTracker {
+	return &SpendTracker{
+		entries: make(map[string]*spendEntry),
+	}
+}
+
+// Record adds costUSD to the user's daily spend for the model.
+// It finds the matching SpendLimitConfig by prefix and records under that prefix.
+// If no limit matches, the spend is not tracked (no limit = no tracking needed).
+func (t *SpendTracker) Record(userID, model string, costUSD float64, limits []SpendLimitConfig) {
+	if costUSD <= 0 || len(limits) == 0 {
+		return
+	}
+
+	lc := matchSpendLimit(model, limits)
+	if lc == nil {
+		return // no limit configured for this model
+	}
+
+	today := time.Now().UTC().Format("2006-01-02")
+	key := userID + "\x00" + strings.ToLower(lc.Model)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	e, ok := t.entries[key]
+	if !ok || e.date != today {
+		t.entries[key] = &spendEntry{spent: costUSD, date: today}
+		return
+	}
+	e.spent += costUSD
+}
+
+// Check returns whether the user is allowed to make a request for the given
+// model based on daily spend limits. Returns (allowed, spent, limit).
+// If no limit matches the model, returns (true, 0, 0).
+func (t *SpendTracker) Check(userID, model string, limits []SpendLimitConfig) (allowed bool, spent, limit float64) {
+	lc := matchSpendLimit(model, limits)
+	if lc == nil {
+		return true, 0, 0 // no limit for this model
+	}
+
+	today := time.Now().UTC().Format("2006-01-02")
+	key := userID + "\x00" + strings.ToLower(lc.Model)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	e, ok := t.entries[key]
+	if !ok || e.date != today {
+		return true, 0, lc.MaxDailyUSD
+	}
+	return e.spent < lc.MaxDailyUSD, e.spent, lc.MaxDailyUSD
+}
+
+// matchSpendLimit finds the best-matching SpendLimitConfig for a model name.
+// Uses prefix matching — the longest matching prefix wins, giving more specific
+// limits precedence (e.g. "claude-opus-4.7" beats "claude-opus-4").
+// Returns nil if no limit matches.
+func matchSpendLimit(model string, limits []SpendLimitConfig) *SpendLimitConfig {
+	model = strings.ToLower(model)
+	var best *SpendLimitConfig
+	bestLen := 0
+
+	for i := range limits {
+		prefix := strings.ToLower(limits[i].Model)
+		if strings.HasPrefix(model, prefix) && len(prefix) > bestLen {
+			best = &limits[i]
+			bestLen = len(prefix)
+		}
+	}
+	return best
+}
+
+// estimateRequestCost estimates the USD cost of a request based on the request
+// body size and model pricing. This is a conservative estimate used for the
+// per-request cost cap (#277).
+//
+// Methodology:
+//   - Input tokens: body_bytes / 4 (conservative 4 bytes per token)
+//   - Output tokens: estimated at 2× input tokens (capped at 32K)
+//   - Cost: calculated using the cost calculator's pricing table
+//
+// The estimate is intentionally conservative (over-estimates) since it's used
+// as a gate — false positives (blocking cheap requests) are better than false
+// negatives (allowing expensive ones through).
+func estimateRequestCost(calc *costcalc.Calculator, provider, model string, bodySize int) float64 {
+	if calc == nil || bodySize == 0 || model == "" {
+		return 0
+	}
+
+	// Approximate input tokens from body size.
+	// JSON overhead means not all bytes are content, but messages contain
+	// system prompts, conversation history, etc. 4 bytes/token is conservative.
+	inputTokens := int64(bodySize) / 4
+
+	// Estimate output tokens: 2× input is generous for most use cases.
+	// Cap at 32K to avoid absurd estimates for large-context requests.
+	outputTokens := inputTokens * 2
+	const maxOutputEstimate = 32_000
+	if outputTokens > maxOutputEstimate {
+		outputTokens = maxOutputEstimate
+	}
+
+	return calc.Calculate(provider, model, inputTokens, outputTokens)
+}

--- a/pkg/proxy/cost_gate.go
+++ b/pkg/proxy/cost_gate.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"bytes"
 	"strings"
 	"sync"
 	"time"
@@ -16,7 +17,7 @@ import (
 // "claude-opus-4-20250514", "claude-opus-4.6", etc.
 type SpendLimitConfig struct {
 	Model       string  `yaml:"model" json:"model"`                 // Model prefix (e.g. "claude-opus-4")
-	MaxDailyUSD float64 `yaml:"max_daily_usd" json:"max_daily_usd"` // Daily spend cap per user
+	MaxDailyUSD float64 `yaml:"max_daily_usd" json:"max_daily_usd"` // Daily spend cap per user (must be > 0)
 }
 
 // spendEntry tracks a single user+model_prefix daily spend total.
@@ -26,10 +27,12 @@ type spendEntry struct {
 }
 
 // SpendTracker is a thread-safe in-memory tracker for per-user per-model
-// daily spend. Counters auto-reset when the UTC date changes.
+// daily spend. Counters auto-reset when the UTC date changes. Stale entries
+// (from previous days) are evicted lazily on the first Record() of a new day.
 type SpendTracker struct {
-	mu      sync.Mutex
-	entries map[string]*spendEntry // key: "user\x00model_prefix"
+	mu            sync.Mutex
+	entries       map[string]*spendEntry // key: "user\x00model_prefix"
+	lastEvictDate string                 // prevents eviction on every call
 }
 
 // NewSpendTracker creates a new SpendTracker.
@@ -58,6 +61,9 @@ func (t *SpendTracker) Record(userID, model string, costUSD float64, limits []Sp
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
+	// Evict stale entries when the date rolls over (once per day).
+	t.evictStaleLocked(today)
+
 	e, ok := t.entries[key]
 	if !ok || e.date != today {
 		t.entries[key] = &spendEntry{spent: costUSD, date: today}
@@ -67,9 +73,11 @@ func (t *SpendTracker) Record(userID, model string, costUSD float64, limits []Sp
 }
 
 // Check returns whether the user is allowed to make a request for the given
-// model based on daily spend limits. Returns (allowed, spent, limit).
+// model based on daily spend limits. estimatedCost is added to current spend
+// for a forward-looking check, preventing a request that would breach the limit
+// from being sent upstream. Returns (allowed, spent, limit).
 // If no limit matches the model, returns (true, 0, 0).
-func (t *SpendTracker) Check(userID, model string, limits []SpendLimitConfig) (allowed bool, spent, limit float64) {
+func (t *SpendTracker) Check(userID, model string, limits []SpendLimitConfig, estimatedCost float64) (allowed bool, spent, limit float64) {
 	lc := matchSpendLimit(model, limits)
 	if lc == nil {
 		return true, 0, 0 // no limit for this model
@@ -83,14 +91,37 @@ func (t *SpendTracker) Check(userID, model string, limits []SpendLimitConfig) (a
 
 	e, ok := t.entries[key]
 	if !ok || e.date != today {
-		return true, 0, lc.MaxDailyUSD
+		// No spend today — check if just the estimated cost exceeds the limit.
+		return estimatedCost <= lc.MaxDailyUSD, 0, lc.MaxDailyUSD
 	}
-	return e.spent < lc.MaxDailyUSD, e.spent, lc.MaxDailyUSD
+	return e.spent+estimatedCost <= lc.MaxDailyUSD, e.spent, lc.MaxDailyUSD
+}
+
+// Len returns the number of tracked entries (for testing/metrics).
+func (t *SpendTracker) Len() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.entries)
+}
+
+// evictStaleLocked removes entries from previous days.
+// Must be called with t.mu held. Only sweeps once per calendar day.
+func (t *SpendTracker) evictStaleLocked(today string) {
+	if t.lastEvictDate == today {
+		return
+	}
+	t.lastEvictDate = today
+	for k, e := range t.entries {
+		if e.date != today {
+			delete(t.entries, k)
+		}
+	}
 }
 
 // matchSpendLimit finds the best-matching SpendLimitConfig for a model name.
 // Uses prefix matching — the longest matching prefix wins, giving more specific
 // limits precedence (e.g. "claude-opus-4.7" beats "claude-opus-4").
+// Skips entries with MaxDailyUSD <= 0 (invalid configuration).
 // Returns nil if no limit matches.
 func matchSpendLimit(model string, limits []SpendLimitConfig) *SpendLimitConfig {
 	model = strings.ToLower(model)
@@ -98,6 +129,9 @@ func matchSpendLimit(model string, limits []SpendLimitConfig) *SpendLimitConfig 
 	bestLen := 0
 
 	for i := range limits {
+		if limits[i].MaxDailyUSD <= 0 {
+			continue // skip invalid limits
+		}
 		prefix := strings.ToLower(limits[i].Model)
 		if strings.HasPrefix(model, prefix) && len(prefix) > bestLen {
 			best = &limits[i]
@@ -108,26 +142,43 @@ func matchSpendLimit(model string, limits []SpendLimitConfig) *SpendLimitConfig 
 }
 
 // estimateRequestCost estimates the USD cost of a request based on the request
-// body size and model pricing. This is a conservative estimate used for the
+// body content and model pricing. This is a conservative estimate used for the
 // per-request cost cap (#277).
 //
 // Methodology:
-//   - Input tokens: body_bytes / 4 (conservative 4 bytes per token)
+//   - Input tokens: text_bytes / 4 (conservative 4 bytes per token)
+//   - For multimodal requests (base64 images), the base64 data is discounted
+//     and each detected image adds ~1000 tokens (typical vision model cost)
 //   - Output tokens: estimated at 2× input tokens (capped at 32K)
 //   - Cost: calculated using the cost calculator's pricing table
 //
 // The estimate is intentionally conservative (over-estimates) since it's used
 // as a gate — false positives (blocking cheap requests) are better than false
 // negatives (allowing expensive ones through).
-func estimateRequestCost(calc *costcalc.Calculator, provider, model string, bodySize int) float64 {
-	if calc == nil || bodySize == 0 || model == "" {
+func estimateRequestCost(calc *costcalc.Calculator, provider, model string, reqBody []byte) float64 {
+	if calc == nil || len(reqBody) == 0 || model == "" {
 		return 0
 	}
 
-	// Approximate input tokens from body size.
-	// JSON overhead means not all bytes are content, but messages contain
-	// system prompts, conversation history, etc. 4 bytes/token is conservative.
+	bodySize := len(reqBody)
 	inputTokens := int64(bodySize) / 4
+
+	// Detect multimodal requests containing base64-encoded images.
+	// Base64 images inflate body size massively (a 1MB image = 1.3MB base64)
+	// but only cost ~1000 tokens per image in vision models.
+	// Without this discount, a single 1MB image would be estimated as
+	// 250K input tokens ($0.50 on GPT-4o) when the actual cost is ~$0.003.
+	imageCount := countBase64Images(reqBody)
+	if imageCount > 0 {
+		// Heuristic: each base64 image averages ~100KB of JSON body.
+		// Subtract that from the body size and add ~1000 tokens per image.
+		estimatedImageBytes := int64(imageCount) * 100_000
+		textBytes := int64(bodySize) - estimatedImageBytes
+		if textBytes < 0 {
+			textBytes = 0
+		}
+		inputTokens = textBytes/4 + int64(imageCount)*1000
+	}
 
 	// Estimate output tokens: 2× input is generous for most use cases.
 	// Cap at 32K to avoid absurd estimates for large-context requests.
@@ -138,4 +189,17 @@ func estimateRequestCost(calc *costcalc.Calculator, provider, model string, body
 	}
 
 	return calc.Calculate(provider, model, inputTokens, outputTokens)
+}
+
+// countBase64Images counts approximate number of base64-encoded images in a
+// request body by looking for common patterns across OpenAI, Anthropic, and
+// Google vision API formats.
+func countBase64Images(body []byte) int {
+	count := 0
+	// OpenAI/Gemini: "data:image/..."
+	count += bytes.Count(body, []byte("data:image/"))
+	// Anthropic: "type": "image" + "source": {"type": "base64", ...}
+	count += bytes.Count(body, []byte(`"type":"base64"`))
+	count += bytes.Count(body, []byte(`"type": "base64"`))
+	return count
 }

--- a/pkg/proxy/cost_gate_test.go
+++ b/pkg/proxy/cost_gate_test.go
@@ -1,0 +1,268 @@
+package proxy
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/costcalc"
+)
+
+func TestMatchSpendLimit_ExactMatch(t *testing.T) {
+	limits := []SpendLimitConfig{
+		{Model: "gpt-4.1", MaxDailyUSD: 25},
+		{Model: "claude-opus-4", MaxDailyUSD: 50},
+	}
+	got := matchSpendLimit("gpt-4.1", limits)
+	if got == nil || got.Model != "gpt-4.1" {
+		t.Fatalf("expected gpt-4.1 match, got %v", got)
+	}
+}
+
+func TestMatchSpendLimit_PrefixMatch(t *testing.T) {
+	limits := []SpendLimitConfig{
+		{Model: "claude-opus-4", MaxDailyUSD: 50},
+	}
+	// Should match dated variant
+	got := matchSpendLimit("claude-opus-4-20250514", limits)
+	if got == nil || got.Model != "claude-opus-4" {
+		t.Fatalf("expected claude-opus-4 prefix match, got %v", got)
+	}
+	// Should match extended version
+	got = matchSpendLimit("claude-opus-4.7", limits)
+	if got == nil || got.Model != "claude-opus-4" {
+		t.Fatalf("expected claude-opus-4 prefix match for 4.7, got %v", got)
+	}
+}
+
+func TestMatchSpendLimit_LongestPrefix(t *testing.T) {
+	limits := []SpendLimitConfig{
+		{Model: "claude-opus-4", MaxDailyUSD: 50},
+		{Model: "claude-opus-4.7", MaxDailyUSD: 100},
+	}
+	got := matchSpendLimit("claude-opus-4.7-20260101", limits)
+	if got == nil || got.Model != "claude-opus-4.7" {
+		t.Fatalf("expected longest prefix claude-opus-4.7, got %v", got)
+	}
+	// Shorter model should still match the shorter prefix
+	got = matchSpendLimit("claude-opus-4.6", limits)
+	if got == nil || got.Model != "claude-opus-4" {
+		t.Fatalf("expected claude-opus-4 for 4.6, got %v", got)
+	}
+}
+
+func TestMatchSpendLimit_NoMatch(t *testing.T) {
+	limits := []SpendLimitConfig{
+		{Model: "claude-opus-4", MaxDailyUSD: 50},
+	}
+	got := matchSpendLimit("gpt-4.1", limits)
+	if got != nil {
+		t.Fatalf("expected no match, got %v", got)
+	}
+}
+
+func TestMatchSpendLimit_CaseInsensitive(t *testing.T) {
+	limits := []SpendLimitConfig{
+		{Model: "Claude-Opus-4", MaxDailyUSD: 50},
+	}
+	got := matchSpendLimit("claude-opus-4-20250514", limits)
+	if got == nil {
+		t.Fatal("expected case-insensitive match")
+	}
+}
+
+func TestSpendTracker_RecordAndCheck(t *testing.T) {
+	tr := NewSpendTracker()
+	limits := []SpendLimitConfig{
+		{Model: "gpt-4.1", MaxDailyUSD: 10.0},
+	}
+
+	// Initially allowed
+	allowed, spent, limit := tr.Check("user1", "gpt-4.1", limits)
+	if !allowed || spent != 0 || limit != 10.0 {
+		t.Fatalf("expected allowed=true, spent=0, limit=10; got %v, %v, %v", allowed, spent, limit)
+	}
+
+	// Record some spend
+	tr.Record("user1", "gpt-4.1", 3.0, limits)
+	allowed, spent, _ = tr.Check("user1", "gpt-4.1", limits)
+	if !allowed || spent != 3.0 {
+		t.Fatalf("expected allowed=true, spent=3; got %v, %v", allowed, spent)
+	}
+
+	// Record more, exceeding limit
+	tr.Record("user1", "gpt-4.1", 8.0, limits)
+	allowed, spent, _ = tr.Check("user1", "gpt-4.1", limits)
+	if allowed || spent != 11.0 {
+		t.Fatalf("expected allowed=false, spent=11; got %v, %v", allowed, spent)
+	}
+}
+
+func TestSpendTracker_MultipleUsers(t *testing.T) {
+	tr := NewSpendTracker()
+	limits := []SpendLimitConfig{
+		{Model: "gpt-4.1", MaxDailyUSD: 5.0},
+	}
+
+	tr.Record("user1", "gpt-4.1", 6.0, limits) // over limit
+
+	// user2 should still be allowed
+	allowed, spent, _ := tr.Check("user2", "gpt-4.1", limits)
+	if !allowed || spent != 0 {
+		t.Fatalf("user2 should be independent, got allowed=%v spent=%v", allowed, spent)
+	}
+}
+
+func TestSpendTracker_MultipleModels(t *testing.T) {
+	tr := NewSpendTracker()
+	limits := []SpendLimitConfig{
+		{Model: "gpt-4.1", MaxDailyUSD: 5.0},
+		{Model: "claude-opus-4", MaxDailyUSD: 10.0},
+	}
+
+	tr.Record("user1", "gpt-4.1", 6.0, limits)
+
+	// claude should still be allowed
+	allowed, _, _ := tr.Check("user1", "claude-opus-4", limits)
+	if !allowed {
+		t.Fatal("claude-opus-4 should not be blocked by gpt-4.1 overspend")
+	}
+}
+
+func TestSpendTracker_PrefixRecording(t *testing.T) {
+	tr := NewSpendTracker()
+	limits := []SpendLimitConfig{
+		{Model: "claude-opus-4", MaxDailyUSD: 5.0},
+	}
+
+	// Record with dated variant — should accumulate under "claude-opus-4" prefix
+	tr.Record("user1", "claude-opus-4-20250514", 2.0, limits)
+	tr.Record("user1", "claude-opus-4.7", 2.0, limits)
+
+	// Check with yet another variant
+	allowed, spent, _ := tr.Check("user1", "claude-opus-4.6", limits)
+	if !allowed || spent != 4.0 {
+		t.Fatalf("expected all variants to accumulate, got allowed=%v spent=%v", allowed, spent)
+	}
+}
+
+func TestSpendTracker_NoLimitNoTracking(t *testing.T) {
+	tr := NewSpendTracker()
+	limits := []SpendLimitConfig{
+		{Model: "gpt-4.1", MaxDailyUSD: 5.0},
+	}
+
+	// Record for a model with no limit — should not track
+	tr.Record("user1", "gemini-2.5-flash", 100.0, limits)
+
+	// And it should always be allowed
+	allowed, spent, limit := tr.Check("user1", "gemini-2.5-flash", limits)
+	if !allowed || spent != 0 || limit != 0 {
+		t.Fatalf("model without limit should always be allowed, got %v %v %v", allowed, spent, limit)
+	}
+}
+
+func TestSpendTracker_Concurrent(t *testing.T) {
+	tr := NewSpendTracker()
+	limits := []SpendLimitConfig{
+		{Model: "gpt-4.1", MaxDailyUSD: 10000.0},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tr.Record("user1", "gpt-4.1", 1.0, limits)
+			tr.Check("user1", "gpt-4.1", limits)
+		}()
+	}
+	wg.Wait()
+
+	_, spent, _ := tr.Check("user1", "gpt-4.1", limits)
+	if spent != 100.0 {
+		t.Fatalf("expected spent=100 after 100 concurrent records, got %v", spent)
+	}
+}
+
+func TestEstimateRequestCost(t *testing.T) {
+	calc := costcalc.New()
+
+	tests := []struct {
+		name     string
+		provider string
+		model    string
+		bodySize int
+		wantZero bool
+	}{
+		{
+			name:     "normal request",
+			provider: "openai",
+			model:    "gpt-4.1",
+			bodySize: 4000, // ~1000 input tokens, ~2000 output tokens
+			wantZero: false,
+		},
+		{
+			name:     "empty body",
+			provider: "openai",
+			model:    "gpt-4.1",
+			bodySize: 0,
+			wantZero: true,
+		},
+		{
+			name:     "no model",
+			provider: "openai",
+			model:    "",
+			bodySize: 4000,
+			wantZero: true,
+		},
+		{
+			name:     "nil calculator",
+			provider: "openai",
+			model:    "gpt-4.1",
+			bodySize: 4000,
+			wantZero: true,
+		},
+		{
+			name:     "local provider",
+			provider: "local",
+			model:    "llama3",
+			bodySize: 4000,
+			wantZero: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := calc
+			if tt.name == "nil calculator" {
+				c = nil
+			}
+			got := estimateRequestCost(c, tt.provider, tt.model, tt.bodySize)
+			if tt.wantZero && got != 0 {
+				t.Errorf("expected 0, got %f", got)
+			}
+			if !tt.wantZero && got <= 0 {
+				t.Errorf("expected positive cost, got %f", got)
+			}
+		})
+	}
+}
+
+func TestEstimateRequestCost_OutputCap(t *testing.T) {
+	calc := costcalc.New()
+
+	// Very large body: 1MB = ~250K input tokens, output would be 500K uncapped.
+	// With 32K cap on output, the cost should be lower.
+	largeCost := estimateRequestCost(calc, "openai", "gpt-4.1", 1_000_000)
+	// 250K input + 32K output (capped) for gpt-4.1 ($2/M input, $8/M output)
+	// = 250K * $2/M + 32K * $8/M = $0.50 + $0.256 = $0.756
+	if largeCost < 0.5 || largeCost > 1.5 {
+		t.Errorf("expected large request cost in [0.5, 1.5], got %f", largeCost)
+	}
+
+	// Compare: small body (4KB = ~1K tokens) should cost much less
+	smallCost := estimateRequestCost(calc, "openai", "gpt-4.1", 4_000)
+	if smallCost >= largeCost {
+		t.Errorf("small body (%f) should cost less than large body (%f)", smallCost, largeCost)
+	}
+}

--- a/pkg/proxy/cost_gate_test.go
+++ b/pkg/proxy/cost_gate_test.go
@@ -1,11 +1,16 @@
 package proxy
 
 import (
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/candelahq/candela/pkg/costcalc"
 )
+
+// ─────────────────────────────────────────────────────────────
+// matchSpendLimit tests
+// ─────────────────────────────────────────────────────────────
 
 func TestMatchSpendLimit_ExactMatch(t *testing.T) {
 	limits := []SpendLimitConfig{
@@ -70,6 +75,50 @@ func TestMatchSpendLimit_CaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestMatchSpendLimit_ZeroLimit_Skipped(t *testing.T) {
+	limits := []SpendLimitConfig{
+		{Model: "gpt-4.1", MaxDailyUSD: 0},        // invalid — should be skipped
+		{Model: "gpt-4.1", MaxDailyUSD: -5.0},     // invalid — should be skipped
+		{Model: "claude-opus-4", MaxDailyUSD: 50}, // valid
+	}
+	// gpt-4.1 with MaxDailyUSD=0 or negative should be skipped
+	got := matchSpendLimit("gpt-4.1", limits)
+	if got != nil {
+		t.Fatalf("expected nil for zero/negative limit, got %+v", got)
+	}
+	// claude-opus-4 with valid limit should match
+	got = matchSpendLimit("claude-opus-4", limits)
+	if got == nil || got.MaxDailyUSD != 50 {
+		t.Fatalf("expected claude-opus-4 with limit 50, got %v", got)
+	}
+}
+
+func TestMatchSpendLimit_EmptyLimits(t *testing.T) {
+	got := matchSpendLimit("gpt-4.1", nil)
+	if got != nil {
+		t.Fatalf("expected nil for empty limits, got %v", got)
+	}
+	got = matchSpendLimit("gpt-4.1", []SpendLimitConfig{})
+	if got != nil {
+		t.Fatalf("expected nil for empty slice, got %v", got)
+	}
+}
+
+func TestMatchSpendLimit_EmptyModel(t *testing.T) {
+	limits := []SpendLimitConfig{
+		{Model: "gpt-4.1", MaxDailyUSD: 25},
+	}
+	// Empty model name matches everything via HasPrefix("", "gpt-4.1") = false
+	got := matchSpendLimit("", limits)
+	if got != nil {
+		t.Fatalf("expected nil for empty model, got %v", got)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// SpendTracker tests
+// ─────────────────────────────────────────────────────────────
+
 func TestSpendTracker_RecordAndCheck(t *testing.T) {
 	tr := NewSpendTracker()
 	limits := []SpendLimitConfig{
@@ -77,23 +126,70 @@ func TestSpendTracker_RecordAndCheck(t *testing.T) {
 	}
 
 	// Initially allowed
-	allowed, spent, limit := tr.Check("user1", "gpt-4.1", limits)
+	allowed, spent, limit := tr.Check("user1", "gpt-4.1", limits, 0)
 	if !allowed || spent != 0 || limit != 10.0 {
 		t.Fatalf("expected allowed=true, spent=0, limit=10; got %v, %v, %v", allowed, spent, limit)
 	}
 
 	// Record some spend
 	tr.Record("user1", "gpt-4.1", 3.0, limits)
-	allowed, spent, _ = tr.Check("user1", "gpt-4.1", limits)
+	allowed, spent, _ = tr.Check("user1", "gpt-4.1", limits, 0)
 	if !allowed || spent != 3.0 {
 		t.Fatalf("expected allowed=true, spent=3; got %v, %v", allowed, spent)
 	}
 
 	// Record more, exceeding limit
 	tr.Record("user1", "gpt-4.1", 8.0, limits)
-	allowed, spent, _ = tr.Check("user1", "gpt-4.1", limits)
+	allowed, spent, _ = tr.Check("user1", "gpt-4.1", limits, 0)
 	if allowed || spent != 11.0 {
 		t.Fatalf("expected allowed=false, spent=11; got %v, %v", allowed, spent)
+	}
+}
+
+func TestSpendTracker_CheckWithEstimatedCost(t *testing.T) {
+	tr := NewSpendTracker()
+	limits := []SpendLimitConfig{
+		{Model: "gpt-4.1", MaxDailyUSD: 10.0},
+	}
+
+	// Record $8 of spend
+	tr.Record("user1", "gpt-4.1", 8.0, limits)
+
+	// Check with estimated $1 — should be allowed (8+1=9 <= 10)
+	allowed, _, _ := tr.Check("user1", "gpt-4.1", limits, 1.0)
+	if !allowed {
+		t.Fatal("expected allowed=true for 8+1=9 <= 10")
+	}
+
+	// Check with estimated $3 — should be blocked (8+3=11 > 10)
+	allowed, _, _ = tr.Check("user1", "gpt-4.1", limits, 3.0)
+	if allowed {
+		t.Fatal("expected allowed=false for 8+3=11 > 10")
+	}
+
+	// Check with estimated $2 — should be allowed (8+2=10 <= 10)
+	allowed, _, _ = tr.Check("user1", "gpt-4.1", limits, 2.0)
+	if !allowed {
+		t.Fatal("expected allowed=true for 8+2=10 <= 10")
+	}
+}
+
+func TestSpendTracker_CheckEstimatedCost_NoHistory(t *testing.T) {
+	tr := NewSpendTracker()
+	limits := []SpendLimitConfig{
+		{Model: "gpt-4.1", MaxDailyUSD: 5.0},
+	}
+
+	// No spend history — check with estimated cost that exceeds limit
+	allowed, _, _ := tr.Check("user1", "gpt-4.1", limits, 6.0)
+	if allowed {
+		t.Fatal("expected allowed=false when estimated cost alone exceeds limit")
+	}
+
+	// Estimated cost within limit
+	allowed, _, _ = tr.Check("user1", "gpt-4.1", limits, 4.0)
+	if !allowed {
+		t.Fatal("expected allowed=true when estimated cost within limit")
 	}
 }
 
@@ -106,7 +202,7 @@ func TestSpendTracker_MultipleUsers(t *testing.T) {
 	tr.Record("user1", "gpt-4.1", 6.0, limits) // over limit
 
 	// user2 should still be allowed
-	allowed, spent, _ := tr.Check("user2", "gpt-4.1", limits)
+	allowed, spent, _ := tr.Check("user2", "gpt-4.1", limits, 0)
 	if !allowed || spent != 0 {
 		t.Fatalf("user2 should be independent, got allowed=%v spent=%v", allowed, spent)
 	}
@@ -122,7 +218,7 @@ func TestSpendTracker_MultipleModels(t *testing.T) {
 	tr.Record("user1", "gpt-4.1", 6.0, limits)
 
 	// claude should still be allowed
-	allowed, _, _ := tr.Check("user1", "claude-opus-4", limits)
+	allowed, _, _ := tr.Check("user1", "claude-opus-4", limits, 0)
 	if !allowed {
 		t.Fatal("claude-opus-4 should not be blocked by gpt-4.1 overspend")
 	}
@@ -139,7 +235,7 @@ func TestSpendTracker_PrefixRecording(t *testing.T) {
 	tr.Record("user1", "claude-opus-4.7", 2.0, limits)
 
 	// Check with yet another variant
-	allowed, spent, _ := tr.Check("user1", "claude-opus-4.6", limits)
+	allowed, spent, _ := tr.Check("user1", "claude-opus-4.6", limits, 0)
 	if !allowed || spent != 4.0 {
 		t.Fatalf("expected all variants to accumulate, got allowed=%v spent=%v", allowed, spent)
 	}
@@ -155,7 +251,7 @@ func TestSpendTracker_NoLimitNoTracking(t *testing.T) {
 	tr.Record("user1", "gemini-2.5-flash", 100.0, limits)
 
 	// And it should always be allowed
-	allowed, spent, limit := tr.Check("user1", "gemini-2.5-flash", limits)
+	allowed, spent, limit := tr.Check("user1", "gemini-2.5-flash", limits, 0)
 	if !allowed || spent != 0 || limit != 0 {
 		t.Fatalf("model without limit should always be allowed, got %v %v %v", allowed, spent, limit)
 	}
@@ -173,16 +269,89 @@ func TestSpendTracker_Concurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			tr.Record("user1", "gpt-4.1", 1.0, limits)
-			tr.Check("user1", "gpt-4.1", limits)
+			tr.Check("user1", "gpt-4.1", limits, 0)
 		}()
 	}
 	wg.Wait()
 
-	_, spent, _ := tr.Check("user1", "gpt-4.1", limits)
+	_, spent, _ := tr.Check("user1", "gpt-4.1", limits, 0)
 	if spent != 100.0 {
 		t.Fatalf("expected spent=100 after 100 concurrent records, got %v", spent)
 	}
 }
+
+func TestSpendTracker_NegativeCostIgnored(t *testing.T) {
+	tr := NewSpendTracker()
+	limits := []SpendLimitConfig{
+		{Model: "gpt-4.1", MaxDailyUSD: 10.0},
+	}
+
+	tr.Record("user1", "gpt-4.1", -5.0, limits) // negative — ignored
+	tr.Record("user1", "gpt-4.1", 0.0, limits)  // zero — ignored
+	tr.Record("user1", "gpt-4.1", 3.0, limits)  // valid
+
+	_, spent, _ := tr.Check("user1", "gpt-4.1", limits, 0)
+	if spent != 3.0 {
+		t.Fatalf("expected only positive costs tracked, got %v", spent)
+	}
+}
+
+func TestSpendTracker_LocalFallback(t *testing.T) {
+	// Simulates solo mode where effectiveUserID is empty.
+	tr := NewSpendTracker()
+	limits := []SpendLimitConfig{
+		{Model: "gpt-4.1", MaxDailyUSD: 5.0},
+	}
+
+	// Use "local" as the solo-mode fallback user
+	tr.Record("local", "gpt-4.1", 6.0, limits)
+
+	allowed, spent, _ := tr.Check("local", "gpt-4.1", limits, 0)
+	if allowed || spent != 6.0 {
+		t.Fatalf("expected blocked for local user, got allowed=%v spent=%v", allowed, spent)
+	}
+
+	// A real user should be independent
+	allowed, spent, _ = tr.Check("user1", "gpt-4.1", limits, 0)
+	if !allowed || spent != 0 {
+		t.Fatalf("real user should be independent of local, got allowed=%v spent=%v", allowed, spent)
+	}
+}
+
+func TestSpendTracker_EvictStaleEntries(t *testing.T) {
+	tr := NewSpendTracker()
+	limits := []SpendLimitConfig{
+		{Model: "gpt-4.1", MaxDailyUSD: 10.0},
+	}
+
+	// Manually inject a stale entry from yesterday
+	tr.mu.Lock()
+	tr.entries["user1\x00gpt-4.1"] = &spendEntry{spent: 100, date: "2020-01-01"}
+	tr.entries["user2\x00gpt-4.1"] = &spendEntry{spent: 200, date: "2020-01-01"}
+	tr.mu.Unlock()
+
+	if tr.Len() != 2 {
+		t.Fatalf("expected 2 entries, got %d", tr.Len())
+	}
+
+	// Record for today — should trigger eviction of stale entries
+	tr.Record("user1", "gpt-4.1", 1.0, limits)
+
+	// Stale user2 entry should be gone, user1 should have new entry
+	if tr.Len() != 1 {
+		t.Fatalf("expected 1 entry after eviction, got %d", tr.Len())
+	}
+
+	// user1 should have today's spend only (1.0, not 101.0)
+	_, spent, _ := tr.Check("user1", "gpt-4.1", limits, 0)
+	if spent != 1.0 {
+		t.Fatalf("expected fresh spend=1.0 after date change, got %v", spent)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// estimateRequestCost tests
+// ─────────────────────────────────────────────────────────────
 
 func TestEstimateRequestCost(t *testing.T) {
 	calc := costcalc.New()
@@ -191,42 +360,42 @@ func TestEstimateRequestCost(t *testing.T) {
 		name     string
 		provider string
 		model    string
-		bodySize int
+		body     []byte
 		wantZero bool
 	}{
 		{
 			name:     "normal request",
 			provider: "openai",
 			model:    "gpt-4.1",
-			bodySize: 4000, // ~1000 input tokens, ~2000 output tokens
+			body:     []byte(strings.Repeat("x", 4000)),
 			wantZero: false,
 		},
 		{
 			name:     "empty body",
 			provider: "openai",
 			model:    "gpt-4.1",
-			bodySize: 0,
+			body:     nil,
 			wantZero: true,
 		},
 		{
 			name:     "no model",
 			provider: "openai",
 			model:    "",
-			bodySize: 4000,
+			body:     []byte(strings.Repeat("x", 4000)),
 			wantZero: true,
 		},
 		{
 			name:     "nil calculator",
 			provider: "openai",
 			model:    "gpt-4.1",
-			bodySize: 4000,
+			body:     []byte(strings.Repeat("x", 4000)),
 			wantZero: true,
 		},
 		{
 			name:     "local provider",
 			provider: "local",
 			model:    "llama3",
-			bodySize: 4000,
+			body:     []byte(strings.Repeat("x", 4000)),
 			wantZero: true,
 		},
 	}
@@ -237,7 +406,7 @@ func TestEstimateRequestCost(t *testing.T) {
 			if tt.name == "nil calculator" {
 				c = nil
 			}
-			got := estimateRequestCost(c, tt.provider, tt.model, tt.bodySize)
+			got := estimateRequestCost(c, tt.provider, tt.model, tt.body)
 			if tt.wantZero && got != 0 {
 				t.Errorf("expected 0, got %f", got)
 			}
@@ -251,9 +420,9 @@ func TestEstimateRequestCost(t *testing.T) {
 func TestEstimateRequestCost_OutputCap(t *testing.T) {
 	calc := costcalc.New()
 
-	// Very large body: 1MB = ~250K input tokens, output would be 500K uncapped.
-	// With 32K cap on output, the cost should be lower.
-	largeCost := estimateRequestCost(calc, "openai", "gpt-4.1", 1_000_000)
+	// Very large body: 1MB text = ~250K input tokens, output would be 500K uncapped.
+	largeBody := []byte(strings.Repeat("a", 1_000_000))
+	largeCost := estimateRequestCost(calc, "openai", "gpt-4.1", largeBody)
 	// 250K input + 32K output (capped) for gpt-4.1 ($2/M input, $8/M output)
 	// = 250K * $2/M + 32K * $8/M = $0.50 + $0.256 = $0.756
 	if largeCost < 0.5 || largeCost > 1.5 {
@@ -261,8 +430,79 @@ func TestEstimateRequestCost_OutputCap(t *testing.T) {
 	}
 
 	// Compare: small body (4KB = ~1K tokens) should cost much less
-	smallCost := estimateRequestCost(calc, "openai", "gpt-4.1", 4_000)
+	smallBody := []byte(strings.Repeat("a", 4_000))
+	smallCost := estimateRequestCost(calc, "openai", "gpt-4.1", smallBody)
 	if smallCost >= largeCost {
 		t.Errorf("small body (%f) should cost less than large body (%f)", smallCost, largeCost)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// Multimodal / base64 detection tests
+// ─────────────────────────────────────────────────────────────
+
+func TestCountBase64Images(t *testing.T) {
+	tests := []struct {
+		name  string
+		body  string
+		count int
+	}{
+		{"no images", `{"messages":[{"content":"hello"}]}`, 0},
+		{"one openai image", `{"messages":[{"content":[{"type":"image_url","image_url":{"url":"data:image/jpeg;base64,/9j/4AAQ..."}}]}]}`, 1},
+		{"two openai images", `data:image/png;base64,abc data:image/jpeg;base64,def`, 2},
+		{"anthropic base64", `{"type":"base64","media_type":"image/jpeg","data":"abc..."}`, 1},
+		{"anthropic base64 spaced", `{"type": "base64", "media_type": "image/jpeg"}`, 1},
+		{"mixed", `data:image/png;base64,x "type":"base64" data:image/jpeg;base64,y`, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countBase64Images([]byte(tt.body))
+			if got != tt.count {
+				t.Errorf("countBase64Images = %d, want %d", got, tt.count)
+			}
+		})
+	}
+}
+
+func TestEstimateRequestCost_MultimodalDiscount(t *testing.T) {
+	calc := costcalc.New()
+
+	// Simulate a request with a base64-encoded image (~1MB of base64 data)
+	// plus a short text prompt (~100 bytes).
+	textPart := `{"messages":[{"role":"user","content":[{"type":"text","text":"describe this image"},{"type":"image_url","image_url":{"url":"data:image/jpeg;base64,`
+	base64Data := strings.Repeat("A", 1_000_000) // ~1MB of base64
+	closePart := `"}}]}]}`
+	multimodalBody := []byte(textPart + base64Data + closePart)
+
+	// Same total size but pure text (no images)
+	textOnlyBody := []byte(strings.Repeat("x", len(multimodalBody)))
+
+	multimodalCost := estimateRequestCost(calc, "openai", "gpt-4.1", multimodalBody)
+	textOnlyCost := estimateRequestCost(calc, "openai", "gpt-4.1", textOnlyBody)
+
+	// The multimodal request should cost less than the same-size text-only request
+	// because the base64 data is discounted to ~1000 tokens per image instead of
+	// 250K tokens (1MB/4).
+	if multimodalCost >= textOnlyCost {
+		t.Errorf("multimodal cost ($%.4f) should be less than text-only cost ($%.4f) for same body size",
+			multimodalCost, textOnlyCost)
+	}
+
+	// The multimodal input estimate should be dramatically lower:
+	// Text-only: ~250K input tokens. Multimodal: ~1K (image) + tiny text = ~1K.
+	// But output cap (32K) dominates both, so we just check multimodal < text.
+	t.Logf("multimodal=$%.4f text=$%.4f ratio=%.2fx", multimodalCost, textOnlyCost, textOnlyCost/multimodalCost)
+}
+
+func TestEstimateRequestCost_MultimodalSmallBody(t *testing.T) {
+	calc := costcalc.New()
+
+	// A very small multimodal request where text is most of the body.
+	// The discount should not produce negative tokens.
+	body := []byte(`{"messages":[{"content":"data:image/png;base64,tiny"}]}`)
+	cost := estimateRequestCost(calc, "openai", "gpt-4.1", body)
+	if cost < 0 {
+		t.Errorf("cost should never be negative, got %f", cost)
 	}
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -237,6 +237,10 @@ type Proxy struct {
 	// CRIT-3: Durable outbox for failed DeductSpend calls.
 	spendOutbox *spendoutbox.Outbox
 
+	// #277/#278: Per-request cost cap and per-model daily spend limits.
+	config       Config        // retained for limit config access
+	spendTracker *SpendTracker // per-user per-model daily spend tracker (nil if no limits)
+
 	// HIGH-2: Service account spend tracking (micro-USD for precision).
 	saSpendMicroUSD atomic.Int64
 
@@ -246,8 +250,10 @@ type Proxy struct {
 
 // Config holds proxy configuration.
 type Config struct {
-	Providers []Provider `yaml:"providers"`
-	ProjectID string     `yaml:"project_id"`
+	Providers      []Provider         `yaml:"providers"`
+	ProjectID      string             `yaml:"project_id"`
+	MaxRequestCost float64            `yaml:"max_request_cost_usd"` // Per-request cost cap (0 = disabled)
+	DailyLimits    []SpendLimitConfig `yaml:"daily_limits"`         // Per-model daily spend limits
 }
 
 // DefaultProviders returns the standard LLM provider configurations.
@@ -283,17 +289,25 @@ func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) *Proxy 
 		breakers[p.Name] = NewCircuitBreaker(cbCfg)
 	}
 
-	return &Proxy{
+	p := &Proxy{
 		providers: providers,
 		submitter: submitter,
 		calc:      calc,
 		projectID: cfg.ProjectID,
+		config:    cfg,
 		breakers:  breakers,
 		spanSem:   make(chan struct{}, 200), // CRIT-16: cap concurrent span goroutines
 		client: &http.Client{
 			Timeout: 5 * time.Minute, // LLM calls can be slow
 		},
 	}
+
+	// Initialize spend tracker if daily limits are configured.
+	if len(cfg.DailyLimits) > 0 {
+		p.spendTracker = NewSpendTracker()
+	}
+
+	return p
 }
 
 // SetUserStore sets the optional UserStore for budget deduction.
@@ -741,6 +755,54 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte(`{"error":{"message":"budget exhausted — contact your admin for a grant or budget increase","type":"insufficient_budget","code":402}}`))
 			slog.Info("blocked request: budget exhausted",
 				"user_id", effectiveUserID, "remaining_usd", check.RemainingUSD)
+			return
+		}
+	}
+
+	// ── Per-request cost cap (#277) ──
+	// Estimates the request cost from body size and rejects if it exceeds
+	// the configured maximum. Runs for all users (solo + team mode).
+	if p.config.MaxRequestCost > 0 && requestModel != "" {
+		estimatedCost := estimateRequestCost(p.calc, providerName, requestModel, len(reqBody))
+		if estimatedCost > p.config.MaxRequestCost {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusPaymentRequired)
+			errBody, _ := json.Marshal(map[string]any{
+				"error": map[string]any{
+					"message": fmt.Sprintf("estimated request cost $%.2f exceeds cap $%.2f for model %s",
+						estimatedCost, p.config.MaxRequestCost, requestModel),
+					"type": "request_cost_exceeded",
+					"code": 402,
+				},
+			})
+			_, _ = w.Write(errBody)
+			slog.Info("blocked request: estimated cost exceeds cap",
+				"user_id", effectiveUserID, "provider", providerName,
+				"model", requestModel, "estimated_usd", estimatedCost,
+				"cap_usd", p.config.MaxRequestCost)
+			return
+		}
+	}
+
+	// ── Per-model daily spend limit (#278) ──
+	// Checks in-memory per-user per-model daily spend against configured limits.
+	if p.spendTracker != nil && requestModel != "" && effectiveUserID != "" {
+		allowed, spent, limit := p.spendTracker.Check(effectiveUserID, requestModel, p.config.DailyLimits)
+		if !allowed {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusPaymentRequired)
+			errBody, _ := json.Marshal(map[string]any{
+				"error": map[string]any{
+					"message": fmt.Sprintf("daily spend limit for %s reached ($%.2f/$%.2f)",
+						requestModel, spent, limit),
+					"type": "daily_limit_exceeded",
+					"code": 402,
+				},
+			})
+			_, _ = w.Write(errBody)
+			slog.Info("blocked request: daily model spend limit exceeded",
+				"user_id", effectiveUserID, "model", requestModel,
+				"spent_usd", spent, "limit_usd", limit)
 			return
 		}
 	}
@@ -1307,6 +1369,13 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 
 	totalTokens := inputTokens + outputTokens
 	cost := p.calc.Calculate(provider.Name, model, inputTokens, outputTokens)
+
+	// #278: Record per-model daily spend in the in-memory tracker.
+	// This must happen even if DeductSpend fails, since the upstream
+	// response was already forwarded (spend happened, we're tracking it).
+	if p.spendTracker != nil && cost > 0 {
+		p.spendTracker.Record(userID, model, cost, p.config.DailyLimits)
+	}
 
 	// #10: DeductSpend is called when CostUSD>0 OR TotalTokens>0.
 	// The TotalTokens>0 case handles: unknown cloud models (cost=$0 from pricing

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -762,8 +762,9 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// ── Per-request cost cap (#277) ──
 	// Estimates the request cost from body size and rejects if it exceeds
 	// the configured maximum. Runs for all users (solo + team mode).
+	var estimatedCost float64
 	if p.config.MaxRequestCost > 0 && requestModel != "" {
-		estimatedCost := estimateRequestCost(p.calc, providerName, requestModel, len(reqBody))
+		estimatedCost = estimateRequestCost(p.calc, providerName, requestModel, reqBody)
 		if estimatedCost > p.config.MaxRequestCost {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusPaymentRequired)
@@ -786,8 +787,13 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 	// ── Per-model daily spend limit (#278) ──
 	// Checks in-memory per-user per-model daily spend against configured limits.
-	if p.spendTracker != nil && requestModel != "" && effectiveUserID != "" {
-		allowed, spent, limit := p.spendTracker.Check(effectiveUserID, requestModel, p.config.DailyLimits)
+	// Uses "local" fallback for solo mode where effectiveUserID is empty.
+	if p.spendTracker != nil && requestModel != "" {
+		limitUser := effectiveUserID
+		if limitUser == "" {
+			limitUser = "local"
+		}
+		allowed, spent, limit := p.spendTracker.Check(limitUser, requestModel, p.config.DailyLimits, estimatedCost)
 		if !allowed {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusPaymentRequired)
@@ -801,7 +807,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 			})
 			_, _ = w.Write(errBody)
 			slog.Info("blocked request: daily model spend limit exceeded",
-				"user_id", effectiveUserID, "model", requestModel,
+				"user_id", limitUser, "model", requestModel,
 				"spent_usd", spent, "limit_usd", limit)
 			return
 		}
@@ -1149,6 +1155,22 @@ func (p *Proxy) handleStandardResponse(
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
 		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens)
 		deductCancel()
+	} else if cbAllow && p.spendTracker != nil {
+		// Solo mode: no UserStore but spend tracker is active.
+		// Record per-model spend so daily limits work without Firestore.
+		model, _ := extractRequestInfo(provider.Name, reqBody)
+		_, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
+		ct := extractCacheTokens(provider.Name, respBody)
+		if model == "" {
+			model = extractModelFromResponse(provider.Name, respBody)
+		}
+		inputTokens = p.calc.NormalizeCachedInputWithTTL(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens, extendedTTL)
+		cost := p.calc.Calculate(provider.Name, model, inputTokens, outputTokens)
+		limitUser := effectiveUserID
+		if limitUser == "" {
+			limitUser = "local"
+		}
+		p.spendTracker.Record(limitUser, model, cost, p.config.DailyLimits)
 	}
 
 	// Create observability span (async — don't block the handler).
@@ -1291,6 +1313,21 @@ func (p *Proxy) handleStreamingResponse(
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
 		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens)
 		deductCancel()
+	} else if cbAllow && p.spendTracker != nil {
+		// Solo mode: record per-model spend for daily limits.
+		model, _ := extractRequestInfo(provider.Name, reqBody)
+		_, inputTokens, outputTokens := extractStreamingUsage(provider.Name, parseData)
+		ct := extractStreamingCacheTokens(provider.Name, parseData)
+		if model == "" {
+			model = extractModelFromStreamingResponse(provider.Name, parseData)
+		}
+		inputTokens = p.calc.NormalizeCachedInputWithTTL(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens, extendedTTL)
+		cost := p.calc.Calculate(provider.Name, model, inputTokens, outputTokens)
+		limitUser := effectiveUserID
+		if limitUser == "" {
+			limitUser = "local"
+		}
+		p.spendTracker.Record(limitUser, model, cost, p.config.DailyLimits)
 	}
 
 	// Create observability span (async — don't block the handler).


### PR DESCRIPTION
## Summary

Add two complementary budget enforcement features to the proxy:

### Per-request cost cap (`max_request_cost_usd`) — #277
Estimates request cost from body size × model pricing and rejects requests exceeding the configured maximum. Returns HTTP 402 with estimated vs. cap amounts.

### Per-model daily spend limits (`daily_limits`) — #278
In-memory per-user per-model daily spend tracker with prefix-based model matching (e.g. `claude-opus-4` matches `claude-opus-4-20250514`). Returns HTTP 402 when a user's daily spend on a model exceeds the configured limit.

## Config Example
```yaml
proxy:
  max_request_cost_usd: 5.00
  daily_limits:
    - model: claude-opus-4
      max_daily_usd: 50.00
    - model: gpt-4.1
      max_daily_usd: 25.00
```

## Design Decisions
- **In-memory enforcement** — no Firestore schema changes
- **Prefix matching** — longest matching prefix wins
- **Works in both modes** — solo (local CLI) and team (server)
- **Conservative on restart** — counters reset to 0

## Testing
- 13 unit tests covering all paths
- Full suite passes (36 packages)

Closes #277, closes #278