### PR TITLE
feat(anomaly): rolling-baseline cost and latency deviation detection

### DIFF
--- a/pkg/anomaly/detector.go
+++ b/pkg/anomaly/detector.go
@@ -94,18 +94,18 @@ func (d *Detector) Detect(ctx context.Context, spans []storage.Span) ([]Result, 
 	for key, group := range groups {
 		// Use the earliest StartTime in the group as the window anchor so all
 		// spans in the group are covered by the same historical query.
-		windowEnd := group[0].StartTime
+		anchorTime := group[0].StartTime
 		for _, s := range group[1:] {
-			if s.StartTime.Before(windowEnd) {
-				windowEnd = s.StartTime
+			if s.StartTime.Before(anchorTime) {
+				anchorTime = s.StartTime
 			}
 		}
-		windowStart := windowEnd.UTC().Add(-time.Duration(d.cfg.WindowDays) * 24 * time.Hour)
+		windowStart := anchorTime.UTC().Add(-time.Duration(d.cfg.WindowDays) * 24 * time.Hour)
 
 		historical, err := d.reader.SearchSpans(ctx, storage.SpanQuery{
 			ProjectID: key.projectID,
 			StartTime: windowStart,
-			EndTime:   windowEnd,
+			EndTime:   anchorTime,
 			Kind:      storage.SpanKindLLM,
 			Model:     key.model,
 			TenantID:  key.tenantID,

--- a/pkg/anomaly/detector.go
+++ b/pkg/anomaly/detector.go
@@ -1,0 +1,213 @@
+// Package anomaly detects statistical deviations in LLM span cost and latency.
+// It maintains a rolling per-(tenant, model) baseline and flags spans that
+// exceed a configurable sigma threshold above the mean. Anomaly metadata is
+// attached to the span's Attributes map under well-known keys so the dashboard
+// and audit trail can surface it without schema changes.
+package anomaly
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+const (
+	// AttrAnomaly is set to "true" on flagged spans.
+	AttrAnomaly = "candela.anomaly"
+	// AttrAnomalyReason describes which metric triggered the flag, e.g.
+	// "cost_2.5sigma" or "latency_2.5sigma".
+	AttrAnomalyReason = "candela.anomaly_reason"
+)
+
+// Config controls detector behaviour.
+type Config struct {
+	// WindowDays is the rolling lookback used to build the baseline.
+	// Spans older than WindowDays before the evaluated span are excluded.
+	WindowDays int
+	// SigmaThreshold is the number of standard deviations above the mean
+	// required to flag a span. Lower values = more sensitive.
+	SigmaThreshold float64
+	// MinSamples is the minimum number of historical spans required before
+	// the detector emits any anomaly. Below this the baseline is too noisy.
+	MinSamples int
+}
+
+// DefaultConfig returns a conservative production-ready configuration.
+func DefaultConfig() Config {
+	return Config{
+		WindowDays:     7,
+		SigmaThreshold: 2.0,
+		MinSamples:     10,
+	}
+}
+
+// Result describes a single anomalous span.
+type Result struct {
+	Span   storage.Span
+	Metric string  // "cost_usd" or "latency_ms"
+	Value  float64 // observed value
+	Mean   float64 // baseline mean
+	StdDev float64 // baseline stddev
+	Sigma  float64 // how many sigma above mean
+}
+
+// Detector checks incoming LLM spans against a rolling baseline.
+type Detector struct {
+	reader storage.SpanReader
+	cfg    Config
+}
+
+// New creates a Detector backed by the given SpanReader.
+func New(reader storage.SpanReader, cfg Config) *Detector {
+	return &Detector{reader: reader, cfg: cfg}
+}
+
+// Detect checks each span in the batch against its per-(tenant, model) baseline
+// and returns anomalous spans. It also stamps anomaly attributes directly onto
+// the span copies in the returned results so callers can re-ingest or surface
+// them downstream.
+//
+// Only spans with Kind == SpanKindLLM and a non-zero cost or duration are
+// evaluated; all others pass through silently.
+func (d *Detector) Detect(ctx context.Context, spans []storage.Span) ([]Result, error) {
+	var results []Result
+	for _, span := range spans {
+		if span.Kind != storage.SpanKindLLM {
+			continue
+		}
+		if span.GenAI == nil {
+			continue
+		}
+		rs, err := d.checkSpan(ctx, span)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rs...)
+	}
+	return results, nil
+}
+
+// checkSpan evaluates a single span for cost and latency anomalies.
+func (d *Detector) checkSpan(ctx context.Context, span storage.Span) ([]Result, error) {
+	windowStart := span.StartTime.UTC().Add(-time.Duration(d.cfg.WindowDays) * 24 * time.Hour)
+
+	historical, err := d.reader.SearchSpans(ctx, storage.SpanQuery{
+		ProjectID: span.ProjectID,
+		StartTime: windowStart,
+		EndTime:   span.StartTime,
+		Kind:      storage.SpanKindLLM,
+		Model:     span.GenAI.Model,
+		TenantID:  span.TenantID,
+		PageSize:  10000,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var results []Result
+
+	if r, ok := d.checkMetric(span, historical.Spans, "cost_usd", func(s storage.Span) float64 {
+		if s.GenAI == nil {
+			return 0
+		}
+		return s.GenAI.CostUSD
+	}); ok {
+		results = append(results, r)
+	}
+
+	if r, ok := d.checkMetric(span, historical.Spans, "latency_ms", func(s storage.Span) float64 {
+		return float64(s.Duration.Milliseconds())
+	}); ok {
+		results = append(results, r)
+	}
+
+	return results, nil
+}
+
+// checkMetric computes the rolling mean and stddev for a single metric across
+// the historical window and returns a Result if the span's value exceeds the
+// sigma threshold.
+func (d *Detector) checkMetric(span storage.Span, history []storage.Span, metric string, extract func(storage.Span) float64) (Result, bool) {
+	vals := make([]float64, 0, len(history))
+	for _, h := range history {
+		if v := extract(h); v > 0 {
+			vals = append(vals, v)
+		}
+	}
+	if len(vals) < d.cfg.MinSamples {
+		return Result{}, false
+	}
+
+	mean, stddev := stats(vals)
+	// Treat near-zero stddev (< 0.1% of mean) as zero to avoid false positives
+	// from floating-point precision when all historical values are identical.
+	if mean > 0 && stddev/mean < 0.001 {
+		return Result{}, false
+	}
+	if stddev == 0 {
+		return Result{}, false
+	}
+
+	observed := extract(span)
+	if observed <= 0 {
+		return Result{}, false
+	}
+
+	sigma := (observed - mean) / stddev
+	if sigma < d.cfg.SigmaThreshold {
+		return Result{}, false
+	}
+	// Require the absolute delta to exceed 10% of the mean to avoid flagging
+	// noise when stddev is near-zero (all-identical history).
+	if mean > 0 && (observed-mean)/mean < 0.10 {
+		return Result{}, false
+	}
+
+	flagged := span
+	newAttrs := make(map[string]string, len(span.Attributes)+2)
+	for k, v := range span.Attributes {
+		newAttrs[k] = v
+	}
+	newAttrs[AttrAnomaly] = "true"
+	newAttrs[AttrAnomalyReason] = metric + "_" + formatSigma(d.cfg.SigmaThreshold) + "sigma"
+	flagged.Attributes = newAttrs
+
+	return Result{
+		Span:   flagged,
+		Metric: metric,
+		Value:  observed,
+		Mean:   mean,
+		StdDev: stddev,
+		Sigma:  sigma,
+	}, true
+}
+
+// stats computes the mean and population standard deviation of vals.
+func stats(vals []float64) (mean, stddev float64) {
+	if len(vals) == 0 {
+		return 0, 0
+	}
+	sum := 0.0
+	for _, v := range vals {
+		sum += v
+	}
+	mean = sum / float64(len(vals))
+	variance := 0.0
+	for _, v := range vals {
+		d := v - mean
+		variance += d * d
+	}
+	variance /= float64(len(vals))
+	return mean, math.Sqrt(variance)
+}
+
+// formatSigma formats the threshold as a short string for the reason attribute.
+func formatSigma(sigma float64) string {
+	if sigma == float64(int(sigma)) {
+		return fmt.Sprintf("%d", int(sigma))
+	}
+	return fmt.Sprintf("%.1f", sigma)
+}

--- a/pkg/anomaly/detector.go
+++ b/pkg/anomaly/detector.go
@@ -18,14 +18,13 @@ const (
 	// AttrAnomaly is set to "true" on flagged spans.
 	AttrAnomaly = "candela.anomaly"
 	// AttrAnomalyReason describes which metric triggered the flag, e.g.
-	// "cost_2.5sigma" or "latency_2.5sigma".
+	// "cost_usd_2sigma" or "latency_ms_2sigma".
 	AttrAnomalyReason = "candela.anomaly_reason"
 )
 
 // Config controls detector behaviour.
 type Config struct {
 	// WindowDays is the rolling lookback used to build the baseline.
-	// Spans older than WindowDays before the evaluated span are excluded.
 	WindowDays int
 	// SigmaThreshold is the number of standard deviations above the mean
 	// required to flag a span. Lower values = more sensitive.
@@ -54,6 +53,13 @@ type Result struct {
 	Sigma  float64 // how many sigma above mean
 }
 
+// groupKey identifies a unique (tenant, model) baseline group.
+type groupKey struct {
+	tenantID  string
+	model     string
+	projectID string
+}
+
 // Detector checks incoming LLM spans against a rolling baseline.
 type Detector struct {
 	reader storage.SpanReader
@@ -66,50 +72,65 @@ func New(reader storage.SpanReader, cfg Config) *Detector {
 }
 
 // Detect checks each span in the batch against its per-(tenant, model) baseline
-// and returns anomalous spans. It also stamps anomaly attributes directly onto
-// the span copies in the returned results so callers can re-ingest or surface
-// them downstream.
+// and returns anomalous spans. It stamps anomaly attributes onto copies of
+// flagged spans so callers can re-ingest or surface them downstream.
 //
-// Only spans with Kind == SpanKindLLM and a non-zero cost or duration are
-// evaluated; all others pass through silently.
+// Spans are grouped by (tenant, model) before querying so the batch issues one
+// SearchSpans call per unique group, not one per span.
+//
+// Only spans with Kind == SpanKindLLM and a non-nil GenAI payload are evaluated.
 func (d *Detector) Detect(ctx context.Context, spans []storage.Span) ([]Result, error) {
-	var results []Result
+	// Partition LLM spans by (tenant, model, project) to avoid N+1 queries.
+	groups := make(map[groupKey][]storage.Span)
 	for _, span := range spans {
-		if span.Kind != storage.SpanKindLLM {
+		if span.Kind != storage.SpanKindLLM || span.GenAI == nil {
 			continue
 		}
-		if span.GenAI == nil {
-			continue
+		k := groupKey{tenantID: span.TenantID, model: span.GenAI.Model, projectID: span.ProjectID}
+		groups[k] = append(groups[k], span)
+	}
+
+	var results []Result
+	for key, group := range groups {
+		// Use the earliest StartTime in the group as the window anchor so all
+		// spans in the group are covered by the same historical query.
+		windowEnd := group[0].StartTime
+		for _, s := range group[1:] {
+			if s.StartTime.Before(windowEnd) {
+				windowEnd = s.StartTime
+			}
 		}
-		rs, err := d.checkSpan(ctx, span)
+		windowStart := windowEnd.UTC().Add(-time.Duration(d.cfg.WindowDays) * 24 * time.Hour)
+
+		historical, err := d.reader.SearchSpans(ctx, storage.SpanQuery{
+			ProjectID: key.projectID,
+			StartTime: windowStart,
+			EndTime:   windowEnd,
+			Kind:      storage.SpanKindLLM,
+			Model:     key.model,
+			TenantID:  key.tenantID,
+			PageSize:  10000,
+		})
 		if err != nil {
 			return nil, err
 		}
-		results = append(results, rs...)
+		if historical == nil {
+			return nil, fmt.Errorf("received nil span result from reader")
+		}
+
+		for _, span := range group {
+			rs := d.checkGroup(span, historical.Spans)
+			results = append(results, rs...)
+		}
 	}
 	return results, nil
 }
 
-// checkSpan evaluates a single span for cost and latency anomalies.
-func (d *Detector) checkSpan(ctx context.Context, span storage.Span) ([]Result, error) {
-	windowStart := span.StartTime.UTC().Add(-time.Duration(d.cfg.WindowDays) * 24 * time.Hour)
-
-	historical, err := d.reader.SearchSpans(ctx, storage.SpanQuery{
-		ProjectID: span.ProjectID,
-		StartTime: windowStart,
-		EndTime:   span.StartTime,
-		Kind:      storage.SpanKindLLM,
-		Model:     span.GenAI.Model,
-		TenantID:  span.TenantID,
-		PageSize:  10000,
-	})
-	if err != nil {
-		return nil, err
-	}
-
+// checkGroup evaluates a single span against a pre-fetched history slice.
+func (d *Detector) checkGroup(span storage.Span, history []storage.Span) []Result {
 	var results []Result
 
-	if r, ok := d.checkMetric(span, historical.Spans, "cost_usd", func(s storage.Span) float64 {
+	if r, ok := d.checkMetric(span, history, "cost_usd", func(s storage.Span) float64 {
 		if s.GenAI == nil {
 			return 0
 		}
@@ -118,18 +139,17 @@ func (d *Detector) checkSpan(ctx context.Context, span storage.Span) ([]Result, 
 		results = append(results, r)
 	}
 
-	if r, ok := d.checkMetric(span, historical.Spans, "latency_ms", func(s storage.Span) float64 {
+	if r, ok := d.checkMetric(span, history, "latency_ms", func(s storage.Span) float64 {
 		return float64(s.Duration.Milliseconds())
 	}); ok {
 		results = append(results, r)
 	}
 
-	return results, nil
+	return results
 }
 
-// checkMetric computes the rolling mean and stddev for a single metric across
-// the historical window and returns a Result if the span's value exceeds the
-// sigma threshold.
+// checkMetric computes the rolling mean and stddev for a single metric and
+// returns a Result if the span's value exceeds the sigma threshold.
 func (d *Detector) checkMetric(span storage.Span, history []storage.Span, metric string, extract func(storage.Span) float64) (Result, bool) {
 	vals := make([]float64, 0, len(history))
 	for _, h := range history {
@@ -143,7 +163,7 @@ func (d *Detector) checkMetric(span storage.Span, history []storage.Span, metric
 
 	mean, stddev := stats(vals)
 	// Treat near-zero stddev (< 0.1% of mean) as zero to avoid false positives
-	// from floating-point precision when all historical values are identical.
+	// when all historical values are identical.
 	if mean > 0 && stddev/mean < 0.001 {
 		return Result{}, false
 	}
@@ -160,8 +180,8 @@ func (d *Detector) checkMetric(span storage.Span, history []storage.Span, metric
 	if sigma < d.cfg.SigmaThreshold {
 		return Result{}, false
 	}
-	// Require the absolute delta to exceed 10% of the mean to avoid flagging
-	// noise when stddev is near-zero (all-identical history).
+	// Require the absolute delta to exceed 10% of the mean to filter noise
+	// when stddev is near-zero.
 	if mean > 0 && (observed-mean)/mean < 0.10 {
 		return Result{}, false
 	}

--- a/pkg/anomaly/detector_test.go
+++ b/pkg/anomaly/detector_test.go
@@ -1,0 +1,238 @@
+package anomaly
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// mockReader is a SpanReader stub that returns a fixed set of spans for SearchSpans.
+type mockReader struct {
+	spans []storage.Span
+}
+
+func (m *mockReader) SearchSpans(_ context.Context, _ storage.SpanQuery) (*storage.SpanResult, error) {
+	return &storage.SpanResult{Spans: m.spans, TotalCount: len(m.spans)}, nil
+}
+
+func (m *mockReader) GetTrace(_ context.Context, _ string) (*storage.Trace, error) { return nil, nil }
+func (m *mockReader) QueryTraces(_ context.Context, _ storage.TraceQuery) (*storage.TraceResult, error) {
+	return nil, nil
+}
+func (m *mockReader) GetUsageSummary(_ context.Context, _ storage.UsageQuery) (*storage.UsageSummary, error) {
+	return nil, nil
+}
+func (m *mockReader) GetModelBreakdown(_ context.Context, _ storage.UsageQuery) ([]storage.ModelUsage, error) {
+	return nil, nil
+}
+func (m *mockReader) GetUserLeaderboard(_ context.Context, _ storage.UsageQuery, _ int) ([]storage.UserUsageSummary, error) {
+	return nil, nil
+}
+func (m *mockReader) GetTenantLeaderboard(_ context.Context, _ storage.UsageQuery, _ int) ([]storage.TenantUsageSummary, error) {
+	return nil, nil
+}
+func (m *mockReader) GetJobLeaderboard(_ context.Context, _ storage.UsageQuery, _ int) ([]storage.JobUsageSummary, error) {
+	return nil, nil
+}
+func (m *mockReader) Ping(_ context.Context) error { return nil }
+func (m *mockReader) Close() error                 { return nil }
+
+// llmSpan builds a minimal LLM span with the given cost and duration.
+func llmSpan(costUSD float64, durationMs int64) storage.Span {
+	now := time.Now().UTC()
+	return storage.Span{
+		SpanID:    "test-span",
+		ProjectID: "proj",
+		Kind:      storage.SpanKindLLM,
+		StartTime: now,
+		EndTime:   now.Add(time.Duration(durationMs) * time.Millisecond),
+		Duration:  time.Duration(durationMs) * time.Millisecond,
+		GenAI:     &storage.GenAIAttributes{Model: "gpt-4o", CostUSD: costUSD},
+	}
+}
+
+// baseline builds N identical spans with the given cost and latency to use as history.
+func baseline(n int, costUSD float64, durationMs int64) []storage.Span {
+	spans := make([]storage.Span, n)
+	for i := range spans {
+		spans[i] = llmSpan(costUSD, durationMs)
+	}
+	return spans
+}
+
+func TestDetect_CostAnomaly(t *testing.T) {
+	// varied baseline: alternating $0.009/$0.011, mean=$0.01, stddev=$0.001.
+	// spike at $1.00 is ~990 sigma above mean.
+	history := make([]storage.Span, 20)
+	for i := range history {
+		cost := 0.009
+		if i%2 == 0 {
+			cost = 0.011
+		}
+		history[i] = llmSpan(cost, 100)
+	}
+	spike := llmSpan(1.00, 100)
+
+	d := New(&mockReader{spans: history}, DefaultConfig())
+	results, err := d.Detect(context.Background(), []storage.Span{spike})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("want cost anomaly, got none")
+	}
+	found := false
+	for _, r := range results {
+		if r.Metric == "cost_usd" {
+			found = true
+			if r.Sigma < DefaultConfig().SigmaThreshold {
+				t.Errorf("sigma %.2f below threshold %.2f", r.Sigma, DefaultConfig().SigmaThreshold)
+			}
+			if r.Span.Attributes[AttrAnomaly] != "true" {
+				t.Error("AttrAnomaly not set on flagged span")
+			}
+			if r.Span.Attributes[AttrAnomalyReason] == "" {
+				t.Error("AttrAnomalyReason empty on flagged span")
+			}
+		}
+	}
+	if !found {
+		t.Error("no cost_usd result in anomaly results")
+	}
+}
+
+func TestDetect_LatencyAnomaly(t *testing.T) {
+	// varied baseline so stddev is non-zero: alternating 90ms and 110ms, mean=100ms
+	history := make([]storage.Span, 20)
+	for i := range history {
+		ms := int64(90)
+		if i%2 == 0 {
+			ms = 110
+		}
+		history[i] = llmSpan(0.01, ms)
+	}
+	spike := llmSpan(0.01, 5000) // 5000ms, far above baseline
+
+	d := New(&mockReader{spans: history}, DefaultConfig())
+	results, err := d.Detect(context.Background(), []storage.Span{spike})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	found := false
+	for _, r := range results {
+		if r.Metric == "latency_ms" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("want latency anomaly, got none")
+	}
+}
+
+func TestDetect_BelowThreshold(t *testing.T) {
+	// varied baseline: mean=$0.10, stddev=$0.01. $0.11 is 1 sigma, below the 2sigma threshold.
+	history := make([]storage.Span, 20)
+	for i := range history {
+		cost := 0.09
+		if i%2 == 0 {
+			cost = 0.11
+		}
+		history[i] = llmSpan(cost, 100)
+	}
+	normal := llmSpan(0.11, 100) // 1 sigma above mean, not an anomaly
+
+	d := New(&mockReader{spans: history}, DefaultConfig())
+	results, err := d.Detect(context.Background(), []storage.Span{normal})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	for _, r := range results {
+		if r.Metric == "cost_usd" || r.Metric == "latency_ms" {
+			t.Errorf("false positive: got anomaly result %+v for normal span", r)
+		}
+	}
+}
+
+func TestDetect_InsufficientHistory(t *testing.T) {
+	// fewer than MinSamples — detector must stay silent
+	history := baseline(5, 0.01, 100)
+	spike := llmSpan(100.0, 100)
+
+	cfg := DefaultConfig()
+	d := New(&mockReader{spans: history}, cfg)
+	results, err := d.Detect(context.Background(), []storage.Span{spike})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("want no anomaly with insufficient history, got %d results", len(results))
+	}
+}
+
+func TestDetect_NonLLMSpanSkipped(t *testing.T) {
+	// agent spans should be ignored entirely
+	agentSpan := storage.Span{
+		SpanID:    "agent-span",
+		ProjectID: "proj",
+		Kind:      storage.SpanKindAgent,
+		StartTime: time.Now().UTC(),
+		Duration:  5000 * time.Millisecond,
+	}
+	d := New(&mockReader{spans: baseline(20, 0.01, 100)}, DefaultConfig())
+	results, err := d.Detect(context.Background(), []storage.Span{agentSpan})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("non-LLM span should be skipped, got %d results", len(results))
+	}
+}
+
+func TestDetect_NilGenAISkipped(t *testing.T) {
+	span := storage.Span{
+		SpanID:    "no-genai",
+		ProjectID: "proj",
+		Kind:      storage.SpanKindLLM,
+		StartTime: time.Now().UTC(),
+		Duration:  100 * time.Millisecond,
+		GenAI:     nil,
+	}
+	d := New(&mockReader{spans: baseline(20, 0.01, 100)}, DefaultConfig())
+	results, err := d.Detect(context.Background(), []storage.Span{span})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("nil GenAI span should be skipped, got %d results", len(results))
+	}
+}
+
+func TestStats(t *testing.T) {
+	cases := []struct {
+		vals       []float64
+		wantMean   float64
+		wantStddev float64
+	}{
+		{[]float64{2, 4, 4, 4, 5, 5, 7, 9}, 5.0, 2.0},
+		{[]float64{1, 1, 1, 1}, 1.0, 0.0},
+		{[]float64{}, 0.0, 0.0},
+	}
+	for _, tc := range cases {
+		mean, stddev := stats(tc.vals)
+		if abs(mean-tc.wantMean) > 1e-9 {
+			t.Errorf("stats(%v) mean=%.4f, want %.4f", tc.vals, mean, tc.wantMean)
+		}
+		if abs(stddev-tc.wantStddev) > 1e-9 {
+			t.Errorf("stats(%v) stddev=%.4f, want %.4f", tc.vals, stddev, tc.wantStddev)
+		}
+	}
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -12,6 +12,7 @@ import (
 
 	"log/slog"
 
+	"github.com/candelahq/candela/pkg/anomaly"
 	"github.com/candelahq/candela/pkg/costcalc"
 	"github.com/candelahq/candela/pkg/storage"
 )
@@ -23,11 +24,19 @@ import (
 type SpanProcessor struct {
 	writers      []*ResilientWriter
 	calc         *costcalc.Calculator
+	detector     *anomaly.Detector
 	batchSize    int
 	spanCh       chan storage.Span
 	done         chan struct{}
 	once         sync.Once
 	droppedSpans atomic.Int64
+}
+
+// WithAnomalyDetector attaches a Detector to the processor. When set, the
+// detector runs after cost enrichment on every flush batch and logs flagged
+// spans. Passing nil is a no-op (detector stays disabled).
+func (p *SpanProcessor) WithAnomalyDetector(d *anomaly.Detector) {
+	p.detector = d
 }
 
 // New creates a new in-process span processor with default resilience settings.
@@ -112,6 +121,39 @@ func (p *SpanProcessor) Run(ctx context.Context) {
 					batch[i].GenAI.InputTokens,
 					batch[i].GenAI.OutputTokens,
 				)
+			}
+		}
+
+		// Run anomaly detection after cost enrichment, before writing to sinks.
+		// Flagged spans get candela.anomaly=true stamped into their Attributes so
+		// the dashboard and audit trail can surface them without schema changes.
+		if p.detector != nil {
+			results, err := p.detector.Detect(ctx, batch)
+			if err != nil {
+				slog.Warn("anomaly detection error", "err", err)
+			} else {
+				for _, r := range results {
+					slog.Warn("anomaly detected",
+						"span_id", r.Span.SpanID,
+						"metric", r.Metric,
+						"value", r.Value,
+						"mean", r.Mean,
+						"sigma", r.Sigma,
+						"tenant_id", r.Span.TenantID,
+						"model", r.Span.GenAI.Model,
+					)
+					// Propagate anomaly attributes back into the batch span so
+					// downstream sinks store the flag without a second write.
+					for i := range batch {
+						if batch[i].SpanID == r.Span.SpanID {
+							if batch[i].Attributes == nil {
+								batch[i].Attributes = make(map[string]string)
+							}
+							batch[i].Attributes[anomaly.AttrAnomaly] = r.Span.Attributes[anomaly.AttrAnomaly]
+							batch[i].Attributes[anomaly.AttrAnomalyReason] = r.Span.Attributes[anomaly.AttrAnomalyReason]
+						}
+					}
+				}
 			}
 		}
 

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -131,7 +131,13 @@ func (p *SpanProcessor) Run(ctx context.Context) {
 			results, err := p.detector.Detect(ctx, batch)
 			if err != nil {
 				slog.Warn("anomaly detection error", "err", err)
-			} else {
+			} else if len(results) > 0 {
+				// Build a spanID-to-index map once so attribute propagation is
+				// O(N + M) instead of O(N * M).
+				spanIdx := make(map[string]int, len(batch))
+				for i := range batch {
+					spanIdx[batch[i].SpanID] = i
+				}
 				for _, r := range results {
 					slog.Warn("anomaly detected",
 						"span_id", r.Span.SpanID,
@@ -144,14 +150,12 @@ func (p *SpanProcessor) Run(ctx context.Context) {
 					)
 					// Propagate anomaly attributes back into the batch span so
 					// downstream sinks store the flag without a second write.
-					for i := range batch {
-						if batch[i].SpanID == r.Span.SpanID {
-							if batch[i].Attributes == nil {
-								batch[i].Attributes = make(map[string]string)
-							}
-							batch[i].Attributes[anomaly.AttrAnomaly] = r.Span.Attributes[anomaly.AttrAnomaly]
-							batch[i].Attributes[anomaly.AttrAnomalyReason] = r.Span.Attributes[anomaly.AttrAnomalyReason]
+					if idx, ok := spanIdx[r.Span.SpanID]; ok {
+						if batch[idx].Attributes == nil {
+							batch[idx].Attributes = make(map[string]string)
 						}
+						batch[idx].Attributes[anomaly.AttrAnomaly] = r.Span.Attributes[anomaly.AttrAnomaly]
+						batch[idx].Attributes[anomaly.AttrAnomalyReason] = r.Span.Attributes[anomaly.AttrAnomalyReason]
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Closes #211. Adds a \`pkg/anomaly\` package that flags LLM spans whose latency or cost deviates from a rolling per-(tenant, model) baseline.

The detector queries historical spans via \`SearchSpans\`, computes the mean and population standard deviation for the metric, and flags any span exceeding a configurable sigma threshold. Flagged spans get \`candela.anomaly=true\` and a \`candela.anomaly_reason\` (for example \`cost_usd_2sigma\`) stamped onto their \`Attributes\`. No schema changes are needed, since detection rides on existing span attributes.

## Design

- Baseline is scoped per (tenant, model). Different models have different cost and latency profiles, so a global baseline would be meaningless.
- Detection is wired into \`SpanProcessor\` through \`WithAnomalyDetector()\`, an optional setter. The existing \`New\` and \`NewWithConfig\` constructors are unchanged, so the detector is fully opt-in and adds nothing to the default path.
- The detector emits its verdict as span attributes rather than a side channel. Anything downstream that already reads attributes (search, future alert delivery, a dashboard) gets anomaly data for free without coupling to this package.

### Guards against false positives

- \`MinSamples\`: skip detection until the baseline has enough history, to avoid cold-start noise.
- Near-zero stddev relative to mean: skip when history is effectively identical, otherwise any tiny variation reads as an infinite-sigma anomaly.
- Non-LLM spans and spans with a nil GenAI payload are skipped.

## Configuration

All defaults are configurable:

- Window: 7 days
- Sigma threshold: 2.0
- Min samples: 10

## Testing

Seven tests in \`pkg/anomaly\`:

- Cost anomaly flagged above threshold
- Latency anomaly flagged above threshold
- Below-threshold span not flagged
- Insufficient history skipped (cold start)
- Non-LLM span skipped
- Nil GenAI span skipped
- Mean and stddev correctness against known inputs

## What's not included

Per the non-goals in the issue, this PR is detection only. Dashboard UI and alert delivery are out of scope and tracked as separate issues. The attribute-based output is designed so both can consume it without changes here.