### PR TITLE
test(anomaly): add edge-case and processor integration tests

### DIFF
--- a/pkg/anomaly/detector_test.go
+++ b/pkg/anomaly/detector_test.go
@@ -2,6 +2,9 @@ package anomaly
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -235,4 +238,403 @@ func abs(x float64) float64 {
 		return -x
 	}
 	return x
+}
+
+// --- Additional edge-case and gap-coverage tests ---
+
+// errReader is a SpanReader stub that returns a fixed error from SearchSpans.
+type errReader struct {
+	mockReader
+	searchErr error
+}
+
+func (e *errReader) SearchSpans(_ context.Context, _ storage.SpanQuery) (*storage.SpanResult, error) {
+	return nil, e.searchErr
+}
+
+// queryCapturingReader records the SpanQuery arguments passed to SearchSpans
+// so tests can assert on grouping and anchor-time logic.
+type queryCapturingReader struct {
+	mockReader
+	mu      sync.Mutex
+	queries []storage.SpanQuery
+}
+
+func (q *queryCapturingReader) SearchSpans(_ context.Context, query storage.SpanQuery) (*storage.SpanResult, error) {
+	q.mu.Lock()
+	q.queries = append(q.queries, query)
+	q.mu.Unlock()
+	return q.mockReader.SearchSpans(context.Background(), query)
+}
+
+func TestDetect_SearchSpansError(t *testing.T) {
+	// When the reader returns an error, Detect must propagate it.
+	reader := &errReader{searchErr: fmt.Errorf("connection refused")}
+	d := New(reader, DefaultConfig())
+
+	spike := llmSpan(1.00, 100)
+	_, err := d.Detect(context.Background(), []storage.Span{spike})
+	if err == nil {
+		t.Fatal("expected error from Detect when SearchSpans fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("error = %q, want it to contain 'connection refused'", err)
+	}
+}
+
+func TestDetect_MultipleGroups(t *testing.T) {
+	// Spans from two different (tenant, model) groups should each be queried
+	// separately and anomalies detected independently.
+	now := time.Now().UTC()
+
+	// Varied baseline for both groups — alternating costs so stddev is non-zero.
+	history := make([]storage.Span, 20)
+	for i := range history {
+		cost := 0.009
+		if i%2 == 0 {
+			cost = 0.011
+		}
+		history[i] = llmSpan(cost, 100)
+	}
+
+	reader := &queryCapturingReader{mockReader: mockReader{spans: history}}
+	d := New(reader, DefaultConfig())
+
+	// Two spikes from different tenants / models.
+	spikeA := storage.Span{
+		SpanID:    "spike-a",
+		ProjectID: "proj",
+		TenantID:  "tenant-alpha",
+		Kind:      storage.SpanKindLLM,
+		StartTime: now,
+		EndTime:   now.Add(100 * time.Millisecond),
+		Duration:  100 * time.Millisecond,
+		GenAI:     &storage.GenAIAttributes{Model: "gpt-4o", CostUSD: 5.00},
+	}
+	spikeB := storage.Span{
+		SpanID:    "spike-b",
+		ProjectID: "proj",
+		TenantID:  "tenant-beta",
+		Kind:      storage.SpanKindLLM,
+		StartTime: now,
+		EndTime:   now.Add(100 * time.Millisecond),
+		Duration:  100 * time.Millisecond,
+		GenAI:     &storage.GenAIAttributes{Model: "claude-3", CostUSD: 10.00},
+	}
+
+	results, err := d.Detect(context.Background(), []storage.Span{spikeA, spikeB})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+
+	// Should have issued exactly 2 SearchSpans queries (one per group).
+	reader.mu.Lock()
+	numQueries := len(reader.queries)
+	reader.mu.Unlock()
+	if numQueries != 2 {
+		t.Errorf("expected 2 SearchSpans queries (one per group), got %d", numQueries)
+	}
+
+	// Both spikes should be flagged as cost anomalies.
+	spanIDs := make(map[string]bool)
+	for _, r := range results {
+		if r.Metric == "cost_usd" {
+			spanIDs[r.Span.SpanID] = true
+		}
+	}
+	if !spanIDs["spike-a"] {
+		t.Error("spike-a not flagged as cost anomaly")
+	}
+	if !spanIDs["spike-b"] {
+		t.Error("spike-b not flagged as cost anomaly")
+	}
+}
+
+func TestDetect_RelativeDeltaGuard(t *testing.T) {
+	// The 10% relative-delta guard should suppress anomalies where the observed
+	// value is statistically >2 sigma but the absolute difference from the mean
+	// is <10% of the mean. This happens when stddev is very small.
+	//
+	// Build a baseline where mean=100.0 and stddev is very small (~0.5),
+	// then check a value that's >2sigma but <10% above mean.
+	history := make([]storage.Span, 20)
+	for i := range history {
+		// Costs alternating between 99.5 and 100.5 → mean=100, stddev=0.5
+		cost := 99.5
+		if i%2 == 0 {
+			cost = 100.5
+		}
+		history[i] = llmSpan(cost, 100)
+	}
+	// observed=101.5 → sigma=(101.5-100)/0.5=3.0 which is >2sigma threshold,
+	// but (101.5-100)/100 = 0.015 which is < 0.10 → should be filtered.
+	borderline := llmSpan(101.5, 100)
+
+	d := New(&mockReader{spans: history}, DefaultConfig())
+	results, err := d.Detect(context.Background(), []storage.Span{borderline})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	for _, r := range results {
+		if r.Metric == "cost_usd" {
+			t.Errorf("expected 10%% relative-delta guard to suppress cost anomaly, got sigma=%.2f, delta=%.4f%%",
+				r.Sigma, (r.Value-r.Mean)/r.Mean*100)
+		}
+	}
+}
+
+func TestDetect_NearZeroStddevGuard(t *testing.T) {
+	// When all historical values are nearly identical (stddev/mean < 0.001),
+	// the detector should suppress anomalies to avoid false positives.
+	// This is different from stddev==0 (which the existing tests cover via baseline()).
+	history := make([]storage.Span, 20)
+	for i := range history {
+		// Very tight spread: alternating 10.000 and 10.001
+		// mean ~= 10.0005, stddev ~= 0.0005, stddev/mean ~= 0.00005 < 0.001
+		cost := 10.000
+		if i%2 == 0 {
+			cost = 10.001
+		}
+		history[i] = llmSpan(cost, 100)
+	}
+	// Even though sigma would be astronomically high, the near-zero guard should block it.
+	spike := llmSpan(10.01, 100)
+
+	d := New(&mockReader{spans: history}, DefaultConfig())
+	results, err := d.Detect(context.Background(), []storage.Span{spike})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	for _, r := range results {
+		if r.Metric == "cost_usd" {
+			t.Error("near-zero stddev guard should suppress cost anomaly for nearly-identical baseline")
+		}
+	}
+}
+
+func TestFormatSigma(t *testing.T) {
+	cases := []struct {
+		input float64
+		want  string
+	}{
+		{2.0, "2"},
+		{3.0, "3"},
+		{1.5, "1.5"},
+		{2.5, "2.5"},
+		{0.0, "0"},
+		{10.0, "10"},
+	}
+	for _, tc := range cases {
+		got := formatSigma(tc.input)
+		if got != tc.want {
+			t.Errorf("formatSigma(%.1f) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestDetect_CustomSigmaThreshold(t *testing.T) {
+	// With a very high sigma threshold (e.g. 10), a moderate spike should not
+	// be flagged even though it would be flagged at the default 2-sigma.
+	history := make([]storage.Span, 20)
+	for i := range history {
+		cost := 0.009
+		if i%2 == 0 {
+			cost = 0.011
+		}
+		history[i] = llmSpan(cost, 100)
+	}
+	// $0.05 is ~40 sigma above mean=$0.01 with stddev=$0.001, well above 2 sigma
+	// but let's use threshold=100 to ensure it's not flagged.
+	moderateSpike := llmSpan(0.05, 100)
+
+	cfg := Config{
+		WindowDays:     7,
+		SigmaThreshold: 100.0, // very high threshold
+		MinSamples:     10,
+	}
+	d := New(&mockReader{spans: history}, cfg)
+	results, err := d.Detect(context.Background(), []storage.Span{moderateSpike})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	for _, r := range results {
+		if r.Metric == "cost_usd" {
+			t.Errorf("sigma=%.2f should be below threshold=100, but got flagged", r.Sigma)
+		}
+	}
+}
+
+func TestDetect_EmptyBatch(t *testing.T) {
+	// Empty batch should return nil results, no error, and no SearchSpans calls.
+	reader := &queryCapturingReader{mockReader: mockReader{spans: baseline(20, 0.01, 100)}}
+	d := New(reader, DefaultConfig())
+
+	results, err := d.Detect(context.Background(), []storage.Span{})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("want 0 results for empty batch, got %d", len(results))
+	}
+	reader.mu.Lock()
+	numQueries := len(reader.queries)
+	reader.mu.Unlock()
+	if numQueries != 0 {
+		t.Errorf("expected 0 SearchSpans queries for empty batch, got %d", numQueries)
+	}
+}
+
+func TestDetect_AnchorTimeUsesEarliestSpan(t *testing.T) {
+	// When a group has multiple spans, the window anchor should be based on
+	// the earliest StartTime, not the first span in the slice.
+	now := time.Now().UTC()
+	earlier := now.Add(-1 * time.Hour)
+
+	span1 := storage.Span{
+		SpanID:    "span-later",
+		ProjectID: "proj",
+		Kind:      storage.SpanKindLLM,
+		StartTime: now,
+		EndTime:   now.Add(100 * time.Millisecond),
+		Duration:  100 * time.Millisecond,
+		GenAI:     &storage.GenAIAttributes{Model: "gpt-4o", CostUSD: 5.00},
+	}
+	span2 := storage.Span{
+		SpanID:    "span-earlier",
+		ProjectID: "proj",
+		Kind:      storage.SpanKindLLM,
+		StartTime: earlier,
+		EndTime:   earlier.Add(100 * time.Millisecond),
+		Duration:  100 * time.Millisecond,
+		GenAI:     &storage.GenAIAttributes{Model: "gpt-4o", CostUSD: 5.00},
+	}
+
+	// Varied baseline to avoid near-zero stddev guard
+	history := make([]storage.Span, 20)
+	for i := range history {
+		cost := 0.009
+		if i%2 == 0 {
+			cost = 0.011
+		}
+		history[i] = llmSpan(cost, 100)
+	}
+
+	reader := &queryCapturingReader{mockReader: mockReader{spans: history}}
+	d := New(reader, DefaultConfig())
+
+	// Submit span1 first (later time), then span2 (earlier time).
+	_, err := d.Detect(context.Background(), []storage.Span{span1, span2})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+	if len(reader.queries) != 1 {
+		t.Fatalf("expected 1 query, got %d", len(reader.queries))
+	}
+	// The EndTime of the query should be the earlier span's StartTime.
+	if !reader.queries[0].EndTime.Equal(earlier) {
+		t.Errorf("query EndTime = %v, want %v (earliest span's StartTime)", reader.queries[0].EndTime, earlier)
+	}
+}
+
+func TestDetect_BothMetricsFlaggedSimultaneously(t *testing.T) {
+	// A span that's anomalous in BOTH cost and latency should produce two Results.
+	history := make([]storage.Span, 20)
+	for i := range history {
+		cost := 0.009
+		ms := int64(90)
+		if i%2 == 0 {
+			cost = 0.011
+			ms = 110
+		}
+		history[i] = llmSpan(cost, ms)
+	}
+	// Both cost ($5.00 vs $0.01) and latency (10000ms vs 100ms) are massive spikes.
+	spike := llmSpan(5.00, 10000)
+
+	d := New(&mockReader{spans: history}, DefaultConfig())
+	results, err := d.Detect(context.Background(), []storage.Span{spike})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+
+	metrics := make(map[string]bool)
+	for _, r := range results {
+		metrics[r.Metric] = true
+	}
+	if !metrics["cost_usd"] {
+		t.Error("expected cost_usd anomaly")
+	}
+	if !metrics["latency_ms"] {
+		t.Error("expected latency_ms anomaly")
+	}
+}
+
+func TestDetect_ReasonAttributeFormat(t *testing.T) {
+	// Verify the anomaly reason attribute format matches the expected pattern.
+	history := make([]storage.Span, 20)
+	for i := range history {
+		cost := 0.009
+		if i%2 == 0 {
+			cost = 0.011
+		}
+		history[i] = llmSpan(cost, 100)
+	}
+	spike := llmSpan(1.00, 100)
+
+	// Test with default 2-sigma threshold.
+	d := New(&mockReader{spans: history}, DefaultConfig())
+	results, err := d.Detect(context.Background(), []storage.Span{spike})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	for _, r := range results {
+		if r.Metric == "cost_usd" {
+			want := "cost_usd_2sigma"
+			got := r.Span.Attributes[AttrAnomalyReason]
+			if got != want {
+				t.Errorf("AttrAnomalyReason = %q, want %q", got, want)
+			}
+		}
+	}
+
+	// Test with fractional sigma threshold (1.5).
+	cfg := Config{WindowDays: 7, SigmaThreshold: 1.5, MinSamples: 10}
+	d2 := New(&mockReader{spans: history}, cfg)
+	results2, err := d2.Detect(context.Background(), []storage.Span{spike})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	for _, r := range results2 {
+		if r.Metric == "cost_usd" {
+			want := "cost_usd_1.5sigma"
+			got := r.Span.Attributes[AttrAnomalyReason]
+			if got != want {
+				t.Errorf("AttrAnomalyReason = %q, want %q", got, want)
+			}
+		}
+	}
+}
+
+func BenchmarkDetect(b *testing.B) {
+	// Benchmark detection with a realistic batch size and history.
+	history := make([]storage.Span, 1000)
+	for i := range history {
+		cost := 0.009 + float64(i%5)*0.001
+		history[i] = llmSpan(cost, int64(90+i%20))
+	}
+	batch := make([]storage.Span, 50)
+	for i := range batch {
+		batch[i] = llmSpan(0.01, 100)
+	}
+
+	d := New(&mockReader{spans: history}, DefaultConfig())
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = d.Detect(ctx, batch)
+	}
 }

--- a/pkg/processor/processor_anomaly_test.go
+++ b/pkg/processor/processor_anomaly_test.go
@@ -97,15 +97,20 @@ func TestProcessor_AnomalyAttributePropagation(t *testing.T) {
 	proc.WithAnomalyDetector(detector)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go proc.Run(ctx)
+	defer cancel()
+
+	runDone := make(chan struct{})
+	go func() {
+		proc.Run(ctx)
+		close(runDone)
+	}()
 
 	// Submit a cost spike that should be flagged.
 	spike := anomalyTestSpan("spike-1", 5.00, 100)
 	proc.Submit(spike)
 
-	time.Sleep(500 * time.Millisecond)
-	cancel()
 	proc.Stop()
+	<-runDone
 
 	spans := w.allSpans()
 	if len(spans) == 0 {
@@ -137,14 +142,19 @@ func TestProcessor_AnomalyDetectorError_DoesNotBlockWrite(t *testing.T) {
 	proc.WithAnomalyDetector(detector)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go proc.Run(ctx)
+	defer cancel()
+
+	runDone := make(chan struct{})
+	go func() {
+		proc.Run(ctx)
+		close(runDone)
+	}()
 
 	span := anomalyTestSpan("s1", 0.01, 100)
 	proc.Submit(span)
 
-	time.Sleep(500 * time.Millisecond)
-	cancel()
 	proc.Stop()
+	<-runDone
 
 	spans := w.allSpans()
 	if len(spans) == 0 {
@@ -166,14 +176,19 @@ func TestProcessor_NilDetector_NoOp(t *testing.T) {
 	// Deliberately not calling WithAnomalyDetector.
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go proc.Run(ctx)
+	defer cancel()
+
+	runDone := make(chan struct{})
+	go func() {
+		proc.Run(ctx)
+		close(runDone)
+	}()
 
 	span := anomalyTestSpan("no-detector", 0.01, 100)
 	proc.Submit(span)
 
-	time.Sleep(500 * time.Millisecond)
-	cancel()
 	proc.Stop()
+	<-runDone
 
 	spans := w.allSpans()
 	if len(spans) == 0 {
@@ -207,16 +222,21 @@ func TestProcessor_AnomalyNilAttributes_Initialized(t *testing.T) {
 	proc.WithAnomalyDetector(detector)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go proc.Run(ctx)
+	defer cancel()
+
+	runDone := make(chan struct{})
+	go func() {
+		proc.Run(ctx)
+		close(runDone)
+	}()
 
 	// Submit a spike with explicitly nil Attributes.
 	spike := anomalyTestSpan("nil-attrs", 5.00, 100)
 	spike.Attributes = nil
 	proc.Submit(spike)
 
-	time.Sleep(500 * time.Millisecond)
-	cancel()
 	proc.Stop()
+	<-runDone
 
 	spans := w.allSpans()
 	if len(spans) == 0 {
@@ -252,7 +272,13 @@ func TestProcessor_AnomalyPreservesExistingAttributes(t *testing.T) {
 	proc.WithAnomalyDetector(detector)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go proc.Run(ctx)
+	defer cancel()
+
+	runDone := make(chan struct{})
+	go func() {
+		proc.Run(ctx)
+		close(runDone)
+	}()
 
 	spike := anomalyTestSpan("existing-attrs", 5.00, 100)
 	spike.Attributes = map[string]string{
@@ -261,9 +287,8 @@ func TestProcessor_AnomalyPreservesExistingAttributes(t *testing.T) {
 	}
 	proc.Submit(spike)
 
-	time.Sleep(500 * time.Millisecond)
-	cancel()
 	proc.Stop()
+	<-runDone
 
 	spans := w.allSpans()
 	if len(spans) == 0 {
@@ -306,15 +331,20 @@ func TestProcessor_AnomalyNormalSpan_NoFlag(t *testing.T) {
 	proc.WithAnomalyDetector(detector)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go proc.Run(ctx)
+	defer cancel()
+
+	runDone := make(chan struct{})
+	go func() {
+		proc.Run(ctx)
+		close(runDone)
+	}()
 
 	// Submit a normal span (cost within baseline range).
 	normal := anomalyTestSpan("normal-1", 0.01, 100)
 	proc.Submit(normal)
 
-	time.Sleep(500 * time.Millisecond)
-	cancel()
 	proc.Stop()
+	<-runDone
 
 	spans := w.allSpans()
 	if len(spans) == 0 {

--- a/pkg/processor/processor_anomaly_test.go
+++ b/pkg/processor/processor_anomaly_test.go
@@ -1,0 +1,326 @@
+package processor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/anomaly"
+	"github.com/candelahq/candela/pkg/costcalc"
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// mockAnomalyReader implements storage.SpanReader for the anomaly detector.
+// It returns configurable spans from SearchSpans and ignores all other methods.
+type mockAnomalyReader struct {
+	spans     []storage.Span
+	searchErr error
+}
+
+func (m *mockAnomalyReader) SearchSpans(_ context.Context, _ storage.SpanQuery) (*storage.SpanResult, error) {
+	if m.searchErr != nil {
+		return nil, m.searchErr
+	}
+	return &storage.SpanResult{Spans: m.spans, TotalCount: len(m.spans)}, nil
+}
+
+func (m *mockAnomalyReader) GetTrace(_ context.Context, _ string) (*storage.Trace, error) {
+	return nil, nil
+}
+func (m *mockAnomalyReader) QueryTraces(_ context.Context, _ storage.TraceQuery) (*storage.TraceResult, error) {
+	return nil, nil
+}
+func (m *mockAnomalyReader) GetUsageSummary(_ context.Context, _ storage.UsageQuery) (*storage.UsageSummary, error) {
+	return nil, nil
+}
+func (m *mockAnomalyReader) GetModelBreakdown(_ context.Context, _ storage.UsageQuery) ([]storage.ModelUsage, error) {
+	return nil, nil
+}
+func (m *mockAnomalyReader) GetUserLeaderboard(_ context.Context, _ storage.UsageQuery, _ int) ([]storage.UserUsageSummary, error) {
+	return nil, nil
+}
+func (m *mockAnomalyReader) GetTenantLeaderboard(_ context.Context, _ storage.UsageQuery, _ int) ([]storage.TenantUsageSummary, error) {
+	return nil, nil
+}
+func (m *mockAnomalyReader) GetJobLeaderboard(_ context.Context, _ storage.UsageQuery, _ int) ([]storage.JobUsageSummary, error) {
+	return nil, nil
+}
+func (m *mockAnomalyReader) Ping(_ context.Context) error { return nil }
+func (m *mockAnomalyReader) Close() error                 { return nil }
+
+// anomalyTestSpan builds an LLM span with specific cost and duration for anomaly testing.
+func anomalyTestSpan(id string, costUSD float64, durationMs int64) storage.Span {
+	now := time.Now().UTC()
+	return storage.Span{
+		SpanID:    id,
+		TraceID:   "trace-" + id,
+		Name:      "test." + id,
+		Kind:      storage.SpanKindLLM,
+		Status:    storage.SpanStatusOK,
+		StartTime: now,
+		EndTime:   now.Add(time.Duration(durationMs) * time.Millisecond),
+		Duration:  time.Duration(durationMs) * time.Millisecond,
+		ProjectID: "proj-test",
+		GenAI: &storage.GenAIAttributes{
+			Model:        "gpt-4o",
+			Provider:     "openai",
+			CostUSD:      costUSD,
+			InputTokens:  100,
+			OutputTokens: 50,
+			TotalTokens:  150,
+		},
+	}
+}
+
+func TestProcessor_AnomalyAttributePropagation(t *testing.T) {
+	// When the anomaly detector flags a span, the processor should propagate
+	// candela.anomaly and candela.anomaly_reason attributes onto the batch
+	// span that gets written to sinks.
+	w := &mockWriter{}
+	calc := costcalc.New()
+
+	// Build a varied historical baseline (alternating costs for non-zero stddev).
+	history := make([]storage.Span, 20)
+	for i := range history {
+		cost := 0.009
+		if i%2 == 0 {
+			cost = 0.011
+		}
+		history[i] = anomalyTestSpan(fmt.Sprintf("h%d", i), cost, 100)
+	}
+
+	reader := &mockAnomalyReader{spans: history}
+	detector := anomaly.New(reader, anomaly.DefaultConfig())
+
+	proc := New([]storage.SpanWriter{w}, calc, 1) // batch size 1 → flush immediately
+	proc.WithAnomalyDetector(detector)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go proc.Run(ctx)
+
+	// Submit a cost spike that should be flagged.
+	spike := anomalyTestSpan("spike-1", 5.00, 100)
+	proc.Submit(spike)
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+	proc.Stop()
+
+	spans := w.allSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least 1 span written to sink")
+	}
+
+	written := spans[0]
+	if written.Attributes == nil {
+		t.Fatal("expected Attributes map to be non-nil on written span")
+	}
+	if written.Attributes[anomaly.AttrAnomaly] != "true" {
+		t.Errorf("expected %s = 'true', got %q", anomaly.AttrAnomaly, written.Attributes[anomaly.AttrAnomaly])
+	}
+	if written.Attributes[anomaly.AttrAnomalyReason] == "" {
+		t.Error("expected non-empty anomaly reason attribute on flagged span")
+	}
+}
+
+func TestProcessor_AnomalyDetectorError_DoesNotBlockWrite(t *testing.T) {
+	// When the anomaly detector returns an error (e.g. storage unavailable),
+	// the processor should still write spans to sinks (graceful degradation).
+	w := &mockWriter{}
+	calc := costcalc.New()
+
+	reader := &mockAnomalyReader{searchErr: fmt.Errorf("storage timeout")}
+	detector := anomaly.New(reader, anomaly.DefaultConfig())
+
+	proc := New([]storage.SpanWriter{w}, calc, 1)
+	proc.WithAnomalyDetector(detector)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go proc.Run(ctx)
+
+	span := anomalyTestSpan("s1", 0.01, 100)
+	proc.Submit(span)
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+	proc.Stop()
+
+	spans := w.allSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected spans to be written even when anomaly detector errors")
+	}
+	// Span should NOT have anomaly attributes when detection failed.
+	if spans[0].Attributes != nil && spans[0].Attributes[anomaly.AttrAnomaly] == "true" {
+		t.Error("span should not be flagged when anomaly detection errors")
+	}
+}
+
+func TestProcessor_NilDetector_NoOp(t *testing.T) {
+	// When no detector is attached, the processor should function normally
+	// without panics or anomaly attributes.
+	w := &mockWriter{}
+	calc := costcalc.New()
+
+	proc := New([]storage.SpanWriter{w}, calc, 1)
+	// Deliberately not calling WithAnomalyDetector.
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go proc.Run(ctx)
+
+	span := anomalyTestSpan("no-detector", 0.01, 100)
+	proc.Submit(span)
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+	proc.Stop()
+
+	spans := w.allSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least 1 span written to sink")
+	}
+	// No anomaly attributes should be present.
+	if spans[0].Attributes != nil && spans[0].Attributes[anomaly.AttrAnomaly] != "" {
+		t.Error("anomaly attribute should not be set when no detector is attached")
+	}
+}
+
+func TestProcessor_AnomalyNilAttributes_Initialized(t *testing.T) {
+	// Verify that if a span has nil Attributes before anomaly detection, the
+	// processor initializes the map and adds anomaly attributes correctly.
+	w := &mockWriter{}
+	calc := costcalc.New()
+
+	history := make([]storage.Span, 20)
+	for i := range history {
+		cost := 0.009
+		if i%2 == 0 {
+			cost = 0.011
+		}
+		history[i] = anomalyTestSpan(fmt.Sprintf("h%d", i), cost, 100)
+	}
+
+	reader := &mockAnomalyReader{spans: history}
+	detector := anomaly.New(reader, anomaly.DefaultConfig())
+
+	proc := New([]storage.SpanWriter{w}, calc, 1)
+	proc.WithAnomalyDetector(detector)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go proc.Run(ctx)
+
+	// Submit a spike with explicitly nil Attributes.
+	spike := anomalyTestSpan("nil-attrs", 5.00, 100)
+	spike.Attributes = nil
+	proc.Submit(spike)
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+	proc.Stop()
+
+	spans := w.allSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least 1 span written to sink")
+	}
+	if spans[0].Attributes == nil {
+		t.Fatal("expected Attributes map to be initialized for flagged span with nil Attributes")
+	}
+	if spans[0].Attributes[anomaly.AttrAnomaly] != "true" {
+		t.Errorf("expected %s = 'true' on span with initially nil Attributes", anomaly.AttrAnomaly)
+	}
+}
+
+func TestProcessor_AnomalyPreservesExistingAttributes(t *testing.T) {
+	// When a span already has Attributes, anomaly detection should ADD
+	// the anomaly keys without clobbering existing ones.
+	w := &mockWriter{}
+	calc := costcalc.New()
+
+	history := make([]storage.Span, 20)
+	for i := range history {
+		cost := 0.009
+		if i%2 == 0 {
+			cost = 0.011
+		}
+		history[i] = anomalyTestSpan(fmt.Sprintf("h%d", i), cost, 100)
+	}
+
+	reader := &mockAnomalyReader{spans: history}
+	detector := anomaly.New(reader, anomaly.DefaultConfig())
+
+	proc := New([]storage.SpanWriter{w}, calc, 1)
+	proc.WithAnomalyDetector(detector)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go proc.Run(ctx)
+
+	spike := anomalyTestSpan("existing-attrs", 5.00, 100)
+	spike.Attributes = map[string]string{
+		"user.custom_tag": "important",
+		"env":             "production",
+	}
+	proc.Submit(spike)
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+	proc.Stop()
+
+	spans := w.allSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least 1 span written to sink")
+	}
+
+	attrs := spans[0].Attributes
+	// Check anomaly attributes were added.
+	if attrs[anomaly.AttrAnomaly] != "true" {
+		t.Error("anomaly attribute not set on flagged span")
+	}
+	// Check existing attributes were preserved.
+	if attrs["user.custom_tag"] != "important" {
+		t.Errorf("existing attribute user.custom_tag = %q, want 'important'", attrs["user.custom_tag"])
+	}
+	if attrs["env"] != "production" {
+		t.Errorf("existing attribute env = %q, want 'production'", attrs["env"])
+	}
+}
+
+func TestProcessor_AnomalyNormalSpan_NoFlag(t *testing.T) {
+	// A span within normal range should NOT have anomaly attributes after
+	// passing through the processor with an active detector.
+	w := &mockWriter{}
+	calc := costcalc.New()
+
+	history := make([]storage.Span, 20)
+	for i := range history {
+		cost := 0.009
+		if i%2 == 0 {
+			cost = 0.011
+		}
+		history[i] = anomalyTestSpan(fmt.Sprintf("h%d", i), cost, 100)
+	}
+
+	reader := &mockAnomalyReader{spans: history}
+	detector := anomaly.New(reader, anomaly.DefaultConfig())
+
+	proc := New([]storage.SpanWriter{w}, calc, 1)
+	proc.WithAnomalyDetector(detector)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go proc.Run(ctx)
+
+	// Submit a normal span (cost within baseline range).
+	normal := anomalyTestSpan("normal-1", 0.01, 100)
+	proc.Submit(normal)
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+	proc.Stop()
+
+	spans := w.allSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least 1 span written to sink")
+	}
+	if spans[0].Attributes != nil && spans[0].Attributes[anomaly.AttrAnomaly] == "true" {
+		t.Error("normal span should not be flagged as anomalous")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #295. Adds **16 new tests + 1 benchmark** to close the testing gaps identified during code review.

### `pkg/anomaly/detector_test.go` — 10 new tests + 1 benchmark

| Test | Gap Covered |
|---|---|
| `TestDetect_SearchSpansError` | Error propagation when `SearchSpans` fails |
| `TestDetect_MultipleGroups` | Multi-tenant/model grouping with separate queries |
| `TestDetect_RelativeDeltaGuard` | 10% relative-delta noise filter (>2σ but <10% of mean) |
| `TestDetect_NearZeroStddevGuard` | `stddev/mean < 0.001` early-return path |
| `TestFormatSigma` | Integer vs. fractional sigma string formatting |
| `TestDetect_CustomSigmaThreshold` | Non-default threshold config respected |
| `TestDetect_EmptyBatch` | Empty input produces no queries |
| `TestDetect_AnchorTimeUsesEarliestSpan` | Window anchor uses earliest span, not first |
| `TestDetect_BothMetricsFlaggedSimultaneously` | Both cost + latency anomalies returned |
| `TestDetect_ReasonAttributeFormat` | Attribute format correctness (`cost_usd_2sigma`, `cost_usd_1.5sigma`) |
| `BenchmarkDetect` | Performance baseline (~1.9ms/op for 50-span batch vs 1000 history) |

### `pkg/processor/processor_anomaly_test.go` — 6 new tests (new file)

| Test | Gap Covered |
|---|---|
| `TestProcessor_AnomalyAttributePropagation` | End-to-end: flagged span gets `candela.anomaly=true` in sink |
| `TestProcessor_AnomalyDetectorError_DoesNotBlockWrite` | Graceful degradation: spans still written on detector error |
| `TestProcessor_NilDetector_NoOp` | No panic when no detector attached |
| `TestProcessor_AnomalyNilAttributes_Initialized` | `nil` Attributes map initialized correctly |
| `TestProcessor_AnomalyPreservesExistingAttributes` | Existing attributes not clobbered by anomaly keys |
| `TestProcessor_AnomalyNormalSpan_NoFlag` | No false positives in the pipeline |

### Verification
- All tests pass with `-race`
- All pre-commit hooks pass (gofmt, go-vet, golangci-lint, full test suite)
- Benchmark: ~1.9ms/op, ~862KB/op for 50-span batch against 1000-span history