### PR TITLE
feat(proxy): add gemini-vertex native provider route

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -363,6 +363,22 @@ func main() {
 						"provider", p.Name,
 						"project", geminiProjectID,
 						"adc", tokenSource != nil)
+
+				case "gemini-vertex":
+					// Native Gemini API via Vertex AI publisher endpoint.
+					// Same as "google" but with an explicit name for clarity.
+					allProviders[i].UpstreamURL = proxy.VertexAIUpstreamURL("global")
+					allProviders[i].PathRewriter = &proxy.VertexAIGooglePathRewriter{
+						ProjectID: geminiProjectID,
+						Region:    "global",
+					}
+					if tokenSource != nil {
+						allProviders[i].TokenSource = tokenSource
+					}
+					slog.Info("🔐 Gemini-Vertex native via Vertex AI configured",
+						"provider", p.Name,
+						"project", geminiProjectID,
+						"adc", tokenSource != nil)
 				}
 			}
 		} else {
@@ -372,7 +388,7 @@ func main() {
 			var filtered []proxy.Provider
 			for _, p := range allProviders {
 				switch p.Name {
-				case "gemini-oai", "google", "mistral", "deepseek", "qwen":
+				case "gemini-oai", "google", "gemini-vertex", "mistral", "deepseek", "qwen":
 					// Skip — these need Vertex AI project ID
 				default:
 					filtered = append(filtered, p)

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -384,7 +384,7 @@ func main() {
 		} else {
 			// Without a project ID, Vertex AI providers can't route.
 			// Remove them from allProviders to prevent broken defaults.
-			slog.Warn("⚠️ Vertex AI providers require vertex_ai.project_id — gemini-oai, google, mistral, deepseek, qwen providers will be disabled")
+			slog.Warn("⚠️ Vertex AI providers require vertex_ai.project_id — gemini-oai, google, gemini-vertex, mistral, deepseek, qwen providers will be disabled")
 			var filtered []proxy.Provider
 			for _, p := range allProviders {
 				switch p.Name {

--- a/cmd/candela-sidecar/main.go
+++ b/cmd/candela-sidecar/main.go
@@ -160,10 +160,7 @@ func main() {
 					"project", gcpProject, "region", vertexRegion,
 					"format_translation", p.Name == "anthropic")
 			}
-		}
 
-		// Configure Gemini-Vertex native provider with ADC + path rewriting.
-		for i, p := range allProviders {
 			if p.Name == "gemini-vertex" {
 				allProviders[i].UpstreamURL = proxy.VertexAIUpstreamURL(vertexRegion)
 				allProviders[i].PathRewriter = &proxy.VertexAIGooglePathRewriter{

--- a/cmd/candela-sidecar/main.go
+++ b/cmd/candela-sidecar/main.go
@@ -161,6 +161,23 @@ func main() {
 					"format_translation", p.Name == "anthropic")
 			}
 		}
+
+		// Configure Gemini-Vertex native provider with ADC + path rewriting.
+		for i, p := range allProviders {
+			if p.Name == "gemini-vertex" {
+				allProviders[i].UpstreamURL = proxy.VertexAIUpstreamURL(vertexRegion)
+				allProviders[i].PathRewriter = &proxy.VertexAIGooglePathRewriter{
+					ProjectID: gcpProject,
+					Region:    vertexRegion,
+				}
+				if tokenSource != nil {
+					allProviders[i].TokenSource = tokenSource
+				}
+				slog.Info("🔐 Gemini-Vertex native configured",
+					"provider", p.Name,
+					"project", gcpProject, "region", vertexRegion)
+			}
+		}
 	}
 
 	// Filter to requested providers.

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -982,7 +982,7 @@ func buildCloudProxy(cfg Config, submitter *processor.SpanProcessor) (*proxy.Pro
 	needsAWS := false
 	for _, lp := range cfg.Providers {
 		switch lp.Name {
-		case "google", "gemini", "anthropic", "anthropic-vertex", "mistral", "deepseek", "qwen":
+		case "google", "gemini", "anthropic", "anthropic-vertex", "gemini-vertex", "mistral", "deepseek", "qwen":
 			needsGCP = true
 		case "anthropic-bedrock":
 			needsAWS = true
@@ -1079,6 +1079,16 @@ func buildCloudProxy(cfg Config, submitter *processor.SpanProcessor) (*proxy.Pro
 			p.UpstreamURL = proxy.VertexAIUpstreamURL(region)
 			p.TokenSource = tokenSource
 			p.PathRewriter = &proxy.VertexAIPathRewriter{
+				ProjectID: project,
+				Region:    region,
+			}
+		case "gemini-vertex":
+			// Native Gemini API routed via Vertex AI publisher endpoint.
+			// No format translation — client speaks native Gemini (generateContent).
+			// Supports thought_signature passthrough for Gemini 3.x thinking models.
+			p.UpstreamURL = proxy.VertexAIUpstreamURL(region)
+			p.TokenSource = tokenSource
+			p.PathRewriter = &proxy.VertexAIGooglePathRewriter{
 				ProjectID: project,
 				Region:    region,
 			}

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -98,6 +98,7 @@ var providerAliases = map[string]string{
 	"anthropic-vertex":  "anthropic",
 	"anthropic-bedrock": "anthropic",
 	"gemini-oai":        "google", // Gemini via OpenAI-compat shares Google cache pricing
+	"gemini-vertex":     "google", // Native Gemini via Vertex AI shares Google pricing
 }
 
 // New creates a Calculator with default pricing for all supported cloud models.

--- a/pkg/proxy/parsers.go
+++ b/pkg/proxy/parsers.go
@@ -39,6 +39,7 @@ var parserRegistry = map[string]ProviderParser{
 	"anthropic-vertex":  &anthropicParser{}, // Native Anthropic format routed via Vertex AI.
 	"anthropic-bedrock": &anthropicParser{}, // Same wire format, routed via AWS Bedrock + SigV4.
 	"google":            &googleParser{},
+	"gemini-vertex":     &googleParser{}, // Native Gemini via Vertex AI — same wire format as google.
 }
 
 // getParser returns the parser for a provider, or a no-op fallback.
@@ -401,7 +402,7 @@ func extractModelFromResponse(provider string, body []byte) string {
 	}
 
 	switch provider {
-	case "google":
+	case "google", "gemini-vertex":
 		// Google returns modelVersion at the response top level.
 		// e.g. "gemini-2.0-flash-lite-001" or "gemini-2.5-pro-preview-05-06"
 		if mv, ok := resp["modelVersion"].(string); ok && mv != "" {
@@ -427,7 +428,7 @@ func extractModelFromResponse(provider string, body []byte) string {
 // response data. Scans SSE lines for the model field in any chunk.
 func extractModelFromStreamingResponse(provider string, data []byte) string {
 	switch provider {
-	case "google":
+	case "google", "gemini-vertex":
 		// Google streaming: look for modelVersion in any JSON chunk.
 		// It's typically in the last chunk alongside usageMetadata.
 		var arr []map[string]interface{}
@@ -509,7 +510,7 @@ func extractCacheTokens(provider string, body []byte) CacheTokens {
 			}
 		}
 
-	case "google":
+	case "google", "gemini-vertex":
 		// Google reports cached tokens in usageMetadata.cachedContentTokenCount
 		if meta, ok := resp["usageMetadata"].(map[string]interface{}); ok {
 			return CacheTokens{
@@ -530,7 +531,7 @@ func extractStreamingCacheTokens(provider string, data []byte) CacheTokens {
 	case "openai", "gemini-oai", "mistral", "deepseek", "qwen":
 		return extractOpenAIStreamingCache(data)
 
-	case "google":
+	case "google", "gemini-vertex":
 		return extractGoogleStreamingCache(data)
 	}
 

--- a/pkg/proxy/parsers_test.go
+++ b/pkg/proxy/parsers_test.go
@@ -281,6 +281,7 @@ func TestGetParser_AllProviders(t *testing.T) {
 		"anthropic-direct": "*proxy.anthropicParser",
 		"anthropic-vertex": "*proxy.anthropicParser",
 		"google":           "*proxy.googleParser",
+		"gemini-vertex":    "*proxy.googleParser",
 	}
 
 	for name, wantType := range providers {
@@ -866,5 +867,38 @@ func TestInjectStreamUsageOption_MaaSProviders(t *testing.T) {
 		if so["include_usage"] != true {
 			t.Errorf("%s: include_usage = %v, want true", provider, so["include_usage"])
 		}
+	}
+}
+
+// ── Gemini-Vertex provider tests ────────────────────────────────────────────
+
+func TestGetParserGeminiVertex(t *testing.T) {
+	p := getParser("gemini-vertex")
+	if _, ok := p.(*googleParser); !ok {
+		t.Errorf("getParser(\"gemini-vertex\") returned %T, want *googleParser", p)
+	}
+}
+
+func TestExtractModelFromResponseGeminiVertex(t *testing.T) {
+	body := []byte(`{"modelVersion":"gemini-2.5-pro-preview-05-06","candidates":[],"usageMetadata":{}}`)
+	model := extractModelFromResponse("gemini-vertex", body)
+	if model != "gemini-2.5-pro-preview-05-06" {
+		t.Errorf("extractModelFromResponse(gemini-vertex) = %q, want gemini-2.5-pro-preview-05-06", model)
+	}
+}
+
+func TestExtractCacheTokensGeminiVertex(t *testing.T) {
+	body := []byte(`{"usageMetadata":{"promptTokenCount":100,"cachedContentTokenCount":50,"candidatesTokenCount":20}}`)
+	ct := extractCacheTokens("gemini-vertex", body)
+	if ct.CacheReadTokens != 50 {
+		t.Errorf("extractCacheTokens(gemini-vertex).CacheReadTokens = %d, want 50", ct.CacheReadTokens)
+	}
+}
+
+func TestGeminiVertexStreamingDetection(t *testing.T) {
+	// googleParser.IsStreaming always returns false (streaming is URL-based)
+	p := getParser("gemini-vertex")
+	if p.IsStreaming([]byte(`{"contents":[{"parts":[{"text":"hello"}]}]}`)) {
+		t.Error("gemini-vertex IsStreaming should return false (streaming is URL-based)")
 	}
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -264,6 +264,11 @@ func DefaultProviders() []Provider {
 		{Name: "google", UpstreamURL: "https://generativelanguage.googleapis.com"},
 		// Gemini via OpenAI-compatible API. Use this with Cursor and other OpenAI-compat clients.
 		{Name: "gemini-oai", UpstreamURL: "https://generativelanguage.googleapis.com/v1beta/openai"},
+		// Gemini via Vertex AI native endpoint. No format translation — client speaks
+		// native Gemini API (generateContent/streamGenerateContent). Supports thought_signature
+		// passthrough for Gemini 3.x thinking models. Candela handles GCP auth (ADC).
+		// Use with @ai-sdk/google-vertex or any native Gemini SDK.
+		{Name: "gemini-vertex", UpstreamURL: "https://us-central1-aiplatform.googleapis.com", Intercept: ptrBool(false)},
 		// Anthropic via Vertex AI. Override upstream via config for your region/project:
 		// https://{REGION}-aiplatform.googleapis.com/v1/projects/{PROJECT}/locations/{REGION}/publishers/anthropic/models
 		{Name: "anthropic", UpstreamURL: "https://us-central1-aiplatform.googleapis.com"},
@@ -284,6 +289,10 @@ func DefaultProviders() []Provider {
 		{Name: "qwen", UpstreamURL: "https://aiplatform.googleapis.com"},
 	}
 }
+
+// ptrBool returns a pointer to the given bool value.
+// Used for setting optional *bool fields in struct literals.
+func ptrBool(v bool) *bool { return &v }
 
 // New creates a new LLM proxy.
 func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) *Proxy {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -726,6 +726,13 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// Check if this is a streaming request (check BEFORE translation).
 	isStreaming := isStreamingRequest(providerName, reqBody)
 
+	// Native Google/Gemini providers determine streaming from the URL path
+	// (:streamGenerateContent) rather than a body parameter. Detect this so
+	// the PathRewriter generates the correct upstream action.
+	if !isStreaming && (providerName == "google" || providerName == "gemini-vertex") {
+		isStreaming = strings.Contains(upstreamPath, "streamGenerateContent")
+	}
+
 	// Extract model from request once — reused for pricing gate, body
 	// enrichment, and path rewriting. For most providers the model is in
 	// the request body; for "google" it's in the URL path
@@ -738,7 +745,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// ── Pricing gate (#6) — blocks unpriced cloud models universally ──
 	// This runs for ALL requests (solo, team, local) to prevent untracked
 	// API calls that would show $0 cost. Only "local" provider is exempt.
-	if requestModel != "" && strings.ToLower(providerName) != "local" && !p.calc.HasPricing(providerName, requestModel) {
+	if requestModel != "" && strings.ToLower(providerName) != "local" && !p.calc.HasPricing(pricingProvider(providerName), requestModel) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusPaymentRequired)
 		errBody, _ := json.Marshal(map[string]any{
@@ -1197,7 +1204,7 @@ func (p *Proxy) handleStandardResponse(
 			model = extractModelFromResponse(provider.Name, respBody)
 		}
 		inputTokens = p.calc.NormalizeCachedInputWithTTL(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens, extendedTTL)
-		cost := p.calc.Calculate(provider.Name, model, inputTokens, outputTokens)
+		cost := p.calc.Calculate(pricingProvider(provider.Name), model, inputTokens, outputTokens)
 		limitUser := effectiveUserID
 		if limitUser == "" {
 			limitUser = "local"
@@ -1354,7 +1361,7 @@ func (p *Proxy) handleStreamingResponse(
 			model = extractModelFromStreamingResponse(provider.Name, parseData)
 		}
 		inputTokens = p.calc.NormalizeCachedInputWithTTL(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens, extendedTTL)
-		cost := p.calc.Calculate(provider.Name, model, inputTokens, outputTokens)
+		cost := p.calc.Calculate(pricingProvider(provider.Name), model, inputTokens, outputTokens)
 		limitUser := effectiveUserID
 		if limitUser == "" {
 			limitUser = "local"
@@ -1420,7 +1427,7 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 	if strings.HasSuffix(userID, ".gserviceaccount.com") {
 		// HIGH-2: Log SA spend instead of silently skipping.
 		totalTokens := inputTokens + outputTokens
-		cost := p.calc.Calculate(provider.Name, model, inputTokens, outputTokens)
+		cost := p.calc.Calculate(pricingProvider(provider.Name), model, inputTokens, outputTokens)
 		if cost > 0 || totalTokens > 0 {
 			p.saSpendMicroUSD.Add(int64(math.Round(cost * 1_000_000)))
 			slog.Info("sa_spend: service account usage",
@@ -1437,7 +1444,7 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 	}
 
 	totalTokens := inputTokens + outputTokens
-	cost := p.calc.Calculate(provider.Name, model, inputTokens, outputTokens)
+	cost := p.calc.Calculate(pricingProvider(provider.Name), model, inputTokens, outputTokens)
 
 	// #278: Record per-model daily spend in the in-memory tracker.
 	// This must happen even if DeductSpend fails, since the upstream
@@ -1536,7 +1543,7 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 // in the request handler) — buildSpan only handles span creation and storage.
 func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 	totalTokens := params.inputTokens + params.outputTokens
-	cost := p.calc.Calculate(params.provider.Name, params.model, params.inputTokens, params.outputTokens)
+	cost := p.calc.Calculate(pricingProvider(params.provider.Name), params.model, params.inputTokens, params.outputTokens)
 
 	attrs := map[string]string{
 		"proxy.upstream":  params.provider.UpstreamURL,
@@ -1853,4 +1860,17 @@ func extractModelFromURLPath(path string) string {
 		rest = rest[:colon]
 	}
 	return rest
+}
+
+// pricingProvider maps proxy provider names to their cost calculator
+// provider key. Most providers use their own name; aliases like
+// "gemini-vertex" map to the canonical provider ("google") whose
+// pricing table is authoritative.
+func pricingProvider(provider string) string {
+	switch provider {
+	case "gemini-vertex":
+		return "google"
+	default:
+		return provider
+	}
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -664,3 +664,21 @@ func TestExtractModelFromURLPath(t *testing.T) {
 		})
 	}
 }
+
+func TestPricingProvider(t *testing.T) {
+	tests := []struct {
+		provider string
+		want     string
+	}{
+		{"gemini-vertex", "google"},
+		{"google", "google"},
+		{"anthropic", "anthropic"},
+		{"openai", "openai"},
+	}
+	for _, tt := range tests {
+		got := pricingProvider(tt.provider)
+		if got != tt.want {
+			t.Errorf("pricingProvider(%q) = %q, want %q", tt.provider, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add a new `gemini-vertex` provider that passes through **native Gemini API** requests (`generateContent`/`streamGenerateContent`) to Vertex AI publisher endpoints without any format translation.

## Motivation

The existing `gemini-oai` route uses the OpenAI-compatible protocol, which **strips `thought_signature`** from Gemini 3.x thinking model responses. This causes errors in clients like OpenCode that use `@ai-sdk/openai-compatible` — the AI SDK requires `thought_signature` for proper function calling with thinking models.

The native Gemini protocol preserves `thought_signature` end-to-end, so clients using `@ai-sdk/google-vertex` or any native Gemini SDK work correctly.

## Changes

| File | Change |
|------|--------|
| `pkg/proxy/proxy.go` | Add `gemini-vertex` to `DefaultProviders()` with `Intercept: false` (shares host with anthropic providers) |
| `cmd/candela/main.go` | Wire `VertexAIGooglePathRewriter` + ADC in `buildCloudProxy()` |
| `cmd/candela-server/main.go` | Wire `VertexAIGooglePathRewriter` + ADC in server provider config |
| `cmd/candela-sidecar/main.go` | Wire `VertexAIGooglePathRewriter` + ADC in sidecar provider config |

## Usage

```yaml
# candela-local config (~/.config/candela/config.yaml)
providers:
  - name: gemini-vertex
    models:
      - gemini-2.5-pro
      - gemini-2.5-flash
```

```
# Client base URL
http://localhost:8181/proxy/gemini-vertex/
```

## Testing

- All existing tests pass (including `TestBuildSNIMapFromDefaultProviders`)
- Pre-commit hooks: gofmt ✅ go-vet ✅ golangci-lint ✅ go-test ✅