### PR TITLE
deploy: add gemini-vertex, mistral, deepseek, qwen to deploy configs

### DIFF
--- a/deploy/config.production.example.yaml
+++ b/deploy/config.production.example.yaml
@@ -25,7 +25,15 @@ proxy:
     - openai
     - google
     - anthropic
+    - anthropic-vertex
+    - anthropic-direct
+    - anthropic-bedrock
     - gemini-oai
+    - gemini-direct
+    - gemini-vertex
+    - mistral
+    - deepseek
+    - qwen
 
 # No CORS needed — UI and API are same-origin in combined container.
 cors:

--- a/deploy/entrypoint-server.sh
+++ b/deploy/entrypoint-server.sh
@@ -37,6 +37,10 @@ proxy:
     - anthropic-bedrock
     - gemini-oai
     - gemini-direct
+    - gemini-vertex
+    - mistral
+    - deepseek
+    - qwen
 
 cors:
   allowed_origins: []

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -39,6 +39,10 @@ proxy:
     - anthropic-bedrock
     - gemini-oai
     - gemini-direct
+    - gemini-vertex
+    - mistral
+    - deepseek
+    - qwen
 
 cors:
   allowed_origins: []

--- a/deploy/helm/candela-sidecar/values.yaml
+++ b/deploy/helm/candela-sidecar/values.yaml
@@ -44,6 +44,18 @@ providers:
   - name: gemini-oai
     host: generativelanguage.googleapis.com
     intercept: false  # shares host with google
+  - name: gemini-vertex
+    host: us-central1-aiplatform.googleapis.com
+    intercept: false  # shares host with anthropic-vertex
+  - name: mistral
+    host: us-central1-aiplatform.googleapis.com
+    intercept: false  # shares host with anthropic-vertex
+  - name: deepseek
+    host: aiplatform.googleapis.com
+    intercept: true
+  - name: qwen
+    host: aiplatform.googleapis.com
+    intercept: false  # shares host with deepseek
 
 # ── Transparent proxy ──
 transparent:


### PR DESCRIPTION
## Summary

Add the four new providers (from PRs #297 and #298) to all deploy configuration files. Without this, deployed Candela instances won't expose the proxy routes for these providers.

## Files Updated

| File | Purpose |
|------|---------|
| `deploy/entrypoint-server.sh` | Cloud Run server entrypoint |
| `deploy/entrypoint.sh` | Combined container entrypoint |
| `deploy/config.production.yaml` | Azra production config |
| `deploy/config.production.example.yaml` | Example/documentation |
| `deploy/helm/candela-sidecar/values.yaml` | K8s sidecar helm chart |

## New Providers

- `gemini-vertex` — Native Gemini via Vertex AI (thought_signature support)
- `mistral` — Mistral via Vertex AI MaaS
- `deepseek` — DeepSeek via Vertex AI OpenAI-compat
- `qwen` — Qwen via Vertex AI OpenAI-compat