### PR TITLE
fix: address codebase audit issues (admin bypass, fail-closed, pricing aliases)

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -70,9 +70,11 @@ type Config struct {
 		MaxRequestCost float64                  `yaml:"max_request_cost_usd"` // Per-request cost cap (0 = disabled)
 		DailyLimits    []proxy.SpendLimitConfig `yaml:"daily_limits"`         // Per-model daily spend limits
 		VertexAI       struct {
-			ProjectID   string `yaml:"project_id"`   // GCP project for Vertex AI
-			Region      string `yaml:"region"`       // default region (e.g. "us-central1")
-			CachingMode string `yaml:"caching_mode"` // off|auto|system-only (default: auto)
+			ProjectID     string `yaml:"project_id"`     // GCP project for Vertex AI
+			Region        string `yaml:"region"`         // default region (e.g. "us-central1")
+			CachingMode   string `yaml:"caching_mode"`   // off|auto|system-only (default: auto)
+			PromptCaching bool   `yaml:"prompt_caching"` // enable prompt caching (maps to CachingMode: auto)
+			CacheTTL      string `yaml:"cache_ttl"`      // Vertex AI cache TTL ("5m" or "1h")
 			// ProviderOverrides allows per-provider region and endpoint overrides.
 			// MaaS models (Mistral, DeepSeek, Qwen) have limited regional availability;
 			// this lets each provider target the correct region independently.
@@ -117,6 +119,19 @@ type Config struct {
 type ProviderOverride struct {
 	Region   string `yaml:"region"`   // Regional override (e.g. "us-central1" for Mistral)
 	Endpoint string `yaml:"endpoint"` // Full endpoint URL override (e.g. "https://us-central1-aiplatform.googleapis.com")
+}
+
+// getProviderOverride extracts region and endpoint from provider overrides.
+// Returns the defaultRegion if no override is set or region is empty.
+func getProviderOverride(overrides map[string]ProviderOverride, provider, defaultRegion string) (region, endpoint string) {
+	region = defaultRegion
+	if ov, ok := overrides[provider]; ok {
+		if ov.Region != "" {
+			region = ov.Region
+		}
+		endpoint = ov.Endpoint
+	}
+	return
 }
 
 func main() {
@@ -320,6 +335,13 @@ func main() {
 						if cfg.Proxy.VertexAI.CachingMode != "" {
 							ft.SetCachingMode(proxy.ParseCachingMode(cfg.Proxy.VertexAI.CachingMode))
 						}
+						// prompt_caching: true is a shorthand for caching_mode: auto
+						if cfg.Proxy.VertexAI.CachingMode == "" && cfg.Proxy.VertexAI.PromptCaching {
+							ft.SetCachingMode(proxy.CachingAuto)
+						}
+						if cfg.Proxy.VertexAI.CacheTTL != "" {
+							ft.SetCacheTTL(proxy.ParseCacheTTL(cfg.Proxy.VertexAI.CacheTTL))
+						}
 						allProviders[i].FormatTranslator = ft
 					}
 					slog.Info("🔐 Anthropic via Vertex AI configured",
@@ -411,16 +433,7 @@ func main() {
 		// endpoint with publisher "mistralai". Same auth pattern as Anthropic.
 		// Default to us-central1 since Mistral is only available in limited regions.
 		if cfg.Proxy.VertexAI.ProjectID != "" {
-			mistralRegion := "us-central1" // Mistral default — not available in all regions
-			mistralEndpoint := ""
-			if ov, ok := cfg.Proxy.VertexAI.ProviderOverrides["mistral"]; ok {
-				if ov.Region != "" {
-					mistralRegion = ov.Region
-				}
-				if ov.Endpoint != "" {
-					mistralEndpoint = ov.Endpoint
-				}
-			}
+			mistralRegion, mistralEndpoint := getProviderOverride(cfg.Proxy.VertexAI.ProviderOverrides, "mistral", "us-central1")
 			for i, p := range allProviders {
 				switch p.Name {
 				case "mistral":
@@ -454,16 +467,7 @@ func main() {
 			for i, p := range allProviders {
 				switch p.Name {
 				case "deepseek", "qwen":
-					provRegion := "global"
-					provEndpoint := ""
-					if ov, ok := cfg.Proxy.VertexAI.ProviderOverrides[p.Name]; ok {
-						if ov.Region != "" {
-							provRegion = ov.Region
-						}
-						if ov.Endpoint != "" {
-							provEndpoint = ov.Endpoint
-						}
-					}
+					provRegion, provEndpoint := getProviderOverride(cfg.Proxy.VertexAI.ProviderOverrides, p.Name, "global")
 					if provEndpoint != "" {
 						allProviders[i].UpstreamURL = provEndpoint
 					} else {
@@ -482,6 +486,21 @@ func main() {
 						"region", provRegion,
 						"endpoint_override", provEndpoint != "",
 						"adc", tokenSource != nil)
+				}
+			}
+		}
+
+		// Validate provider_overrides keys — warn on unknown providers.
+		if len(cfg.Proxy.VertexAI.ProviderOverrides) > 0 {
+			validOverrideProviders := map[string]bool{
+				"mistral": true, "deepseek": true, "qwen": true,
+				"anthropic": true, "anthropic-vertex": true,
+				"gemini-oai": true, "gemini-vertex": true, "google": true,
+			}
+			for name := range cfg.Proxy.VertexAI.ProviderOverrides {
+				if !validOverrideProviders[name] {
+					slog.Warn("⚠️ unknown provider in provider_overrides — will be ignored",
+						"provider", name)
 				}
 			}
 		}

--- a/deploy/config.production.example.yaml
+++ b/deploy/config.production.example.yaml
@@ -20,7 +20,9 @@ proxy:
   vertex_ai:
     project_id: "your-gcp-project-id"
     region: "us-east5"
-    prompt_caching: true  # Inject cache_control for Anthropic prompt caching (~10x cost reduction)
+    prompt_caching: true  # Shorthand for caching_mode: auto (~10x cost reduction)
+    # caching_mode: auto  # Explicit alternative: off|auto|system-only
+    # cache_ttl: "5m"     # Vertex AI cache TTL ("5m" or "1h")
     # Per-provider region/endpoint overrides for MaaS models with limited availability.
     provider_overrides:
       mistral:
@@ -34,7 +36,6 @@ proxy:
     - anthropic-direct
     - anthropic-bedrock
     - gemini-oai
-    - gemini-direct
     - gemini-vertex
     - mistral
     - deepseek

--- a/pkg/proxy/budget_gate_test.go
+++ b/pkg/proxy/budget_gate_test.go
@@ -188,11 +188,11 @@ func TestBudgetGate_AllowsWhenBudgetRemains(t *testing.T) {
 	}
 }
 
-func TestBudgetGate_CheckErrorAllowsRequest(t *testing.T) {
-	// When CheckBudget fails, the request should be allowed (fail-open).
+func TestBudgetGate_CheckErrorBlocksRequest(t *testing.T) {
+	// When CheckBudget fails, the request should be blocked (fail-closed).
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)
+		t.Error("upstream should NOT be called when budget check fails")
+		w.WriteHeader(500)
 	}))
 	defer upstream.Close()
 
@@ -225,10 +225,10 @@ func TestBudgetGate_CheckErrorAllowsRequest(t *testing.T) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Fail-open: should still get 200, not 5xx.
-	if resp.StatusCode != http.StatusOK {
+	// Fail-closed: should return 503 Service Unavailable.
+	if resp.StatusCode != http.StatusServiceUnavailable {
 		body, _ := io.ReadAll(resp.Body)
-		t.Errorf("status = %d, want 200 (fail-open); body = %s", resp.StatusCode, body)
+		t.Errorf("status = %d, want 503 (fail-closed); body = %s", resp.StatusCode, body)
 	}
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -674,13 +674,23 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ── Pre-flight budget check ──
+	// Check if user is admin — admins bypass rate limits and budget gates.
+	var isAdmin bool
 	if p.users != nil && effectiveUserID != "" && !isServiceAccount {
+		if u, err := p.users.GetUser(r.Context(), effectiveUserID); err == nil && u != nil && u.Role == storage.RoleAdmin {
+			isAdmin = true
+		}
+	}
+
+	// ── Pre-flight budget check ──
+	if p.users != nil && effectiveUserID != "" && !isServiceAccount && !isAdmin {
 		// ── Rate limiting ──
 		allowed, count, limit, rlErr := p.users.CheckRateLimit(r.Context(), effectiveUserID)
 		if rlErr != nil {
-			slog.Warn("rate limit check failed, allowing request",
+			slog.Error("rate limit check failed, blocking request",
 				"user_id", effectiveUserID, "error", rlErr)
+			http.Error(w, `{"error":{"message":"rate limit check unavailable — try again shortly","type":"service_error","code":503}}`, http.StatusServiceUnavailable)
+			return
 		} else if !allowed {
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Retry-After", "60")
@@ -763,14 +773,21 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 	// ── Budget pre-flight with model-aware floor (#7) ──
 	// Only applies in team mode (UserStore configured).
-	if p.users != nil && effectiveUserID != "" && !isServiceAccount {
+	if p.users != nil && effectiveUserID != "" && !isServiceAccount && !isAdmin {
 		// #7: Budget check with a per-call floor so even a $0.001-remaining
 		// user can't fire a $50 request. Floor = minimum meaningful API cost.
 		const budgetCheckFloor = 0.001 // $0.001 — lower than any cloud model's minimum call
 		check, err := p.users.CheckBudget(r.Context(), effectiveUserID, budgetCheckFloor)
 		if err != nil {
-			slog.Warn("budget check failed, allowing request",
+			slog.Error("budget check failed, blocking request",
 				"user_id", effectiveUserID, "error", err)
+			http.Error(w, `{"error":{"message":"budget check unavailable — try again shortly","type":"service_error","code":503}}`, http.StatusServiceUnavailable)
+			return
+		} else if check == nil {
+			slog.Error("budget check returned nil result, blocking request",
+				"user_id", effectiveUserID)
+			http.Error(w, `{"error":{"message":"budget check failed — try again shortly","type":"service_error","code":503}}`, http.StatusServiceUnavailable)
+			return
 		} else if !check.Allowed {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusPaymentRequired)
@@ -1868,8 +1885,10 @@ func extractModelFromURLPath(path string) string {
 // pricing table is authoritative.
 func pricingProvider(provider string) string {
 	switch provider {
-	case "gemini-vertex":
+	case "gemini-vertex", "gemini-oai":
 		return "google"
+	case "anthropic-vertex", "anthropic-direct", "anthropic-bedrock":
+		return "anthropic"
 	default:
 		return provider
 	}


### PR DESCRIPTION
## Summary

Deep review of the codebase uncovered 7 issues. This PR fixes all of them.

## Changes

### 🔴 Critical Fixes

**1. Admin budget bypass** — admins now skip rate limit and budget gates
- `proxy.go`: added `GetUser` check for `RoleAdmin` before rate limit and budget blocks
- Without this, admins with no budget doc were blocked from using the proxy (402)

**2. `pricingProvider()` alias gaps** — extended the pricing alias map:
- `gemini-oai` → `google` (was missing, blocked Gemini models via OAI-compat)
- `anthropic-vertex`, `anthropic-direct`, `anthropic-bedrock` → `anthropic`

**3. Fail-closed safety** — rate limit and budget Firestore error paths now return 503 instead of silently allowing the request. Updated `TestBudgetGate_CheckErrorBlocksRequest` accordingly.

### 🟡 Medium Fixes

**4. Dead config fields** — wired `prompt_caching` (bool → CachingAuto) and `cache_ttl` into the config struct so YAML values are no longer silently ignored.

**5. Ghost provider** — removed `gemini-direct` from example config (doesn't exist in `DefaultProviders()`).

**6. Override key validation** — startup now warns on unknown `provider_overrides` keys (typo protection).

**7. DRY helper** — extracted `getProviderOverride()` per PR #302 review feedback.

## Files Changed

| File | Changes |
|---|---|
| `cmd/candela-server/main.go` | Config struct, helper, validation, caching wiring |
| `pkg/proxy/proxy.go` | Admin bypass, pricingProvider, fail-closed |
| `pkg/proxy/budget_gate_test.go` | Updated test for fail-closed semantics |
| `deploy/config.production.example.yaml` | Removed ghost provider, documented fields |