### PR TITLE
fix(deploy): clean up entrypoint config generation

### DIFF
--- a/deploy/entrypoint-server.sh
+++ b/deploy/entrypoint-server.sh
@@ -28,6 +28,11 @@ proxy:
   vertex_ai:
     project_id: "${CANDELA_VERTEX_PROJECT:-}"
     region: "${CANDELA_VERTEX_REGION:-us-east5}"
+    caching_mode: "${CANDELA_CACHING_MODE:-auto}"
+    cache_ttl: "${CANDELA_CACHE_TTL:-}"
+    provider_overrides:
+      mistral:
+        region: "${CANDELA_MISTRAL_REGION:-us-central1}"
   providers:
     - openai
     - google
@@ -36,7 +41,6 @@ proxy:
     - anthropic-direct
     - anthropic-bedrock
     - gemini-oai
-    - gemini-direct
     - gemini-vertex
     - mistral
     - deepseek


### PR DESCRIPTION
## Summary

Cleans up the server entrypoint config template to match the current codebase.

### Changes

1. **Remove ghost provider** `gemini-direct` — doesn't exist in `DefaultProviders()`, removed from example config in #304
2. **Add `provider_overrides`** — exposes `CANDELA_MISTRAL_REGION` env var (defaults to `us-central1`) so Mistral routing is explicitly configurable
3. **Add caching config** — `CANDELA_CACHING_MODE` (default: `auto`) and `CANDELA_CACHE_TTL` env vars, wiring the config fields added in #304

### No runtime impact
All three have safe defaults matching current behavior. No env vars need to be set for existing deployments.