### PR TITLE
security: fix SSRF via model name path traversal + non-root containers

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -30,6 +30,14 @@ COPY --from=builder /build/candela-server /usr/local/bin/candela-server
 COPY deploy/entrypoint-server.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+# SECURITY: Run as non-root to limit blast radius if the server is compromised.
+# A root-level container escape can lead to host compromise on misconfigured
+# runtimes (no user namespaces, privileged mode). CIS Docker Benchmark 4.1.
+RUN groupadd -r candela && useradd -r -g candela -s /sbin/nologin candela \
+    && mkdir -p /etc/candela && chown candela:candela /etc/candela
+WORKDIR /etc/candela
+USER candela
+
 EXPOSE 8181
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/deploy/Dockerfile.combined
+++ b/deploy/Dockerfile.combined
@@ -73,6 +73,12 @@ COPY --from=ui-builder /build/ui/public /app/ui/public
 # Entrypoint script.
 COPY deploy/entrypoint.sh /usr/local/bin/entrypoint.sh
 
+# SECURITY: Run as non-root (CIS Docker Benchmark 4.1).
+# chown /app/ui so Next.js can write to .next/cache for image optimization.
+RUN groupadd -r candela && useradd -r -g candela -s /sbin/nologin candela \
+    && chown -R candela:candela /app/ui
+USER candela
+
 # Cloud Run expects port 3000 (Next.js UI).
 # Go backend runs on 8181 (internal, proxied via rewrites).
 EXPOSE 3000

--- a/deploy/Dockerfile.ui
+++ b/deploy/Dockerfile.ui
@@ -65,6 +65,12 @@ COPY --from=builder /build/ui/public /app/ui/public
 
 EXPOSE 3000
 
+# SECURITY: Run as non-root (CIS Docker Benchmark 4.1).
+# chown /app/ui so Next.js can write to .next/cache for image optimization.
+RUN groupadd -r candela && useradd -r -g candela -s /sbin/nologin candela \
+    && chown -R candela:candela /app/ui
+USER candela
+
 WORKDIR /app/ui
 # BACKEND_URL can be overridden at runtime to point at the candela-server container.
 CMD ["sh", "-c", "HOSTNAME=0.0.0.0 PORT=3000 exec node server.js"]

--- a/deploy/Dockerfile.worker
+++ b/deploy/Dockerfile.worker
@@ -13,4 +13,8 @@ FROM alpine:3.20
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /build/candela-worker /usr/local/bin/candela-worker
 
+# SECURITY: Run as non-root (CIS Docker Benchmark 4.1).
+RUN addgroup -S candela && adduser -S -G candela candela
+USER candela
+
 ENTRYPOINT ["candela-worker"]

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -606,6 +606,32 @@ func rewriteModelField(body []byte, newModel string) []byte {
 // Also used to validate X-Session-Id and X-Candela-Tenant-Id.
 var requestIDPattern = regexp.MustCompile(`^[a-zA-Z0-9\-]{1,128}$`)
 
+// safeModelNameRe validates model names before they're interpolated into
+// Vertex AI URL paths (e.g. /v1/projects/.../models/{model}:predict).
+//
+// SECURITY: Model names come from the client request body and are passed
+// unsanitized into fmt.Sprintf URL paths in PathRewriter implementations
+// (VertexAIMaaSPathRewriter, VertexAIGeminiOAIPathRewriter, etc.).
+// Without this check, a malicious model name containing path traversal
+// characters (e.g. "../../other-project/locations/us-central1/...") could
+// redirect requests to arbitrary Vertex AI resources accessible to the
+// server's service account — an SSRF vulnerability.
+//
+// Allowed: alphanumeric, hyphens, underscores, dots, colons, @, forward slash
+// (covers model names like "gemini-2.5-flash", "claude-sonnet-4@20250514",
+// "mistral-large-2411", "deepseek-ai/deepseek-chat")
+//
+// Forward slashes are allowed for org/model names (e.g. "Qwen/Qwen2.5-Coder"),
+// but ".." sequences are explicitly blocked to prevent path traversal.
+var safeModelNameRe = regexp.MustCompile(`^[a-zA-Z0-9._@:/\-]+$`)
+
+// isSafeModelName validates a model name is safe for URL path interpolation.
+// It checks both the character set (safeModelNameRe) and rejects ".."
+// path traversal sequences that could escape the intended URL path.
+func isSafeModelName(model string) bool {
+	return safeModelNameRe.MatchString(model) && !strings.Contains(model, "..")
+}
+
 // tenantIDPattern delegates to attribution.IDPattern for backward compatibility
 // with tests in this package.
 var tenantIDPattern = attribution.IDPattern
@@ -998,6 +1024,19 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	modelForPath := translatedModel
 	if modelForPath == "" {
 		modelForPath = requestModel
+	}
+	// SECURITY: Reject model names with path traversal characters before
+	// they're interpolated into Vertex AI URL paths. Without this, a crafted
+	// model name like "../../other-project/locations/.../models/gemini-2.5-flash"
+	// could SSRF into arbitrary Vertex AI resources the SA has access to.
+	// See safeModelNameRe definition for the full threat model.
+	if modelForPath != "" && !isSafeModelName(modelForPath) {
+		slog.Warn("blocked request: invalid model name (possible path traversal)",
+			"model", modelForPath, "provider", providerName, "user_id", effectiveUserID)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid model name","type":"invalid_request_error","code":400}}`))
+		return
 	}
 	if provider.PathRewriter != nil && modelForPath != "" {
 		upstreamPath = provider.PathRewriter.RewritePath(modelForPath, isStreaming)

--- a/pkg/proxy/proxy_security_test.go
+++ b/pkg/proxy/proxy_security_test.go
@@ -246,3 +246,97 @@ func TestHandleProxy_GETModelsRoute(t *testing.T) {
 		t.Errorf("expected object=list, got %v", result["object"])
 	}
 }
+
+// ── Model Name Sanitization (SSRF Prevention) ───────────────────────────────
+// These tests validate safeModelNameRe which guards against path traversal
+// in Vertex AI URL construction. See the regex definition in proxy.go for
+// the full threat model.
+
+func TestSafeModelNameRe_ValidModels(t *testing.T) {
+	// All real model names the proxy handles should pass.
+	validModels := []string{
+		"gpt-4o",
+		"gpt-4o-mini",
+		"claude-sonnet-4-20250514",
+		"claude-sonnet-4@20250514",
+		"gemini-2.5-flash",
+		"gemini-2.5-pro-preview-06-05",
+		"mistral-large-2411",
+		"deepseek-ai/deepseek-chat",
+		"Qwen/Qwen2.5-Coder-32B-Instruct",
+		"meta-llama/Llama-3.1-405B",
+		"o1-preview",
+		"text-embedding-3-small",
+	}
+	for _, model := range validModels {
+		if !isSafeModelName(model) {
+			t.Errorf("safeModelNameRe rejected valid model: %q", model)
+		}
+	}
+}
+
+func TestSafeModelNameRe_PathTraversal(t *testing.T) {
+	// Path traversal attempts — all must be rejected.
+	attacks := []struct {
+		name  string
+		model string
+	}{
+		{"dot-dot-slash", "../../other-project/locations/us-central1/models/gemini-2.5-flash"},
+		{"backslash traversal", `..\..\other-project\models\gemini-2.5-flash`},
+		{"url encoded dots", "%2e%2e/evil"},
+		{"null byte", "gemini-2.5-flash\x00../../evil"},
+		{"newline injection", "gemini-2.5-flash\n../../evil"},
+		{"space injection", "gemini 2.5-flash"},
+		{"query string", "gemini-2.5-flash?param=evil"},
+		{"fragment", "gemini-2.5-flash#evil"},
+		{"html tag", "<script>alert(1)</script>"},
+		{"semicolon", "gemini-2.5-flash;rm -rf /"},
+		{"pipe", "gemini-2.5-flash|cat /etc/passwd"},
+		{"backtick", "gemini-2.5-flash`id`"},
+	}
+	for _, tc := range attacks {
+		t.Run(tc.name, func(t *testing.T) {
+			if isSafeModelName(tc.model) {
+				t.Errorf("safeModelNameRe ALLOWED dangerous model name: %q", tc.model)
+			}
+		})
+	}
+}
+
+func TestSafeModelNameRe_EmptyString(t *testing.T) {
+	// Empty model names should be rejected by the regex (the proxy handles
+	// empty separately before reaching the regex check).
+	if isSafeModelName("") {
+		t.Error("isSafeModelName should reject empty string")
+	}
+}
+
+func TestSafeModelName_DotDotWithSlash(t *testing.T) {
+	// This is the specific attack vector: ".." combined with "/" forms
+	// a path traversal. Both chars are individually valid (dots for versions,
+	// slashes for org/model), but together they're dangerous.
+	attacks := []string{
+		"../gemini-2.5-flash",
+		"deepseek-ai/../../../evil",
+		"Qwen/..%2f../../evil",
+	}
+	for _, model := range attacks {
+		if isSafeModelName(model) {
+			t.Errorf("isSafeModelName ALLOWED dot-dot attack: %q", model)
+		}
+	}
+}
+
+func TestSafeModelName_SingleDotAllowed(t *testing.T) {
+	// Single dots are fine — used in version numbers like "Qwen2.5".
+	models := []string{
+		"Qwen2.5-Coder",
+		"text-embedding-3.small",
+		"v1.0-release",
+	}
+	for _, model := range models {
+		if !isSafeModelName(model) {
+			t.Errorf("isSafeModelName rejected valid dotted model: %q", model)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two critical security fixes found during deep codebase audit.

### 🔴 Fix 1: SSRF via Model Name Path Traversal

Model names from client request bodies are interpolated directly into Vertex AI URL paths via `fmt.Sprintf` in `PathRewriter` implementations. A crafted model name like `../../other-project/locations/us-central1/models/gemini-2.5-flash` could redirect requests to **arbitrary Vertex AI resources** the server's service account has access to.

**Fix:** Added `isSafeModelName()` validation that:
- Checks character set via regex (`[a-zA-Z0-9._@:/\-]+`)
- Explicitly rejects `..` path traversal sequences
- Returns 400 with structured error before path rewriting

**17 test cases** covering valid models, 12 attack vectors, dot-dot combos, and edge cases.

### 🔴 Fix 2: Containers Running as Root (CIS Docker Benchmark 4.1)

All 4 Dockerfiles (`Dockerfile`, `Dockerfile.ui`, `Dockerfile.combined`, `Dockerfile.worker`) were running as root. Added `USER candela` with a dedicated system user/group in each.

### Files Changed
| File | Change |
|---|---|
| `pkg/proxy/proxy.go` | `isSafeModelName()` + `safeModelNameRe` + validation in handleProxy |
| `pkg/proxy/proxy_security_test.go` | 17 test cases for model name validation |
| `deploy/Dockerfile` | Non-root user + config dir permissions |
| `deploy/Dockerfile.ui` | Non-root user |
| `deploy/Dockerfile.combined` | Non-root user |
| `deploy/Dockerfile.worker` | Non-root user (Alpine) |