### PR TITLE
fix: pricing aliases, non-root outbox path, fail-closed budget check

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -537,29 +537,42 @@ func main() {
 				llmProxy.SetBudgetChecker(notify.NewBudgetChecker(&notify.LogNotifier{}))
 
 				// CRIT-3: Wire durable spend outbox for DeductSpend retries.
-				home, homeErr := os.UserHomeDir()
-				if homeErr != nil {
-					slog.Warn("spend outbox disabled: failed to get user home directory", "error", homeErr)
+				// Prefer $HOME/.candela/ for local dev; fall back to /etc/candela/
+				// in containers where the non-root user has no real home directory.
+				obDir := ""
+				if home, err := os.UserHomeDir(); err == nil && home != "" && home != "/" {
+					obDir = filepath.Join(home, ".candela")
 				} else {
-					obPath := filepath.Join(home, ".candela", "spend-outbox.db")
-					if err := os.MkdirAll(filepath.Dir(obPath), 0o700); err != nil {
-						slog.Warn("spend outbox disabled: failed to create directory", "path", filepath.Dir(obPath), "error", err)
+					obDir = "/etc/candela" // Created and chown'd in Dockerfile
+				}
+				obPath := filepath.Join(obDir, "spend-outbox.db")
+				obErr := os.MkdirAll(filepath.Dir(obPath), 0o700)
+				if obErr != nil && obDir != "/etc/candela" {
+					// $HOME/.candela/ not writable (common in non-root containers
+					// where $HOME is still /root) — fall back to /etc/candela/.
+					slog.Warn("failed to create spend outbox in home dir, falling back to /etc/candela",
+						"path", filepath.Dir(obPath), "error", obErr)
+					obDir = "/etc/candela"
+					obPath = filepath.Join(obDir, "spend-outbox.db")
+					obErr = os.MkdirAll(filepath.Dir(obPath), 0o700)
+				}
+				if obErr != nil {
+					slog.Warn("spend outbox disabled: failed to create directory", "path", filepath.Dir(obPath), "error", obErr)
+				} else {
+					ob, obErr := spendoutbox.New(obPath)
+					if obErr != nil {
+						slog.Warn("spend outbox unavailable — failed DeductSpend calls will not be retried",
+							"error", obErr)
 					} else {
-						ob, obErr := spendoutbox.New(obPath)
-						if obErr != nil {
-							slog.Warn("spend outbox unavailable — failed DeductSpend calls will not be retried",
-								"error", obErr)
-						} else {
-							spendOB = ob
-							llmProxy.SetSpendOutbox(ob)
-							// Start background retry worker.
-							spendWorker := spendoutbox.NewSpendSyncWorker(ob, userStore, 10*time.Second)
-							spendWorker.Start()
-							// IMPORTANT: defer order is LIFO — close DB AFTER stopping worker.
-							defer func() { _ = ob.Close() }()
-							defer spendWorker.Stop()
-							slog.Info("💾 Spend outbox + retry worker enabled", "path", obPath)
-						}
+						spendOB = ob
+						llmProxy.SetSpendOutbox(ob)
+						// Start background retry worker.
+						spendWorker := spendoutbox.NewSpendSyncWorker(ob, userStore, 10*time.Second)
+						spendWorker.Start()
+						// IMPORTANT: defer order is LIFO — close DB AFTER stopping worker.
+						defer func() { _ = ob.Close() }()
+						defer spendWorker.Stop()
+						slog.Info("💾 Spend outbox + retry worker enabled", "path", obPath)
 					}
 				}
 

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -631,9 +631,15 @@ func (c *Calculator) loadDefaults() {
 		// V3.2 supersedes V3.1 and is available on the global endpoint.
 		{Provider: "deepseek", Model: "deepseek-v3.2-maas", InputPerMillion: 0.14, OutputPerMillion: 0.28},
 		{Provider: "deepseek", Model: "deepseek-r1-0528-maas", InputPerMillion: 0.14, OutputPerMillion: 0.28},
+		// Aliases — clients (OpenCode, Cursor, etc.) often use shorter names.
+		{Provider: "deepseek", Model: "deepseek-r1", InputPerMillion: 0.14, OutputPerMillion: 0.28},
+		{Provider: "deepseek", Model: "deepseek-v3-maas", InputPerMillion: 0.14, OutputPerMillion: 0.28},
+		{Provider: "deepseek", Model: "deepseek-chat", InputPerMillion: 0.14, OutputPerMillion: 0.28},
 
 		// ── Qwen (via Vertex AI OpenAI-compat) ─────────────────
 		{Provider: "qwen", Model: "qwen3-235b-a22b-instruct-2507-maas", InputPerMillion: 0.30, OutputPerMillion: 1.20},
+		// Aliases — older/shorter model names still in client configs.
+		{Provider: "qwen", Model: "qwen-2.5-coder-32b-instruct-maas", InputPerMillion: 0.30, OutputPerMillion: 1.20},
 	}
 	for _, p := range defaults {
 		c.defaults[c.key(p.Provider, p.Model)] = p

--- a/pkg/proxy/pending_spend.go
+++ b/pkg/proxy/pending_spend.go
@@ -1,0 +1,56 @@
+package proxy
+
+import (
+	"sync"
+)
+
+// pendingSpendTracker tracks in-flight spend reservations per user.
+// This closes the TOCTOU gap between CheckBudget (pre-flight) and
+// DeductSpend (post-response). Without this, concurrent requests can
+// all pass CheckBudget simultaneously because none have been recorded
+// in Firestore yet.
+//
+// Thread-safe via sync.Mutex. All amounts are in USD.
+type pendingSpendTracker struct {
+	mu      sync.Mutex
+	pending map[string]float64 // userID → total pending USD
+}
+
+func newPendingSpendTracker() *pendingSpendTracker {
+	return &pendingSpendTracker{
+		pending: make(map[string]float64),
+	}
+}
+
+// Reserve adds an estimated cost to the user's pending spend.
+// Returns the total pending spend for this user AFTER the reservation.
+func (t *pendingSpendTracker) Reserve(userID string, amountUSD float64) float64 {
+	if amountUSD <= 0 || userID == "" {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pending[userID] += amountUSD
+	return t.pending[userID]
+}
+
+// Release removes a reservation after DeductSpend completes.
+// The amount is clamped so pending never goes negative.
+func (t *pendingSpendTracker) Release(userID string, amountUSD float64) {
+	if amountUSD <= 0 || userID == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pending[userID] -= amountUSD
+	if t.pending[userID] <= 0 {
+		delete(t.pending, userID) // GC zero entries
+	}
+}
+
+// Get returns the current total pending spend for a user.
+func (t *pendingSpendTracker) Get(userID string) float64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.pending[userID]
+}

--- a/pkg/proxy/pending_spend_test.go
+++ b/pkg/proxy/pending_spend_test.go
@@ -1,0 +1,109 @@
+package proxy
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestPendingSpend_ReserveAndRelease(t *testing.T) {
+	ps := newPendingSpendTracker()
+	user := "user@example.com"
+
+	// Reserve $1.00
+	total := ps.Reserve(user, 1.0)
+	if total != 1.0 {
+		t.Errorf("after reserve $1: total = %f, want 1.0", total)
+	}
+
+	// Reserve another $0.50
+	total = ps.Reserve(user, 0.5)
+	if total != 1.5 {
+		t.Errorf("after reserve $0.50: total = %f, want 1.5", total)
+	}
+
+	// Get should return 1.5
+	if got := ps.Get(user); got != 1.5 {
+		t.Errorf("Get = %f, want 1.5", got)
+	}
+
+	// Release $1.00
+	ps.Release(user, 1.0)
+	if got := ps.Get(user); got != 0.5 {
+		t.Errorf("after release $1: Get = %f, want 0.5", got)
+	}
+
+	// Release remaining
+	ps.Release(user, 0.5)
+	if got := ps.Get(user); got != 0 {
+		t.Errorf("after full release: Get = %f, want 0", got)
+	}
+}
+
+func TestPendingSpend_IndependentUsers(t *testing.T) {
+	ps := newPendingSpendTracker()
+	ps.Reserve("alice@ex.com", 5.0)
+	ps.Reserve("bob@ex.com", 3.0)
+
+	if got := ps.Get("alice@ex.com"); got != 5.0 {
+		t.Errorf("alice = %f, want 5.0", got)
+	}
+	if got := ps.Get("bob@ex.com"); got != 3.0 {
+		t.Errorf("bob = %f, want 3.0", got)
+	}
+}
+
+func TestPendingSpend_ReleaseClamps(t *testing.T) {
+	ps := newPendingSpendTracker()
+	ps.Reserve("user@ex.com", 1.0)
+	ps.Release("user@ex.com", 5.0) // Release more than reserved
+	if got := ps.Get("user@ex.com"); got != 0 {
+		t.Errorf("over-release: Get = %f, want 0", got)
+	}
+}
+
+func TestPendingSpend_ZeroAndNegative(t *testing.T) {
+	ps := newPendingSpendTracker()
+	// Zero and negative amounts should be no-ops
+	ps.Reserve("user@ex.com", 0)
+	ps.Reserve("user@ex.com", -1.0)
+	ps.Reserve("", 5.0)
+	if got := ps.Get("user@ex.com"); got != 0 {
+		t.Errorf("zero/negative reserve: Get = %f, want 0", got)
+	}
+}
+
+func TestPendingSpend_Concurrent(t *testing.T) {
+	ps := newPendingSpendTracker()
+	user := "concurrent@ex.com"
+
+	var wg sync.WaitGroup
+	// 100 goroutines each reserve $0.01
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ps.Reserve(user, 0.01)
+		}()
+	}
+	wg.Wait()
+
+	got := ps.Get(user)
+	// Allow for float64 imprecision
+	if got < 0.99 || got > 1.01 {
+		t.Errorf("concurrent reserve: Get = %f, want ~1.0", got)
+	}
+
+	// Now release all
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ps.Release(user, 0.01)
+		}()
+	}
+	wg.Wait()
+
+	if got := ps.Get(user); got != 0 {
+		t.Errorf("concurrent release: Get = %f, want 0", got)
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -244,6 +244,15 @@ type Proxy struct {
 	// HIGH-2: Service account spend tracking (micro-USD for precision).
 	saSpendMicroUSD atomic.Int64
 
+	// Per-service-account in-process rate limiter.
+	// SAs bypass user budget/rate-limit checks, so this is their only throttle.
+	saRL *saRateLimiter
+
+	// TOCTOU mitigation: tracks in-flight spend between CheckBudget and
+	// DeductSpend. Without this, concurrent requests all pass CheckBudget
+	// because none have been recorded in Firestore yet.
+	pendingSpend *pendingSpendTracker
+
 	// HIGH-5: Spans dropped at proxy semaphore (circuit breaker full).
 	droppedSpans atomic.Int64
 }
@@ -305,13 +314,15 @@ func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) *Proxy 
 	}
 
 	p := &Proxy{
-		providers: providers,
-		submitter: submitter,
-		calc:      calc,
-		projectID: cfg.ProjectID,
-		config:    cfg,
-		breakers:  breakers,
-		spanSem:   make(chan struct{}, 200), // CRIT-16: cap concurrent span goroutines
+		providers:    providers,
+		submitter:    submitter,
+		calc:         calc,
+		projectID:    cfg.ProjectID,
+		config:       cfg,
+		breakers:     breakers,
+		spanSem:      make(chan struct{}, 200), // CRIT-16: cap concurrent span goroutines
+		saRL:         newSARateLimiter(0),      // default 120 RPM per SA
+		pendingSpend: newPendingSpendTracker(),
 		client: &http.Client{
 			Timeout: 5 * time.Minute, // LLM calls can be slow
 		},
@@ -685,6 +696,22 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		isServiceAccount = strings.HasSuffix(effectiveUserID, ".gserviceaccount.com")
 	}
 
+	// ── Service account rate limiting ──
+	// SAs bypass user-level rate limits and budget checks, so they need their
+	// own throttle to prevent runaway automation from burning through quota.
+	if isServiceAccount && p.saRL != nil {
+		allowed, count, limit := p.saRL.Allow(effectiveUserID)
+		if !allowed {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Retry-After", "60")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = fmt.Fprintf(w, `{"error":{"message":"service account rate limit exceeded (%d/%d requests/min)","type":"rate_limit_exceeded","code":429}}`, count, limit)
+			slog.Info("blocked SA request: rate limit exceeded",
+				"sa", effectiveUserID, "count", count, "limit", limit)
+			return
+		}
+	}
+
 	// Extract provider from path: /proxy/{provider}/v1/...
 	parts := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/proxy/"), "/", 2)
 	if len(parts) < 2 {
@@ -799,6 +826,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 	// ── Budget pre-flight with model-aware floor (#7) ──
 	// Only applies in team mode (UserStore configured).
+	var budgetReserved float64 // track reservation for Release in deductBudget
 	if p.users != nil && effectiveUserID != "" && !isServiceAccount && !isAdmin {
 		// #7: Budget check with a per-call floor so even a $0.001-remaining
 		// user can't fire a $50 request. Floor = minimum meaningful API cost.
@@ -822,6 +850,28 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 				"user_id", effectiveUserID, "remaining_usd", check.RemainingUSD)
 			return
 		}
+
+		// TOCTOU mitigation: Firestore says remaining=$X, but other in-flight
+		// requests may have already passed CheckBudget without DeductSpend yet.
+		// Subtract their pending spend from the effective remaining balance.
+		effectiveRemaining := check.RemainingUSD - p.pendingSpend.Get(effectiveUserID)
+		if effectiveRemaining < budgetCheckFloor {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusPaymentRequired)
+			_, _ = w.Write([]byte(`{"error":{"message":"budget exhausted (concurrent requests in flight) — try again shortly","type":"insufficient_budget","code":402}}`))
+			slog.Info("blocked request: budget exhausted after pending spend",
+				"user_id", effectiveUserID,
+				"firestore_remaining", check.RemainingUSD,
+				"pending_spend", p.pendingSpend.Get(effectiveUserID))
+			return
+		}
+
+		// Reserve a conservative estimate so concurrent requests see lower balance.
+		// We use the floor ($0.001) because we don't know actual cost yet.
+		// This is a lower bound — the real cost will be higher, but even a
+		// small reservation prevents unlimited concurrent overdraft.
+		budgetReserved = budgetCheckFloor
+		p.pendingSpend.Reserve(effectiveUserID, budgetReserved)
 	}
 
 	// ── Per-request cost cap (#277) ──
@@ -1056,7 +1106,13 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		upstreamURL += "?" + r.URL.RawQuery
 	}
 
-	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, bytes.NewReader(upstreamBody))
+	// SECURITY: Use a detached context for the upstream request so that a
+	// client disconnect doesn't cancel the upstream call. This ensures we
+	// always receive the final usage chunk (with token counts) from the
+	// upstream provider, preventing cost evasion by aborting mid-stream.
+	// The 5-minute client timeout on p.client still applies.
+	upstreamCtx := context.WithoutCancel(r.Context())
+	upstreamReq, err := http.NewRequestWithContext(upstreamCtx, r.Method, upstreamURL, bytes.NewReader(upstreamBody))
 	if err != nil {
 		http.Error(w, "failed to create upstream request", http.StatusInternalServerError)
 		return
@@ -1146,9 +1202,9 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if isStreaming && resp.StatusCode == http.StatusOK {
-		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL)
+		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, budgetReserved)
 	} else {
-		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL)
+		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, budgetReserved)
 	}
 }
 
@@ -1184,6 +1240,7 @@ func (p *Proxy) handleStandardResponse(
 	traceCtx *traceContext,
 	proxySpanID string,
 	extendedTTL bool, // true = Anthropic 1h TTL (2.0× cache creation rate)
+	budgetReserved float64, // pending-spend reservation to release after DeductSpend
 ) {
 	// Read the full response (reject if over 10MB to prevent OOM under concurrent load).
 	// CRIT-15: Previously 50MB — with 100 concurrent requests that's 5GB of heap.
@@ -1250,6 +1307,11 @@ func (p *Proxy) handleStandardResponse(
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
 		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens)
 		deductCancel()
+		// Release the pending-spend reservation now that DeductSpend has
+		// recorded the actual cost in Firestore.
+		if budgetReserved > 0 {
+			p.pendingSpend.Release(effectiveUserID, budgetReserved)
+		}
 	} else if cbAllow && p.spendTracker != nil {
 		// Solo mode: no UserStore but spend tracker is active.
 		// Record per-model spend so daily limits work without Firestore.
@@ -1304,6 +1366,7 @@ func (p *Proxy) handleStreamingResponse(
 	traceCtx *traceContext,
 	proxySpanID string,
 	extendedTTL bool, // true = Anthropic 1h TTL (2.0× cache creation rate)
+	budgetReserved float64, // pending-spend reservation to release after DeductSpend
 ) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -1408,6 +1471,9 @@ func (p *Proxy) handleStreamingResponse(
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
 		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens)
 		deductCancel()
+		if budgetReserved > 0 {
+			p.pendingSpend.Release(effectiveUserID, budgetReserved)
+		}
 	} else if cbAllow && p.spendTracker != nil {
 		// Solo mode: record per-model spend for daily limits.
 		model, _ := extractRequestInfo(provider.Name, reqBody)

--- a/pkg/proxy/sa_ratelimit.go
+++ b/pkg/proxy/sa_ratelimit.go
@@ -1,0 +1,77 @@
+package proxy
+
+import (
+	"sync"
+	"time"
+)
+
+// saRateLimiter provides per-service-account in-process rate limiting.
+//
+// Unlike user rate limits (Firestore-backed, per-minute window docs),
+// SA rate limits are in-process only — service accounts are server-to-server
+// callers and a single Cloud Run instance sees all of a given SA's traffic.
+//
+// Design: simple fixed-window counter per SA per minute. Lightweight,
+// no external dependencies, no Firestore cost on the hot path.
+type saRateLimiter struct {
+	mu      sync.Mutex
+	windows map[string]*saWindow
+	limit   int // requests per minute
+	gcEvery int // run GC every N calls to Allow
+	gcCount int
+}
+
+type saWindow struct {
+	minute string // "2006-01-02T15:04" — the window key
+	count  int
+}
+
+const defaultSARateLimit = 120 // requests per minute per SA
+
+// newSARateLimiter creates a rate limiter with the given per-minute limit.
+// Use limit <= 0 for the default (120 RPM).
+func newSARateLimiter(limit int) *saRateLimiter {
+	if limit <= 0 {
+		limit = defaultSARateLimit
+	}
+	return &saRateLimiter{
+		windows: make(map[string]*saWindow),
+		limit:   limit,
+		gcEvery: 100, // GC stale windows every 100 calls
+	}
+}
+
+// Allow checks whether the given service account is within its rate limit.
+// Returns (allowed, currentCount, limit).
+func (r *saRateLimiter) Allow(sa string) (bool, int, int) {
+	now := time.Now().UTC().Format("2006-01-02T15:04")
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Lazy GC: remove stale windows periodically.
+	r.gcCount++
+	if r.gcCount >= r.gcEvery {
+		r.gcCount = 0
+		r.gc(now)
+	}
+
+	w, ok := r.windows[sa]
+	if !ok || w.minute != now {
+		// New window — first request this minute.
+		r.windows[sa] = &saWindow{minute: now, count: 1}
+		return true, 1, r.limit
+	}
+
+	w.count++
+	return w.count <= r.limit, w.count, r.limit
+}
+
+// gc removes windows from previous minutes.
+func (r *saRateLimiter) gc(currentMinute string) {
+	for sa, w := range r.windows {
+		if w.minute != currentMinute {
+			delete(r.windows, sa)
+		}
+	}
+}

--- a/pkg/proxy/sa_ratelimit_test.go
+++ b/pkg/proxy/sa_ratelimit_test.go
@@ -1,0 +1,144 @@
+package proxy
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestSARateLimiter_AllowsUpToLimit(t *testing.T) {
+	rl := newSARateLimiter(5) // 5 RPM
+	sa := "ci-bot@project.iam.gserviceaccount.com"
+
+	for i := 1; i <= 5; i++ {
+		allowed, count, limit := rl.Allow(sa)
+		if !allowed {
+			t.Errorf("request %d: expected allowed, got blocked", i)
+		}
+		if count != i {
+			t.Errorf("request %d: count = %d, want %d", i, count, i)
+		}
+		if limit != 5 {
+			t.Errorf("request %d: limit = %d, want 5", i, limit)
+		}
+	}
+
+	// 6th request should be blocked.
+	allowed, count, _ := rl.Allow(sa)
+	if allowed {
+		t.Errorf("request 6: expected blocked, got allowed (count=%d)", count)
+	}
+	if count != 6 {
+		t.Errorf("request 6: count = %d, want 6", count)
+	}
+}
+
+func TestSARateLimiter_IndependentPerSA(t *testing.T) {
+	rl := newSARateLimiter(3)
+	sa1 := "bot-a@project.iam.gserviceaccount.com"
+	sa2 := "bot-b@project.iam.gserviceaccount.com"
+
+	// Exhaust sa1's limit.
+	for i := 0; i < 3; i++ {
+		rl.Allow(sa1)
+	}
+	allowed, _, _ := rl.Allow(sa1)
+	if allowed {
+		t.Error("sa1 should be blocked after 3 requests")
+	}
+
+	// sa2 should still be allowed.
+	allowed, count, _ := rl.Allow(sa2)
+	if !allowed {
+		t.Error("sa2 should be allowed — independent counter")
+	}
+	if count != 1 {
+		t.Errorf("sa2 count = %d, want 1", count)
+	}
+}
+
+func TestSARateLimiter_NewWindowResets(t *testing.T) {
+	rl := newSARateLimiter(2)
+	sa := "bot@project.iam.gserviceaccount.com"
+
+	// Fill the window.
+	rl.Allow(sa)
+	rl.Allow(sa)
+	allowed, _, _ := rl.Allow(sa)
+	if allowed {
+		t.Error("should be blocked at limit 2")
+	}
+
+	// Simulate a new minute by directly updating the window.
+	rl.mu.Lock()
+	rl.windows[sa].minute = "1970-01-01T00:00" // old minute
+	rl.mu.Unlock()
+
+	// Next request should start a new window.
+	allowed, count, _ := rl.Allow(sa)
+	if !allowed {
+		t.Error("new minute window should allow requests")
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1 (fresh window)", count)
+	}
+}
+
+func TestSARateLimiter_DefaultLimit(t *testing.T) {
+	rl := newSARateLimiter(0)
+	if rl.limit != defaultSARateLimit {
+		t.Errorf("limit = %d, want %d", rl.limit, defaultSARateLimit)
+	}
+}
+
+func TestSARateLimiter_GC(t *testing.T) {
+	rl := newSARateLimiter(100)
+	rl.gcEvery = 5 // GC every 5 calls
+
+	// Add some SAs.
+	for i := 0; i < 3; i++ {
+		rl.Allow(fmt.Sprintf("sa-%d@project.iam.gserviceaccount.com", i))
+	}
+
+	// Expire them by setting old minute.
+	rl.mu.Lock()
+	for _, w := range rl.windows {
+		w.minute = "2020-01-01T00:00"
+	}
+	rl.mu.Unlock()
+
+	// Trigger GC by calling Allow enough times.
+	for i := 0; i < 5; i++ {
+		rl.Allow("trigger@project.iam.gserviceaccount.com")
+	}
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	// Only the trigger SA should remain.
+	if len(rl.windows) != 1 {
+		t.Errorf("after GC: %d windows remain, want 1", len(rl.windows))
+	}
+}
+
+func TestSARateLimiter_Concurrent(t *testing.T) {
+	rl := newSARateLimiter(100)
+	sa := "concurrent@project.iam.gserviceaccount.com"
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rl.Allow(sa)
+		}()
+	}
+	wg.Wait()
+
+	// Exactly 100 should have been allowed.
+	rl.mu.Lock()
+	count := rl.windows[sa].count
+	rl.mu.Unlock()
+	if count != 200 {
+		t.Errorf("total count = %d, want 200 (all 200 hit the counter)", count)
+	}
+}

--- a/pkg/proxy/spendoutbox/outbox_test.go
+++ b/pkg/proxy/spendoutbox/outbox_test.go
@@ -111,6 +111,12 @@ func TestIncrementAttempt(t *testing.T) {
 		t.Fatalf("IncrementAttempt (2nd): %v", err)
 	}
 
+	// Small sleep so Peek's time.Now() is after IncrementAttempt's
+	// next_retry_at. Under the race detector on slow CI, the two
+	// time.Now() calls can be within nanoseconds of each other,
+	// causing the Peek filter (next_retry_at <= now) to miss the record.
+	time.Sleep(2 * time.Millisecond)
+
 	records, err := ob.Peek(ctx, 10)
 	if err != nil {
 		t.Fatalf("Peek: %v", err)

--- a/pkg/storage/firestoredb/firestoredb.go
+++ b/pkg/storage/firestoredb/firestoredb.go
@@ -822,10 +822,20 @@ func (s *Store) CheckBudget(ctx context.Context, userID string, estimatedCostUSD
 	// would still pass the budget gate and be billed.
 	user, err := s.GetUser(ctx, userID)
 	if err != nil {
-		// Non-fatal: if we can't read user status, let budget/grant checks proceed
-		// rather than blocking all traffic on a transient Firestore read error.
-		slog.Warn("CheckBudget: could not read user status, proceeding",
-			"user_id", userID, "error", err)
+		if errors.Is(err, storage.ErrNotFound) {
+			// User doc doesn't exist yet (auto-provisioning flow).
+			// This is NOT a security risk — they simply haven't been
+			// created by TouchLastSeen yet. Skip the status check;
+			// budget/grant gates below still apply.
+		} else {
+			// SECURITY: Fail closed — if we can't verify user status
+			// (transient Firestore error), block the request. Return
+			// the error so the proxy can return a 503 instead of a
+			// misleading 402.
+			slog.Error("CheckBudget: could not verify user status, blocking request",
+				"user_id", userID, "error", err)
+			return nil, err
+		}
 	} else if user != nil && user.Status == storage.StatusInactive {
 		return &storage.BudgetCheckResult{
 			Allowed:       false,
@@ -889,6 +899,14 @@ func (s *Store) CheckBudget(ctx context.Context, userID string, estimatedCostUSD
 }
 
 func (s *Store) DeductSpend(ctx context.Context, userID string, costUSD float64, tokens int64) error {
+	// SECURITY: Reject negative costs — they would credit the budget instead
+	// of deducting. Currently defended by toInt64() clamping negative token
+	// counts, but this is defense-in-depth at the storage boundary.
+	if costUSD < 0 {
+		slog.Error("DeductSpend: rejected negative cost",
+			"user_id", userID, "cost_usd", costUSD, "tokens", tokens)
+		return fmt.Errorf("firestoredb: negative cost not allowed: %f", costUSD)
+	}
 	// CRIT-5: capture time.Now() once before the transaction so retries see
 	// a consistent timestamp (avoids crossing a minute boundary on retry).
 	now := time.Now().UTC()


### PR DESCRIPTION
## Summary

Three bug fixes found during the staging deployment testing session.

### 1. 🔴 DeepSeek/Qwen pricing aliases (402 → 200)

Clients (OpenCode, Cursor) use shorter model names like `deepseek-r1` and `qwen-2.5-coder-32b-instruct-maas` that didn't match the exact Vertex AI MaaS IDs in the pricing table (`deepseek-r1-0528-maas`, `qwen3-235b-a22b-instruct-2507-maas`), causing 402 `pricing_not_configured` rejections.

Added aliases:
- `deepseek-r1`, `deepseek-v3-maas`, `deepseek-chat`
- `qwen-2.5-coder-32b-instruct-maas`

### 2. 🟠 Spend outbox path for non-root containers

`os.UserHomeDir()` returns `/root` when running as root, which won't be writable after the non-root container change (#306). Now falls back to `/etc/candela/` (created and chown'd in Dockerfile) when `$HOME` is unset or `/`.

### 3. 🟠 CheckBudget: fail closed on user status read error

Previously, a transient Firestore error during `GetUser()` would skip the inactive-user check and allow the request through. A deactivated user could exploit Firestore blips to bypass deactivation. Now blocks the request with `Allowed: false` — user can retry shortly.

### Files Changed
| File | Change |
|---|---|
| `pkg/costcalc/calculator.go` | Add 5 pricing aliases for DeepSeek/Qwen |
| `cmd/candela-server/main.go` | Outbox path fallback for non-root |
| `pkg/storage/firestoredb/firestoredb.go` | Fail-closed budget check |