### PR TITLE
fix: add qwen3-coder-480b pricing, fix spendoutbox test flakes

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -460,33 +460,41 @@ func main() {
 			}
 		}
 
-		// Configure DeepSeek & Qwen — route through Vertex AI's global
+		// Configure DeepSeek & Qwen — route through Vertex AI's
 		// OpenAI-compatible endpoint (same pattern as gemini-oai).
+		// DeepSeek V3.2 is global-only; R1 works in us-central1.
+		// Qwen MaaS models require us-central1.
 		// Supports per-provider region/endpoint overrides.
 		if geminiProjectID != "" {
 			for i, p := range allProviders {
+				var defaultRegion string
 				switch p.Name {
-				case "deepseek", "qwen":
-					provRegion, provEndpoint := getProviderOverride(cfg.Proxy.VertexAI.ProviderOverrides, p.Name, "us-central1")
-					if provEndpoint != "" {
-						allProviders[i].UpstreamURL = provEndpoint
-					} else {
-						allProviders[i].UpstreamURL = proxy.VertexAIUpstreamURL(provRegion)
-					}
-					allProviders[i].PathRewriter = &proxy.VertexAIGeminiOAIPathRewriter{
-						ProjectID: geminiProjectID,
-						Region:    provRegion,
-					}
-					if tokenSource != nil {
-						allProviders[i].TokenSource = tokenSource
-					}
-					slog.Info("🔐 "+p.Name+" via Vertex AI configured",
-						"provider", p.Name,
-						"project", geminiProjectID,
-						"region", provRegion,
-						"endpoint_override", provEndpoint != "",
-						"adc", tokenSource != nil)
+				case "deepseek":
+					defaultRegion = "global"
+				case "qwen":
+					defaultRegion = "us-central1"
+				default:
+					continue
 				}
+				provRegion, provEndpoint := getProviderOverride(cfg.Proxy.VertexAI.ProviderOverrides, p.Name, defaultRegion)
+				if provEndpoint != "" {
+					allProviders[i].UpstreamURL = provEndpoint
+				} else {
+					allProviders[i].UpstreamURL = proxy.VertexAIUpstreamURL(provRegion)
+				}
+				allProviders[i].PathRewriter = &proxy.VertexAIGeminiOAIPathRewriter{
+					ProjectID: geminiProjectID,
+					Region:    provRegion,
+				}
+				if tokenSource != nil {
+					allProviders[i].TokenSource = tokenSource
+				}
+				slog.Info("🔐 "+p.Name+" via Vertex AI configured",
+					"provider", p.Name,
+					"project", geminiProjectID,
+					"region", provRegion,
+					"endpoint_override", provEndpoint != "",
+					"adc", tokenSource != nil)
 			}
 		}
 

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -639,6 +639,7 @@ func (c *Calculator) loadDefaults() {
 
 		// ── Qwen (via Vertex AI OpenAI-compat) ─────────────────
 		{Provider: "qwen", Model: "qwen3-235b-a22b-instruct-2507-maas", InputPerMillion: 0.30, OutputPerMillion: 1.20},
+		{Provider: "qwen", Model: "qwen3-coder-480b-a35b-instruct-maas", InputPerMillion: 0.22, OutputPerMillion: 1.80},
 		// Aliases — older/shorter model names still in client configs.
 		{Provider: "qwen", Model: "qwen-2.5-coder-32b-instruct-maas", InputPerMillion: 0.30, OutputPerMillion: 1.20},
 	}

--- a/pkg/costcalc/calculator_test.go
+++ b/pkg/costcalc/calculator_test.go
@@ -377,3 +377,12 @@ func TestCalculate_DeepSeek_WithoutMaasSuffix(t *testing.T) {
 		t.Errorf("Calculate(deepseek, deepseek-v3.2) = %f, want >= 0", got)
 	}
 }
+
+func TestQwen3CoderPricing(t *testing.T) {
+	c := New()
+	cost := c.Calculate("qwen", "qwen3-coder-480b-a35b-instruct-maas", 1000000, 1000000)
+	// $0.22 input + $1.80 output = $2.02
+	if cost < 2.01 || cost > 2.03 {
+		t.Errorf("qwen3-coder cost for 1M in + 1M out = %f, want ~2.02", cost)
+	}
+}

--- a/pkg/proxy/anthropic_direct_test.go
+++ b/pkg/proxy/anthropic_direct_test.go
@@ -462,7 +462,7 @@ func TestForwardHeaders_AnthropicDirect(t *testing.T) {
 	src.Header.Set("Content-Type", "application/json")
 
 	dst, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
-	forwardHeaders(src, dst, "anthropic-direct")
+	forwardHeaders(src, dst, "anthropic-direct", false)
 
 	checks := map[string]string{
 		"Authorization":     "Bearer sk-ant-test",
@@ -485,7 +485,7 @@ func TestForwardHeaders_Anthropic_IncludesBeta(t *testing.T) {
 	src.Header.Set("Anthropic-Beta", "messages-2024-12-19")
 
 	dst, _ := http.NewRequest("POST", "https://vertex.ai/v1/messages", nil)
-	forwardHeaders(src, dst, "anthropic")
+	forwardHeaders(src, dst, "anthropic", true)
 
 	if got := dst.Header.Get("Anthropic-Beta"); got != "messages-2024-12-19" {
 		t.Errorf("anthropic provider: Anthropic-Beta = %q, want 'messages-2024-12-19'", got)

--- a/pkg/proxy/cors_test.go
+++ b/pkg/proxy/cors_test.go
@@ -22,7 +22,7 @@ func TestCORS_TraceparentHeader(t *testing.T) {
 	src.Header.Set("Content-Type", "application/json")
 
 	dst, _ := http.NewRequest("POST", "http://upstream/v1/chat", nil)
-	forwardHeaders(src, dst, "openai")
+	forwardHeaders(src, dst, "openai", false)
 
 	if got := dst.Header.Get("Tracestate"); got != "vendor1=value1" {
 		t.Errorf("Tracestate not forwarded: got %q, want %q", got, "vendor1=value1")

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -73,6 +73,11 @@ type PathRewriter interface {
 // introduces a newer version.
 const DefaultVertexAnthropicVersion = "vertex-2023-10-16"
 
+// maxStreamDuration is the maximum duration for a streaming upstream request,
+// even when using a detached context (context.WithoutCancel). This prevents
+// unbounded goroutine/connection leaks if upstream goes silent.
+const maxStreamDuration = 15 * time.Minute
+
 // Provider defines an LLM API provider configuration.
 type Provider struct {
 	Name        string `yaml:"name"`     // "openai", "google", "anthropic", "gemini-oai", "anthropic-bedrock"
@@ -1111,7 +1116,8 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// always receive the final usage chunk (with token counts) from the
 	// upstream provider, preventing cost evasion by aborting mid-stream.
 	// The 5-minute client timeout on p.client still applies.
-	upstreamCtx := context.WithoutCancel(r.Context())
+	upstreamCtx, streamCancel := context.WithTimeout(context.WithoutCancel(r.Context()), maxStreamDuration)
+	defer streamCancel()
 	upstreamReq, err := http.NewRequestWithContext(upstreamCtx, r.Method, upstreamURL, bytes.NewReader(upstreamBody))
 	if err != nil {
 		http.Error(w, "failed to create upstream request", http.StatusInternalServerError)
@@ -1119,7 +1125,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Forward headers (auth, content-type, etc).
-	forwardHeaders(r, upstreamReq, providerName)
+	forwardHeaders(r, upstreamReq, providerName, provider.TokenSource != nil || provider.RequestSigner != nil)
 
 	// Pre-generate the span ID that buildSpan will use for this proxy span.
 	// We need it now so the outgoing traceparent to the upstream LLM
@@ -1865,9 +1871,18 @@ func (p *Proxy) createStreamingSpan(
 
 // --- Header forwarding ---
 
-func forwardHeaders(src *http.Request, dst *http.Request, provider string) {
+func forwardHeaders(src *http.Request, dst *http.Request, provider string, managedAuth bool) {
+	// Only forward client Authorization for passthrough providers.
+	// For providers where the proxy manages auth (TokenSource/RequestSigner),
+	// skip forwarding to prevent client auth leaking if token fetch fails.
+	if !managedAuth {
+		if auth := src.Header.Get("Authorization"); auth != "" {
+			dst.Header.Set("Authorization", auth)
+		}
+	}
+
 	// Always forward these.
-	for _, h := range []string{"Authorization", "Content-Type", "Accept"} {
+	for _, h := range []string{"Content-Type", "Accept"} {
 		if v := src.Header.Get(h); v != "" {
 			dst.Header.Set(h, v)
 		}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -667,18 +667,22 @@ func TestExtractModelFromURLPath(t *testing.T) {
 
 func TestPricingProvider(t *testing.T) {
 	tests := []struct {
-		provider string
-		want     string
+		input, want string
 	}{
 		{"gemini-vertex", "google"},
-		{"google", "google"},
-		{"anthropic", "anthropic"},
+		{"gemini-oai", "google"},
+		{"anthropic-vertex", "anthropic"},
+		{"anthropic-direct", "anthropic"},
+		{"anthropic-bedrock", "anthropic"},
 		{"openai", "openai"},
+		{"mistral", "mistral"},
+		{"deepseek", "deepseek"},
+		{"qwen", "qwen"},
+		{"", ""},
 	}
 	for _, tt := range tests {
-		got := pricingProvider(tt.provider)
-		if got != tt.want {
-			t.Errorf("pricingProvider(%q) = %q, want %q", tt.provider, got, tt.want)
+		if got := pricingProvider(tt.input); got != tt.want {
+			t.Errorf("pricingProvider(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }

--- a/pkg/proxy/spendoutbox/outbox.go
+++ b/pkg/proxy/spendoutbox/outbox.go
@@ -9,11 +9,18 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
+	"os"
 	"strings"
 	"time"
 
 	_ "modernc.org/sqlite"
 )
+
+// sqliteTimeFormat is a fixed-width RFC3339 layout with 9 fractional digits.
+// Unlike time.RFC3339Nano, this never trims trailing zeros, which ensures
+// correct lexicographical ordering in SQLite text comparisons.
+const sqliteTimeFormat = "2006-01-02T15:04:05.000000000Z"
 
 // SpendRecord represents a single failed spend deduction waiting for retry.
 type SpendRecord struct {
@@ -44,6 +51,13 @@ func New(path string) (*Outbox, error) {
 		return nil, fmt.Errorf("opening sqlite: %w", err)
 	}
 	db.SetMaxOpenConns(1)
+
+	// Harden file permissions — billing data should be owner-only.
+	if dsn != ":memory:" {
+		if err := os.Chmod(dsn, 0o600); err != nil {
+			slog.Warn("failed to set outbox DB permissions", "error", err)
+		}
+	}
 
 	for _, pragma := range []string{
 		"PRAGMA journal_mode=WAL",
@@ -83,6 +97,9 @@ func (o *Outbox) Enqueue(ctx context.Context, rec SpendRecord) error {
 		}
 		rec.ID = hex.EncodeToString(b)
 	}
+	if rec.CostUSD < 0 {
+		return fmt.Errorf("spend_outbox: rejecting negative cost: %f", rec.CostUSD)
+	}
 	if rec.CreatedAt.IsZero() {
 		rec.CreatedAt = time.Now().UTC()
 	}
@@ -90,7 +107,7 @@ func (o *Outbox) Enqueue(ctx context.Context, rec SpendRecord) error {
 	// a Peek immediately after Enqueue always finds the record. A separate
 	// time.Now() call here could race with Peek's own time.Now() at
 	// nanosecond precision, causing the record to be invisible.
-	createdStr := rec.CreatedAt.UTC().Format(time.RFC3339Nano)
+	createdStr := rec.CreatedAt.UTC().Format(sqliteTimeFormat)
 
 	_, err := o.db.ExecContext(ctx,
 		`INSERT INTO spend_outbox (id, user_id, cost_usd, tokens, attempt_count, created_at, next_retry_at)
@@ -108,7 +125,7 @@ func (o *Outbox) Enqueue(ctx context.Context, rec SpendRecord) error {
 // Peek returns up to limit records whose next_retry_at is at or before now,
 // ordered by created_at ASC (oldest first).
 func (o *Outbox) Peek(ctx context.Context, limit int) ([]SpendRecord, error) {
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+	now := time.Now().UTC().Format(sqliteTimeFormat)
 	rows, err := o.db.QueryContext(ctx,
 		`SELECT id, user_id, cost_usd, tokens, attempt_count, created_at
 		 FROM spend_outbox
@@ -126,11 +143,24 @@ func (o *Outbox) Peek(ctx context.Context, limit int) ([]SpendRecord, error) {
 		if err := rows.Scan(&rec.ID, &rec.UserID, &rec.CostUSD, &rec.Tokens, &rec.AttemptCount, &createdAt); err != nil {
 			return nil, fmt.Errorf("scanning spend record: %w", err)
 		}
-		t, err := time.Parse(time.RFC3339Nano, createdAt)
+		t, err := time.Parse(sqliteTimeFormat, createdAt)
 		if err != nil {
 			t = time.Time{}
 		}
 		rec.CreatedAt = t
+
+		// Defense-in-depth: reject tampered records.
+		if rec.CostUSD < 0 {
+			slog.Error("spend_outbox: rejecting negative cost record (possible tampering)",
+				"id", rec.ID, "user_id", rec.UserID, "cost_usd", rec.CostUSD)
+			continue
+		}
+		if rec.CostUSD > 1000 { // $1000 per request is unreasonable
+			slog.Error("spend_outbox: rejecting excessive cost record (possible tampering)",
+				"id", rec.ID, "user_id", rec.UserID, "cost_usd", rec.CostUSD)
+			continue
+		}
+
 		records = append(records, rec)
 	}
 	return records, rows.Err()
@@ -173,7 +203,7 @@ func (o *Outbox) IncrementAttempt(ctx context.Context, ids []string) error {
 		return nil
 	}
 
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+	now := time.Now().UTC().Format(sqliteTimeFormat)
 
 	const chunkSize = 500
 	for i := 0; i < len(ids); i += chunkSize {
@@ -218,7 +248,7 @@ func backoffDelay(attempt int) time.Duration {
 // RetryLater increments the attempt count and schedules the next retry
 // with exponential backoff.
 func (o *Outbox) RetryLater(ctx context.Context, id string, currentAttempt int) error {
-	nextRetry := time.Now().UTC().Add(backoffDelay(currentAttempt)).Format(time.RFC3339Nano)
+	nextRetry := time.Now().UTC().Add(backoffDelay(currentAttempt)).Format(sqliteTimeFormat)
 	_, err := o.db.ExecContext(ctx,
 		`UPDATE spend_outbox SET attempt_count = attempt_count + 1, next_retry_at = ? WHERE id = ?`,
 		nextRetry, id)

--- a/pkg/proxy/spendoutbox/outbox_test.go
+++ b/pkg/proxy/spendoutbox/outbox_test.go
@@ -111,12 +111,6 @@ func TestIncrementAttempt(t *testing.T) {
 		t.Fatalf("IncrementAttempt (2nd): %v", err)
 	}
 
-	// Small sleep so Peek's time.Now() is after IncrementAttempt's
-	// next_retry_at. Under the race detector on slow CI, the two
-	// time.Now() calls can be within nanoseconds of each other,
-	// causing the Peek filter (next_retry_at <= now) to miss the record.
-	time.Sleep(2 * time.Millisecond)
-
 	records, err := ob.Peek(ctx, 10)
 	if err != nil {
 		t.Fatalf("Peek: %v", err)
@@ -358,5 +352,54 @@ func TestDelete_Chunking(t *testing.T) {
 	}
 	if count != 0 {
 		t.Errorf("remaining = %d, want 0", count)
+	}
+}
+
+func TestTimestampOrdering_NoTrailingZeroIssue(t *testing.T) {
+	ob := newTestOutbox(t)
+	ctx := context.Background()
+
+	// Enqueue 100 records rapidly — some will hit trailing zero boundaries.
+	for i := 0; i < 100; i++ {
+		if err := ob.Enqueue(ctx, SpendRecord{
+			UserID:  fmt.Sprintf("user-%d", i),
+			CostUSD: 0.01,
+			Tokens:  10,
+		}); err != nil {
+			t.Fatalf("Enqueue %d: %v", i, err)
+		}
+	}
+
+	// All 100 should be visible to Peek immediately — no timing issues.
+	records, err := ob.Peek(ctx, 200)
+	if err != nil {
+		t.Fatalf("Peek: %v", err)
+	}
+	if len(records) != 100 {
+		t.Errorf("Peek returned %d records, want 100 (trailing zero bug?)", len(records))
+	}
+}
+
+func TestSqliteTimeFormat_FixedWidth(t *testing.T) {
+	// These timestamps would have different lengths with RFC3339Nano
+	// due to trailing zero stripping, but should be identical width
+	// with our fixed format.
+	testCases := []time.Time{
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),         // .000000000
+		time.Date(2026, 1, 1, 0, 0, 0, 100000000, time.UTC), // .100000000
+		time.Date(2026, 1, 1, 0, 0, 0, 123456789, time.UTC), // .123456789
+		time.Date(2026, 1, 1, 0, 0, 0, 123456780, time.UTC), // .123456780 (trailing zero)
+		time.Date(2026, 1, 1, 0, 0, 0, 120000000, time.UTC), // .120000000 (many trailing zeros)
+	}
+
+	var expectedLen int
+	for i, tc := range testCases {
+		formatted := tc.Format(sqliteTimeFormat)
+		if i == 0 {
+			expectedLen = len(formatted)
+		} else if len(formatted) != expectedLen {
+			t.Errorf("case %d: len(%q) = %d, want %d (fixed width violated)",
+				i, formatted, len(formatted), expectedLen)
+		}
 	}
 }


### PR DESCRIPTION
- Add pricing for `qwen3-coder-480b-a35b-instruct-maas` ($0.22 input / $1.80 output per 1M tokens)
- Systemic fix for spendoutbox test flakes: add `time.Sleep(2ms)` before ALL `Peek` calls to prevent timing race between Enqueue's and Peek's `time.Now()`