### PR TITLE
fix: configure custom HTTP Transport for proxy upstream connections

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -86,6 +86,11 @@ proxy:
   #   - model: "gpt-4.1"
   #     max_daily_usd: 25.00
 
+  # HTTP transport tuning (advanced). Defaults are tuned for production.
+  # max_idle_conns: 200         # Total idle connections across all hosts
+  # max_idle_conns_per_host: 50 # Idle connections per upstream host
+  # max_conns_per_host: 100     # Hard cap per upstream host
+
 # Pricing overrides.
 # Built-in defaults cover all cloud models at list prices.
 # Use this section for negotiated rates or enterprise discounts.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -338,12 +338,18 @@ func newUpstreamHTTPClient(cfg Config) *http.Client {
 		maxConnsPerHost = 100
 	}
 
+	slog.Info("proxy: upstream HTTP transport configured",
+		"max_idle_conns", maxIdleConns,
+		"max_idle_conns_per_host", maxIdlePerHost,
+		"max_conns_per_host", maxConnsPerHost,
+	)
+
 	return &http.Client{
 		Timeout: 5 * time.Minute, // LLM calls can be slow
 		Transport: &http.Transport{
 			DialContext:           (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
 			TLSHandshakeTimeout:   10 * time.Second,
-			ResponseHeaderTimeout: 30 * time.Second,
+			ResponseHeaderTimeout: 2 * time.Minute, // reasoning models can take 60s+ before first byte
 			MaxIdleConns:          maxIdleConns,
 			MaxIdleConnsPerHost:   maxIdlePerHost,
 			MaxConnsPerHost:       maxConnsPerHost,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -268,6 +269,11 @@ type Config struct {
 	ProjectID      string             `yaml:"project_id"`
 	MaxRequestCost float64            `yaml:"max_request_cost_usd"` // Per-request cost cap (0 = disabled)
 	DailyLimits    []SpendLimitConfig `yaml:"daily_limits"`         // Per-model daily spend limits
+
+	// HTTP transport tuning for upstream LLM provider connections.
+	MaxIdleConns        int `yaml:"max_idle_conns"`          // default: 200
+	MaxIdleConnsPerHost int `yaml:"max_idle_conns_per_host"` // default: 50
+	MaxConnsPerHost     int `yaml:"max_conns_per_host"`      // default: 100
 }
 
 // DefaultProviders returns the standard LLM provider configurations.
@@ -310,6 +316,43 @@ func DefaultProviders() []Provider {
 // Used for setting optional *bool fields in struct literals.
 func ptrBool(v bool) *bool { return &v }
 
+// newUpstreamHTTPClient builds a production-tuned HTTP client for upstream LLM
+// provider connections. The default http.DefaultTransport has MaxIdleConnsPerHost=2,
+// which causes constant TCP/TLS connection churn under concurrent load to Vertex AI
+// (*.aiplatform.googleapis.com). Each new connection requires a full TLS handshake
+// (~100ms) instead of reusing an existing one.
+//
+// Follows the pattern established in pkg/runtime/helpers.go but tuned for
+// cloud provider traffic rather than local runtimes.
+func newUpstreamHTTPClient(cfg Config) *http.Client {
+	maxIdleConns := cfg.MaxIdleConns
+	if maxIdleConns <= 0 {
+		maxIdleConns = 200
+	}
+	maxIdlePerHost := cfg.MaxIdleConnsPerHost
+	if maxIdlePerHost <= 0 {
+		maxIdlePerHost = 50
+	}
+	maxConnsPerHost := cfg.MaxConnsPerHost
+	if maxConnsPerHost <= 0 {
+		maxConnsPerHost = 100
+	}
+
+	return &http.Client{
+		Timeout: 5 * time.Minute, // LLM calls can be slow
+		Transport: &http.Transport{
+			DialContext:           (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			MaxIdleConns:          maxIdleConns,
+			MaxIdleConnsPerHost:   maxIdlePerHost,
+			MaxConnsPerHost:       maxConnsPerHost,
+			IdleConnTimeout:       120 * time.Second,
+			ForceAttemptHTTP2:     true,
+		},
+	}
+}
+
 // New creates a new LLM proxy.
 func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) *Proxy {
 	providers := make(map[string]Provider)
@@ -330,9 +373,7 @@ func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) *Proxy 
 		spanSem:      make(chan struct{}, 200), // CRIT-16: cap concurrent span goroutines
 		saRL:         newSARateLimiter(0),      // default 120 RPM per SA
 		pendingSpend: newPendingSpendTracker(),
-		client: &http.Client{
-			Timeout: 5 * time.Minute, // LLM calls can be slow
-		},
+		client:       newUpstreamHTTPClient(cfg),
 	}
 
 	// Initialize spend tracker if daily limits are configured.

--- a/pkg/proxy/upstream_client_test.go
+++ b/pkg/proxy/upstream_client_test.go
@@ -1,0 +1,63 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewUpstreamHTTPClient_Defaults(t *testing.T) {
+	client := newUpstreamHTTPClient(Config{})
+	if client.Timeout != 5*time.Minute {
+		t.Errorf("Timeout = %v, want 5m", client.Timeout)
+	}
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("Transport is not *http.Transport")
+	}
+	if tr.MaxIdleConns != 200 {
+		t.Errorf("MaxIdleConns = %d, want 200", tr.MaxIdleConns)
+	}
+	if tr.MaxIdleConnsPerHost != 50 {
+		t.Errorf("MaxIdleConnsPerHost = %d, want 50", tr.MaxIdleConnsPerHost)
+	}
+	if tr.MaxConnsPerHost != 100 {
+		t.Errorf("MaxConnsPerHost = %d, want 100", tr.MaxConnsPerHost)
+	}
+	if !tr.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 should be true")
+	}
+	if tr.ResponseHeaderTimeout != 2*time.Minute {
+		t.Errorf("ResponseHeaderTimeout = %v, want 2m", tr.ResponseHeaderTimeout)
+	}
+}
+
+func TestNewUpstreamHTTPClient_ConfigOverrides(t *testing.T) {
+	client := newUpstreamHTTPClient(Config{
+		MaxIdleConns: 42, MaxIdleConnsPerHost: 7, MaxConnsPerHost: 15,
+	})
+	tr := client.Transport.(*http.Transport)
+	if tr.MaxIdleConns != 42 {
+		t.Errorf("MaxIdleConns = %d, want 42", tr.MaxIdleConns)
+	}
+	if tr.MaxIdleConnsPerHost != 7 {
+		t.Errorf("MaxIdleConnsPerHost = %d, want 7", tr.MaxIdleConnsPerHost)
+	}
+	if tr.MaxConnsPerHost != 15 {
+		t.Errorf("MaxConnsPerHost = %d, want 15", tr.MaxConnsPerHost)
+	}
+}
+
+func TestNewUpstreamHTTPClient_ZeroValuesGetDefaults(t *testing.T) {
+	client := newUpstreamHTTPClient(Config{MaxIdleConns: 0, MaxIdleConnsPerHost: 0, MaxConnsPerHost: 0})
+	tr := client.Transport.(*http.Transport)
+	if tr.MaxIdleConns != 200 {
+		t.Errorf("MaxIdleConns = %d, want 200", tr.MaxIdleConns)
+	}
+	if tr.MaxIdleConnsPerHost != 50 {
+		t.Errorf("MaxIdleConnsPerHost = %d, want 50", tr.MaxIdleConnsPerHost)
+	}
+	if tr.MaxConnsPerHost != 100 {
+		t.Errorf("MaxConnsPerHost = %d, want 100", tr.MaxConnsPerHost)
+	}
+}


### PR DESCRIPTION
## Problem

The proxy uses `http.DefaultTransport` with `MaxIdleConnsPerHost: 2` (Go default). Under concurrent load to Vertex AI (`*.aiplatform.googleapis.com`), this causes constant TCP/TLS connection churn — each new connection requires a full TLS handshake (~100ms) instead of reusing an existing one.

## Fix

Add `newUpstreamHTTPClient()` helper with a production-tuned `http.Transport`:
- `MaxIdleConnsPerHost: 50` (was 2)
- `MaxConnsPerHost: 100` (was unlimited)
- `ForceAttemptHTTP2: true` (HTTP/2 multiplexing for Vertex AI)
- Explicit dial, TLS handshake, and response header timeouts

Values are configurable via the `proxy:` config section:
```yaml
proxy:
  max_idle_conns: 200
  max_idle_conns_per_host: 50
  max_conns_per_host: 100
```

Follows the pattern already established in `pkg/runtime/helpers.go`.

## Testing
- `go test ./pkg/proxy/... -race` ✅
- `go build ./cmd/candela-server/` ✅
- All 10 pre-commit hooks pass ✅

Closes #327