### PR TITLE
feat: add ModelCatalogStore interface, ConfigStore, and conformance tests

### DIFF
--- a/pkg/catalog/config_store.go
+++ b/pkg/catalog/config_store.go
@@ -1,0 +1,61 @@
+package catalog
+
+import (
+	"context"
+	"strings"
+)
+
+// ConfigStore is a read-only ModelCatalogStore backed by a static slice
+// of entries. It is used for compiled-in defaults and YAML/JSON config.
+type ConfigStore struct {
+	entries []Entry
+}
+
+// NewConfigStore creates a ConfigStore from the given entries.
+// The slice is copied so the caller can safely mutate the original after construction.
+func NewConfigStore(entries []Entry) *ConfigStore {
+	cp := make([]Entry, len(entries))
+	copy(cp, entries)
+	return &ConfigStore{entries: cp}
+}
+
+// List returns catalog entries. When includeDisabled is false, only
+// entries with Enabled==true are returned.
+func (s *ConfigStore) List(_ context.Context, includeDisabled bool) ([]Entry, error) {
+	if includeDisabled {
+		out := make([]Entry, len(s.entries))
+		copy(out, s.entries)
+		return out, nil
+	}
+
+	out := make([]Entry, 0, len(s.entries))
+	for _, e := range s.entries {
+		if e.Enabled {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+// Get returns a single entry by provider and model ID (case-insensitive).
+// Returns ErrNotFound if no matching entry exists.
+func (s *ConfigStore) Get(_ context.Context, provider, modelID string) (*Entry, error) {
+	for _, e := range s.entries {
+		if strings.EqualFold(e.Provider, provider) && strings.EqualFold(e.ModelID, modelID) {
+			cp := e
+			return &cp, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+// Update always returns ErrReadOnly — ConfigStore is immutable.
+func (s *ConfigStore) Update(_ context.Context, _ Entry) error {
+	return ErrReadOnly
+}
+
+// Source returns "config".
+func (s *ConfigStore) Source() string { return "config" }
+
+// Writable returns false — ConfigStore does not support mutations.
+func (s *ConfigStore) Writable() bool { return false }

--- a/pkg/catalog/config_store_test.go
+++ b/pkg/catalog/config_store_test.go
@@ -1,0 +1,12 @@
+package catalog_test
+
+import (
+	"testing"
+
+	"github.com/candelahq/candela/pkg/catalog"
+)
+
+func TestConfigStore(t *testing.T) {
+	store := catalog.NewConfigStore(testEntries)
+	runConformanceSuite(t, store, false)
+}

--- a/pkg/catalog/conformance_test.go
+++ b/pkg/catalog/conformance_test.go
@@ -1,0 +1,147 @@
+package catalog_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/catalog"
+)
+
+// testEntries is the canonical fixture set used by all conformance tests.
+// Two enabled entries + one disabled entry.
+var testEntries = []catalog.Entry{
+	{
+		ModelID:          "gemini-2.5-pro",
+		Provider:         "google",
+		DisplayName:      "Gemini 2.5 Pro",
+		InputPerMillion:  1.25,
+		OutputPerMillion: 10.00,
+		Enabled:          true,
+		Category:         "flagship",
+		ContextWindow:    1_000_000,
+	},
+	{
+		ModelID:          "claude-sonnet-4",
+		Provider:         "anthropic",
+		DisplayName:      "Claude Sonnet 4",
+		InputPerMillion:  3.00,
+		OutputPerMillion: 15.00,
+		Enabled:          true,
+		Category:         "flagship",
+		ContextWindow:    200_000,
+	},
+	{
+		ModelID:          "gpt-4.1",
+		Provider:         "openai",
+		DisplayName:      "GPT-4.1",
+		InputPerMillion:  2.00,
+		OutputPerMillion: 8.00,
+		Enabled:          false,
+		Category:         "flagship",
+		ContextWindow:    1_000_000,
+	},
+}
+
+// runConformanceSuite exercises the full ModelCatalogStore contract.
+// writable indicates whether the store supports Update.
+func runConformanceSuite(t *testing.T, store catalog.ModelCatalogStore, writable bool) {
+	t.Helper()
+	ctx := context.Background()
+
+	// ── List (enabled only) ──────────────────────────────────────────────
+	t.Run("List_EnabledOnly", func(t *testing.T) {
+		entries, err := store.List(ctx, false)
+		if err != nil {
+			t.Fatalf("List(includeDisabled=false): %v", err)
+		}
+		for _, e := range entries {
+			if !e.Enabled {
+				t.Errorf("List(includeDisabled=false) returned disabled entry: %s/%s", e.Provider, e.ModelID)
+			}
+		}
+		if len(entries) != 2 {
+			t.Errorf("List(includeDisabled=false): got %d entries, want 2", len(entries))
+		}
+	})
+
+	// ── List (include disabled) ──────────────────────────────────────────
+	t.Run("List_IncludeDisabled", func(t *testing.T) {
+		entries, err := store.List(ctx, true)
+		if err != nil {
+			t.Fatalf("List(includeDisabled=true): %v", err)
+		}
+		if len(entries) != 3 {
+			t.Errorf("List(includeDisabled=true): got %d entries, want 3", len(entries))
+		}
+	})
+
+	// ── Get (found) ──────────────────────────────────────────────────────
+	t.Run("Get_Found", func(t *testing.T) {
+		e, err := store.Get(ctx, "google", "gemini-2.5-pro")
+		if err != nil {
+			t.Fatalf("Get(google, gemini-2.5-pro): %v", err)
+		}
+		if e.ModelID != "gemini-2.5-pro" {
+			t.Errorf("ModelID = %q, want %q", e.ModelID, "gemini-2.5-pro")
+		}
+		if e.Provider != "google" {
+			t.Errorf("Provider = %q, want %q", e.Provider, "google")
+		}
+		if e.InputPerMillion != 1.25 {
+			t.Errorf("InputPerMillion = %v, want 1.25", e.InputPerMillion)
+		}
+	})
+
+	// ── Get (not found) ──────────────────────────────────────────────────
+	t.Run("Get_NotFound", func(t *testing.T) {
+		_, err := store.Get(ctx, "google", "nonexistent-model")
+		if !errors.Is(err, catalog.ErrNotFound) {
+			t.Errorf("Get(nonexistent): got %v, want %v", err, catalog.ErrNotFound)
+		}
+	})
+
+	// ── Source ────────────────────────────────────────────────────────────
+	t.Run("Source", func(t *testing.T) {
+		if src := store.Source(); src == "" {
+			t.Error("Source() returned empty string")
+		}
+	})
+
+	// ── Writable ─────────────────────────────────────────────────────────
+	t.Run("Writable", func(t *testing.T) {
+		if got := store.Writable(); got != writable {
+			t.Errorf("Writable() = %v, want %v", got, writable)
+		}
+	})
+
+	// ── Update ───────────────────────────────────────────────────────────
+	t.Run("Update", func(t *testing.T) {
+		entry := catalog.Entry{
+			ModelID:          "test-model",
+			Provider:         "test-provider",
+			InputPerMillion:  1.00,
+			OutputPerMillion: 2.00,
+			Enabled:          true,
+		}
+		err := store.Update(ctx, entry)
+
+		if writable {
+			if err != nil {
+				t.Fatalf("Update on writable store: %v", err)
+			}
+			// Verify the entry was persisted.
+			got, err := store.Get(ctx, "test-provider", "test-model")
+			if err != nil {
+				t.Fatalf("Get after Update: %v", err)
+			}
+			if got.InputPerMillion != 1.00 {
+				t.Errorf("InputPerMillion = %v, want 1.00", got.InputPerMillion)
+			}
+		} else {
+			if !errors.Is(err, catalog.ErrReadOnly) {
+				t.Errorf("Update on read-only store: got %v, want %v", err, catalog.ErrReadOnly)
+			}
+		}
+	})
+}

--- a/pkg/catalog/store.go
+++ b/pkg/catalog/store.go
@@ -1,0 +1,83 @@
+// Package catalog defines the ModelCatalogStore interface — the pluggable
+// abstraction for listing, looking up, and updating model catalog entries.
+//
+// Implementations include:
+//   - ConfigStore: read-only, backed by static config / compiled-in defaults
+//   - (future) FirestoreStore: read-write, backed by Cloud Firestore
+package catalog
+
+import (
+	"context"
+	"errors"
+)
+
+// Sentinel errors returned by ModelCatalogStore implementations.
+var (
+	// ErrNotFound indicates that the requested model entry does not exist.
+	ErrNotFound = errors.New("catalog: not found")
+
+	// ErrReadOnly indicates that the store does not support mutations.
+	ErrReadOnly = errors.New("catalog: read-only store")
+)
+
+// Entry represents a single model in the catalog.
+// This is a plain Go struct with no protobuf dependency — proto conversion
+// lives in the handler layer.
+type Entry struct {
+	// ModelID is the canonical model identifier (e.g. "gemini-2.5-pro").
+	ModelID  string `json:"model_id"`
+	Provider string `json:"provider"`
+
+	// DisplayName is a human-friendly label (e.g. "Gemini 2.5 Pro").
+	DisplayName string `json:"display_name,omitempty"`
+
+	// Pricing — base tier (USD per 1M tokens).
+	InputPerMillion  float64 `json:"input_per_million"`
+	OutputPerMillion float64 `json:"output_per_million"`
+
+	// Enabled controls whether the model is available for routing.
+	Enabled bool `json:"enabled"`
+
+	// Category groups models (e.g. "flagship", "lite", "reasoning").
+	Category string `json:"category,omitempty"`
+
+	// ContextWindow is the maximum context length in tokens.
+	ContextWindow int64 `json:"context_window,omitempty"`
+
+	// Tiered pricing — high tier (optional).
+	InputPerMillionHigh  float64 `json:"input_per_million_high,omitempty"`
+	OutputPerMillionHigh float64 `json:"output_per_million_high,omitempty"`
+	TierThresholdTokens  int64   `json:"tier_threshold_tokens,omitempty"`
+
+	// Aliases are alternative model names that resolve to this entry.
+	Aliases []string `json:"aliases,omitempty"`
+
+	// AllowedTenants restricts this model to specific tenant IDs.
+	// An empty slice means "available to all tenants".
+	AllowedTenants []string `json:"allowed_tenants,omitempty"`
+
+	// DiscountPercent is a model-specific discount (0.0–1.0).
+	DiscountPercent float64 `json:"discount_percent,omitempty"`
+}
+
+// ModelCatalogStore is the core abstraction for the model catalog.
+// Read-only stores (config, compiled-in defaults) return ErrReadOnly from Update.
+// Read-write stores (Firestore) support full CRUD.
+type ModelCatalogStore interface {
+	// List returns catalog entries. When includeDisabled is false, only
+	// entries with Enabled==true are returned.
+	List(ctx context.Context, includeDisabled bool) ([]Entry, error)
+
+	// Get returns a single entry by provider and model ID.
+	// Returns ErrNotFound if no matching entry exists.
+	Get(ctx context.Context, provider, modelID string) (*Entry, error)
+
+	// Update creates or replaces an entry. Read-only stores return ErrReadOnly.
+	Update(ctx context.Context, entry Entry) error
+
+	// Source returns a human-readable label for this store (e.g. "config", "firestore").
+	Source() string
+
+	// Writable reports whether this store supports Update.
+	Writable() bool
+}


### PR DESCRIPTION
## Overview
Pluggable catalog store layer for the model catalog feature.

## Changes
- `pkg/catalog/store.go`: ModelCatalogStore interface + Entry struct (no proto dependency)
- `pkg/catalog/config_store.go`: Read-only implementation
- `pkg/catalog/conformance_test.go`: Shared test suite

Closes #314, #315, #317