### PR TITLE
fix: split /healthz into liveness and readiness probes

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -170,16 +170,26 @@ func main() {
 	// Build the HTTP mux for ConnectRPC handlers.
 	mux := http.NewServeMux()
 
-	// Health check.
+	// Liveness probe: returns 200 if the process is alive.
+	// No external dependency checks — a failing DB should not cause restarts.
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintln(w, `{"status": "ok"}`)
+	})
+
+	// Readiness probe: checks that the server can serve traffic.
+	// Used by Cloud Run / Kubernetes for traffic routing decisions.
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if err := reader.Ping(r.Context()); err != nil {
-			slog.Error("healthz: storage ping failed", "error", err)
+			slog.Error("readyz: storage ping failed", "error", err)
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = fmt.Fprintln(w, `{"status": "unhealthy"}`)
+			_, _ = fmt.Fprintln(w, `{"status": "not_ready", "reason": "storage_unavailable"}`)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintln(w, `{"status": "ok"}`)
+		_, _ = fmt.Fprintln(w, `{"status": "ready"}`)
 	})
 
 	var spendOB *spendoutbox.Outbox

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - candela_data:/data
     healthcheck:
-      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8181/healthz"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8181/readyz"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -76,7 +76,7 @@ GO_PID=$!
 # Wait for backend to be ready (up to 10s).
 echo "Waiting for backend..."
 for i in $(seq 1 20); do
-  if wget -q -O /dev/null http://localhost:8181/healthz 2>/dev/null; then
+  if wget -q -O /dev/null http://localhost:8181/readyz 2>/dev/null; then
     echo "Backend ready."
     break
   fi

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -71,6 +71,7 @@ Next.js rewrites:
   /proxy/*         → localhost:8181
   /candela.v1.*    → localhost:8181
   /healthz         → localhost:8181
+  /readyz          → localhost:8181
 ```
 
 ## candela Setup

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -64,19 +64,32 @@ See [docs/env-vars.md](env-vars.md) for the full reference.
 
 ### Backend Health
 
+Two endpoints are available for health checking:
+
+- **`/healthz`** (liveness): Always returns `200 OK` if the process is alive. No external dependencies are checked. Used by container runtimes to decide whether to restart a container.
+- **`/readyz`** (readiness): Pings the storage backend (BigQuery/DuckDB). Used by load balancers (Cloud Run, Kubernetes) for traffic routing decisions.
+
 ```bash
-# Local
+# Local — liveness
 curl http://localhost:8181/healthz
+
+# Local — readiness (checks storage)
+curl http://localhost:8181/readyz
 
 # Production (requires auth)
 curl -H "Authorization: Bearer $(gcloud auth print-identity-token)" \
-  https://candela-xxx.a.run.app/healthz
+  https://candela-xxx.a.run.app/readyz
 ```
 
-Response:
+Liveness response:
 ```json
-{"status": "ok"}        // healthy
-{"status": "error", "detail": "..."} // storage unreachable
+{"status": "ok"}
+```
+
+Readiness responses:
+```json
+{"status": "ready"}                                          // storage reachable
+{"status": "not_ready", "reason": "storage_unavailable"}     // storage unreachable
 ```
 
 ### Cloud Run Health

--- a/docs/security.md
+++ b/docs/security.md
@@ -6,7 +6,7 @@ Candela uses a **multi-strategy authentication** system designed to securely ser
 
 ```mermaid
 flowchart TD
-    REQ[Incoming Request] --> SKIP{Path = /healthz?}
+    REQ[Incoming Request] --> SKIP{Path = /healthz or /readyz?}
     SKIP -->|yes| PASS[Pass through]
     SKIP -->|no| DEV{Dev Mode?}
     DEV -->|yes| SYNTH["Inject synthetic admin\n(admin@localhost)"]
@@ -39,7 +39,8 @@ The middleware (`pkg/auth/firebase.go`) tries three strategies in sequence. The 
 ### Auth Bypass
 
 These paths skip authentication entirely:
-- `/healthz` — health check endpoint (Cloud Run readiness probe)
+- `/healthz` — liveness probe (always returns 200 if process is alive)
+- `/readyz` — readiness probe (pings storage backend for traffic routing)
 
 ---
 

--- a/pkg/auth/firebase.go
+++ b/pkg/auth/firebase.go
@@ -60,8 +60,8 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth *fbauth.Client, cloudRunAu
 		slog.Info("🔐 service account allowlist empty — all SAs will be denied")
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Skip auth for health checks.
-		if r.URL.Path == "/healthz" {
+		// Skip auth for health checks (liveness + readiness).
+		if r.URL.Path == "/healthz" || r.URL.Path == "/readyz" {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/pkg/auth/iap.go
+++ b/pkg/auth/iap.go
@@ -19,8 +19,8 @@ import (
 // Header: x-goog-iap-jwt-assertion (set by IAP automatically)
 func IAPMiddleware(next http.Handler, audience string, devMode bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Skip auth for health checks.
-		if r.URL.Path == "/healthz" {
+		// Skip auth for health checks (liveness + readiness).
+		if r.URL.Path == "/healthz" || r.URL.Path == "/readyz" {
 			next.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
## Problem
Single `/healthz` pings BigQuery. Slow writes → Cloud Run restarts healthy instances.

## Fix
- `/healthz` (liveness): Always 200 if process alive. No external deps.
- `/readyz` (readiness): Pings storage. Used for traffic routing.

### Changes
- **`cmd/candela-server/main.go`**: Split handler — `/healthz` is now a simple 200, `/readyz` pings storage
- **`pkg/auth/firebase.go`**, **`pkg/auth/iap.go`**: Auth bypass for `/readyz`
- **`deploy/docker-compose.yml`**: Healthcheck → `/readyz`
- **`deploy/entrypoint.sh`**: Backend readiness wait → `/readyz`
- **`docs/`**: Updated operations, deployment, security docs

Closes #328