### PR TITLE
feat: add catalog config schema with backend selection

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -81,7 +81,8 @@ type Config struct {
 			ProviderOverrides map[string]ProviderOverride `yaml:"provider_overrides"`
 		} `yaml:"vertex_ai"`
 	} `yaml:"proxy"`
-	CORS struct {
+	Catalog CatalogConfig `yaml:"catalog"`
+	CORS    struct {
 		AllowedOrigins []string `yaml:"allowed_origins"` // e.g. ["http://localhost:3000"]
 	} `yaml:"cors"`
 	Worker struct {
@@ -113,6 +114,18 @@ type Config struct {
 			TimeoutSec  int               `yaml:"timeout_sec"` // per-export timeout (default: 30)
 		} `yaml:"otlp"`
 	} `yaml:"sinks"`
+}
+
+// CatalogConfig holds model catalog configuration.
+type CatalogConfig struct {
+	Backend   string                 `yaml:"backend"` // "config" (default), "firestore"
+	Firestore FirestoreCatalogConfig `yaml:"firestore"`
+}
+
+// FirestoreCatalogConfig holds Firestore-specific catalog settings.
+type FirestoreCatalogConfig struct {
+	Collection string `yaml:"collection"` // Firestore collection name (default: "model_catalog")
+	ProjectID  string `yaml:"project_id"` // GCP project (defaults to server's project_id)
 }
 
 // ProviderOverride holds per-provider Vertex AI configuration overrides.
@@ -853,6 +866,14 @@ func loadConfig() (*Config, error) {
 	}
 	if cfg.Storage.Backend == "" {
 		cfg.Storage.Backend = "duckdb"
+	}
+
+	// Catalog backend: env var override, then default to "config".
+	if env := os.Getenv("CANDELA_CATALOG_BACKEND"); env != "" {
+		cfg.Catalog.Backend = env
+	}
+	if cfg.Catalog.Backend == "" {
+		cfg.Catalog.Backend = "config"
 	}
 
 	return &cfg, nil

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -91,6 +91,21 @@ proxy:
   # max_idle_conns_per_host: 50 # Idle connections per upstream host
   # max_conns_per_host: 100     # Hard cap per upstream host
 
+# Model catalog configuration.
+# Controls how the server discovers available models and their pricing.
+catalog:
+  # Backend for the model catalog. Options:
+  #   "config"    — Read-only, uses built-in defaults + pricing overrides below (default)
+  #   "firestore" — Read/write, uses Firestore collection for dynamic model management
+  #
+  # Can be overridden with CANDELA_CATALOG_BACKEND env var.
+  backend: "config"
+
+  # Firestore-specific settings (only used when backend: "firestore")
+  # firestore:
+  #   collection: "model_catalog"    # Firestore collection name
+  #   project_id: ""                 # GCP project (defaults to server's project_id)
+
 # Pricing overrides.
 # Built-in defaults cover all cloud models at list prices.
 # Use this section for negotiated rates or enterprise discounts.


### PR DESCRIPTION
## Changes
- `config.example.yaml`: New `catalog:` section with backend selection + firestore sub-config
- Config struct: `CatalogConfig` with `Backend` and `FirestoreCatalogConfig`
- Env var: `CANDELA_CATALOG_BACKEND` override
- Default backend: `"config"` (read-only built-in pricing)

Closes #326