### PR TITLE
fix: race condition in TestIntegration_ProxyCallsTouchLastActive

### DIFF
--- a/pkg/proxy/hardening_v5_integration_test.go
+++ b/pkg/proxy/hardening_v5_integration_test.go
@@ -301,8 +301,8 @@ type trackingUserStore struct {
 }
 
 func (t *trackingUserStore) TouchLastActive(_ context.Context, id string) error {
+	t.lastUserID.Store(id) // store ID before incrementing counter — test polls counter then asserts ID
 	t.touchCalls.Add(1)
-	t.lastUserID.Store(id)
 	return nil
 }
 


### PR DESCRIPTION
## Problem
`TestIntegration_ProxyCallsTouchLastActive` panics intermittently in CI:
```
panic: interface conversion: interface {} is nil, not string
```

## Root Cause
The mock `TouchLastActive` stores values in the wrong order:
```go
t.touchCalls.Add(1)    // ← test polls this
t.lastUserID.Store(id) // ← test asserts this immediately after
```
Under CI load, the goroutine is preempted between the two atomic operations. The test sees `touchCalls > 0` and type-asserts `lastUserID.Load().(string)` — but `lastUserID` is still `nil`.

## Fix
Swap the order: store the ID **before** incrementing the counter.

```diff
 func (t *trackingUserStore) TouchLastActive(_ context.Context, id string) error {
-    t.touchCalls.Add(1)
-    t.lastUserID.Store(id)
+    t.lastUserID.Store(id) // store ID before incrementing counter
+    t.touchCalls.Add(1)
     return nil
 }
```

Verified: passes with `-race -count=10` locally.