### PR TITLE
feat: wire catalog store into server and Calculator

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -18,6 +18,7 @@ import (
 
 	_ "go.uber.org/automaxprocs" // automatically sets GOMAXPROCS from container CPU quota
 
+	"cloud.google.com/go/firestore"
 	firebase "firebase.google.com/go/v4"
 	fbauth "firebase.google.com/go/v4/auth"
 	"golang.org/x/net/http2"
@@ -29,6 +30,7 @@ import (
 	"connectrpc.com/validate"
 	"github.com/candelahq/candela/gen/go/candela/v1/candelav1connect"
 	"github.com/candelahq/candela/pkg/auth"
+	"github.com/candelahq/candela/pkg/catalog"
 	"github.com/candelahq/candela/pkg/connecthandlers"
 	"github.com/candelahq/candela/pkg/costcalc"
 	"github.com/candelahq/candela/pkg/notify"
@@ -175,6 +177,53 @@ func main() {
 	calc := costcalc.New()
 	if cfg.Pricing.DiscountPercent > 0 || len(cfg.Pricing.Models) > 0 {
 		calc.LoadFromConfig(cfg.Pricing)
+	}
+
+	// Initialize model catalog store.
+	var catalogStore catalog.ModelCatalogStore
+	var catalogClosers []func()
+	switch cfg.Catalog.Backend {
+	case "firestore":
+		collection := cfg.Catalog.Firestore.Collection
+		if collection == "" {
+			collection = "model_catalog"
+		}
+		projectID := cfg.Catalog.Firestore.ProjectID
+		if projectID == "" {
+			projectID = cfg.Firestore.ProjectID
+		}
+		fsClient, err := firestore.NewClient(context.Background(), projectID)
+		if err != nil {
+			slog.Error("failed to create Firestore client for catalog", "error", err)
+			slog.Warn("falling back to config-based catalog")
+			catalogStore = catalog.NewConfigStore(nil) // falls back to built-in defaults
+		} else {
+			catalogStore = catalog.NewFirestoreStore(fsClient, collection)
+			catalogClosers = append(catalogClosers, func() { _ = fsClient.Close() })
+		}
+	case "config", "":
+		catalogStore = catalog.NewConfigStore(nil) // uses Calculator's built-in defaults
+	default:
+		slog.Error("unknown catalog backend", "backend", cfg.Catalog.Backend)
+		os.Exit(1)
+	}
+	defer func() {
+		for _, fn := range catalogClosers {
+			fn()
+		}
+	}()
+	slog.Info("catalog store initialized", "backend", catalogStore.Source(), "writable", catalogStore.Writable())
+
+	// If the catalog is backed by a real store (not config), load entries into Calculator.
+	if catalogStore.Source() != "config" {
+		ctx := context.Background()
+		entries, err := catalogStore.List(ctx, true) // include disabled for admin visibility
+		if err != nil {
+			slog.Error("failed to load catalog entries", "error", err)
+			slog.Warn("using built-in default pricing (catalog unavailable)")
+		} else {
+			calc.LoadFromCatalog(entries)
+		}
 	}
 
 	// Start the in-process span processor (fan-out to all writers).

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -128,8 +128,9 @@ type CatalogConfig struct {
 
 // FirestoreCatalogConfig holds Firestore-specific catalog settings.
 type FirestoreCatalogConfig struct {
-	Collection string `yaml:"collection"` // Firestore collection name (default: "model_catalog")
-	ProjectID  string `yaml:"project_id"` // GCP project (defaults to server's project_id)
+	Collection string `yaml:"collection"`  // Firestore collection name (default: "model_catalog")
+	ProjectID  string `yaml:"project_id"`  // GCP project (defaults to server's project_id)
+	DatabaseID string `yaml:"database_id"` // Firestore database ID (default: "(default)")
 }
 
 // ProviderOverride holds per-provider Vertex AI configuration overrides.
@@ -192,7 +193,17 @@ func main() {
 		if projectID == "" {
 			projectID = cfg.Firestore.ProjectID
 		}
-		fsClient, err := firestore.NewClient(context.Background(), projectID)
+		databaseID := cfg.Catalog.Firestore.DatabaseID
+		if databaseID == "" {
+			databaseID = cfg.Firestore.DatabaseID
+		}
+		var fsClient *firestore.Client
+		var err error
+		if databaseID != "" && databaseID != "(default)" {
+			fsClient, err = firestore.NewClientWithDatabase(context.Background(), projectID, databaseID)
+		} else {
+			fsClient, err = firestore.NewClient(context.Background(), projectID)
+		}
 		if err != nil {
 			slog.Error("failed to create Firestore client for catalog", "error", err)
 			slog.Warn("falling back to config-based catalog")
@@ -217,7 +228,7 @@ func main() {
 	// If the catalog is backed by a real store (not config), load entries into Calculator.
 	if catalogStore.Source() != "config" {
 		ctx := context.Background()
-		entries, err := catalogStore.List(ctx, true) // include disabled for admin visibility
+		entries, err := catalogStore.List(ctx, false) // only enabled models needed for pricing
 		if err != nil {
 			slog.Error("failed to load catalog entries", "error", err)
 			slog.Warn("using built-in default pricing (catalog unavailable)")

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -217,7 +217,7 @@ func (c *Calculator) LoadFromCatalog(entries []catalog.Entry) {
 			Provider:             e.Provider,
 			InputPerMillion:      e.InputPerMillion,
 			OutputPerMillion:     e.OutputPerMillion,
-			DiscountPercent:      e.DiscountPercent,
+			DiscountPercent:      clampDiscount(e.DiscountPercent),
 			InputPerMillionHigh:  e.InputPerMillionHigh,
 			OutputPerMillionHigh: e.OutputPerMillionHigh,
 			TierThresholdTokens:  e.TierThresholdTokens,

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/candelahq/candela/pkg/catalog"
 )
 
 // ModelPricing defines the per-token pricing for a model.
@@ -195,6 +197,34 @@ func (c *Calculator) LoadFromConfig(cfg PricingConfig) {
 		slog.Info("💰 pricing overrides loaded",
 			"count", len(cfg.Models))
 	}
+}
+
+// LoadFromCatalog loads pricing from a ModelCatalogStore.
+// This replaces the built-in defaults with catalog entries,
+// preserving any config overrides that were loaded separately.
+func (c *Calculator) LoadFromCatalog(entries []catalog.Entry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Clear and rebuild defaults from catalog entries.
+	c.defaults = make(map[string]ModelPricing)
+	for _, e := range entries {
+		if !e.Enabled {
+			continue
+		}
+		c.defaults[c.key(e.Provider, e.ModelID)] = ModelPricing{
+			Model:                e.ModelID,
+			Provider:             e.Provider,
+			InputPerMillion:      e.InputPerMillion,
+			OutputPerMillion:     e.OutputPerMillion,
+			DiscountPercent:      e.DiscountPercent,
+			InputPerMillionHigh:  e.InputPerMillionHigh,
+			OutputPerMillionHigh: e.OutputPerMillionHigh,
+			TierThresholdTokens:  e.TierThresholdTokens,
+		}
+	}
+	c.rebuildFallback()
+	slog.Info("📦 catalog pricing loaded", "models", len(c.defaults))
 }
 
 // SetPricing adds or updates pricing for a model (runtime override).

--- a/pkg/costcalc/calculator_catalog_test.go
+++ b/pkg/costcalc/calculator_catalog_test.go
@@ -108,3 +108,23 @@ func TestLoadFromCatalog_PreservesConfigOverrides(t *testing.T) {
 		t.Errorf("catalog model: expected 5.0, got %f", cost)
 	}
 }
+
+func TestLoadFromCatalog_ClampsDiscount(t *testing.T) {
+	c := costcalc.New()
+
+	entries := []catalog.Entry{{
+		ModelID:          "test-model",
+		Provider:         "test",
+		InputPerMillion:  10.0,
+		OutputPerMillion: 20.0,
+		DiscountPercent:  1.5, // invalid: > 1.0
+		Enabled:          true,
+	}}
+	c.LoadFromCatalog(entries)
+
+	// With clamped discount of 1.0, cost should be 0.
+	cost := c.Calculate("test", "test-model", 1_000_000, 0)
+	if cost != 0 {
+		t.Errorf("expected 0 with 100%% discount, got %f", cost)
+	}
+}

--- a/pkg/costcalc/calculator_catalog_test.go
+++ b/pkg/costcalc/calculator_catalog_test.go
@@ -1,0 +1,110 @@
+package costcalc_test
+
+import (
+	"testing"
+
+	"github.com/candelahq/candela/pkg/catalog"
+	"github.com/candelahq/candela/pkg/costcalc"
+)
+
+func TestLoadFromCatalog(t *testing.T) {
+	c := costcalc.New()
+
+	// Verify a known default exists.
+	cost := c.Calculate("google", "gemini-2.5-pro", 1_000_000, 0)
+	if cost == 0 {
+		t.Fatal("expected non-zero cost for default model")
+	}
+
+	// Load catalog with a single custom entry.
+	entries := []catalog.Entry{{
+		ModelID:          "test-model",
+		Provider:         "test-provider",
+		InputPerMillion:  5.0,
+		OutputPerMillion: 10.0,
+		Enabled:          true,
+	}}
+	c.LoadFromCatalog(entries)
+
+	// Custom entry should now be priced.
+	cost = c.Calculate("test-provider", "test-model", 1_000_000, 0)
+	if cost != 5.0 {
+		t.Errorf("expected 5.0, got %f", cost)
+	}
+
+	// Old defaults should be gone (replaced by catalog).
+	cost = c.Calculate("google", "gemini-2.5-pro", 1_000_000, 0)
+	if cost != 0 {
+		t.Errorf("expected 0 (cleared defaults), got %f", cost)
+	}
+}
+
+func TestLoadFromCatalog_SkipsDisabledEntries(t *testing.T) {
+	c := costcalc.New()
+
+	entries := []catalog.Entry{
+		{
+			ModelID:          "enabled-model",
+			Provider:         "test",
+			InputPerMillion:  5.0,
+			OutputPerMillion: 10.0,
+			Enabled:          true,
+		},
+		{
+			ModelID:          "disabled-model",
+			Provider:         "test",
+			InputPerMillion:  3.0,
+			OutputPerMillion: 6.0,
+			Enabled:          false,
+		},
+	}
+	c.LoadFromCatalog(entries)
+
+	// Enabled model should be priced.
+	cost := c.Calculate("test", "enabled-model", 1_000_000, 0)
+	if cost != 5.0 {
+		t.Errorf("enabled model: expected 5.0, got %f", cost)
+	}
+
+	// Disabled model should NOT be priced.
+	cost = c.Calculate("test", "disabled-model", 1_000_000, 0)
+	if cost != 0 {
+		t.Errorf("disabled model: expected 0, got %f", cost)
+	}
+}
+
+func TestLoadFromCatalog_PreservesConfigOverrides(t *testing.T) {
+	c := costcalc.New()
+
+	// Apply a config override first.
+	c.LoadFromConfig(costcalc.PricingConfig{
+		Models: []costcalc.ModelPricing{{
+			Provider:         "test-provider",
+			Model:            "override-model",
+			InputPerMillion:  99.0,
+			OutputPerMillion: 199.0,
+		}},
+	})
+
+	// Load catalog — this replaces defaults but NOT overrides.
+	entries := []catalog.Entry{{
+		ModelID:          "catalog-model",
+		Provider:         "test-provider",
+		InputPerMillion:  5.0,
+		OutputPerMillion: 10.0,
+		Enabled:          true,
+	}}
+	c.LoadFromCatalog(entries)
+
+	// Config override should still be in effect.
+	cost := c.Calculate("test-provider", "override-model", 1_000_000, 0)
+	if cost != 99.0 {
+		t.Errorf("config override: expected 99.0, got %f", cost)
+	}
+
+	// Catalog model should also be priced.
+	cost = c.Calculate("test-provider", "catalog-model", 1_000_000, 0)
+	if cost != 5.0 {
+		t.Errorf("catalog model: expected 5.0, got %f", cost)
+	}
+}


### PR DESCRIPTION
## Overview
Connects the catalog store layer to the server startup, closing the loop on the model catalog feature.

## Changes
- `pkg/costcalc/calculator.go`: New `LoadFromCatalog([]catalog.Entry)` method
- `cmd/candela-server/main.go`: Initialize catalog store from config, load into Calculator
- `pkg/costcalc/calculator_catalog_test.go`: Tests for LoadFromCatalog

## Behavior
- `catalog.backend: config` → uses built-in defaults (no change from today)
- `catalog.backend: firestore` → loads pricing from Firestore, falls back to defaults on error

Closes #319