### PR TITLE
ci: verify generated proto code is up-to-date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,16 @@ jobs:
       - name: Generate proto stubs
         run: nix develop . --command buf generate
 
+      - name: Verify generated code is up-to-date
+        run: |
+          nix develop . --command bash -c '
+            if ! git diff --exit-code -- gen/ ui/src/gen/; then
+              echo "::error::Generated code is out of date. Run buf generate and commit the results."
+              git diff --stat -- gen/ ui/src/gen/
+              exit 1
+            fi
+          '
+
       - name: Build
         run: nix develop . --command go build ./...
 


### PR DESCRIPTION
## Problem
BSR plugin updates can silently change generated code, breaking builds without code changes.

## Solution
Add a CI step in `build-and-lint` that runs `buf generate` and then fails if `git diff` detects uncommitted changes in `gen/` or `ui/src/gen/`. This catches version drift automatically.

Closes #338