### PR TITLE
feat: add catalog health endpoint

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -267,6 +267,21 @@ func main() {
 		_, _ = fmt.Fprintln(w, `{"status": "ready"}`)
 	})
 
+	// Catalog health check: returns backend, model count, latency, writable flag.
+	// 503 when catalog is unhealthy (e.g. Firestore unavailable).
+	mux.HandleFunc("/catalog/healthz", func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+
+		status := catalog.CheckHealth(ctx, catalogStore)
+
+		w.Header().Set("Content-Type", "application/json")
+		if !status.Healthy {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+		_ = json.NewEncoder(w).Encode(status)
+	})
+
 	var spendOB *spendoutbox.Outbox
 	var llmProxy *proxy.Proxy
 

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -270,12 +270,19 @@ func main() {
 	// Catalog health check: returns backend, model count, latency, writable flag.
 	// 503 when catalog is unhealthy (e.g. Firestore unavailable).
 	mux.HandleFunc("/catalog/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if catalogStore == nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(catalog.HealthStatus{Error: "catalog store is nil"})
+			return
+		}
+
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 		defer cancel()
 
 		status := catalog.CheckHealth(ctx, catalogStore)
 
-		w.Header().Set("Content-Type", "application/json")
 		if !status.Healthy {
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}

--- a/pkg/catalog/health.go
+++ b/pkg/catalog/health.go
@@ -1,0 +1,38 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// HealthStatus represents the health of the catalog store.
+type HealthStatus struct {
+	Healthy    bool          `json:"healthy"`
+	Backend    string        `json:"backend"`
+	Writable   bool          `json:"writable"`
+	ModelCount int           `json:"model_count"`
+	Latency    time.Duration `json:"latency_ms"`
+	Error      string        `json:"error,omitempty"`
+}
+
+// CheckHealth performs a health check on the catalog store.
+func CheckHealth(ctx context.Context, store ModelCatalogStore) HealthStatus {
+	start := time.Now()
+	status := HealthStatus{
+		Backend:  store.Source(),
+		Writable: store.Writable(),
+	}
+
+	entries, err := store.List(ctx, false)
+	status.Latency = time.Since(start)
+
+	if err != nil {
+		status.Error = fmt.Sprintf("list failed: %v", err)
+		return status
+	}
+
+	status.Healthy = true
+	status.ModelCount = len(entries)
+	return status
+}

--- a/pkg/catalog/health.go
+++ b/pkg/catalog/health.go
@@ -2,22 +2,25 @@ package catalog
 
 import (
 	"context"
-	"fmt"
 	"time"
 )
 
 // HealthStatus represents the health of the catalog store.
 type HealthStatus struct {
-	Healthy    bool          `json:"healthy"`
-	Backend    string        `json:"backend"`
-	Writable   bool          `json:"writable"`
-	ModelCount int           `json:"model_count"`
-	Latency    time.Duration `json:"latency_ms"`
-	Error      string        `json:"error,omitempty"`
+	Healthy    bool    `json:"healthy"`
+	Backend    string  `json:"backend"`
+	Writable   bool    `json:"writable"`
+	ModelCount int     `json:"model_count"`
+	LatencyMs  float64 `json:"latency_ms"`
+	Error      string  `json:"error,omitempty"`
 }
 
 // CheckHealth performs a health check on the catalog store.
 func CheckHealth(ctx context.Context, store ModelCatalogStore) HealthStatus {
+	if store == nil {
+		return HealthStatus{Error: "catalog store is nil"}
+	}
+
 	start := time.Now()
 	status := HealthStatus{
 		Backend:  store.Source(),
@@ -25,10 +28,10 @@ func CheckHealth(ctx context.Context, store ModelCatalogStore) HealthStatus {
 	}
 
 	entries, err := store.List(ctx, false)
-	status.Latency = time.Since(start)
+	status.LatencyMs = float64(time.Since(start).Microseconds()) / 1000.0
 
 	if err != nil {
-		status.Error = fmt.Sprintf("list failed: %v", err)
+		status.Error = "catalog list failed"
 		return status
 	}
 

--- a/pkg/catalog/health_test.go
+++ b/pkg/catalog/health_test.go
@@ -2,6 +2,7 @@ package catalog_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/candelahq/candela/pkg/catalog"
@@ -20,21 +21,60 @@ func TestCheckHealth_ConfigStore(t *testing.T) {
 	if status.Writable {
 		t.Error("ConfigStore should not be writable")
 	}
-	if status.Latency == 0 {
-		t.Error("expected non-zero latency")
+	if status.LatencyMs < 0 {
+		t.Error("expected non-negative latency")
 	}
 }
 
-func TestCheckHealth_ReportsError(t *testing.T) {
-	// Use a store that will fail — create a mock or use a nil context
+func TestCheckHealth_NilStore(t *testing.T) {
+	status := catalog.CheckHealth(context.Background(), nil)
+	if status.Healthy {
+		t.Error("nil store should not be healthy")
+	}
+	if status.Error == "" {
+		t.Error("nil store should have an error message")
+	}
+}
+
+func TestCheckHealth_LatencyIsMilliseconds(t *testing.T) {
 	store := catalog.NewConfigStore(nil)
+	status := catalog.CheckHealth(context.Background(), store)
+	// Latency should be a reasonable millisecond value, not nanoseconds
+	if status.LatencyMs > 1000 {
+		t.Errorf("latency_ms = %f, suspiciously high (nanoseconds leaked?)", status.LatencyMs)
+	}
+	if status.LatencyMs < 0 {
+		t.Errorf("latency_ms = %f, should be non-negative", status.LatencyMs)
+	}
+}
 
-	// Cancelled context should cause the health check to report failure
+func TestCheckHealth_CancelledContext(t *testing.T) {
+	store := catalog.NewConfigStore(nil)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel immediately
-
+	cancel()
 	status := catalog.CheckHealth(ctx, store)
-	// ConfigStore may not respect context cancellation, so just verify
-	// the function completes without panic
-	_ = status
+	// Just verify it doesn't panic and returns in bounded time
+	if status.LatencyMs < 0 {
+		t.Error("latency should be non-negative even on error")
+	}
+}
+
+func TestHealthStatus_JSONSerialization(t *testing.T) {
+	status := catalog.HealthStatus{
+		Healthy:    true,
+		Backend:    "config",
+		ModelCount: 42,
+		LatencyMs:  1.5,
+	}
+	data, err := json.Marshal(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["latency_ms"] != 1.5 {
+		t.Errorf("latency_ms = %v, want 1.5", decoded["latency_ms"])
+	}
 }

--- a/pkg/catalog/health_test.go
+++ b/pkg/catalog/health_test.go
@@ -1,0 +1,40 @@
+package catalog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/catalog"
+)
+
+func TestCheckHealth_ConfigStore(t *testing.T) {
+	store := catalog.NewConfigStore(nil)
+	status := catalog.CheckHealth(context.Background(), store)
+
+	if !status.Healthy {
+		t.Errorf("expected healthy, got error: %s", status.Error)
+	}
+	if status.Backend != "config" {
+		t.Errorf("backend = %q, want %q", status.Backend, "config")
+	}
+	if status.Writable {
+		t.Error("ConfigStore should not be writable")
+	}
+	if status.Latency == 0 {
+		t.Error("expected non-zero latency")
+	}
+}
+
+func TestCheckHealth_ReportsError(t *testing.T) {
+	// Use a store that will fail — create a mock or use a nil context
+	store := catalog.NewConfigStore(nil)
+
+	// Cancelled context should cause the health check to report failure
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	status := catalog.CheckHealth(ctx, store)
+	// ConfigStore may not respect context cancellation, so just verify
+	// the function completes without panic
+	_ = status
+}


### PR DESCRIPTION
## Overview
JSON health check for the catalog store at `/catalog/healthz`.

Returns: backend type, model count, latency, writable flag, error status.
503 when unhealthy.

Closes #322