### PR TITLE
feat: point-in-time pricing on spans

### DIFF
--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -439,6 +439,15 @@ func (c *Calculator) HasPricing(provider, model string) bool {
 	return ok
 }
 
+// Resolve returns the resolved pricing for a model without calculating cost.
+// Returns the resolved ModelPricing and true if found, or zero value and false.
+// This is used to snapshot pricing at request time for cost auditing.
+func (c *Calculator) Resolve(provider, model string) (ModelPricing, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.resolve(provider, model)
+}
+
 // resolve looks up pricing: config overrides first, then built-in defaults,
 // then precomputed provider-agnostic fallback, then prefix-based fuzzy match.
 // Provider aliases (e.g. "anthropic-direct" → "anthropic") are resolved before

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -448,6 +448,36 @@ func (c *Calculator) Resolve(provider, model string) (ModelPricing, bool) {
 	return c.resolve(provider, model)
 }
 
+// ResolveEffective returns the pricing that would be used for the given token counts,
+// accounting for tiered pricing. This captures the actual rates for cost auditing.
+// When the input context exceeds the tier threshold, the high-tier rates are returned
+// in InputPerMillion/OutputPerMillion so the snapshot reflects what was actually charged.
+func (c *Calculator) ResolveEffective(provider, model string, inputTokens int64) (ModelPricing, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	p, ok := c.resolve(provider, model)
+	if !ok {
+		return p, false
+	}
+	// Apply tiered pricing selection (same logic as Calculate).
+	if p.TierThresholdTokens > 0 && inputTokens > p.TierThresholdTokens {
+		if p.InputPerMillionHigh > 0 {
+			p.InputPerMillion = p.InputPerMillionHigh
+		}
+		if p.OutputPerMillionHigh > 0 {
+			p.OutputPerMillion = p.OutputPerMillionHigh
+		}
+	}
+	return p, true
+}
+
+// GlobalDiscount returns the current global discount percentage (0.0–1.0).
+func (c *Calculator) GlobalDiscount() float64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.globalDiscount
+}
+
 // resolve looks up pricing: config overrides first, then built-in defaults,
 // then precomputed provider-agnostic fallback, then prefix-based fuzzy match.
 // Provider aliases (e.g. "anthropic-direct" → "anthropic") are resolved before

--- a/pkg/costcalc/calculator_test.go
+++ b/pkg/costcalc/calculator_test.go
@@ -402,3 +402,37 @@ func TestDefaults_Deterministic(t *testing.T) {
 		}
 	}
 }
+
+func TestResolve(t *testing.T) {
+	c := New()
+
+	// Known model should resolve
+	p, ok := c.Resolve("openai", "gpt-4o")
+	if !ok {
+		t.Fatal("expected gpt-4o to resolve")
+	}
+	if p.InputPerMillion == 0 {
+		t.Error("expected non-zero input rate")
+	}
+	if p.OutputPerMillion == 0 {
+		t.Error("expected non-zero output rate")
+	}
+
+	// Unknown model should not resolve
+	_, ok = c.Resolve("unknown", "unknown-model")
+	if ok {
+		t.Error("expected unknown model to not resolve")
+	}
+
+	// Config override should take priority
+	c.LoadFromConfig(PricingConfig{
+		Models: []ModelPricing{{
+			Provider: "openai", Model: "gpt-4o",
+			InputPerMillion: 999.0, OutputPerMillion: 999.0,
+		}},
+	})
+	p, ok = c.Resolve("openai", "gpt-4o")
+	if !ok || p.InputPerMillion != 999.0 {
+		t.Errorf("expected override rate 999.0, got %f", p.InputPerMillion)
+	}
+}

--- a/pkg/costcalc/calculator_test.go
+++ b/pkg/costcalc/calculator_test.go
@@ -2,6 +2,7 @@ package costcalc
 
 import (
 	"math"
+	"sync"
 	"testing"
 )
 
@@ -435,4 +436,78 @@ func TestResolve(t *testing.T) {
 	if !ok || p.InputPerMillion != 999.0 {
 		t.Errorf("expected override rate 999.0, got %f", p.InputPerMillion)
 	}
+}
+
+func TestResolveEffective_TieredPricing(t *testing.T) {
+	c := New()
+
+	// gemini-2.5-pro has tiered pricing: threshold 200K tokens,
+	// base $1.25/$10.00, high $2.50/$15.00.
+	pBase, ok := c.ResolveEffective("google", "gemini-2.5-pro", 100_000)
+	if !ok {
+		t.Fatal("expected resolve")
+	}
+
+	// Above threshold: high rates
+	pHigh, ok := c.ResolveEffective("google", "gemini-2.5-pro", 500_000)
+	if !ok {
+		t.Fatal("expected resolve")
+	}
+
+	if pBase.InputPerMillion == pHigh.InputPerMillion {
+		t.Errorf("expected different input rates: base=%f, high=%f",
+			pBase.InputPerMillion, pHigh.InputPerMillion)
+	}
+	if pBase.OutputPerMillion == pHigh.OutputPerMillion {
+		t.Errorf("expected different output rates: base=%f, high=%f",
+			pBase.OutputPerMillion, pHigh.OutputPerMillion)
+	}
+
+	// Verify the exact high-tier rates match what Calculate would use.
+	if pHigh.InputPerMillion != 2.50 {
+		t.Errorf("expected high input rate 2.50, got %f", pHigh.InputPerMillion)
+	}
+	if pHigh.OutputPerMillion != 15.00 {
+		t.Errorf("expected high output rate 15.00, got %f", pHigh.OutputPerMillion)
+	}
+}
+
+func TestResolveEffective_BelowThreshold(t *testing.T) {
+	c := New()
+	pBase, _ := c.Resolve("google", "gemini-2.5-pro")
+	pEff, _ := c.ResolveEffective("google", "gemini-2.5-pro", 100)
+	if pBase.InputPerMillion != pEff.InputPerMillion {
+		t.Errorf("below threshold should use base input rate: base=%f, effective=%f",
+			pBase.InputPerMillion, pEff.InputPerMillion)
+	}
+	if pBase.OutputPerMillion != pEff.OutputPerMillion {
+		t.Errorf("below threshold should use base output rate: base=%f, effective=%f",
+			pBase.OutputPerMillion, pEff.OutputPerMillion)
+	}
+}
+
+func TestGlobalDiscount_Accessor(t *testing.T) {
+	c := New()
+	if c.GlobalDiscount() != 0 {
+		t.Errorf("default global discount should be 0, got %f", c.GlobalDiscount())
+	}
+	c.LoadFromConfig(PricingConfig{DiscountPercent: 0.15})
+	if c.GlobalDiscount() != 0.15 {
+		t.Errorf("expected 0.15, got %f", c.GlobalDiscount())
+	}
+}
+
+func TestResolve_ConcurrentSafe(t *testing.T) {
+	c := New()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.Resolve("openai", "gpt-4o")
+			c.ResolveEffective("google", "gemini-2.5-pro", 500_000)
+			c.GlobalDiscount()
+		}()
+	}
+	wg.Wait()
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1748,7 +1748,16 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 // in the request handler) — buildSpan only handles span creation and storage.
 func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 	totalTokens := params.inputTokens + params.outputTokens
-	cost := p.calc.Calculate(pricingProvider(params.provider.Name), params.model, params.inputTokens, params.outputTokens)
+	pprov := pricingProvider(params.provider.Name)
+	cost := p.calc.Calculate(pprov, params.model, params.inputTokens, params.outputTokens)
+
+	// Snapshot point-in-time pricing so historical spans retain the rates
+	// that were active at request time (enables cost auditing, #321).
+	var inputRate, outputRate float64
+	if pricing, ok := p.calc.Resolve(pprov, params.model); ok {
+		inputRate = pricing.InputPerMillion
+		outputRate = pricing.OutputPerMillion
+	}
 
 	attrs := map[string]string{
 		"proxy.upstream":  params.provider.UpstreamURL,
@@ -1798,6 +1807,8 @@ func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 			OutputContent:       params.outputContent,
 			CacheReadTokens:     params.cacheTokens.CacheReadTokens,
 			CacheCreationTokens: params.cacheTokens.CacheCreationTokens,
+			InputRate:           inputRate,
+			OutputRate:          outputRate,
 		},
 		Attributes: attrs,
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1753,11 +1753,15 @@ func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 
 	// Snapshot point-in-time pricing so historical spans retain the rates
 	// that were active at request time (enables cost auditing, #321).
-	var inputRate, outputRate float64
-	if pricing, ok := p.calc.Resolve(pprov, params.model); ok {
+	// Use ResolveEffective to capture the tier-adjusted rates that were
+	// actually used for cost calculation (e.g. Gemini 2.5 Pro >200K tokens).
+	var inputRate, outputRate, discountPct, globalDisc float64
+	if pricing, ok := p.calc.ResolveEffective(pprov, params.model, params.inputTokens); ok {
 		inputRate = pricing.InputPerMillion
 		outputRate = pricing.OutputPerMillion
+		discountPct = pricing.DiscountPercent
 	}
+	globalDisc = p.calc.GlobalDiscount()
 
 	attrs := map[string]string{
 		"proxy.upstream":  params.provider.UpstreamURL,
@@ -1809,6 +1813,8 @@ func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 			CacheCreationTokens: params.cacheTokens.CacheCreationTokens,
 			InputRate:           inputRate,
 			OutputRate:          outputRate,
+			DiscountPercent:     discountPct,
+			GlobalDiscount:      globalDisc,
 		},
 		Attributes: attrs,
 	}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -104,6 +104,12 @@ type GenAIAttributes struct {
 	// that were active, enabling cost auditing and re-derivation.
 	InputRate  float64 `json:"input_rate,omitempty"`
 	OutputRate float64 `json:"output_rate,omitempty"`
+
+	// Discount snapshot: records the discounts that were active at request time.
+	// DiscountPercent is the model-specific discount (0.0–1.0).
+	// GlobalDiscount is the org-wide discount (0.0–1.0).
+	DiscountPercent float64 `json:"discount_percent,omitempty" firestore:"discount_percent,omitempty" bigquery:"discount_percent"`
+	GlobalDiscount  float64 `json:"global_discount,omitempty" firestore:"global_discount,omitempty" bigquery:"global_discount"`
 }
 
 // Span represents a single span in the storage layer.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -98,6 +98,12 @@ type GenAIAttributes struct {
 	// Showing both lets developers see their cache hit rate and optimize prompts.
 	CacheReadTokens     int64 `json:"cache_read_tokens,omitempty"`
 	CacheCreationTokens int64 `json:"cache_creation_tokens,omitempty"`
+
+	// Point-in-time pricing snapshot (USD per 1M tokens).
+	// Recorded at request time so historical spans retain the rates
+	// that were active, enabling cost auditing and re-derivation.
+	InputRate  float64 `json:"input_rate,omitempty"`
+	OutputRate float64 `json:"output_rate,omitempty"`
 }
 
 // Span represents a single span in the storage layer.


### PR DESCRIPTION
## Problem
Cost is calculated at request time but not recorded on the span. If pricing changes, historical costs cannot be audited.

## Solution
- `Calculator.Resolve()` exposes pricing lookup without calculating cost
- Proxy records `input_rate` and `output_rate` on `GenAIAttributes` at span creation time
- Historical spans retain the pricing snapshot for re-derivation

## Changes
- **pkg/costcalc/calculator.go** — New `Resolve(provider, model)` method
- **pkg/storage/store.go** — `InputRate` and `OutputRate` fields on `GenAIAttributes`
- **pkg/proxy/proxy.go** — `buildSpan` resolves pricing and records rates
- **pkg/costcalc/calculator_test.go** — `TestResolve` covering known, unknown, and override cases

Closes #321