### PR TITLE
ci: deduplicate server/sidecar Docker workflows

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,106 @@
+name: Docker Build & Push
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        required: true
+        type: string
+        description: 'Image name (e.g., candela-server)'
+      dockerfile:
+        required: true
+        type: string
+        description: 'Path to Dockerfile'
+      context:
+        required: false
+        type: string
+        default: '.'
+        description: 'Docker build context'
+      setup_go:
+        required: false
+        type: boolean
+        default: false
+        description: 'Whether to set up Go before building'
+      go_test_packages:
+        required: false
+        type: string
+        default: ''
+        description: 'Go packages to test before building (space-separated). Skipped if empty.'
+      platforms:
+        required: false
+        type: string
+        default: ''
+        description: 'Platforms for multi-arch build (e.g., linux/amd64,linux/arm64). Omit for single-platform.'
+      tag_prefix_strip:
+        required: false
+        type: string
+        default: ''
+        description: 'Prefix to strip from GITHUB_REF_NAME for version tag (e.g., sidecar-). If set, uses explicit version+latest tags instead of metadata-action.'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/${{ inputs.image_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        if: inputs.setup_go
+        with:
+          go-version-file: go.mod
+
+      - name: Test
+        if: inputs.go_test_packages != ''
+        run: go test ${{ inputs.go_test_packages }} -count=1 -timeout 60s
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute version tags
+        if: inputs.tag_prefix_strip != ''
+        id: version
+        env:
+          FULL_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: |
+          ver="${GITHUB_REF_NAME#${{ inputs.tag_prefix_strip }}}"
+          {
+            echo "tags<<EOF"
+            echo "${FULL_IMAGE}:${ver}"
+            echo "${FULL_IMAGE}:latest"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Extract metadata
+        if: inputs.tag_prefix_strip == ''
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          push: true
+          platforms: ${{ inputs.platforms || '' }}
+          tags: ${{ steps.version.outputs.tags || steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/server-image.yml
+++ b/.github/workflows/server-image.yml
@@ -15,47 +15,9 @@ on:
       - 'deploy/entrypoint-server.sh'
   workflow_dispatch: # Manual trigger
 
-permissions:
-  contents: read
-  packages: write
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/candela-server
-
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=sha,prefix=
-            type=ref,event=branch
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: deploy/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+  build:
+    uses: ./.github/workflows/docker-build-push.yml
+    with:
+      image_name: candela-server
+      dockerfile: deploy/Dockerfile

--- a/.github/workflows/sidecar.yml
+++ b/.github/workflows/sidecar.yml
@@ -5,51 +5,13 @@ on:
     tags:
       - 'sidecar-v*'
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/candela-sidecar
-
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      # Verify it compiles and tests pass.
-      - name: Test
-        run: go test ./cmd/candela-sidecar/... ./pkg/proxy/... ./pkg/processor/... -count=1 -timeout 60s
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#sidecar-}" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.sidecar
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+  build:
+    uses: ./.github/workflows/docker-build-push.yml
+    with:
+      image_name: candela-sidecar
+      dockerfile: Dockerfile.sidecar
+      setup_go: true
+      go_test_packages: ./cmd/candela-sidecar/... ./pkg/proxy/... ./pkg/processor/...
+      platforms: linux/amd64,linux/arm64
+      tag_prefix_strip: 'sidecar-'

--- a/cmd/candela-sidecar/integration_test.go
+++ b/cmd/candela-sidecar/integration_test.go
@@ -25,11 +25,21 @@ func TestSidecar_CIWorkflow_References_SidecarTag(t *testing.T) {
 	if !strings.Contains(content, "sidecar-v*") {
 		t.Error("sidecar.yml does not trigger on sidecar-v* tags")
 	}
-	if !strings.Contains(content, "ghcr.io") {
-		t.Error("sidecar.yml does not publish to GHCR")
-	}
 	if !strings.Contains(content, "Dockerfile.sidecar") {
 		t.Error("sidecar.yml does not reference Dockerfile.sidecar")
+	}
+	// After deduplication, sidecar.yml delegates to the reusable workflow
+	if !strings.Contains(content, "docker-build-push.yml") {
+		t.Error("sidecar.yml does not use the reusable docker-build-push workflow")
+	}
+
+	// Verify the reusable workflow publishes to GHCR
+	reusable, err := os.ReadFile("../../.github/workflows/docker-build-push.yml")
+	if err != nil {
+		t.Fatalf("reusable workflow missing: %v", err)
+	}
+	if !strings.Contains(string(reusable), "ghcr.io") {
+		t.Error("docker-build-push.yml does not publish to GHCR")
 	}
 }
 


### PR DESCRIPTION
## Problem
`server-image.yml` and `sidecar.yml` have nearly identical Docker build+push logic.

## Solution
Extract into reusable `docker-build-push.yml` workflow. Both callers now pass `image_name`, `dockerfile`, and optional flags (`setup_go`, `go_test_packages`, `platforms`, `tag_prefix_strip`).

Closes #340