### PR TITLE
feat: useCatalog hook + ListCatalog RPC client

### DIFF
--- a/ui/src/hooks/useCatalog.ts
+++ b/ui/src/hooks/useCatalog.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useCallback, useEffect, useReducer, useMemo } from "react";
+import { catalogClient } from "@/lib/api";
+import type { ModelCatalogEntry } from "@/gen/candela/types/model_catalog_pb";
+
+// ──────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────
+
+interface CatalogState {
+  models: ModelCatalogEntry[];
+  source: string;
+  adminEditable: boolean;
+  loading: boolean;
+  error: string | null;
+}
+
+type CatalogAction =
+  | { type: "LOADING" }
+  | { type: "SUCCESS"; models: ModelCatalogEntry[]; source: string; adminEditable: boolean }
+  | { type: "ERROR"; error: string };
+
+function reducer(state: CatalogState, action: CatalogAction): CatalogState {
+  switch (action.type) {
+    case "LOADING":
+      return { ...state, loading: true, error: null };
+    case "SUCCESS":
+      return { models: action.models, source: action.source, adminEditable: action.adminEditable, loading: false, error: null };
+    case "ERROR":
+      return { ...state, loading: false, error: action.error };
+  }
+}
+
+export interface CatalogPricing {
+  inputPerMillion: number;
+  outputPerMillion: number;
+}
+
+// ──────────────────────────────────────────
+// Hook
+// ──────────────────────────────────────────
+
+/**
+ * Hook for fetching the model catalog via ListModelCatalog RPC.
+ *
+ * Returns the full list of catalog entries, metadata (source, adminEditable),
+ * loading/error state, a refresh function, and a pricing lookup helper.
+ */
+export function useCatalog() {
+  const [state, dispatch] = useReducer(reducer, {
+    models: [],
+    source: "",
+    adminEditable: false,
+    loading: true,
+    error: null,
+  });
+
+  const fetch = useCallback(async () => {
+    dispatch({ type: "LOADING" });
+    try {
+      const resp = await catalogClient.listModelCatalog({});
+      dispatch({
+        type: "SUCCESS",
+        models: resp.models,
+        source: resp.source,
+        adminEditable: resp.adminEditable,
+      });
+    } catch (err) {
+      dispatch({ type: "ERROR", error: err instanceof Error ? err.message : "Failed to load catalog" });
+    }
+  }, []);
+
+  useEffect(() => { fetch(); }, [fetch]);
+
+  // Build a pricing lookup map indexed by provider/model and model-only (fallback).
+  const pricingMap = useMemo(() => {
+    const map = new Map<string, CatalogPricing>();
+    for (const m of state.models) {
+      const pricing: CatalogPricing = {
+        inputPerMillion: m.inputPerMillion,
+        outputPerMillion: m.outputPerMillion,
+      };
+      // Primary key: provider/modelId
+      map.set(`${m.provider}/${m.modelId}`.toLowerCase(), pricing);
+      // Fallback key: modelId only
+      map.set(m.modelId.toLowerCase(), pricing);
+    }
+    return map;
+  }, [state.models]);
+
+  const getPricing = useCallback(
+    (provider: string, model: string): CatalogPricing | null => {
+      return pricingMap.get(`${provider}/${model}`.toLowerCase())
+        ?? pricingMap.get(model.toLowerCase())
+        ?? null;
+    },
+    [pricingMap],
+  );
+
+  return {
+    models: state.models,
+    source: state.source,
+    adminEditable: state.adminEditable,
+    loading: state.loading,
+    error: state.error,
+    refresh: fetch,
+    getPricing,
+  };
+}

--- a/ui/src/hooks/useCatalog.ts
+++ b/ui/src/hooks/useCatalog.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useReducer, useMemo } from "react";
+import { useCallback, useEffect, useReducer, useMemo, useRef } from "react";
 import { catalogClient } from "@/lib/api";
 import type { ModelCatalogEntry } from "@/gen/candela/types/model_catalog_pb";
 
@@ -56,30 +56,44 @@ export function useCatalog() {
     error: null,
   });
 
-  const fetch = useCallback(async () => {
+  const fetchRef = useRef<AbortController | null>(null);
+
+  const refresh = useCallback(async () => {
+    fetchRef.current?.abort();
+    const controller = new AbortController();
+    fetchRef.current = controller;
+
     dispatch({ type: "LOADING" });
     try {
-      const resp = await catalogClient.listModelCatalog({});
-      dispatch({
-        type: "SUCCESS",
-        models: resp.models,
-        source: resp.source,
-        adminEditable: resp.adminEditable,
-      });
+      const resp = await catalogClient.listModelCatalog({}, { signal: controller.signal });
+      if (!controller.signal.aborted) {
+        dispatch({
+          type: "SUCCESS",
+          models: resp.models,
+          source: resp.source,
+          adminEditable: resp.adminEditable,
+        });
+      }
     } catch (err) {
-      dispatch({ type: "ERROR", error: err instanceof Error ? err.message : "Failed to load catalog" });
+      if (!controller.signal.aborted) {
+        dispatch({ type: "ERROR", error: err instanceof Error ? err.message : "Failed to load catalog" });
+      }
     }
   }, []);
 
-  useEffect(() => { fetch(); }, [fetch]);
+  useEffect(() => {
+    refresh();
+    return () => fetchRef.current?.abort();
+  }, [refresh]);
 
   // Build a pricing lookup map indexed by provider/model and model-only (fallback).
   const pricingMap = useMemo(() => {
     const map = new Map<string, CatalogPricing>();
     for (const m of state.models) {
+      if (!m.provider || !m.modelId) continue; // skip invalid entries
       const pricing: CatalogPricing = {
-        inputPerMillion: m.inputPerMillion,
-        outputPerMillion: m.outputPerMillion,
+        inputPerMillion: m.inputPerMillion ?? 0,
+        outputPerMillion: m.outputPerMillion ?? 0,
       };
       // Primary key: provider/modelId
       map.set(`${m.provider}/${m.modelId}`.toLowerCase(), pricing);
@@ -104,7 +118,7 @@ export function useCatalog() {
     adminEditable: state.adminEditable,
     loading: state.loading,
     error: state.error,
-    refresh: fetch,
+    refresh,
     getPricing,
   };
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -4,9 +4,11 @@ import { TraceService } from "@/gen/candela/v1/trace_service_pb";
 import { DashboardService } from "@/gen/candela/v1/dashboard_service_pb";
 import { ProjectService } from "@/gen/candela/v1/project_service_pb";
 import { UserService } from "@/gen/candela/v1/user_service_pb";
+import { ModelCatalogService } from "@/gen/candela/v1/model_catalog_service_pb";
 
 // Singleton clients — reuse across hooks.
 export const traceClient = createClient(TraceService, transport);
 export const dashboardClient = createClient(DashboardService, transport);
 export const projectClient = createClient(ProjectService, transport);
 export const userClient = createClient(UserService, transport);
+export const catalogClient = createClient(ModelCatalogService, transport);


### PR DESCRIPTION
## Overview
React hook for the model catalog, consuming the ListModelCatalog RPC.

## Changes
- `ui/src/lib/api.ts`: Add catalog service client
- `ui/src/hooks/useCatalog.ts`: New hook with state management + pricing lookup

## API
```typescript
const { models, loading, error, refresh, getPricing } = useCatalog();
const pricing = getPricing("openai", "gpt-4o");
```

Closes #323