### PR TITLE
feat: externalize provider config

### DIFF
--- a/cmd/candela-server/config_test.go
+++ b/cmd/candela-server/config_test.go
@@ -529,3 +529,173 @@ proxy:
 		t.Errorf("disabled providers should be empty, got %d", len(cfg.DisabledProviders))
 	}
 }
+
+// ── buildCustomProviders Tests ───────────────────────────────────────────────
+
+func TestCustomProviderEmptyNameSkipped(t *testing.T) {
+	cfgs := []ProviderConfig{
+		{Name: "", UpstreamURL: "https://api.example.com"},
+		{Name: "valid", UpstreamURL: "https://api.valid.com"},
+	}
+	got := buildCustomProviders(cfgs, func(string) string { return "" })
+	if len(got) != 1 {
+		t.Fatalf("expected 1 provider, got %d", len(got))
+	}
+	if got[0].Name != "valid" {
+		t.Errorf("expected 'valid', got %q", got[0].Name)
+	}
+}
+
+func TestCustomProviderEmptyURLSkipped(t *testing.T) {
+	cfgs := []ProviderConfig{
+		{Name: "no-url", UpstreamURL: ""},
+		{Name: "valid", UpstreamURL: "https://api.valid.com"},
+	}
+	got := buildCustomProviders(cfgs, func(string) string { return "" })
+	if len(got) != 1 {
+		t.Fatalf("expected 1 provider, got %d", len(got))
+	}
+	if got[0].Name != "valid" {
+		t.Errorf("expected 'valid', got %q", got[0].Name)
+	}
+}
+
+func TestCustomProviderDisabledSkipped(t *testing.T) {
+	disabled := false
+	cfgs := []ProviderConfig{
+		{Name: "off", UpstreamURL: "https://api.off.com", Enabled: &disabled},
+		{Name: "on", UpstreamURL: "https://api.on.com"},
+	}
+	got := buildCustomProviders(cfgs, func(string) string { return "" })
+	if len(got) != 1 {
+		t.Fatalf("expected 1 provider, got %d", len(got))
+	}
+	if got[0].Name != "on" {
+		t.Errorf("expected 'on', got %q", got[0].Name)
+	}
+}
+
+func TestCustomProviderAuthHeaderWired(t *testing.T) {
+	cfgs := []ProviderConfig{
+		{
+			Name:        "custom-llm",
+			UpstreamURL: "https://api.custom-llm.com",
+			AuthHeader:  "x-api-key",
+			AuthEnvVar:  "CUSTOM_LLM_KEY",
+		},
+	}
+	envLookup := func(key string) string {
+		if key == "CUSTOM_LLM_KEY" {
+			return "secret-123"
+		}
+		return ""
+	}
+	got := buildCustomProviders(cfgs, envLookup)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 provider, got %d", len(got))
+	}
+	if got[0].APIKey != "secret-123" {
+		t.Errorf("APIKey = %q, want %q", got[0].APIKey, "secret-123")
+	}
+	if got[0].AuthHeader != "x-api-key" {
+		t.Errorf("AuthHeader = %q, want %q", got[0].AuthHeader, "x-api-key")
+	}
+}
+
+func TestCustomProviderAuthDefaultHeader(t *testing.T) {
+	// When AuthHeader is empty, APIKey should be set but AuthHeader left empty
+	// (the proxy defaults to "Authorization: Bearer <key>").
+	cfgs := []ProviderConfig{
+		{
+			Name:        "openai-compat",
+			UpstreamURL: "https://api.openai-compat.com",
+			AuthEnvVar:  "COMPAT_KEY",
+		},
+	}
+	envLookup := func(key string) string {
+		if key == "COMPAT_KEY" {
+			return "bearer-key"
+		}
+		return ""
+	}
+	got := buildCustomProviders(cfgs, envLookup)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 provider, got %d", len(got))
+	}
+	if got[0].APIKey != "bearer-key" {
+		t.Errorf("APIKey = %q, want %q", got[0].APIKey, "bearer-key")
+	}
+	if got[0].AuthHeader != "" {
+		t.Errorf("AuthHeader = %q, want empty (default to Bearer)", got[0].AuthHeader)
+	}
+}
+
+func TestCustomProviderEnvVarMissing(t *testing.T) {
+	// When the env var is set but empty, APIKey should remain empty.
+	cfgs := []ProviderConfig{
+		{
+			Name:        "needs-key",
+			UpstreamURL: "https://api.needs-key.com",
+			AuthEnvVar:  "MISSING_KEY",
+		},
+	}
+	got := buildCustomProviders(cfgs, func(string) string { return "" })
+	if len(got) != 1 {
+		t.Fatalf("expected 1 provider, got %d", len(got))
+	}
+	if got[0].APIKey != "" {
+		t.Errorf("APIKey should be empty when env var is missing, got %q", got[0].APIKey)
+	}
+}
+
+func TestCustomProviderAllInvalid(t *testing.T) {
+	cfgs := []ProviderConfig{
+		{Name: "", UpstreamURL: "https://api.example.com"},
+		{Name: "no-url", UpstreamURL: ""},
+	}
+	got := buildCustomProviders(cfgs, func(string) string { return "" })
+	if len(got) != 0 {
+		t.Errorf("expected 0 providers, got %d", len(got))
+	}
+}
+
+func TestCustomProviderAuthHeaderYAMLParsing(t *testing.T) {
+	yamlData := `
+custom_providers:
+  - name: custom-llm
+    upstream_url: https://api.custom-llm.com
+    auth_header: x-api-key
+    auth_env_var: CUSTOM_LLM_KEY
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlData), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.CustomProviders) != 1 {
+		t.Fatalf("expected 1 custom provider, got %d", len(cfg.CustomProviders))
+	}
+	cp := cfg.CustomProviders[0]
+	if cp.AuthHeader != "x-api-key" {
+		t.Errorf("auth_header = %q, want %q", cp.AuthHeader, "x-api-key")
+	}
+	if cp.AuthEnvVar != "CUSTOM_LLM_KEY" {
+		t.Errorf("auth_env_var = %q, want %q", cp.AuthEnvVar, "CUSTOM_LLM_KEY")
+	}
+
+	// Verify buildCustomProviders wires it correctly.
+	providers := buildCustomProviders(cfg.CustomProviders, func(key string) string {
+		if key == "CUSTOM_LLM_KEY" {
+			return "test-secret"
+		}
+		return ""
+	})
+	if len(providers) != 1 {
+		t.Fatalf("expected 1 provider, got %d", len(providers))
+	}
+	if providers[0].APIKey != "test-secret" {
+		t.Errorf("APIKey = %q, want %q", providers[0].APIKey, "test-secret")
+	}
+	if providers[0].AuthHeader != "x-api-key" {
+		t.Errorf("AuthHeader = %q, want %q", providers[0].AuthHeader, "x-api-key")
+	}
+}

--- a/cmd/candela-server/config_test.go
+++ b/cmd/candela-server/config_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/candelahq/candela/pkg/proxy"
 	"gopkg.in/yaml.v3"
 )
 
@@ -370,5 +372,160 @@ func TestProviderOverride_YAMLRoundTrip(t *testing.T) {
 	}
 	if decoded.Endpoint != original.Endpoint {
 		t.Errorf("round-trip Endpoint = %q, want %q", decoded.Endpoint, original.Endpoint)
+	}
+}
+
+// ── Custom Provider Config Tests ─────────────────────────────────────────────
+
+func TestConfigParsesCustomProviders(t *testing.T) {
+	yamlData := `
+custom_providers:
+  - name: my-provider
+    upstream_url: https://api.example.com
+    auth_env_var: MY_API_KEY
+disabled_providers:
+  - anthropic-direct
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlData), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.CustomProviders) != 1 {
+		t.Fatalf("expected 1 custom provider, got %d", len(cfg.CustomProviders))
+	}
+	if cfg.CustomProviders[0].Name != "my-provider" {
+		t.Errorf("expected 'my-provider', got %q", cfg.CustomProviders[0].Name)
+	}
+	if cfg.CustomProviders[0].UpstreamURL != "https://api.example.com" {
+		t.Errorf("upstream_url = %q, want %q", cfg.CustomProviders[0].UpstreamURL, "https://api.example.com")
+	}
+	if cfg.CustomProviders[0].AuthEnvVar != "MY_API_KEY" {
+		t.Errorf("auth_env_var = %q, want %q", cfg.CustomProviders[0].AuthEnvVar, "MY_API_KEY")
+	}
+	if cfg.CustomProviders[0].Enabled != nil {
+		t.Errorf("enabled should be nil when not set, got %v", *cfg.CustomProviders[0].Enabled)
+	}
+	if len(cfg.DisabledProviders) != 1 {
+		t.Fatalf("expected 1 disabled provider, got %d", len(cfg.DisabledProviders))
+	}
+	if cfg.DisabledProviders[0] != "anthropic-direct" {
+		t.Errorf("disabled provider = %q, want %q", cfg.DisabledProviders[0], "anthropic-direct")
+	}
+}
+
+func TestCustomProviderExplicitlyDisabled(t *testing.T) {
+	yamlData := `
+custom_providers:
+  - name: skip-me
+    upstream_url: https://api.skip.com
+    enabled: false
+  - name: keep-me
+    upstream_url: https://api.keep.com
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlData), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.CustomProviders) != 2 {
+		t.Fatalf("expected 2 custom providers parsed, got %d", len(cfg.CustomProviders))
+	}
+	if cfg.CustomProviders[0].Enabled == nil || *cfg.CustomProviders[0].Enabled {
+		t.Error("first provider should be explicitly disabled")
+	}
+	if cfg.CustomProviders[1].Enabled != nil {
+		t.Errorf("second provider enabled should be nil, got %v", *cfg.CustomProviders[1].Enabled)
+	}
+}
+
+func TestCustomProviderWithAuthHeader(t *testing.T) {
+	yamlData := `
+custom_providers:
+  - name: custom-llm
+    upstream_url: https://api.custom-llm.com
+    auth_header: x-api-key
+    auth_env_var: CUSTOM_LLM_KEY
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlData), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.CustomProviders[0].AuthHeader != "x-api-key" {
+		t.Errorf("auth_header = %q, want %q", cfg.CustomProviders[0].AuthHeader, "x-api-key")
+	}
+}
+
+func TestDisabledProvidersFiltering(t *testing.T) {
+	// Simulate the filtering logic from main.go.
+	allProviders := proxy.DefaultProviders()
+	disabledNames := []string{"anthropic-direct", "OpenAI"} // mixed case to test case-insensitivity
+
+	disabled := make(map[string]bool, len(disabledNames))
+	for _, name := range disabledNames {
+		disabled[strings.ToLower(name)] = true
+	}
+	var filtered []proxy.Provider
+	for _, p := range allProviders {
+		if !disabled[strings.ToLower(p.Name)] {
+			filtered = append(filtered, p)
+		}
+	}
+
+	// Verify the disabled providers are removed.
+	for _, p := range filtered {
+		lower := strings.ToLower(p.Name)
+		if lower == "anthropic-direct" || lower == "openai" {
+			t.Errorf("provider %q should have been filtered out", p.Name)
+		}
+	}
+
+	// Verify count is reduced by 2.
+	if len(filtered) != len(allProviders)-2 {
+		t.Errorf("expected %d providers after filtering, got %d",
+			len(allProviders)-2, len(filtered))
+	}
+}
+
+func TestDisabledAndCustomCombined(t *testing.T) {
+	yamlData := `
+custom_providers:
+  - name: my-llm
+    upstream_url: https://api.my-llm.com
+    auth_env_var: MY_LLM_KEY
+disabled_providers:
+  - anthropic-direct
+  - openai
+proxy:
+  enabled: true
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlData), &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cfg.CustomProviders) != 1 {
+		t.Errorf("custom providers = %d, want 1", len(cfg.CustomProviders))
+	}
+	if len(cfg.DisabledProviders) != 2 {
+		t.Errorf("disabled providers = %d, want 2", len(cfg.DisabledProviders))
+	}
+	if !cfg.Proxy.Enabled {
+		t.Error("proxy should be enabled")
+	}
+}
+
+func TestEmptyCustomAndDisabled(t *testing.T) {
+	yamlData := `
+proxy:
+  enabled: true
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlData), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.CustomProviders) != 0 {
+		t.Errorf("custom providers should be empty, got %d", len(cfg.CustomProviders))
+	}
+	if len(cfg.DisabledProviders) != 0 {
+		t.Errorf("disabled providers should be empty, got %d", len(cfg.DisabledProviders))
 	}
 }

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -46,9 +47,21 @@ import (
 	sqlitestore "github.com/candelahq/candela/pkg/storage/sqlite"
 )
 
+// ProviderConfig defines a custom LLM provider added via YAML config.
+// This allows adding new providers without code changes.
+type ProviderConfig struct {
+	Name        string `yaml:"name"`
+	UpstreamURL string `yaml:"upstream_url"`
+	AuthHeader  string `yaml:"auth_header"`  // e.g., "Authorization", "x-api-key"
+	AuthEnvVar  string `yaml:"auth_env_var"` // env var for API key
+	Enabled     *bool  `yaml:"enabled"`      // nil = default (enabled)
+}
+
 // Config holds the server configuration.
 type Config struct {
-	Server struct {
+	CustomProviders   []ProviderConfig `yaml:"custom_providers"`
+	DisabledProviders []string         `yaml:"disabled_providers"`
+	Server            struct {
 		Host string `yaml:"host"`
 		Port int    `yaml:"port"`
 	} `yaml:"server"`
@@ -406,6 +419,35 @@ func main() {
 	// Register LLM proxy routes (selective activation).
 	if cfg.Proxy.Enabled {
 		allProviders := proxy.DefaultProviders()
+
+		// Remove disabled providers (from config YAML).
+		if len(cfg.DisabledProviders) > 0 {
+			disabled := make(map[string]bool, len(cfg.DisabledProviders))
+			for _, name := range cfg.DisabledProviders {
+				disabled[strings.ToLower(name)] = true
+			}
+			filtered := allProviders[:0]
+			for _, p := range allProviders {
+				if !disabled[strings.ToLower(p.Name)] {
+					filtered = append(filtered, p)
+				}
+			}
+			allProviders = filtered
+			slog.Info("disabled providers from config", "count", len(cfg.DisabledProviders), "names", cfg.DisabledProviders)
+		}
+
+		// Add custom providers (from config YAML).
+		for _, cp := range cfg.CustomProviders {
+			if cp.Enabled != nil && !*cp.Enabled {
+				continue
+			}
+			p := proxy.Provider{
+				Name:        cp.Name,
+				UpstreamURL: cp.UpstreamURL,
+			}
+			allProviders = append(allProviders, p)
+			slog.Info("added custom provider", "name", cp.Name, "upstream", cp.UpstreamURL)
+		}
 
 		// Get ADC token source for automatic GCP auth.
 		// Used by Anthropic (Vertex AI), Gemini, and Google providers so the

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -165,6 +165,41 @@ func getProviderOverride(overrides map[string]ProviderOverride, provider, defaul
 	return
 }
 
+// buildCustomProviders converts ProviderConfig entries into proxy.Provider
+// values, applying validation (skip empty name/upstream_url) and wiring
+// AuthEnvVar / AuthHeader into the Provider's APIKey / AuthHeader fields.
+// envLookup is typically os.Getenv but can be swapped for testing.
+func buildCustomProviders(cfgs []ProviderConfig, envLookup func(string) string) []proxy.Provider {
+	var out []proxy.Provider
+	for _, cp := range cfgs {
+		if cp.Enabled != nil && !*cp.Enabled {
+			continue
+		}
+		if cp.Name == "" {
+			slog.Warn("skipping custom provider with empty name")
+			continue
+		}
+		if cp.UpstreamURL == "" {
+			slog.Warn("skipping custom provider with empty upstream_url", "name", cp.Name)
+			continue
+		}
+		p := proxy.Provider{
+			Name:        cp.Name,
+			UpstreamURL: cp.UpstreamURL,
+		}
+		if cp.AuthEnvVar != "" {
+			if key := envLookup(cp.AuthEnvVar); key != "" {
+				p.APIKey = key
+				if cp.AuthHeader != "" {
+					p.AuthHeader = cp.AuthHeader
+				}
+			}
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
 func main() {
 	// Set up structured logging to stderr.
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
@@ -437,17 +472,12 @@ func main() {
 		}
 
 		// Add custom providers (from config YAML).
-		for _, cp := range cfg.CustomProviders {
-			if cp.Enabled != nil && !*cp.Enabled {
-				continue
-			}
-			p := proxy.Provider{
-				Name:        cp.Name,
-				UpstreamURL: cp.UpstreamURL,
-			}
-			allProviders = append(allProviders, p)
-			slog.Info("added custom provider", "name", cp.Name, "upstream", cp.UpstreamURL)
+		customProviders := buildCustomProviders(cfg.CustomProviders, os.Getenv)
+		for _, p := range customProviders {
+			slog.Info("added custom provider", "name", p.Name, "upstream", p.UpstreamURL,
+				"has_api_key", p.APIKey != "", "auth_header", p.AuthHeader)
 		}
+		allProviders = append(allProviders, customProviders...)
 
 		// Get ADC token source for automatic GCP auth.
 		// Used by Anthropic (Vertex AI), Gemini, and Google providers so the

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -115,6 +115,17 @@ type Provider struct {
 	// AnthropicVersion overrides the anthropic_version injected into Vertex AI
 	// rawPredict bodies. Empty = DefaultVertexAnthropicVersion.
 	AnthropicVersion string `yaml:"-"`
+
+	// APIKey is a static API key for authenticating with the upstream provider.
+	// Used by custom providers configured via YAML (populated from AuthEnvVar).
+	// When set, injected as "Authorization: Bearer <key>" unless AuthHeader
+	// is specified, in which case it is injected as "<AuthHeader>: <key>".
+	APIKey string `yaml:"-"`
+
+	// AuthHeader overrides the header name used to send APIKey.
+	// If empty, defaults to "Authorization" with "Bearer " prefix.
+	// Examples: "x-api-key", "X-Auth-Token".
+	AuthHeader string `yaml:"-"`
 }
 
 // EffectiveHost returns the hostname used for SNI matching.
@@ -1183,7 +1194,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Forward headers (auth, content-type, etc).
-	forwardHeaders(r, upstreamReq, providerName, provider.TokenSource != nil || provider.RequestSigner != nil)
+	forwardHeaders(r, upstreamReq, providerName, provider.TokenSource != nil || provider.RequestSigner != nil || provider.APIKey != "")
 
 	// Pre-generate the span ID that buildSpan will use for this proxy span.
 	// We need it now so the outgoing traceparent to the upstream LLM
@@ -1213,6 +1224,13 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		upstreamReq.Header.Set("Authorization", "Bearer "+token.AccessToken)
+	} else if provider.APIKey != "" {
+		// Static API key auth (custom providers configured via YAML).
+		if provider.AuthHeader != "" {
+			upstreamReq.Header.Set(provider.AuthHeader, provider.APIKey)
+		} else {
+			upstreamReq.Header.Set("Authorization", "Bearer "+provider.APIKey)
+		}
 	}
 
 	// Propagate request ID to upstream.


### PR DESCRIPTION
## Problem
Adding a new provider requires code changes to `DefaultProviders()` and redeployment.

## Solution (Phase 1)
- `custom_providers`: Add new providers via YAML config
- `disabled_providers`: Disable built-in providers without code changes
- `DefaultProviders()` is still the fallback

## Example config
```yaml
custom_providers:
  - name: my-llm
    upstream_url: https://api.my-llm.com
    auth_env_var: MY_LLM_KEY
disabled_providers:
  - anthropic-direct
```

## Tests
6 new tests covering YAML parsing, enabled/disabled pointer semantics, case-insensitive filtering, and combined scenarios. All 25 tests pass with `-race`.

Closes #311