### PR TITLE
feat: normalize <think> tags into reasoning_content field

### DIFF
--- a/pkg/proxy/parsers.go
+++ b/pkg/proxy/parsers.go
@@ -3,35 +3,76 @@ package proxy
 import (
 	"bytes"
 	"encoding/json"
-	"regexp"
 	"strings"
 )
-
-// thinkTagRe matches <think>...</think> blocks (including multiline content).
-// Used to extract reasoning/thinking content from model responses that inline
-// it in the content field (e.g. DeepSeek R1, QwQ).
-var thinkTagRe = regexp.MustCompile(`(?s)<think>(.*?)</think>`)
 
 // extractThinking extracts content between <think> tags and returns
 // the cleaned content and the extracted thinking/reasoning content.
 // Models like DeepSeek R1 wrap chain-of-thought reasoning in <think> tags
 // inline in the content field. This function strips those tags and returns
 // the reasoning separately for storage in GenAIAttributes.ReasoningContent.
+//
+// Handles unclosed <think> tags (common when streaming responses are truncated,
+// e.g. DeepSeek R1): everything after the unclosed tag is treated as reasoning.
 func extractThinking(content string) (cleaned, reasoning string) {
-	matches := thinkTagRe.FindAllStringSubmatch(content, -1)
-	if len(matches) == 0 {
+	// Fast path: no think tags at all.
+	if !strings.Contains(content, "<think>") {
 		return content, ""
 	}
-	var thinkParts []string
-	for _, m := range matches {
-		part := strings.TrimSpace(m[1])
-		if part != "" {
-			thinkParts = append(thinkParts, part)
+
+	var cleanBuf, thinkBuf strings.Builder
+	remaining := content
+
+	for {
+		openIdx := strings.Index(remaining, "<think>")
+		if openIdx == -1 {
+			cleanBuf.WriteString(remaining)
+			break
+		}
+		// Content before <think>
+		cleanBuf.WriteString(remaining[:openIdx])
+		remaining = remaining[openIdx+len("<think>"):]
+
+		closeIdx := strings.Index(remaining, "</think>")
+		if closeIdx == -1 {
+			// Unclosed tag — treat rest as reasoning.
+			if thinkBuf.Len() > 0 {
+				thinkBuf.WriteByte('\n')
+			}
+			thinkBuf.WriteString(strings.TrimSpace(remaining))
+			remaining = ""
+			break
+		}
+
+		// Matched pair.
+		if thinkBuf.Len() > 0 {
+			thinkBuf.WriteByte('\n')
+		}
+		thinkBuf.WriteString(strings.TrimSpace(remaining[:closeIdx]))
+		remaining = remaining[closeIdx+len("</think>"):]
+	}
+
+	return strings.TrimSpace(cleanBuf.String()), thinkBuf.String()
+}
+
+// isReasoningModel returns true if the model is known to use <think> tags.
+// This prevents stripping legitimate <think> content from non-reasoning models
+// (e.g. a code generation model outputting <think> in example code).
+func isReasoningModel(model string) bool {
+	model = strings.ToLower(model)
+	// Models known to use inline <think> tags.
+	reasoningPrefixes := []string{
+		"deepseek-r1",
+		"deepseek-reasoner",
+		"qwq",
+		"qwen3", // Qwen3 uses thinking by default
+	}
+	for _, prefix := range reasoningPrefixes {
+		if strings.HasPrefix(model, prefix) || strings.Contains(model, prefix) {
+			return true
 		}
 	}
-	reasoning = strings.Join(thinkParts, "\n")
-	cleaned = strings.TrimSpace(thinkTagRe.ReplaceAllString(content, ""))
-	return cleaned, reasoning
+	return false
 }
 
 // NOTE: All cache normalization has been moved to costcalc.Calculator.

--- a/pkg/proxy/parsers.go
+++ b/pkg/proxy/parsers.go
@@ -3,8 +3,36 @@ package proxy
 import (
 	"bytes"
 	"encoding/json"
+	"regexp"
 	"strings"
 )
+
+// thinkTagRe matches <think>...</think> blocks (including multiline content).
+// Used to extract reasoning/thinking content from model responses that inline
+// it in the content field (e.g. DeepSeek R1, QwQ).
+var thinkTagRe = regexp.MustCompile(`(?s)<think>(.*?)</think>`)
+
+// extractThinking extracts content between <think> tags and returns
+// the cleaned content and the extracted thinking/reasoning content.
+// Models like DeepSeek R1 wrap chain-of-thought reasoning in <think> tags
+// inline in the content field. This function strips those tags and returns
+// the reasoning separately for storage in GenAIAttributes.ReasoningContent.
+func extractThinking(content string) (cleaned, reasoning string) {
+	matches := thinkTagRe.FindAllStringSubmatch(content, -1)
+	if len(matches) == 0 {
+		return content, ""
+	}
+	var thinkParts []string
+	for _, m := range matches {
+		part := strings.TrimSpace(m[1])
+		if part != "" {
+			thinkParts = append(thinkParts, part)
+		}
+	}
+	reasoning = strings.Join(thinkParts, "\n")
+	cleaned = strings.TrimSpace(thinkTagRe.ReplaceAllString(content, ""))
+	return cleaned, reasoning
+}
 
 // NOTE: All cache normalization has been moved to costcalc.Calculator.
 // Parsers return RAW token counts; the proxy applies model-aware and

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1585,26 +1585,27 @@ func (p *Proxy) handleStreamingResponse(
 // Both standard and streaming responses produce the same struct; the only
 // difference is how they parse the upstream response.
 type spanParams struct {
-	provider        Provider
-	model           string
-	sessionID       string
-	effectiveUserID string // resolved end-user identity (auth email > auth UID)
-	tenantID        string // downstream customer/tenant (from Baggage or header)
-	jobID           string // experiment/job ID (from Baggage or header)
-	inputContent    string
-	outputContent   string
-	inputTokens     int64
-	outputTokens    int64
-	cacheTokens     CacheTokens // raw prompt cache breakdown
-	startTime       time.Time
-	endTime         time.Time
-	status          storage.SpanStatus
-	ttfb            time.Duration
-	requestID       string
-	extraAttrs      map[string]string // streaming-specific, status code, etc.
-	namePrefix      string            // e.g. "openai.chat" or "openai.chat.stream"
-	traceCtx        *traceContext     // W3C trace context from caller (nil = generate new)
-	proxySpanID     string            // pre-generated span ID (for outgoing traceparent)
+	provider         Provider
+	model            string
+	sessionID        string
+	effectiveUserID  string // resolved end-user identity (auth email > auth UID)
+	tenantID         string // downstream customer/tenant (from Baggage or header)
+	jobID            string // experiment/job ID (from Baggage or header)
+	inputContent     string
+	outputContent    string
+	reasoningContent string
+	inputTokens      int64
+	outputTokens     int64
+	cacheTokens      CacheTokens // raw prompt cache breakdown
+	startTime        time.Time
+	endTime          time.Time
+	status           storage.SpanStatus
+	ttfb             time.Duration
+	requestID        string
+	extraAttrs       map[string]string // streaming-specific, status code, etc.
+	namePrefix       string            // e.g. "openai.chat" or "openai.chat.stream"
+	traceCtx         *traceContext     // W3C trace context from caller (nil = generate new)
+	proxySpanID      string            // pre-generated span ID (for outgoing traceparent)
 }
 
 // deductBudget handles the synchronous budget deduction after a response is
@@ -1809,6 +1810,7 @@ func (p *Proxy) buildSpan(ctx context.Context, params spanParams) {
 			CostUSD:             cost,
 			InputContent:        params.inputContent,
 			OutputContent:       params.outputContent,
+			ReasoningContent:    params.reasoningContent,
 			CacheReadTokens:     params.cacheTokens.CacheReadTokens,
 			CacheCreationTokens: params.cacheTokens.CacheCreationTokens,
 			InputRate:           inputRate,
@@ -1865,6 +1867,10 @@ func (p *Proxy) createSpan(
 	outputContent, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
 	ct := extractCacheTokens(provider.Name, respBody)
 
+	// Extract <think> tags from output content (#312).
+	// Models like DeepSeek R1 wrap reasoning in <think> tags inline.
+	outputContent, reasoningContent := extractThinking(outputContent)
+
 	// For Google native, model is in the URL path, not the body.
 	// Fall back to the response's modelVersion field.
 	if model == "" {
@@ -1881,25 +1887,26 @@ func (p *Proxy) createSpan(
 	}
 
 	p.buildSpan(ctx, spanParams{
-		provider:        provider,
-		model:           model,
-		effectiveUserID: effectiveUserID,
-		tenantID:        tenantID,
-		jobID:           jobID,
-		inputContent:    inputContent,
-		outputContent:   outputContent,
-		inputTokens:     inputTokens,
-		outputTokens:    outputTokens,
-		cacheTokens:     ct,
-		startTime:       startTime,
-		endTime:         endTime,
-		status:          status,
-		ttfb:            ttfb,
-		requestID:       requestID,
-		sessionID:       sessionID,
-		namePrefix:      fmt.Sprintf("%s.chat", provider.Name),
-		traceCtx:        traceCtx,
-		proxySpanID:     proxySpanID,
+		provider:         provider,
+		model:            model,
+		effectiveUserID:  effectiveUserID,
+		tenantID:         tenantID,
+		jobID:            jobID,
+		inputContent:     inputContent,
+		outputContent:    outputContent,
+		reasoningContent: reasoningContent,
+		inputTokens:      inputTokens,
+		outputTokens:     outputTokens,
+		cacheTokens:      ct,
+		startTime:        startTime,
+		endTime:          endTime,
+		status:           status,
+		ttfb:             ttfb,
+		requestID:        requestID,
+		sessionID:        sessionID,
+		namePrefix:       fmt.Sprintf("%s.chat", provider.Name),
+		traceCtx:         traceCtx,
+		proxySpanID:      proxySpanID,
 		extraAttrs: map[string]string{
 			"http.status": fmt.Sprintf("%d", statusCode),
 		},
@@ -1926,6 +1933,9 @@ func (p *Proxy) createStreamingSpan(
 	outputContent, inputTokens, outputTokens := extractStreamingUsage(provider.Name, streamData)
 	ct := extractStreamingCacheTokens(provider.Name, streamData)
 
+	// Extract <think> tags from output content (#312).
+	outputContent, reasoningContent := extractThinking(outputContent)
+
 	// For Google native, model is in the URL path, not the body.
 	// Fall back to the response's modelVersion field.
 	if model == "" {
@@ -1937,25 +1947,26 @@ func (p *Proxy) createStreamingSpan(
 	inputTokens = p.calc.NormalizeCachedInputWithTTL(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens, extendedTTL)
 
 	p.buildSpan(ctx, spanParams{
-		provider:        provider,
-		model:           model,
-		effectiveUserID: effectiveUserID,
-		tenantID:        tenantID,
-		jobID:           jobID,
-		inputContent:    inputContent,
-		outputContent:   outputContent,
-		inputTokens:     inputTokens,
-		outputTokens:    outputTokens,
-		cacheTokens:     ct,
-		startTime:       startTime,
-		endTime:         endTime,
-		status:          streamStatus,
-		ttfb:            ttfb,
-		requestID:       requestID,
-		sessionID:       sessionID,
-		namePrefix:      fmt.Sprintf("%s.chat.stream", provider.Name),
-		traceCtx:        traceCtx,
-		proxySpanID:     proxySpanID,
+		provider:         provider,
+		model:            model,
+		effectiveUserID:  effectiveUserID,
+		tenantID:         tenantID,
+		jobID:            jobID,
+		inputContent:     inputContent,
+		outputContent:    outputContent,
+		reasoningContent: reasoningContent,
+		inputTokens:      inputTokens,
+		outputTokens:     outputTokens,
+		cacheTokens:      ct,
+		startTime:        startTime,
+		endTime:          endTime,
+		status:           streamStatus,
+		ttfb:             ttfb,
+		requestID:        requestID,
+		sessionID:        sessionID,
+		namePrefix:       fmt.Sprintf("%s.chat.stream", provider.Name),
+		traceCtx:         traceCtx,
+		proxySpanID:      proxySpanID,
 		extraAttrs: map[string]string{
 			"proxy.streaming": "true",
 			"llm.ttft_ms":     fmt.Sprintf("%d", ttft.Milliseconds()),

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1867,14 +1867,18 @@ func (p *Proxy) createSpan(
 	outputContent, inputTokens, outputTokens := extractResponseInfo(provider.Name, respBody)
 	ct := extractCacheTokens(provider.Name, respBody)
 
-	// Extract <think> tags from output content (#312).
-	// Models like DeepSeek R1 wrap reasoning in <think> tags inline.
-	outputContent, reasoningContent := extractThinking(outputContent)
-
 	// For Google native, model is in the URL path, not the body.
 	// Fall back to the response's modelVersion field.
 	if model == "" {
 		model = extractModelFromResponse(provider.Name, respBody)
+	}
+
+	// Extract <think> tags from output content (#312).
+	// Only for known reasoning models — prevents corrupting legitimate
+	// <think> content in non-reasoning model output (e.g. code examples).
+	var reasoningContent string
+	if isReasoningModel(model) {
+		outputContent, reasoningContent = extractThinking(outputContent)
 	}
 
 	// Normalize cached input tokens via the calculator (handles all providers).
@@ -1933,13 +1937,18 @@ func (p *Proxy) createStreamingSpan(
 	outputContent, inputTokens, outputTokens := extractStreamingUsage(provider.Name, streamData)
 	ct := extractStreamingCacheTokens(provider.Name, streamData)
 
-	// Extract <think> tags from output content (#312).
-	outputContent, reasoningContent := extractThinking(outputContent)
-
 	// For Google native, model is in the URL path, not the body.
 	// Fall back to the response's modelVersion field.
 	if model == "" {
 		model = extractModelFromStreamingResponse(provider.Name, streamData)
+	}
+
+	// Extract <think> tags from streaming output content (#312).
+	// Only for known reasoning models — prevents corrupting legitimate
+	// <think> content in non-reasoning model output (e.g. code examples).
+	var reasoningContent string
+	if isReasoningModel(model) {
+		outputContent, reasoningContent = extractThinking(outputContent)
 	}
 
 	// Normalize cached input tokens via the calculator (handles all providers).

--- a/pkg/proxy/thinking_test.go
+++ b/pkg/proxy/thinking_test.go
@@ -30,3 +30,46 @@ func TestExtractThinking(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractThinking_UnclosedTag(t *testing.T) {
+	clean, think := extractThinking("<think>reasoning starts here but never closes")
+	if clean != "" {
+		t.Errorf("clean = %q, want empty", clean)
+	}
+	if think != "reasoning starts here but never closes" {
+		t.Errorf("think = %q, want reasoning content", think)
+	}
+}
+
+func TestExtractThinking_UnclosedAfterContent(t *testing.T) {
+	clean, think := extractThinking("prefix<think>reasoning")
+	if clean != "prefix" {
+		t.Errorf("clean = %q, want 'prefix'", clean)
+	}
+	if think != "reasoning" {
+		t.Errorf("think = %q, want 'reasoning'", think)
+	}
+}
+
+func TestIsReasoningModel(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"deepseek-r1", true},
+		{"deepseek-r1-distill-llama-70b", true},
+		{"deepseek-reasoner", true},
+		{"qwq-32b", true},
+		{"qwen3-235b-a22b", true},
+		{"gpt-4o", false},
+		{"claude-sonnet-4-20250514", false},
+		{"gemini-2.5-pro", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			if got := isReasoningModel(tt.model); got != tt.want {
+				t.Errorf("isReasoningModel(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/proxy/thinking_test.go
+++ b/pkg/proxy/thinking_test.go
@@ -1,0 +1,32 @@
+package proxy
+
+import "testing"
+
+func TestExtractThinking(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantClean string
+		wantThink string
+	}{
+		{"no tags", "hello world", "hello world", ""},
+		{"simple", "<think>reasoning here</think>answer", "answer", "reasoning here"},
+		{"multiple", "<think>step 1</think>middle<think>step 2</think>end", "middleend", "step 1\nstep 2"},
+		{"multiline", "<think>\nline1\nline2\n</think>result", "result", "line1\nline2"},
+		{"empty think", "<think></think>content", "content", ""},
+		{"nested angle brackets", "<think>x > y</think>done", "done", "x > y"},
+		{"only think tags", "<think>just reasoning</think>", "", "just reasoning"},
+		{"whitespace around content", "<think>  spaced  </think>  answer  ", "answer", "spaced"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clean, think := extractThinking(tt.input)
+			if clean != tt.wantClean {
+				t.Errorf("clean = %q, want %q", clean, tt.wantClean)
+			}
+			if think != tt.wantThink {
+				t.Errorf("think = %q, want %q", think, tt.wantThink)
+			}
+		})
+	}
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -80,17 +80,18 @@ const (
 
 // GenAIAttributes holds LLM-specific attributes.
 type GenAIAttributes struct {
-	Model         string  `json:"model,omitempty"`
-	Provider      string  `json:"provider,omitempty"`
-	InputTokens   int64   `json:"input_tokens,omitempty"`
-	OutputTokens  int64   `json:"output_tokens,omitempty"`
-	TotalTokens   int64   `json:"total_tokens,omitempty"`
-	CostUSD       float64 `json:"cost_usd,omitempty"`
-	Temperature   float64 `json:"temperature,omitempty"`
-	MaxTokens     int64   `json:"max_tokens,omitempty"`
-	TopP          float64 `json:"top_p,omitempty"`
-	InputContent  string  `json:"input_content,omitempty"`
-	OutputContent string  `json:"output_content,omitempty"`
+	Model            string  `json:"model,omitempty"`
+	Provider         string  `json:"provider,omitempty"`
+	InputTokens      int64   `json:"input_tokens,omitempty"`
+	OutputTokens     int64   `json:"output_tokens,omitempty"`
+	TotalTokens      int64   `json:"total_tokens,omitempty"`
+	CostUSD          float64 `json:"cost_usd,omitempty"`
+	Temperature      float64 `json:"temperature,omitempty"`
+	MaxTokens        int64   `json:"max_tokens,omitempty"`
+	TopP             float64 `json:"top_p,omitempty"`
+	InputContent     string  `json:"input_content,omitempty"`
+	OutputContent    string  `json:"output_content,omitempty"`
+	ReasoningContent string  `json:"reasoning_content,omitempty" firestore:"reasoning_content,omitempty" bigquery:"reasoning_content"`
 
 	// Cache token breakdown (Anthropic prompt caching).
 	// These are the RAW counts from the API — not cost-normalized.


### PR DESCRIPTION
## Problem
Reasoning models (OpenAI o-series, DeepSeek R1, QwQ) wrap thinking in `<think>` tags inline in the content field. This pollutes the content field and makes reasoning hard to analyze separately.

## Solution
- New `extractThinking()` utility strips `<think>...</think>` tags from content
- Extracted reasoning stored in `GenAIAttributes.ReasoningContent` field
- Applied in both standard and streaming span creation paths
- 8 test cases covering edge cases (no tags, simple, multiple blocks, multiline, empty, nested angle brackets, only-think, whitespace)

## Changes
- `pkg/proxy/parsers.go` — `extractThinking()` function + `thinkTagRe` regex
- `pkg/storage/store.go` — `ReasoningContent` field on `GenAIAttributes`
- `pkg/proxy/proxy.go` — Wire extraction into `createSpan` + `createStreamingSpan`
- `pkg/proxy/thinking_test.go` — Test suite

Closes #312