### PR TITLE
feat: deprecate hardcoded modelPricing.ts

### DIFF
--- a/ui/src/app/models/page.tsx
+++ b/ui/src/app/models/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useModels, type ModelSortKey, type EnrichedModelRow } from "@/hooks/useModels";
-import { type CacheEfficiency } from "@/lib/modelPricing";
+import { type CacheEfficiency } from "@/lib/cacheUtils";
 import { TimeRangeSelector } from "@/components/TimeRangeSelector";
 import { ScopeToggle } from "@/components/ScopeToggle";
 import { useScope } from "@/components/UserScopeProvider";

--- a/ui/src/hooks/useModels.ts
+++ b/ui/src/hooks/useModels.ts
@@ -52,7 +52,12 @@ function compare(a: EnrichedModelRow, b: EnrichedModelRow, key: ModelSortKey): n
  */
 export function useModels(options?: { includeBudget?: boolean }) {
   const dashboard = useDashboard(options);
-  const catalog = useCatalog();
+  const {
+    getPricing,
+    loading: catalogLoading,
+    error: catalogError,
+    source: catalogSource,
+  } = useCatalog();
   const [sort, setSort] = useState<SortState>({ key: "costUsd", desc: true });
   const [search, setSearch] = useState("");
 
@@ -65,7 +70,7 @@ export function useModels(options?: { includeBudget?: boolean }) {
   // Enrich rows with catalog pricing and cache efficiency
   const enriched: EnrichedModelRow[] = useMemo(() => {
     return dashboard.models.map((m) => {
-      const pricing = catalog.getPricing(m.provider, m.model);
+      const pricing = getPricing(m.provider, m.model);
       return {
         ...m,
         inputPricePerMillion: pricing?.inputPerMillion ?? null,
@@ -73,7 +78,7 @@ export function useModels(options?: { includeBudget?: boolean }) {
         cacheEfficiency: getCacheEfficiency(m.cacheReadTokens, m.inputTokens),
       };
     });
-  }, [dashboard.models, catalog.getPricing]);
+  }, [dashboard.models, getPricing]);
 
   const filtered = useMemo(() => {
     let rows = [...enriched];
@@ -116,8 +121,9 @@ export function useModels(options?: { includeBudget?: boolean }) {
   return {
     models: filtered,
     totals,
-    loading: dashboard.loading,
-    error: dashboard.error,
+    loading: dashboard.loading || catalogLoading,
+    error: dashboard.error ?? catalogError,
+    catalogSource,
     timeRange: dashboard.timeRange,
     setTimeRange: dashboard.setTimeRange,
     refresh: dashboard.refresh,

--- a/ui/src/hooks/useModels.ts
+++ b/ui/src/hooks/useModels.ts
@@ -2,7 +2,8 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { useDashboard, type ModelUsageRow } from "@/hooks/useDashboard";
-import { getModelPricing, getCacheEfficiency, type CacheEfficiency } from "@/lib/modelPricing";
+import { getCacheEfficiency, type CacheEfficiency } from "@/lib/cacheUtils";
+import { useCatalog } from "@/hooks/useCatalog";
 
 // ──────────────────────────────────────────
 // Sort logic
@@ -46,10 +47,12 @@ function compare(a: EnrichedModelRow, b: EnrichedModelRow, key: ModelSortKey): n
  * Hook for the Models page.
  *
  * Re-uses useDashboard() to get model breakdown from GetDashboardData,
- * and adds client-side sort + search.
+ * and adds client-side sort + search. Pricing is sourced from the backend
+ * catalog via useCatalog().
  */
 export function useModels(options?: { includeBudget?: boolean }) {
   const dashboard = useDashboard(options);
+  const catalog = useCatalog();
   const [sort, setSort] = useState<SortState>({ key: "costUsd", desc: true });
   const [search, setSearch] = useState("");
 
@@ -59,10 +62,10 @@ export function useModels(options?: { includeBudget?: boolean }) {
     );
   }, []);
 
-  // Enrich rows with static pricing and cache efficiency
+  // Enrich rows with catalog pricing and cache efficiency
   const enriched: EnrichedModelRow[] = useMemo(() => {
     return dashboard.models.map((m) => {
-      const pricing = getModelPricing(m.model);
+      const pricing = catalog.getPricing(m.provider, m.model);
       return {
         ...m,
         inputPricePerMillion: pricing?.inputPerMillion ?? null,
@@ -70,7 +73,7 @@ export function useModels(options?: { includeBudget?: boolean }) {
         cacheEfficiency: getCacheEfficiency(m.cacheReadTokens, m.inputTokens),
       };
     });
-  }, [dashboard.models]);
+  }, [dashboard.models, catalog.getPricing]);
 
   const filtered = useMemo(() => {
     let rows = [...enriched];

--- a/ui/src/lib/cacheUtils.ts
+++ b/ui/src/lib/cacheUtils.ts
@@ -1,0 +1,37 @@
+/**
+ * Cache-efficiency analysis utilities.
+ *
+ * Extracted from modelPricing.ts so they survive the deprecation of the
+ * hardcoded pricing registry.
+ */
+
+export interface CacheEfficiency {
+  /** Hit rate 0.0–1.0 */
+  rate: number;
+  label: string;
+  /** CSS-friendly color */
+  color: string;
+  /** CSS class suffix: "excellent" | "good" | "low" */
+  tier: "excellent" | "good" | "low";
+}
+
+/**
+ * Compute cache efficiency from per-model token counts.
+ * Returns null when there are no cache read tokens.
+ */
+export function getCacheEfficiency(
+  cacheReadTokens: number,
+  inputTokens: number
+): CacheEfficiency | null {
+  if (inputTokens <= 0 || cacheReadTokens <= 0) return null;
+
+  const rate = Math.min(1, cacheReadTokens / inputTokens);
+
+  if (rate >= 0.5) {
+    return { rate, label: "Excellent", color: "var(--success, #4ade80)", tier: "excellent" };
+  }
+  if (rate >= 0.2) {
+    return { rate, label: "Good", color: "var(--accent, #60a5fa)", tier: "good" };
+  }
+  return { rate, label: "Low", color: "var(--warning, #fbbf24)", tier: "low" };
+}

--- a/ui/src/lib/modelPricing.ts
+++ b/ui/src/lib/modelPricing.ts
@@ -1,5 +1,11 @@
 /**
- * Static per-model pricing registry.
+ * @deprecated Use `useCatalog()` hook for pricing and `@/lib/cacheUtils` for
+ * CacheEfficiency utilities. This file will be removed once all consumers
+ * migrate to catalog-based pricing.
+ * See: https://github.com/candelahq/candela/issues/325
+ *
+ * ---
+ * Static per-model pricing registry (LEGACY).
  *
  * SOURCE OF TRUTH: pkg/costcalc/calculator.go → loadDefaults()
  * Keep this file in sync whenever model pricing is added or changed.


### PR DESCRIPTION
## Problem
`modelPricing.ts` contains ~60 hardcoded model prices that must be manually synced with `calculator.go`. Drift is inevitable.

## Solution
- `useModels` now uses `useCatalog().getPricing()` for live backend pricing
- `CacheEfficiency` utilities moved to `lib/cacheUtils.ts`
- `modelPricing.ts` marked `@deprecated` (kept for safety)

Closes #325