### PR TITLE
feat: copy-pasteable client configs in web UI

### DIFF
--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -2584,3 +2584,152 @@ tr:hover .model-bar {
   filter: drop-shadow(0 0 8px rgba(240, 160, 48, 0.3));
 }
 
+/* ──────────────────────────────────────────
+   Setup Page
+   ────────────────────────────────────────── */
+
+.setup-inline-code {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 12px;
+  color: var(--accent);
+}
+
+.setup-proxy-url {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.setup-proxy-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--success);
+  flex-shrink: 0;
+  box-shadow: 0 0 6px rgba(52, 211, 153, 0.4);
+}
+
+.setup-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border-subtle);
+  overflow-x: auto;
+  background: var(--bg-tertiary);
+}
+
+.setup-tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.setup-tab:hover {
+  color: var(--text-secondary);
+  background: var(--bg-hover);
+}
+
+.setup-tab-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.setup-tab-icon {
+  font-size: 14px;
+}
+
+.setup-tab-label {
+  font-size: 13px;
+}
+
+.setup-snippet-container {
+  position: relative;
+}
+
+.setup-snippet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.setup-snippet-lang {
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.setup-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.setup-copy-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--accent-dim);
+}
+
+.setup-copy-btn-copied {
+  background: rgba(52, 211, 153, 0.12);
+  border-color: rgba(52, 211, 153, 0.3);
+  color: var(--success);
+}
+
+.setup-copy-btn-copied:hover {
+  background: rgba(52, 211, 153, 0.18);
+  color: var(--success);
+  border-color: rgba(52, 211, 153, 0.4);
+}
+
+.setup-snippet-code {
+  margin: 0;
+  padding: 20px;
+  background: var(--bg-primary);
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  overflow-x: auto;
+  tab-size: 2;
+}
+
+.setup-snippet-code code {
+  font-family: inherit;
+}

--- a/ui/src/app/setup/page.tsx
+++ b/ui/src/app/setup/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback, useRef, useSyncExternalStore } from "react";
 
 // ──────────────────────────────────────────
 // Config snippets
@@ -86,23 +86,31 @@ export OPENAI_API_KEY=YOUR_CANDELA_API_KEY`,
 // Page
 // ──────────────────────────────────────────
 
+function getOrigin() {
+  return typeof window === "undefined" ? "https://your-candela-host" : window.location.origin;
+}
+
+const subscribe = () => () => {};
+
 export default function SetupPage() {
   const [activeTab, setActiveTab] = useState(CONFIG_TABS[0].id);
-  const [proxyUrl, setProxyUrl] = useState("https://your-candela-host");
+  const proxyUrl = useSyncExternalStore(subscribe, getOrigin, () => "https://your-candela-host");
   const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  useEffect(() => {
-    setProxyUrl(window.location.origin);
-  }, []);
-
-  const currentTab = CONFIG_TABS.find((t) => t.id === activeTab)!;
+  const currentTab = CONFIG_TABS.find((t) => t.id === activeTab) ?? CONFIG_TABS[0];
   const snippetText = currentTab.snippet(proxyUrl);
+
+  const scheduleCopyReset = useCallback(() => {
+    if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+  }, []);
 
   const handleCopy = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(snippetText);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      scheduleCopyReset();
     } catch {
       // Fallback for older browsers
       const textarea = document.createElement("textarea");
@@ -112,14 +120,18 @@ export default function SetupPage() {
       document.execCommand("copy");
       document.body.removeChild(textarea);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      scheduleCopyReset();
     }
-  }, [snippetText]);
+  }, [snippetText, scheduleCopyReset]);
 
-  // Reset copied state on tab switch
-  useEffect(() => {
+  const handleTabSwitch = useCallback((tabId: string) => {
+    setActiveTab(tabId);
     setCopied(false);
-  }, [activeTab]);
+    if (copyTimeoutRef.current) {
+      clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = null;
+    }
+  }, []);
 
   return (
     <>
@@ -162,7 +174,7 @@ export default function SetupPage() {
               <button
                 key={tab.id}
                 className={`setup-tab ${activeTab === tab.id ? "setup-tab-active" : ""}`}
-                onClick={() => setActiveTab(tab.id)}
+                onClick={() => handleTabSwitch(tab.id)}
               >
                 <span className="setup-tab-icon">{tab.icon}</span>
                 <span className="setup-tab-label">{tab.label}</span>

--- a/ui/src/app/setup/page.tsx
+++ b/ui/src/app/setup/page.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+// ──────────────────────────────────────────
+// Config snippets
+// ──────────────────────────────────────────
+
+interface ConfigTab {
+  id: string;
+  label: string;
+  icon: string;
+  language: string;
+  snippet: (proxyUrl: string) => string;
+}
+
+const CONFIG_TABS: ConfigTab[] = [
+  {
+    id: "python",
+    label: "Python SDK",
+    icon: "🐍",
+    language: "python",
+    snippet: (url) =>
+      `import openai
+
+client = openai.OpenAI(
+    base_url="${url}/openai/v1",
+    api_key="YOUR_CANDELA_API_KEY",  # Your Candela API key
+)`,
+  },
+  {
+    id: "curl",
+    label: "curl",
+    icon: "🌐",
+    language: "bash",
+    snippet: (url) =>
+      `curl ${url}/openai/v1/chat/completions \\
+  -H "Authorization: Bearer YOUR_CANDELA_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "gpt-4o",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'`,
+  },
+  {
+    id: "vscode",
+    label: "VS Code / Continue",
+    icon: "📝",
+    language: "json",
+    snippet: (url) =>
+      `{
+  "models": [
+    {
+      "title": "GPT-4o via Candela",
+      "provider": "openai",
+      "model": "gpt-4o",
+      "apiBase": "${url}/openai/v1",
+      "apiKey": "YOUR_CANDELA_API_KEY"
+    }
+  ]
+}`,
+  },
+  {
+    id: "cursor",
+    label: "Cursor",
+    icon: "⚡",
+    language: "json",
+    snippet: (url) =>
+      `{
+  "openai.api_base": "${url}/openai/v1",
+  "openai.api_key": "YOUR_CANDELA_API_KEY"
+}`,
+  },
+  {
+    id: "env",
+    label: "Env Variables",
+    icon: "🔑",
+    language: "bash",
+    snippet: (url) =>
+      `export OPENAI_API_BASE=${url}/openai/v1
+export OPENAI_API_KEY=YOUR_CANDELA_API_KEY`,
+  },
+];
+
+// ──────────────────────────────────────────
+// Page
+// ──────────────────────────────────────────
+
+export default function SetupPage() {
+  const [activeTab, setActiveTab] = useState(CONFIG_TABS[0].id);
+  const [proxyUrl, setProxyUrl] = useState("https://your-candela-host");
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    setProxyUrl(window.location.origin);
+  }, []);
+
+  const currentTab = CONFIG_TABS.find((t) => t.id === activeTab)!;
+  const snippetText = currentTab.snippet(proxyUrl);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(snippetText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for older browsers
+      const textarea = document.createElement("textarea");
+      textarea.value = snippetText;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [snippetText]);
+
+  // Reset copied state on tab switch
+  useEffect(() => {
+    setCopied(false);
+  }, [activeTab]);
+
+  return (
+    <>
+      <header className="main-header">
+        <h1>Setup</h1>
+      </header>
+
+      <div className="main-body">
+        {/* Intro */}
+        <div className="card animate-in" style={{ marginBottom: 16 }}>
+          <div className="card-title">Connect Your Tools</div>
+          <p style={{ fontSize: 14, color: "var(--text-secondary)", lineHeight: 1.6 }}>
+            Configure your AI tools to route through Candela. Select a tool below, copy
+            the configuration snippet, and replace{" "}
+            <code className="setup-inline-code">YOUR_CANDELA_API_KEY</code> with your
+            actual API key.
+          </p>
+        </div>
+
+        {/* Proxy URL display */}
+        <div
+          className="card animate-in"
+          style={{ marginBottom: 16, animationDelay: "0.05s" }}
+        >
+          <div className="card-title">Your Proxy URL</div>
+          <div className="setup-proxy-url">
+            <span className="setup-proxy-dot" />
+            <code>{proxyUrl}</code>
+          </div>
+        </div>
+
+        {/* Tabs + Snippet */}
+        <div
+          className="card animate-in"
+          style={{ animationDelay: "0.1s", padding: 0, overflow: "hidden" }}
+        >
+          {/* Tab bar */}
+          <div className="setup-tabs">
+            {CONFIG_TABS.map((tab) => (
+              <button
+                key={tab.id}
+                className={`setup-tab ${activeTab === tab.id ? "setup-tab-active" : ""}`}
+                onClick={() => setActiveTab(tab.id)}
+              >
+                <span className="setup-tab-icon">{tab.icon}</span>
+                <span className="setup-tab-label">{tab.label}</span>
+              </button>
+            ))}
+          </div>
+
+          {/* Snippet area */}
+          <div className="setup-snippet-container">
+            <div className="setup-snippet-header">
+              <span className="setup-snippet-lang">{currentTab.language}</span>
+              <button
+                className={`setup-copy-btn ${copied ? "setup-copy-btn-copied" : ""}`}
+                onClick={handleCopy}
+              >
+                {copied ? (
+                  <>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                    Copied!
+                  </>
+                ) : (
+                  <>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                    </svg>
+                    Copy
+                  </>
+                )}
+              </button>
+            </div>
+            <pre className="setup-snippet-code"><code>{snippetText}</code></pre>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/ui/src/components/sidebar.tsx
+++ b/ui/src/components/sidebar.tsx
@@ -21,6 +21,7 @@ const navItems = [
     items: [
       { href: "/models", label: "Models", icon: "🤖" },
       { href: "/projects", label: "Projects", icon: "📁" },
+      { href: "/setup", label: "Setup", icon: "🔌" },
       { href: "/settings", label: "Settings", icon: "⚙️" },
     ],
   },


### PR DESCRIPTION
## Problem
Users have to manually figure out proxy URL format and tool configuration.

## Solution
New `/setup` page with tabbed config snippets for Python, curl, VS Code, Cursor, and env vars. Copy button with visual feedback. URL auto-detected.

Closes #300