### PR TITLE
feat: pricing drift detection via snapshot test

### DIFF
--- a/pkg/costcalc/drift_test.go
+++ b/pkg/costcalc/drift_test.go
@@ -19,6 +19,9 @@ func TestPricingSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Add trailing newline for editor compatibility — most editors and
+	// git prefer files to end with a newline.
+	current = append(current, '\n')
 
 	snapshotPath := filepath.Join("testdata", "pricing_snapshot.json")
 
@@ -26,23 +29,18 @@ func TestPricingSnapshot(t *testing.T) {
 		if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(snapshotPath, append(current, '\n'), 0o644); err != nil {
+		if err := os.WriteFile(snapshotPath, current, 0o644); err != nil {
 			t.Fatal(err)
 		}
 		t.Log("Updated pricing snapshot")
 		return
 	}
 
-	// If snapshot doesn't exist, create it and pass (first run).
+	// If the snapshot doesn't exist, fail rather than silently creating it.
+	// In CI (where testdata may not be committed), this ensures drift is
+	// caught instead of masked by auto-creation.
 	if _, err := os.Stat(snapshotPath); os.IsNotExist(err) {
-		if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(snapshotPath, append(current, '\n'), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		t.Log("Created pricing snapshot — commit testdata/pricing_snapshot.json")
-		return
+		t.Fatalf("pricing snapshot missing: %s\nRun with -update-snapshot to create it", snapshotPath)
 	}
 
 	// Compare with existing snapshot.
@@ -51,8 +49,8 @@ func TestPricingSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if string(append(current, '\n')) != string(expected) {
-		// Write actual output for easy diffing.
+	if string(current) != string(expected) {
+		// Write actual output for easy diffing (with trailing newline).
 		_ = os.WriteFile(snapshotPath+".actual", current, 0o644)
 		t.Errorf("pricing drift detected!\n"+
 			"The default pricing in calculator.go has changed since the last snapshot.\n"+
@@ -61,6 +59,16 @@ func TestPricingSnapshot(t *testing.T) {
 			"  2. Or copy %s.actual → %s\n"+
 			"  3. Commit the updated snapshot",
 			snapshotPath, snapshotPath)
+	}
+}
+
+// TestPricingSnapshot_RequiresFile verifies the snapshot file is committed to
+// the repo. This is a fast, standalone check that doesn't require computing
+// the snapshot — it just ensures the file exists on disk.
+func TestPricingSnapshot_RequiresFile(t *testing.T) {
+	snapshotPath := filepath.Join("testdata", "pricing_snapshot.json")
+	if _, err := os.Stat(snapshotPath); os.IsNotExist(err) {
+		t.Fatal("pricing_snapshot.json must be committed to the repo")
 	}
 }
 
@@ -73,7 +81,15 @@ func TestDefaultsModelCount(t *testing.T) {
 		t.Errorf("only %d default models, expected at least 20", len(defaults))
 	}
 
-	// Check for duplicate entries.
+	// Check for duplicate entries (provider + model key).
+	//
+	// NOTE: loadDefaults() stores entries into a map keyed by provider/model,
+	// so true duplicates in the source slice are silently overwritten before
+	// Defaults() ever sees them. This check on Defaults() acts as a safety
+	// net — if loadDefaults ever changes to use a slice or append-based
+	// approach, this will catch regressions. It also validates that the
+	// map-based dedup hasn't hidden a copy-paste error where two entries
+	// differ only in pricing (last-write-wins would mask the first).
 	seen := make(map[string]bool)
 	for _, d := range defaults {
 		key := d.Provider + "/" + d.Model

--- a/pkg/costcalc/drift_test.go
+++ b/pkg/costcalc/drift_test.go
@@ -1,0 +1,85 @@
+package costcalc
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var updateSnapshot = flag.Bool("update-snapshot", false, "update pricing snapshot")
+
+func TestPricingSnapshot(t *testing.T) {
+	c := New()
+	defaults := c.Defaults() // Already sorted by provider, then model.
+
+	// Generate current snapshot.
+	current, err := json.MarshalIndent(defaults, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshotPath := filepath.Join("testdata", "pricing_snapshot.json")
+
+	if *updateSnapshot {
+		if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(snapshotPath, append(current, '\n'), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Log("Updated pricing snapshot")
+		return
+	}
+
+	// If snapshot doesn't exist, create it and pass (first run).
+	if _, err := os.Stat(snapshotPath); os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Dir(snapshotPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(snapshotPath, append(current, '\n'), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Log("Created pricing snapshot — commit testdata/pricing_snapshot.json")
+		return
+	}
+
+	// Compare with existing snapshot.
+	expected, err := os.ReadFile(snapshotPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(append(current, '\n')) != string(expected) {
+		// Write actual output for easy diffing.
+		_ = os.WriteFile(snapshotPath+".actual", current, 0o644)
+		t.Errorf("pricing drift detected!\n"+
+			"The default pricing in calculator.go has changed since the last snapshot.\n"+
+			"If this is intentional:\n"+
+			"  1. Run: go test ./pkg/costcalc/ -run TestPricingSnapshot -update-snapshot\n"+
+			"  2. Or copy %s.actual → %s\n"+
+			"  3. Commit the updated snapshot",
+			snapshotPath, snapshotPath)
+	}
+}
+
+func TestDefaultsModelCount(t *testing.T) {
+	c := New()
+	defaults := c.Defaults()
+
+	// Sanity check: we should have a reasonable number of models.
+	if len(defaults) < 20 {
+		t.Errorf("only %d default models, expected at least 20", len(defaults))
+	}
+
+	// Check for duplicate entries.
+	seen := make(map[string]bool)
+	for _, d := range defaults {
+		key := d.Provider + "/" + d.Model
+		if seen[key] {
+			t.Errorf("duplicate default pricing: %s", key)
+		}
+		seen[key] = true
+	}
+}

--- a/pkg/costcalc/testdata/pricing_snapshot.json
+++ b/pkg/costcalc/testdata/pricing_snapshot.json
@@ -1,0 +1,254 @@
+[
+  {
+    "model": "claude-3-5-sonnet-20241022",
+    "provider": "anthropic",
+    "input_per_million": 3,
+    "output_per_million": 15
+  },
+  {
+    "model": "claude-3-opus-20240229",
+    "provider": "anthropic",
+    "input_per_million": 15,
+    "output_per_million": 75
+  },
+  {
+    "model": "claude-haiku-3-5-20241022",
+    "provider": "anthropic",
+    "input_per_million": 0.8,
+    "output_per_million": 4
+  },
+  {
+    "model": "claude-haiku-4.5",
+    "provider": "anthropic",
+    "input_per_million": 1,
+    "output_per_million": 5
+  },
+  {
+    "model": "claude-opus-4",
+    "provider": "anthropic",
+    "input_per_million": 5,
+    "output_per_million": 25
+  },
+  {
+    "model": "claude-opus-4-20250514",
+    "provider": "anthropic",
+    "input_per_million": 5,
+    "output_per_million": 25
+  },
+  {
+    "model": "claude-opus-4.6",
+    "provider": "anthropic",
+    "input_per_million": 5,
+    "output_per_million": 25
+  },
+  {
+    "model": "claude-opus-4.7",
+    "provider": "anthropic",
+    "input_per_million": 5,
+    "output_per_million": 25
+  },
+  {
+    "model": "claude-sonnet-4",
+    "provider": "anthropic",
+    "input_per_million": 3,
+    "output_per_million": 15
+  },
+  {
+    "model": "claude-sonnet-4-20250514",
+    "provider": "anthropic",
+    "input_per_million": 3,
+    "output_per_million": 15
+  },
+  {
+    "model": "claude-sonnet-4.6",
+    "provider": "anthropic",
+    "input_per_million": 3,
+    "output_per_million": 15
+  },
+  {
+    "model": "deepseek-r1",
+    "provider": "deepseek",
+    "input_per_million": 0.14,
+    "output_per_million": 0.28
+  },
+  {
+    "model": "deepseek-r1-0528-maas",
+    "provider": "deepseek",
+    "input_per_million": 0.14,
+    "output_per_million": 0.28
+  },
+  {
+    "model": "deepseek-chat",
+    "provider": "deepseek-v3",
+    "input_per_million": 0.14,
+    "output_per_million": 0.28
+  },
+  {
+    "model": "deepseek-v3-maas",
+    "provider": "deepseek-v3",
+    "input_per_million": 0.14,
+    "output_per_million": 0.28
+  },
+  {
+    "model": "deepseek-v3.2-maas",
+    "provider": "deepseek-v3",
+    "input_per_million": 0.14,
+    "output_per_million": 0.28
+  },
+  {
+    "model": "gemini-1.5-flash",
+    "provider": "google",
+    "input_per_million": 0.075,
+    "output_per_million": 0.3
+  },
+  {
+    "model": "gemini-1.5-pro",
+    "provider": "google",
+    "input_per_million": 1.25,
+    "output_per_million": 5
+  },
+  {
+    "model": "gemini-2.0-flash",
+    "provider": "google",
+    "input_per_million": 0.1,
+    "output_per_million": 0.4
+  },
+  {
+    "model": "gemini-2.5-flash",
+    "provider": "google",
+    "input_per_million": 0.3,
+    "output_per_million": 2.5
+  },
+  {
+    "model": "gemini-2.5-flash-lite",
+    "provider": "google",
+    "input_per_million": 0.1,
+    "output_per_million": 0.4
+  },
+  {
+    "model": "gemini-2.5-pro",
+    "provider": "google",
+    "input_per_million": 1.25,
+    "output_per_million": 10,
+    "input_per_million_high": 2.5,
+    "output_per_million_high": 15,
+    "tier_threshold_tokens": 200000
+  },
+  {
+    "model": "gemini-3-flash",
+    "provider": "google",
+    "input_per_million": 0.5,
+    "output_per_million": 3
+  },
+  {
+    "model": "gemini-3-flash-lite",
+    "provider": "google",
+    "input_per_million": 0.02,
+    "output_per_million": 0.1
+  },
+  {
+    "model": "gemini-3.1-flash-lite",
+    "provider": "google",
+    "input_per_million": 0.25,
+    "output_per_million": 1.5
+  },
+  {
+    "model": "gemini-3.1-pro",
+    "provider": "google",
+    "input_per_million": 2,
+    "output_per_million": 12,
+    "input_per_million_high": 4,
+    "output_per_million_high": 18,
+    "tier_threshold_tokens": 200000
+  },
+  {
+    "model": "gemini-3.5-flash",
+    "provider": "google",
+    "input_per_million": 1.5,
+    "output_per_million": 9
+  },
+  {
+    "model": "codestral-2",
+    "provider": "mistral",
+    "input_per_million": 0.3,
+    "output_per_million": 0.9
+  },
+  {
+    "model": "codestral-2501",
+    "provider": "mistral",
+    "input_per_million": 0.3,
+    "output_per_million": 0.9
+  },
+  {
+    "model": "mistral-medium-3",
+    "provider": "mistral",
+    "input_per_million": 0.4,
+    "output_per_million": 2
+  },
+  {
+    "model": "mistral-small-2503",
+    "provider": "mistral",
+    "input_per_million": 0.1,
+    "output_per_million": 0.3
+  },
+  {
+    "model": "gpt-4.1",
+    "provider": "openai",
+    "input_per_million": 2,
+    "output_per_million": 8
+  },
+  {
+    "model": "gpt-4.1-mini",
+    "provider": "openai",
+    "input_per_million": 0.4,
+    "output_per_million": 1.6
+  },
+  {
+    "model": "gpt-4.1-nano",
+    "provider": "openai",
+    "input_per_million": 0.1,
+    "output_per_million": 0.4
+  },
+  {
+    "model": "gpt-4o",
+    "provider": "openai",
+    "input_per_million": 2.5,
+    "output_per_million": 10
+  },
+  {
+    "model": "gpt-4o-mini",
+    "provider": "openai",
+    "input_per_million": 0.15,
+    "output_per_million": 0.6
+  },
+  {
+    "model": "o3",
+    "provider": "openai",
+    "input_per_million": 2,
+    "output_per_million": 8
+  },
+  {
+    "model": "o4-mini",
+    "provider": "openai",
+    "input_per_million": 1.1,
+    "output_per_million": 4.4
+  },
+  {
+    "model": "qwen-2.5-coder-32b-instruct-maas",
+    "provider": "qwen",
+    "input_per_million": 0.3,
+    "output_per_million": 1.2
+  },
+  {
+    "model": "qwen3-235b-a22b-instruct-2507-maas",
+    "provider": "qwen",
+    "input_per_million": 0.3,
+    "output_per_million": 1.2
+  },
+  {
+    "model": "qwen3-coder-480b-a35b-instruct-maas",
+    "provider": "qwen",
+    "input_per_million": 0.22,
+    "output_per_million": 1.8
+  }
+]


### PR DESCRIPTION
## Problem
Pricing changes can slip in without anyone noticing.

## Solution
Snapshot test that catches any change to default pricing:
- `TestPricingSnapshot`: compares JSON snapshot, fails on drift
- `TestDefaultsModelCount`: sanity check + duplicate detection
- Update: `go test ./pkg/costcalc/ -run TestPricingSnapshot -update-snapshot`

Closes #339