### PR TITLE
feat: add load testing suite for proxy

### DIFF
--- a/test/loadtest/cmd/main.go
+++ b/test/loadtest/cmd/main.go
@@ -1,0 +1,91 @@
+// Command loadtest-runner is a CLI tool for running load tests against a live
+// Candela proxy instance.
+//
+// Usage:
+//
+//	go run ./test/loadtest/cmd -url http://localhost:8080/proxy/openai/v1/chat/completions -c 10 -d 30s
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/candelahq/candela/test/loadtest"
+)
+
+func main() {
+	url := flag.String("url", "http://localhost:8080/proxy/openai/v1/chat/completions", "target URL")
+	concurrency := flag.Int("c", 10, "number of concurrent workers")
+	duration := flag.Duration("d", 30*time.Second, "test duration")
+	rps := flag.Int("rps", 0, "requests per second limit (0 = unlimited)")
+	provider := flag.String("provider", "openai", "LLM provider name")
+	model := flag.String("model", "gpt-4o-mini", "model identifier")
+	prompt := flag.String("prompt", "Say hello in one word.", "prompt text")
+	token := flag.String("token", "", "Bearer auth token (env: LOADTEST_TOKEN)")
+	flag.Parse()
+
+	authToken := *token
+	if authToken == "" {
+		authToken = os.Getenv("LOADTEST_TOKEN")
+	}
+
+	cfg := loadtest.Config{
+		TargetURL:      *url,
+		Concurrency:    *concurrency,
+		Duration:       *duration,
+		RequestsPerSec: *rps,
+		AuthToken:      authToken,
+		Provider:       *provider,
+		Model:          *model,
+		Prompt:         *prompt,
+	}
+
+	fmt.Printf("🔥 Load test starting\n")
+	fmt.Printf("   Target:      %s\n", cfg.TargetURL)
+	fmt.Printf("   Workers:     %d\n", cfg.Concurrency)
+	fmt.Printf("   Duration:    %v\n", cfg.Duration)
+	if cfg.RequestsPerSec > 0 {
+		fmt.Printf("   Rate limit:  %d RPS\n", cfg.RequestsPerSec)
+	} else {
+		fmt.Printf("   Rate limit:  unlimited\n")
+	}
+	fmt.Printf("   Provider:    %s\n", cfg.Provider)
+	fmt.Printf("   Model:       %s\n", cfg.Model)
+	fmt.Println()
+
+	// Allow Ctrl-C to gracefully stop the test.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	result, err := loadtest.Run(ctx, cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("📊 Results\n")
+	fmt.Printf("   Total requests:  %d\n", result.TotalRequests)
+	fmt.Printf("   Success:         %d\n", result.SuccessCount)
+	fmt.Printf("   Errors:          %d\n", result.ErrorCount)
+	fmt.Printf("   Duration:        %v\n", result.TotalDuration.Round(time.Millisecond))
+	fmt.Printf("   RPS:             %.1f\n", result.RequestsPerSec)
+	fmt.Println()
+	fmt.Printf("   Latency:\n")
+	fmt.Printf("     avg:  %v\n", result.AvgLatency.Round(time.Microsecond))
+	fmt.Printf("     p50:  %v\n", result.P50Latency.Round(time.Microsecond))
+	fmt.Printf("     p95:  %v\n", result.P95Latency.Round(time.Microsecond))
+	fmt.Printf("     p99:  %v\n", result.P99Latency.Round(time.Microsecond))
+	fmt.Printf("     max:  %v\n", result.MaxLatency.Round(time.Microsecond))
+
+	if len(result.Errors) > 0 {
+		fmt.Println()
+		fmt.Printf("   Error breakdown:\n")
+		for errType, count := range result.Errors {
+			fmt.Printf("     %s: %d\n", errType, count)
+		}
+	}
+}

--- a/test/loadtest/loadtest.go
+++ b/test/loadtest/loadtest.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -97,29 +96,33 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	results := make(chan requestResult, cfg.Concurrency*100)
 
 	// Rate limiter: simple token-bucket using a ticker.
-	var ticker *time.Ticker
-	var tokenCh <-chan time.Time
+	var limiter <-chan time.Time
 	if cfg.RequestsPerSec > 0 {
 		interval := time.Second / time.Duration(cfg.RequestsPerSec)
-		ticker = time.NewTicker(interval)
-		tokenCh = ticker.C
+		if interval <= 0 {
+			interval = time.Millisecond // minimum 1ms between requests
+		}
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
+		limiter = ticker.C
 	}
 
 	// Shared HTTP client with keep-alive.
+	transport := &http.Transport{
+		MaxIdleConns:        cfg.Concurrency * 2,
+		MaxIdleConnsPerHost: cfg.Concurrency * 2,
+		IdleConnTimeout:     90 * time.Second,
+	}
+	defer transport.CloseIdleConnections()
+
 	client := &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			MaxIdleConns:        cfg.Concurrency * 2,
-			MaxIdleConnsPerHost: cfg.Concurrency * 2,
-			IdleConnTimeout:     90 * time.Second,
-		},
+		Timeout:   30 * time.Second,
+		Transport: transport,
 	}
 
 	body := buildRequestBody(cfg)
 
 	var wg sync.WaitGroup
-	var totalSent atomic.Int64
 
 	startTime := time.Now()
 
@@ -137,16 +140,15 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 				}
 
 				// Rate limiting: wait for a token if configured.
-				if tokenCh != nil {
+				if limiter != nil {
 					select {
-					case <-tokenCh:
+					case <-limiter:
 					case <-runCtx.Done():
 						return
 					}
 				}
 
 				rr := sendRequest(runCtx, client, cfg, body)
-				totalSent.Add(1)
 
 				select {
 				case results <- rr:

--- a/test/loadtest/loadtest.go
+++ b/test/loadtest/loadtest.go
@@ -1,0 +1,269 @@
+// Package loadtest provides a reusable load testing framework for the Candela
+// proxy. It drives concurrent HTTP requests against a target URL, collects
+// latency percentiles (p50/p95/p99), and reports per-status-code error
+// breakdowns.
+//
+// Usage:
+//
+//	result, err := loadtest.Run(ctx, loadtest.Config{
+//	    TargetURL:   "http://localhost:8080/proxy/openai/v1/chat/completions",
+//	    Concurrency: 10,
+//	    Duration:    30 * time.Second,
+//	})
+package loadtest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Config configures a load test run.
+type Config struct {
+	// TargetURL is the endpoint to send requests to.
+	TargetURL string
+
+	// Concurrency is the number of concurrent worker goroutines.
+	Concurrency int
+
+	// Duration is how long the load test runs before stopping.
+	Duration time.Duration
+
+	// RequestsPerSec limits the aggregate request rate across all workers.
+	// 0 means unlimited.
+	RequestsPerSec int
+
+	// AuthToken is the Bearer token for Authorization header. Empty = no auth.
+	AuthToken string
+
+	// Provider is the LLM provider name (used in request body).
+	Provider string
+
+	// Model is the model identifier (used in request body).
+	Model string
+
+	// Prompt is the user message content.
+	Prompt string
+}
+
+// Result holds the aggregated results of a load test.
+type Result struct {
+	TotalRequests  int64
+	SuccessCount   int64
+	ErrorCount     int64
+	TotalDuration  time.Duration
+	AvgLatency     time.Duration
+	P50Latency     time.Duration
+	P95Latency     time.Duration
+	P99Latency     time.Duration
+	MaxLatency     time.Duration
+	RequestsPerSec float64
+	Errors         map[string]int // error description → count
+}
+
+// requestResult captures the outcome of a single HTTP request.
+type requestResult struct {
+	latency    time.Duration
+	statusCode int
+	err        error
+}
+
+// Run executes a load test with the given configuration.
+// It spawns cfg.Concurrency worker goroutines that continuously send requests
+// until cfg.Duration elapses or ctx is cancelled.
+func Run(ctx context.Context, cfg Config) (*Result, error) {
+	if cfg.Concurrency <= 0 {
+		cfg.Concurrency = 1
+	}
+	if cfg.Duration <= 0 {
+		cfg.Duration = 10 * time.Second
+	}
+	if cfg.Prompt == "" {
+		cfg.Prompt = "Hello"
+	}
+
+	// Build a context that expires after Duration or when the parent ctx is done.
+	runCtx, cancel := context.WithTimeout(ctx, cfg.Duration)
+	defer cancel()
+
+	// Channel for collecting per-request results.
+	results := make(chan requestResult, cfg.Concurrency*100)
+
+	// Rate limiter: simple token-bucket using a ticker.
+	var ticker *time.Ticker
+	var tokenCh <-chan time.Time
+	if cfg.RequestsPerSec > 0 {
+		interval := time.Second / time.Duration(cfg.RequestsPerSec)
+		ticker = time.NewTicker(interval)
+		tokenCh = ticker.C
+		defer ticker.Stop()
+	}
+
+	// Shared HTTP client with keep-alive.
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:        cfg.Concurrency * 2,
+			MaxIdleConnsPerHost: cfg.Concurrency * 2,
+			IdleConnTimeout:     90 * time.Second,
+		},
+	}
+
+	body := buildRequestBody(cfg)
+
+	var wg sync.WaitGroup
+	var totalSent atomic.Int64
+
+	startTime := time.Now()
+
+	// Launch workers.
+	for i := range cfg.Concurrency {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for {
+				// Check context before sending.
+				select {
+				case <-runCtx.Done():
+					return
+				default:
+				}
+
+				// Rate limiting: wait for a token if configured.
+				if tokenCh != nil {
+					select {
+					case <-tokenCh:
+					case <-runCtx.Done():
+						return
+					}
+				}
+
+				rr := sendRequest(runCtx, client, cfg, body)
+				totalSent.Add(1)
+
+				select {
+				case results <- rr:
+				case <-runCtx.Done():
+					return
+				}
+			}
+		}(i)
+	}
+
+	// Close results channel when all workers are done.
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// Collect results.
+	var latencies []time.Duration
+	errors := make(map[string]int)
+	var successCount, errorCount int64
+
+	for rr := range results {
+		latencies = append(latencies, rr.latency)
+		if rr.err != nil {
+			errorCount++
+			errors[rr.err.Error()]++
+		} else if rr.statusCode >= 400 {
+			errorCount++
+			key := fmt.Sprintf("HTTP %d", rr.statusCode)
+			errors[key]++
+		} else {
+			successCount++
+		}
+	}
+
+	totalDuration := time.Since(startTime)
+
+	result := &Result{
+		TotalRequests:  int64(len(latencies)),
+		SuccessCount:   successCount,
+		ErrorCount:     errorCount,
+		TotalDuration:  totalDuration,
+		Errors:         errors,
+		RequestsPerSec: float64(len(latencies)) / totalDuration.Seconds(),
+	}
+
+	if len(latencies) > 0 {
+		sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+
+		var total time.Duration
+		for _, l := range latencies {
+			total += l
+		}
+		result.AvgLatency = total / time.Duration(len(latencies))
+		result.P50Latency = percentile(latencies, 0.50)
+		result.P95Latency = percentile(latencies, 0.95)
+		result.P99Latency = percentile(latencies, 0.99)
+		result.MaxLatency = latencies[len(latencies)-1]
+	}
+
+	return result, nil
+}
+
+// sendRequest sends a single HTTP POST to the target and measures latency.
+func sendRequest(ctx context.Context, client *http.Client, cfg Config, body string) requestResult {
+	start := time.Now()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.TargetURL, strings.NewReader(body))
+	if err != nil {
+		return requestResult{latency: time.Since(start), err: fmt.Errorf("create request: %w", err)}
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if cfg.AuthToken != "" {
+		req.Header.Set("Authorization", "Bearer "+cfg.AuthToken)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return requestResult{latency: time.Since(start), err: fmt.Errorf("do request: %w", err)}
+	}
+	// Drain and close body to allow connection reuse.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	return requestResult{
+		latency:    time.Since(start),
+		statusCode: resp.StatusCode,
+	}
+}
+
+// buildRequestBody constructs an OpenAI-compatible chat completion request.
+func buildRequestBody(cfg Config) string {
+	reqBody := map[string]interface{}{
+		"model": cfg.Model,
+		"messages": []map[string]string{
+			{"role": "user", "content": cfg.Prompt},
+		},
+		"max_tokens": 10,
+	}
+	b, err := json.Marshal(reqBody)
+	if err != nil {
+		// Fallback — should never happen with simple string maps.
+		return fmt.Sprintf(`{"model":"%s","messages":[{"role":"user","content":"%s"}],"max_tokens":10}`, cfg.Model, cfg.Prompt)
+	}
+	return string(b)
+}
+
+// percentile returns the value at the given percentile (0.0–1.0) from a
+// pre-sorted slice.
+func percentile(sorted []time.Duration, p float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(float64(len(sorted)-1) * p)
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}

--- a/test/loadtest/loadtest_test.go
+++ b/test/loadtest/loadtest_test.go
@@ -162,11 +162,46 @@ func TestLoadTestRateLimited(t *testing.T) {
 	}
 
 	// With 50 RPS cap over 2 seconds, expect roughly 100 requests (±margin).
+	targetRPS := 50
+	duration := 2 * time.Second
 	maxExpected := int64(150) // generous upper bound
 	if result.TotalRequests > maxExpected {
 		t.Errorf("rate limiter not effective: got %d requests, expected at most ~%d",
 			result.TotalRequests, maxExpected)
 	}
+	minExpected := int64(float64(targetRPS) * duration.Seconds() * 0.5) // at least 50% of target
+	if result.TotalRequests < minExpected {
+		t.Errorf("expected at least %d requests at %d RPS, got %d", minExpected, targetRPS, result.TotalRequests)
+	}
 	t.Logf("Rate-limited results: %d requests, %.1f RPS (target: 50)",
+		result.TotalRequests, result.RequestsPerSec)
+}
+
+func TestLoadTestUnlimitedRPS(t *testing.T) {
+	// Verify that RPS=0 means unlimited (no ticker panic).
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	result, err := Run(ctx, Config{
+		TargetURL:   server.URL,
+		Concurrency: 2,
+		Duration:    500 * time.Millisecond,
+		Provider:    "test",
+		Model:       "test",
+		Prompt:      "Hi",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TotalRequests == 0 {
+		t.Error("expected requests with unlimited RPS")
+	}
+	t.Logf("Unlimited RPS results: %d requests, %.1f RPS",
 		result.TotalRequests, result.RequestsPerSec)
 }

--- a/test/loadtest/loadtest_test.go
+++ b/test/loadtest/loadtest_test.go
@@ -1,0 +1,172 @@
+package loadtest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestLoadTestBasic(t *testing.T) {
+	// Create a mock server that simulates an LLM API.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate some latency.
+		time.Sleep(5 * time.Millisecond)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{{
+				"message": map[string]string{
+					"role":    "assistant",
+					"content": "Hello!",
+				},
+			}},
+			"usage": map[string]int{
+				"prompt_tokens":     10,
+				"completion_tokens": 5,
+			},
+		})
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := Run(ctx, Config{
+		TargetURL:   server.URL,
+		Concurrency: 5,
+		Duration:    2 * time.Second,
+		Provider:    "test",
+		Model:       "test-model",
+		Prompt:      "Hello",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.TotalRequests == 0 {
+		t.Error("expected some requests")
+	}
+	// A small number of context-deadline errors is expected at the tail end
+	// of the run when the duration timer fires and cancels in-flight requests.
+	// Allow up to 1% error rate.
+	maxAllowedErrors := result.TotalRequests / 100
+	if maxAllowedErrors < 5 {
+		maxAllowedErrors = 5
+	}
+	if result.ErrorCount > maxAllowedErrors {
+		t.Errorf("too many errors (%d/%d): %v", result.ErrorCount, result.TotalRequests, result.Errors)
+	}
+	if result.AvgLatency == 0 {
+		t.Error("expected non-zero avg latency")
+	}
+	if result.RequestsPerSec == 0 {
+		t.Error("expected non-zero RPS")
+	}
+	t.Logf("Results: %d requests, %.1f RPS, avg=%v, p50=%v, p95=%v, p99=%v",
+		result.TotalRequests, result.RequestsPerSec,
+		result.AvgLatency, result.P50Latency, result.P95Latency, result.P99Latency)
+}
+
+func TestLoadTestWithErrors(t *testing.T) {
+	var requestCount atomic.Int64
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := requestCount.Add(1)
+		if count%3 == 0 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"choices": []interface{}{}})
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	result, err := Run(ctx, Config{
+		TargetURL:   server.URL,
+		Concurrency: 3,
+		Duration:    1 * time.Second,
+		Provider:    "test",
+		Model:       "test-model",
+		Prompt:      "Hello",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ErrorCount == 0 {
+		t.Error("expected some errors")
+	}
+	t.Logf("Results: %d total, %d success, %d errors",
+		result.TotalRequests, result.SuccessCount, result.ErrorCount)
+	t.Logf("Error breakdown: %v", result.Errors)
+}
+
+func TestLoadTestCancellation(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	result, err := Run(ctx, Config{
+		TargetURL:   server.URL,
+		Concurrency: 10,
+		Duration:    30 * time.Second, // much longer than context
+		Provider:    "test",
+		Model:       "test-model",
+		Prompt:      "Hello",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should have stopped early due to context cancellation.
+	if result.TotalDuration > 2*time.Second {
+		t.Errorf("expected early termination, ran for %v", result.TotalDuration)
+	}
+	t.Logf("Terminated after %v with %d requests", result.TotalDuration, result.TotalRequests)
+}
+
+func TestLoadTestRateLimited(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"choices": []interface{}{}})
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := Run(ctx, Config{
+		TargetURL:      server.URL,
+		Concurrency:    5,
+		Duration:       2 * time.Second,
+		RequestsPerSec: 50, // cap at 50 RPS
+		Provider:       "test",
+		Model:          "test-model",
+		Prompt:         "Hello",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// With 50 RPS cap over 2 seconds, expect roughly 100 requests (±margin).
+	maxExpected := int64(150) // generous upper bound
+	if result.TotalRequests > maxExpected {
+		t.Errorf("rate limiter not effective: got %d requests, expected at most ~%d",
+			result.TotalRequests, maxExpected)
+	}
+	t.Logf("Rate-limited results: %d requests, %.1f RPS (target: 50)",
+		result.TotalRequests, result.RequestsPerSec)
+}


### PR DESCRIPTION
## Overview
Load testing framework for the Candela proxy. Drives concurrent HTTP requests against a target endpoint and reports latency percentiles and error breakdowns.

## Files
- `test/loadtest/loadtest.go` — Reusable `Run()` function with `Config` / `Result` types
- `test/loadtest/loadtest_test.go` — 4 test cases (basic, errors, cancellation, rate limiting)
- `test/loadtest/cmd/main.go` — CLI runner for manual testing

## Usage
```bash
go run ./test/loadtest/cmd -url http://localhost:8080/proxy/openai/v1/chat/completions -c 10 -d 30s
```

## Features
- Concurrent workers with configurable RPS throttling
- Latency percentiles (p50/p95/p99/max)
- Error breakdown by HTTP status code
- Context-aware cancellation (Ctrl-C graceful stop)
- Connection pooling with keep-alive for realistic load patterns

## Test Results
All 4 tests pass with `-race`:
- `TestLoadTestBasic` — Validates request execution, latency collection, RPS calculation
- `TestLoadTestWithErrors` — Confirms error counting with simulated 429s
- `TestLoadTestCancellation` — Verifies early termination via context deadline
- `TestLoadTestRateLimited` — Validates RPS cap enforcement

Closes #332