### PR TITLE
docs: ADRs + documentation sync strategy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# Candela Documentation
+
+This directory contains **developer-facing documentation** for the Candela codebase.
+
+## Relationship to Docs Site
+
+The public-facing documentation lives in the [`candela-docs`](https://github.com/candelahq/candela-docs) repository and is published via Astro.
+
+**Strategy: Option C — separation of concerns.**
+
+- `candela/docs/` → **Internal developer docs**: architecture, operations, development guides, ADRs
+- `candela-docs/` → **User-facing docs**: getting started, API reference, deployment guides, pricing
+
+There is intentional overlap in some areas (e.g., deployment). The Astro site is the source of truth for user-facing content. This directory is the source of truth for internal/contributor content.
+
+## Contents
+
+| File | Description |
+|------|-------------|
+| `architecture.md` | System architecture overview |
+| `api-reference.md` | Internal API documentation |
+| `budgets.md` | Budget system design |
+| `cost-calculation.md` | Cost calculation internals |
+| `deployment.md` | Deployment procedures |
+| `development.md` | Development setup |
+| `env-vars.md` | Environment variables reference |
+| `nix-setup.md` | Nix development environment |
+| `operations.md` | Operational procedures |
+| `proxy.md` | Proxy architecture |
+| `security.md` | Security model |
+| `testing.md` | Testing guide |
+| `adr/` | Architecture Decision Records |

--- a/docs/adr/000-template.md
+++ b/docs/adr/000-template.md
@@ -1,0 +1,16 @@
+# ADR NNN: Title
+
+**Status:** Proposed
+**Date:** YYYY-MM-DD
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?

--- a/docs/adr/001-catalog-pick-one-backend.md
+++ b/docs/adr/001-catalog-pick-one-backend.md
@@ -1,0 +1,23 @@
+# ADR 001: Catalog Pick-One Backend
+
+**Status:** Accepted
+**Date:** 2024-06-14
+
+## Context
+
+The model catalog needs a persistent store. We considered:
+1. **Layered config** — stack multiple sources (config file + database + API)
+2. **Pick-one backend** — select exactly one backend via config
+
+Layered configs add complexity: conflict resolution, precedence rules, and debugging which layer "won".
+
+## Decision
+
+Use a **pick-one backend** pattern: `catalog.backend` selects exactly one of `config`, `firestore`, or `postgres` (future). The `ModelCatalogStore` interface ensures all backends are interchangeable.
+
+## Consequences
+
+- **Simpler debugging**: one source of truth, no precedence ambiguity
+- **Clean interface**: `List`, `Get`, `Update`, `Source()`, `Writable()` — each backend implements all or returns `ErrReadOnly`
+- **Migration path**: switch backends by changing one config field
+- **Limitation**: can't mix config-based models with database-managed ones in the same deployment

--- a/docs/adr/001-catalog-pick-one-backend.md
+++ b/docs/adr/001-catalog-pick-one-backend.md
@@ -19,5 +19,6 @@ Use a **pick-one backend** pattern: `catalog.backend` selects exactly one of `co
 
 - **Simpler debugging**: one source of truth, no precedence ambiguity
 - **Clean interface**: `List`, `Get`, `Update`, `Source()`, `Writable()` — each backend implements all or returns `ErrReadOnly`
+- **No `Delete` by design**: catalog entries are soft-disabled (via `Update`) rather than hard-deleted, preserving referential integrity for historical spans and audit trails
 - **Migration path**: switch backends by changing one config field
 - **Limitation**: can't mix config-based models with database-managed ones in the same deployment

--- a/docs/adr/002-point-in-time-pricing.md
+++ b/docs/adr/002-point-in-time-pricing.md
@@ -11,6 +11,8 @@ When model pricing changes, historical cost calculations become inaccurate. Audi
 
 Record `InputPricePerMillion` and `OutputPricePerMillion` on every span at the time of cost calculation. This creates a permanent audit trail.
 
+> **Note:** The `InputPricePerMillion` and `OutputPricePerMillion` proto fields were added to the span message in PR #356 and are already in production.
+
 ## Consequences
 
 - **Audit-safe**: each span is self-contained with the exact rates used

--- a/docs/adr/002-point-in-time-pricing.md
+++ b/docs/adr/002-point-in-time-pricing.md
@@ -1,0 +1,19 @@
+# ADR 002: Point-in-Time Pricing on Spans
+
+**Status:** Accepted
+**Date:** 2024-06-14
+
+## Context
+
+When model pricing changes, historical cost calculations become inaccurate. Auditors ask "what price was this request billed at?" and we couldn't answer.
+
+## Decision
+
+Record `InputPricePerMillion` and `OutputPricePerMillion` on every span at the time of cost calculation. This creates a permanent audit trail.
+
+## Consequences
+
+- **Audit-safe**: each span is self-contained with the exact rates used
+- **Historical accuracy**: price changes don't retroactively alter past costs
+- **Storage cost**: two extra float64 fields per span (~16 bytes)
+- **Dashboard flexibility**: can recalculate costs with different rates without re-querying the catalog

--- a/docs/adr/003-database-agnostic-interface.md
+++ b/docs/adr/003-database-agnostic-interface.md
@@ -1,0 +1,19 @@
+# ADR 003: Database-Agnostic Storage Interface
+
+**Status:** Accepted
+**Date:** 2024-06-14
+
+## Context
+
+The catalog store could use proto-generated types directly, coupling storage to the protobuf schema. This would make backend implementations depend on proto codegen.
+
+## Decision
+
+Use plain Go structs (`catalog.Entry`) in the storage layer. The ConnectRPC handler converts between proto and Go types at the boundary.
+
+## Consequences
+
+- **No proto dependency in `pkg/catalog/`**: backend implementations are pure Go
+- **Testability**: tests don't need proto codegen tooling
+- **Flexibility**: the Go struct can have fields not in the proto (e.g., internal metadata)
+- **Cost**: manual conversion code in the handler (small, ~20 lines)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,9 +6,9 @@ This directory contains Architecture Decision Records (ADRs) documenting signifi
 
 | # | Title | Status | Date |
 |---|-------|--------|------|
-| 001 | Catalog: pick-one backend | Accepted | 2024-06-14 |
-| 002 | Point-in-time pricing on spans | Accepted | 2024-06-14 |
-| 003 | Database-agnostic storage interface | Accepted | 2024-06-14 |
+| 001 | [Catalog: pick-one backend](001-catalog-pick-one-backend.md) | Accepted | 2024-06-14 |
+| 002 | [Point-in-time pricing on spans](002-point-in-time-pricing.md) | Accepted | 2024-06-14 |
+| 003 | [Database-agnostic storage interface](003-database-agnostic-interface.md) | Accepted | 2024-06-14 |
 
 ## Format
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,19 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) documenting significant technical decisions made in the Candela project.
+
+## ADR Index
+
+| # | Title | Status | Date |
+|---|-------|--------|------|
+| 001 | Catalog: pick-one backend | Accepted | 2024-06-14 |
+| 002 | Point-in-time pricing on spans | Accepted | 2024-06-14 |
+| 003 | Database-agnostic storage interface | Accepted | 2024-06-14 |
+
+## Format
+
+We use the [Michael Nygard format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions):
+- **Status**: Proposed | Accepted | Deprecated | Superseded
+- **Context**: The issue motivating this decision
+- **Decision**: What we decided to do
+- **Consequences**: What became easier or harder


### PR DESCRIPTION
## ADRs
- 001: Catalog pick-one backend
- 002: Point-in-time pricing on spans
- 003: Database-agnostic storage interface

## Doc Sync
Option C: `candela/docs/` = internal/developer, `candela-docs/` = user-facing.

Closes #337, #336