### PR TITLE
feat: add candela restart command

### DIFF
--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -294,6 +294,66 @@ func cmdStop() {
 	fmt.Printf("🛑 candela stopped (PID %d)\n", pid)
 }
 
+// stopProcess reads the PID file at pidPath, sends SIGTERM to the process,
+// waits for it to exit, and cleans up the PID file. If the process does not
+// exit within 5 seconds, it sends SIGKILL. Returns nil if the process was
+// stopped (or was not running). Returns an error only if a running process
+// could not be stopped.
+func stopProcess(pidPath string) error {
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		// No PID file — nothing to stop.
+		return nil
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		// Invalid PID file — clean up and move on.
+		_ = os.Remove(pidPath)
+		return nil
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil || proc.Signal(syscall.Signal(0)) != nil {
+		// Process not running — clean up stale PID file.
+		_ = os.Remove(pidPath)
+		return nil
+	}
+
+	// Process is alive — send SIGTERM for graceful shutdown.
+	fmt.Printf("⏹  Stopping process %d...\n", pid)
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("failed to send SIGTERM to PID %d: %w", pid, err)
+	}
+
+	// Wait for process to fully exit (up to 5 seconds).
+	exited := false
+	for i := 0; i < 50; i++ {
+		time.Sleep(100 * time.Millisecond)
+		if err := proc.Signal(syscall.Signal(0)); err != nil {
+			exited = true
+			break
+		}
+	}
+	if !exited {
+		// Force kill if graceful shutdown timed out.
+		fmt.Println("⚠  Graceful shutdown timed out, force killing...")
+		_ = proc.Signal(syscall.SIGKILL)
+		// Wait for SIGKILL to take effect (up to 3 seconds).
+		for i := 0; i < 30; i++ {
+			time.Sleep(100 * time.Millisecond)
+			if err := proc.Signal(syscall.Signal(0)); err != nil {
+				break
+			}
+		}
+	}
+
+	// Clean up PID file.
+	_ = os.Remove(pidPath)
+	fmt.Printf("🛑 Stopped (PID %d)\n", pid)
+	return nil
+}
+
 // cmdRestart gracefully stops the running proxy (if any) and starts it again.
 // If the proxy is not running, it simply starts it.
 func cmdRestart() {
@@ -305,31 +365,9 @@ func cmdRestart() {
 
 	fmt.Println("🔄 Restarting Candela...")
 
-	// Check if proxy is currently running.
-	data, err := os.ReadFile(pidPath)
-	if err == nil {
-		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-		if err == nil && pid > 0 {
-			process, err := os.FindProcess(pid)
-			if err == nil && process.Signal(syscall.Signal(0)) == nil {
-				// Process is alive — send SIGTERM.
-				fmt.Printf("⏹  Stopping process %d...\n", pid)
-				if err := process.Signal(syscall.SIGTERM); err != nil {
-					slog.Error("failed to stop candela", "pid", pid, "error", err)
-					os.Exit(1)
-				}
-				// Wait for process to exit (up to 5 seconds).
-				for i := 0; i < 50; i++ {
-					time.Sleep(100 * time.Millisecond)
-					if process.Signal(syscall.Signal(0)) != nil {
-						break
-					}
-				}
-				fmt.Printf("🛑 Stopped (PID %d)\n", pid)
-			}
-		}
-		// Remove stale/old PID file before starting.
-		_ = os.Remove(pidPath)
+	if err := stopProcess(pidPath); err != nil {
+		slog.Error("failed to stop candela", "error", err)
+		os.Exit(1)
 	}
 
 	fmt.Println("▶  Starting Candela...")

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -6,6 +6,7 @@
 //
 //	candela start                      # start proxy in background
 //	candela stop                       # stop the background proxy
+//	candela restart                    # restart the background proxy
 //	candela status                     # check if proxy is running
 //	candela run                        # run in foreground (debug)
 //	candela run --config ./my.yaml     # custom config
@@ -139,6 +140,8 @@ func main() {
 		cmdStart()
 	case "stop":
 		cmdStop()
+	case "restart":
+		cmdRestart()
 	case "status":
 		cmdStatus()
 	case "auth":
@@ -152,6 +155,7 @@ func main() {
 Usage:
   candela start          Start proxy in background
   candela stop           Stop the background proxy
+  candela restart        Restart the background proxy
   candela status         Show proxy status
   candela run [flags]    Run in foreground
   candela auth login --provider gcp   Login to GCP via browser
@@ -288,6 +292,48 @@ func cmdStop() {
 
 	_ = os.Remove(pidPath)
 	fmt.Printf("🛑 candela stopped (PID %d)\n", pid)
+}
+
+// cmdRestart gracefully stops the running proxy (if any) and starts it again.
+// If the proxy is not running, it simply starts it.
+func cmdRestart() {
+	pidPath := pidFilePath()
+	if pidPath == "" {
+		slog.Error("cannot determine home directory")
+		os.Exit(1)
+	}
+
+	fmt.Println("🔄 Restarting Candela...")
+
+	// Check if proxy is currently running.
+	data, err := os.ReadFile(pidPath)
+	if err == nil {
+		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err == nil && pid > 0 {
+			process, err := os.FindProcess(pid)
+			if err == nil && process.Signal(syscall.Signal(0)) == nil {
+				// Process is alive — send SIGTERM.
+				fmt.Printf("⏹  Stopping process %d...\n", pid)
+				if err := process.Signal(syscall.SIGTERM); err != nil {
+					slog.Error("failed to stop candela", "pid", pid, "error", err)
+					os.Exit(1)
+				}
+				// Wait for process to exit (up to 5 seconds).
+				for i := 0; i < 50; i++ {
+					time.Sleep(100 * time.Millisecond)
+					if process.Signal(syscall.Signal(0)) != nil {
+						break
+					}
+				}
+				fmt.Printf("🛑 Stopped (PID %d)\n", pid)
+			}
+		}
+		// Remove stale/old PID file before starting.
+		_ = os.Remove(pidPath)
+	}
+
+	fmt.Println("▶  Starting Candela...")
+	cmdStart()
 }
 
 // cmdStatus checks the PID file and health endpoint.

--- a/cmd/candela/main_test.go
+++ b/cmd/candela/main_test.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"syscall"
 	"testing"
 )
@@ -243,72 +243,135 @@ runtime_manage:
 	}
 }
 
-func TestCmdRestart_NotRunning_NoPIDFile(t *testing.T) {
-	// When there is no PID file, cmdRestart should proceed to start.
-	// We can't easily test the full start (it execs a binary), but we can
-	// verify that the restart path doesn't panic or error when no PID file exists.
-
+func TestStopProcess_NoPIDFile(t *testing.T) {
 	dir := t.TempDir()
 	pidPath := filepath.Join(dir, "candela.pid")
 
-	// Verify PID file does not exist.
-	if _, err := os.Stat(pidPath); err == nil {
-		t.Fatal("expected PID file to not exist before test")
-	}
-
-	// Simulate the restart logic for the "not running" path.
-	data, err := os.ReadFile(pidPath)
-	if err != nil {
-		// This is the expected path — no PID file means not running.
-		t.Logf("no PID file found (expected): %v", err)
-	} else {
-		t.Errorf("unexpected PID data: %s", string(data))
+	// No PID file → stopProcess should return nil (nothing to stop).
+	if err := stopProcess(pidPath); err != nil {
+		t.Fatalf("stopProcess returned error for missing PID file: %v", err)
 	}
 }
 
-func TestCmdRestart_StalePIDFile(t *testing.T) {
-	// When a stale PID file exists (process is dead), restart should
-	// clean it up and proceed to start.
-
+func TestStopProcess_InvalidPIDFile(t *testing.T) {
 	dir := t.TempDir()
 	pidPath := filepath.Join(dir, "candela.pid")
 
-	// Write a PID that definitely doesn't exist (use a very high PID).
-	// PID 99999999 is extremely unlikely to be a real process.
-	err := os.WriteFile(pidPath, []byte("99999999"), 0o644)
-	if err != nil {
+	if err := os.WriteFile(pidPath, []byte("not-a-number"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	// Read the PID file — simulating the restart logic.
-	data, readErr := os.ReadFile(pidPath)
-	if readErr != nil {
-		t.Fatal("expected PID file to be readable")
+	if err := stopProcess(pidPath); err != nil {
+		t.Fatalf("stopProcess returned error for invalid PID file: %v", err)
 	}
 
-	pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
-	if parseErr != nil {
-		t.Fatalf("expected valid PID, got parse error: %v", parseErr)
-	}
-	if pid != 99999999 {
-		t.Fatalf("expected PID 99999999, got %d", pid)
-	}
-
-	// The process should not be alive.
-	process, findErr := os.FindProcess(pid)
-	if findErr != nil {
-		t.Logf("FindProcess returned error (expected on some OS): %v", findErr)
-	} else {
-		// Signal(0) should fail for a non-existent process.
-		if process.Signal(syscall.Signal(0)) == nil {
-			t.Skip("PID 99999999 unexpectedly exists — skipping")
-		}
-	}
-
-	// Clean up stale PID file (as cmdRestart would).
-	_ = os.Remove(pidPath)
-
+	// PID file should be cleaned up.
 	if _, err := os.Stat(pidPath); err == nil {
-		t.Error("expected PID file to be removed after stale cleanup")
+		t.Error("expected invalid PID file to be removed")
+	}
+}
+
+func TestStopProcess_StalePID(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "candela.pid")
+
+	// PID 99999999 is extremely unlikely to be a real process.
+	if err := os.WriteFile(pidPath, []byte("99999999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the PID is indeed not running before proceeding.
+	proc, err := os.FindProcess(99999999)
+	if err == nil && proc.Signal(syscall.Signal(0)) == nil {
+		t.Skip("PID 99999999 unexpectedly exists — skipping")
+	}
+
+	if err := stopProcess(pidPath); err != nil {
+		t.Fatalf("stopProcess returned error for stale PID: %v", err)
+	}
+
+	// PID file should be cleaned up.
+	if _, err := os.Stat(pidPath); err == nil {
+		t.Error("expected stale PID file to be removed")
+	}
+}
+
+func TestStopProcess_LiveProcess(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "candela.pid")
+
+	// Start a subprocess that responds to SIGTERM.
+	// Use bash with trap so SIGTERM causes a clean exit.
+	cmd := exec.Command("bash", "-c", `trap 'exit 0' TERM; while true; do sleep 1; done`)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start process: %v", err)
+	}
+
+	pid := cmd.Process.Pid
+
+	// Reap the child in background so the zombie is cleaned up and
+	// Signal(0) correctly returns an error for a dead process.
+	waitDone := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(waitDone)
+	}()
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		<-waitDone
+	})
+
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(pid)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// stopProcess should SIGTERM it and wait for exit.
+	if err := stopProcess(pidPath); err != nil {
+		t.Fatalf("stopProcess returned error for live process: %v", err)
+	}
+
+	// Wait for the child to be reaped.
+	<-waitDone
+
+	// Process should be dead now.
+	proc, _ := os.FindProcess(pid)
+	if proc.Signal(syscall.Signal(0)) == nil {
+		t.Error("expected process to be dead after stopProcess")
+	}
+
+	// PID file should be cleaned up.
+	if _, err := os.Stat(pidPath); err == nil {
+		t.Error("expected PID file to be removed after stopping")
+	}
+}
+
+func TestStopProcess_VerifiesExitBeforeReturn(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "candela.pid")
+
+	// Start a short-lived process that will exit on its own before
+	// the SIGTERM wait loop completes, testing the "dies mid-wait" path.
+	cmd := exec.Command("sleep", "0.1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start process: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	// Reap in background.
+	go func() { _ = cmd.Wait() }()
+
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(pid)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// stopProcess should handle the process dying mid-wait gracefully.
+	if err := stopProcess(pidPath); err != nil {
+		t.Fatalf("stopProcess returned error: %v", err)
+	}
+
+	// PID file must be gone — this is the key invariant that prevents
+	// the race condition (cmdStart checks for existing PID files).
+	if _, err := os.Stat(pidPath); err == nil {
+		t.Error("PID file must be removed before stopProcess returns")
 	}
 }

--- a/cmd/candela/main_test.go
+++ b/cmd/candela/main_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -237,5 +240,75 @@ runtime_manage:
 	}
 	if cfg.RuntimeManage.Models[0] != "llama3.2:8b" {
 		t.Errorf("Models[0] = %q, want %q", cfg.RuntimeManage.Models[0], "llama3.2:8b")
+	}
+}
+
+func TestCmdRestart_NotRunning_NoPIDFile(t *testing.T) {
+	// When there is no PID file, cmdRestart should proceed to start.
+	// We can't easily test the full start (it execs a binary), but we can
+	// verify that the restart path doesn't panic or error when no PID file exists.
+
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "candela.pid")
+
+	// Verify PID file does not exist.
+	if _, err := os.Stat(pidPath); err == nil {
+		t.Fatal("expected PID file to not exist before test")
+	}
+
+	// Simulate the restart logic for the "not running" path.
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		// This is the expected path — no PID file means not running.
+		t.Logf("no PID file found (expected): %v", err)
+	} else {
+		t.Errorf("unexpected PID data: %s", string(data))
+	}
+}
+
+func TestCmdRestart_StalePIDFile(t *testing.T) {
+	// When a stale PID file exists (process is dead), restart should
+	// clean it up and proceed to start.
+
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "candela.pid")
+
+	// Write a PID that definitely doesn't exist (use a very high PID).
+	// PID 99999999 is extremely unlikely to be a real process.
+	err := os.WriteFile(pidPath, []byte("99999999"), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the PID file — simulating the restart logic.
+	data, readErr := os.ReadFile(pidPath)
+	if readErr != nil {
+		t.Fatal("expected PID file to be readable")
+	}
+
+	pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+	if parseErr != nil {
+		t.Fatalf("expected valid PID, got parse error: %v", parseErr)
+	}
+	if pid != 99999999 {
+		t.Fatalf("expected PID 99999999, got %d", pid)
+	}
+
+	// The process should not be alive.
+	process, findErr := os.FindProcess(pid)
+	if findErr != nil {
+		t.Logf("FindProcess returned error (expected on some OS): %v", findErr)
+	} else {
+		// Signal(0) should fail for a non-existent process.
+		if process.Signal(syscall.Signal(0)) == nil {
+			t.Skip("PID 99999999 unexpectedly exists — skipping")
+		}
+	}
+
+	// Clean up stale PID file (as cmdRestart would).
+	_ = os.Remove(pidPath)
+
+	if _, err := os.Stat(pidPath); err == nil {
+		t.Error("expected PID file to be removed after stale cleanup")
 	}
 }


### PR DESCRIPTION
## Problem
No way to restart after config changes without manual stop+start.

## Solution
`candela restart` — gracefully stops the running proxy (SIGTERM + wait up to 5s), then starts it with current config. If not running, just starts.

### What it does:
- 🔄 Checks if proxy is running via PID file
- ⏹ If running: sends SIGTERM, waits for exit (up to 5s timeout), cleans up PID file
- ▶ Starts proxy with current config (reuses `cmdStart`)
- Shows progress messages throughout

### Tests:
- `TestCmdRestart_NotRunning_NoPIDFile` — no PID file → proceeds to start
- `TestCmdRestart_StalePIDFile` — stale PID file → cleans up and proceeds

Closes #313