### PR TITLE
feat: configurable timezone for budget period reset

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -131,6 +131,9 @@ type Config struct {
 			TimeoutSec  int               `yaml:"timeout_sec"` // per-export timeout (default: 30)
 		} `yaml:"otlp"`
 	} `yaml:"sinks"`
+	Budget struct {
+		Timezone string `yaml:"timezone"` // IANA timezone for budget period reset (default: UTC)
+	} `yaml:"budget"`
 }
 
 // CatalogConfig holds model catalog configuration.
@@ -397,6 +400,18 @@ func main() {
 			slog.Error("failed to initialize Firestore", "error", err)
 			os.Exit(1)
 		}
+
+		// Apply budget timezone if configured (#136).
+		if cfg.Budget.Timezone != "" {
+			loc, err := time.LoadLocation(cfg.Budget.Timezone)
+			if err != nil {
+				slog.Error("invalid budget timezone", "timezone", cfg.Budget.Timezone, "error", err)
+				os.Exit(1)
+			}
+			fStore.SetBudgetLocation(loc)
+			slog.Info("budget timezone configured", "timezone", cfg.Budget.Timezone)
+		}
+
 		defer func() { _ = fStore.Close() }()
 		userStore = fStore
 

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	_ "go.uber.org/automaxprocs" // automatically sets GOMAXPROCS from container CPU quota
+	_ "time/tzdata"              // Embed timezone database for scratch/distroless containers
 
 	"cloud.google.com/go/firestore"
 	firebase "firebase.google.com/go/v4"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -164,3 +164,10 @@ sinks:
   #   timeout_sec: 30                   # Per-export timeout in seconds
   #   headers:                           # Optional auth headers
   #     Authorization: "Bearer <token>"
+
+# Budget period reset timezone (#136).
+# Controls when daily/monthly/weekly budgets roll over.
+# Uses IANA timezone names (e.g. "America/New_York", "Europe/London").
+# Default: UTC (backward compatible).
+# budget:
+#   timezone: "America/New_York"

--- a/pkg/storage/firestoredb/billing_criticals_test.go
+++ b/pkg/storage/firestoredb/billing_criticals_test.go
@@ -14,7 +14,7 @@ import (
 // ─── CRIT-14: period type propagates through the full converter chain ─────────
 
 func TestCurrentPeriodKey_UnknownFallsBackToDaily(t *testing.T) {
-	key := currentPeriodKey("quarterly", time.UTC) // unknown → daily fallback
+	key := currentPeriodKey("quarterly", time.UTC, time.Now()) // unknown → daily fallback
 	if len(key) != 10 {
 		t.Errorf("unknown type key = %q, want daily fallback YYYY-MM-DD (10 chars)", key)
 	}
@@ -23,13 +23,15 @@ func TestCurrentPeriodKey_UnknownFallsBackToDaily(t *testing.T) {
 func TestCurrentPeriodKey_DailyAndMonthlyAreDifferent(t *testing.T) {
 	// Regression for CRIT-14: if period_type is ignored, both return the same
 	// key and monthly budgets behave identically to daily budgets.
-	if currentPeriodKey("daily", time.UTC) == currentPeriodKey("monthly", time.UTC) {
+	now := time.Now()
+	if currentPeriodKey("daily", time.UTC, now) == currentPeriodKey("monthly", time.UTC, now) {
 		t.Error("daily key == monthly key — period_type is being ignored")
 	}
 }
 
 func TestCurrentPeriodKey_DailyAndWeeklyAreDifferent(t *testing.T) {
-	if currentPeriodKey("daily", time.UTC) == currentPeriodKey("weekly", time.UTC) {
+	now := time.Now()
+	if currentPeriodKey("daily", time.UTC, now) == currentPeriodKey("weekly", time.UTC, now) {
 		t.Error("daily key == weekly key — period_type is being ignored")
 	}
 }

--- a/pkg/storage/firestoredb/billing_criticals_test.go
+++ b/pkg/storage/firestoredb/billing_criticals_test.go
@@ -6,6 +6,7 @@ package firestoredb
 
 import (
 	"testing"
+	"time"
 
 	"github.com/candelahq/candela/pkg/storage"
 )
@@ -13,7 +14,7 @@ import (
 // ─── CRIT-14: period type propagates through the full converter chain ─────────
 
 func TestCurrentPeriodKey_UnknownFallsBackToDaily(t *testing.T) {
-	key := currentPeriodKey("quarterly") // unknown → daily fallback
+	key := currentPeriodKey("quarterly", time.UTC) // unknown → daily fallback
 	if len(key) != 10 {
 		t.Errorf("unknown type key = %q, want daily fallback YYYY-MM-DD (10 chars)", key)
 	}
@@ -22,13 +23,13 @@ func TestCurrentPeriodKey_UnknownFallsBackToDaily(t *testing.T) {
 func TestCurrentPeriodKey_DailyAndMonthlyAreDifferent(t *testing.T) {
 	// Regression for CRIT-14: if period_type is ignored, both return the same
 	// key and monthly budgets behave identically to daily budgets.
-	if currentPeriodKey("daily") == currentPeriodKey("monthly") {
+	if currentPeriodKey("daily", time.UTC) == currentPeriodKey("monthly", time.UTC) {
 		t.Error("daily key == monthly key — period_type is being ignored")
 	}
 }
 
 func TestCurrentPeriodKey_DailyAndWeeklyAreDifferent(t *testing.T) {
-	if currentPeriodKey("daily") == currentPeriodKey("weekly") {
+	if currentPeriodKey("daily", time.UTC) == currentPeriodKey("weekly", time.UTC) {
 		t.Error("daily key == weekly key — period_type is being ignored")
 	}
 }

--- a/pkg/storage/firestoredb/billing_integration_test.go
+++ b/pkg/storage/firestoredb/billing_integration_test.go
@@ -44,7 +44,7 @@ func TestDeductSpend_AutoRollover_CreatesNewPeriodDoc(t *testing.T) {
 	}
 
 	// Delete the current period spend doc to simulate a new day.
-	periodKey := currentPeriodKey("daily", time.UTC)
+	periodKey := currentPeriodKey("daily", time.UTC, time.Now())
 	_, _ = s.client.Collection(usersCol).Doc(uid).
 		Collection(budgetsCol).Doc(periodKey).Delete(ctx)
 
@@ -93,7 +93,7 @@ func TestGetBudget_FallsBackToConfigDoc_ZeroSpend(t *testing.T) {
 	}
 
 	// Delete the period doc to simulate a new day.
-	periodKey := currentPeriodKey("daily", time.UTC)
+	periodKey := currentPeriodKey("daily", time.UTC, time.Now())
 	_, _ = s.client.Collection(usersCol).Doc(uid).
 		Collection(budgetsCol).Doc(periodKey).Delete(ctx)
 

--- a/pkg/storage/firestoredb/billing_integration_test.go
+++ b/pkg/storage/firestoredb/billing_integration_test.go
@@ -44,7 +44,7 @@ func TestDeductSpend_AutoRollover_CreatesNewPeriodDoc(t *testing.T) {
 	}
 
 	// Delete the current period spend doc to simulate a new day.
-	periodKey := currentPeriodKey("daily")
+	periodKey := currentPeriodKey("daily", time.UTC)
 	_, _ = s.client.Collection(usersCol).Doc(uid).
 		Collection(budgetsCol).Doc(periodKey).Delete(ctx)
 
@@ -93,7 +93,7 @@ func TestGetBudget_FallsBackToConfigDoc_ZeroSpend(t *testing.T) {
 	}
 
 	// Delete the period doc to simulate a new day.
-	periodKey := currentPeriodKey("daily")
+	periodKey := currentPeriodKey("daily", time.UTC)
 	_, _ = s.client.Collection(usersCol).Doc(uid).
 		Collection(budgetsCol).Doc(periodKey).Delete(ctx)
 

--- a/pkg/storage/firestoredb/firestoredb.go
+++ b/pkg/storage/firestoredb/firestoredb.go
@@ -112,7 +112,8 @@ func sweepRateLimitCache() {
 
 // Store implements storage.UserStore using Firestore.
 type Store struct {
-	client *firestore.Client
+	client         *firestore.Client
+	budgetLocation *time.Location // timezone for budget period key computation (default: UTC)
 }
 
 // New creates a new Firestore-backed UserStore.
@@ -121,12 +122,21 @@ func New(ctx context.Context, projectID, databaseID string) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("firestoredb: creating client: %w", err)
 	}
-	return &Store{client: client}, nil
+	return &Store{client: client, budgetLocation: time.UTC}, nil
 }
 
 // NewWithClient creates a Store with an existing Firestore client (useful for tests).
 func NewWithClient(client *firestore.Client) *Store {
-	return &Store{client: client}
+	return &Store{client: client, budgetLocation: time.UTC}
+}
+
+// SetBudgetLocation sets the timezone used for budget period key computation.
+// If loc is nil, UTC is used.
+func (s *Store) SetBudgetLocation(loc *time.Location) {
+	if loc == nil {
+		loc = time.UTC
+	}
+	s.budgetLocation = loc
 }
 
 // Close releases Firestore resources.
@@ -577,7 +587,7 @@ const budgetConfigDocID = "config"
 
 func (s *Store) SetBudget(ctx context.Context, budget *storage.BudgetRecord) error {
 	if budget.PeriodKey == "" {
-		budget.PeriodKey = currentPeriodKey(budget.PeriodType)
+		budget.PeriodKey = currentPeriodKey(budget.PeriodType, s.budgetLocation)
 	}
 	userID := sanitizeID(budget.UserID)
 	userRef := s.client.Collection(usersCol).Doc(userID)
@@ -622,7 +632,7 @@ func (s *Store) GetBudget(ctx context.Context, userID string) (*storage.BudgetRe
 			periodType = pt
 		}
 	}
-	periodKey := currentPeriodKey(periodType)
+	periodKey := currentPeriodKey(periodType, s.budgetLocation)
 
 	ref := userRef.Collection(budgetsCol).Doc(periodKey)
 	snap, err := ref.Get(ctx)
@@ -695,7 +705,7 @@ func (s *Store) ResetSpend(ctx context.Context, userID string) error {
 			periodType = pt
 		}
 	}
-	periodKey := currentPeriodKey(periodType)
+	periodKey := currentPeriodKey(periodType, s.budgetLocation)
 
 	ref := userRef.Collection(budgetsCol).Doc(periodKey)
 	// #H: Use Set+Merge instead of Update so this is idempotent on a missing
@@ -950,7 +960,7 @@ func (s *Store) DeductSpend(ctx context.Context, userID string, costUSD float64,
 				periodType = pt
 			}
 		}
-		periodKey := currentPeriodKey(periodType)
+		periodKey := currentPeriodKey(periodType, s.budgetLocation)
 
 		// Read 3: Load budget period spend doc using the correct period key.
 		budgetRef := userRef.Collection(budgetsCol).Doc(periodKey)
@@ -1285,10 +1295,14 @@ func snapToAudit(snap *firestore.DocumentSnapshot) (*storage.AuditRecord, error)
 // currentPeriodKey returns the period key for the given period type.
 // Supported period types: "daily" (YYYY-MM-DD), "monthly" (YYYY-MM),
 // "weekly" (YYYY-WNN). Unknown types fall back to "daily".
+// If loc is nil, UTC is used.
 // #F: was `func currentPeriodKey(_ string)` — the argument was always
 // ignored, so monthly and weekly budgets always rolled over daily.
-func currentPeriodKey(periodType string) string {
-	now := time.Now().UTC()
+func currentPeriodKey(periodType string, loc *time.Location) string {
+	if loc == nil {
+		loc = time.UTC
+	}
+	now := time.Now().In(loc)
 	switch periodType {
 	case "monthly":
 		return now.Format("2006-01")

--- a/pkg/storage/firestoredb/firestoredb.go
+++ b/pkg/storage/firestoredb/firestoredb.go
@@ -587,7 +587,7 @@ const budgetConfigDocID = "config"
 
 func (s *Store) SetBudget(ctx context.Context, budget *storage.BudgetRecord) error {
 	if budget.PeriodKey == "" {
-		budget.PeriodKey = currentPeriodKey(budget.PeriodType, s.budgetLocation)
+		budget.PeriodKey = currentPeriodKey(budget.PeriodType, s.budgetLocation, time.Now())
 	}
 	userID := sanitizeID(budget.UserID)
 	userRef := s.client.Collection(usersCol).Doc(userID)
@@ -632,7 +632,7 @@ func (s *Store) GetBudget(ctx context.Context, userID string) (*storage.BudgetRe
 			periodType = pt
 		}
 	}
-	periodKey := currentPeriodKey(periodType, s.budgetLocation)
+	periodKey := currentPeriodKey(periodType, s.budgetLocation, time.Now())
 
 	ref := userRef.Collection(budgetsCol).Doc(periodKey)
 	snap, err := ref.Get(ctx)
@@ -705,7 +705,7 @@ func (s *Store) ResetSpend(ctx context.Context, userID string) error {
 			periodType = pt
 		}
 	}
-	periodKey := currentPeriodKey(periodType, s.budgetLocation)
+	periodKey := currentPeriodKey(periodType, s.budgetLocation, time.Now())
 
 	ref := userRef.Collection(budgetsCol).Doc(periodKey)
 	// #H: Use Set+Merge instead of Update so this is idempotent on a missing
@@ -960,7 +960,7 @@ func (s *Store) DeductSpend(ctx context.Context, userID string, costUSD float64,
 				periodType = pt
 			}
 		}
-		periodKey := currentPeriodKey(periodType, s.budgetLocation)
+		periodKey := currentPeriodKey(periodType, s.budgetLocation, time.Now())
 
 		// Read 3: Load budget period spend doc using the correct period key.
 		budgetRef := userRef.Collection(budgetsCol).Doc(periodKey)
@@ -1298,11 +1298,11 @@ func snapToAudit(snap *firestore.DocumentSnapshot) (*storage.AuditRecord, error)
 // If loc is nil, UTC is used.
 // #F: was `func currentPeriodKey(_ string)` — the argument was always
 // ignored, so monthly and weekly budgets always rolled over daily.
-func currentPeriodKey(periodType string, loc *time.Location) string {
+func currentPeriodKey(periodType string, loc *time.Location, now time.Time) string {
 	if loc == nil {
 		loc = time.UTC
 	}
-	now := time.Now().In(loc)
+	now = now.In(loc)
 	switch periodType {
 	case "monthly":
 		return now.Format("2006-01")

--- a/pkg/storage/firestoredb/firestoredb_test.go
+++ b/pkg/storage/firestoredb/firestoredb_test.go
@@ -523,13 +523,13 @@ func TestAuditLog(t *testing.T) {
 
 func TestCurrentPeriodKey(t *testing.T) {
 	// All budgets are daily — verify the format is YYYY-MM-DD.
-	daily := currentPeriodKey("daily")
+	daily := currentPeriodKey("daily", time.UTC)
 	if len(daily) != 10 { // "2026-04-21"
 		t.Errorf("daily key = %q, expected format like 2026-04-21", daily)
 	}
 
 	// Any input should return daily format.
-	also := currentPeriodKey("anything")
+	also := currentPeriodKey("anything", time.UTC)
 	if also != daily {
 		t.Errorf("expected same daily key for any input, got %q vs %q", also, daily)
 	}

--- a/pkg/storage/firestoredb/firestoredb_test.go
+++ b/pkg/storage/firestoredb/firestoredb_test.go
@@ -523,13 +523,14 @@ func TestAuditLog(t *testing.T) {
 
 func TestCurrentPeriodKey(t *testing.T) {
 	// All budgets are daily — verify the format is YYYY-MM-DD.
-	daily := currentPeriodKey("daily", time.UTC)
+	now := time.Now()
+	daily := currentPeriodKey("daily", time.UTC, now)
 	if len(daily) != 10 { // "2026-04-21"
 		t.Errorf("daily key = %q, expected format like 2026-04-21", daily)
 	}
 
 	// Any input should return daily format.
-	also := currentPeriodKey("anything", time.UTC)
+	also := currentPeriodKey("anything", time.UTC, now)
 	if also != daily {
 		t.Errorf("expected same daily key for any input, got %q vs %q", also, daily)
 	}

--- a/pkg/storage/firestoredb/hardening_r2_test.go
+++ b/pkg/storage/firestoredb/hardening_r2_test.go
@@ -18,7 +18,7 @@ import (
 
 // U13: currentPeriodKey("daily") returns YYYY-MM-DD.
 func TestCurrentPeriodKey_Daily(t *testing.T) {
-	got := currentPeriodKey("daily")
+	got := currentPeriodKey("daily", time.UTC)
 	want := time.Now().UTC().Format("2006-01-02")
 	if got != want {
 		t.Errorf("daily: got %q, want %q", got, want)
@@ -29,7 +29,7 @@ func TestCurrentPeriodKey_Daily(t *testing.T) {
 // Before fix #F the argument was ignored and "monthly" silently returned
 // YYYY-MM-DD — causing monthly budgets to reset every day.
 func TestCurrentPeriodKey_Monthly(t *testing.T) {
-	got := currentPeriodKey("monthly")
+	got := currentPeriodKey("monthly", time.UTC)
 	want := time.Now().UTC().Format("2006-01")
 	if got != want {
 		t.Errorf("monthly: got %q, want %q", got, want)
@@ -42,7 +42,7 @@ func TestCurrentPeriodKey_Monthly(t *testing.T) {
 
 // U15: currentPeriodKey("weekly") returns a week-number key (YYYY-WNN).
 func TestCurrentPeriodKey_Weekly(t *testing.T) {
-	got := currentPeriodKey("weekly")
+	got := currentPeriodKey("weekly", time.UTC)
 	yearStr := time.Now().UTC().Format("2006")
 	if !strings.HasPrefix(got, yearStr+"-W") {
 		t.Errorf("weekly key has unexpected format: %q (want prefix %q)", got, yearStr+"-W")
@@ -103,8 +103,8 @@ func TestSetBudget_MonthlyPeriod_CorrectDocKey(t *testing.T) {
 		t.Fatalf("SetBudget (monthly): %v", err)
 	}
 
-	monthlyKey := currentPeriodKey("monthly")
-	dailyKey := currentPeriodKey("daily")
+	monthlyKey := currentPeriodKey("monthly", time.UTC)
+	dailyKey := currentPeriodKey("daily", time.UTC)
 	if monthlyKey == dailyKey {
 		t.Skip("monthly and daily keys identical — skipping (first day of month)")
 	}
@@ -146,7 +146,7 @@ func TestResetSpend_IdempotentOnMissingPeriodDoc(t *testing.T) {
 	}
 
 	// Delete the period doc to simulate a fresh day (no spend doc yet).
-	periodKey := currentPeriodKey("daily")
+	periodKey := currentPeriodKey("daily", time.UTC)
 	_, _ = s.client.Collection(usersCol).Doc(sanitizeID(uid)).
 		Collection(budgetsCol).Doc(periodKey).Delete(ctx)
 

--- a/pkg/storage/firestoredb/hardening_r2_test.go
+++ b/pkg/storage/firestoredb/hardening_r2_test.go
@@ -18,7 +18,7 @@ import (
 
 // U13: currentPeriodKey("daily") returns YYYY-MM-DD.
 func TestCurrentPeriodKey_Daily(t *testing.T) {
-	got := currentPeriodKey("daily", time.UTC)
+	got := currentPeriodKey("daily", time.UTC, time.Now())
 	want := time.Now().UTC().Format("2006-01-02")
 	if got != want {
 		t.Errorf("daily: got %q, want %q", got, want)
@@ -29,7 +29,7 @@ func TestCurrentPeriodKey_Daily(t *testing.T) {
 // Before fix #F the argument was ignored and "monthly" silently returned
 // YYYY-MM-DD — causing monthly budgets to reset every day.
 func TestCurrentPeriodKey_Monthly(t *testing.T) {
-	got := currentPeriodKey("monthly", time.UTC)
+	got := currentPeriodKey("monthly", time.UTC, time.Now())
 	want := time.Now().UTC().Format("2006-01")
 	if got != want {
 		t.Errorf("monthly: got %q, want %q", got, want)
@@ -42,7 +42,7 @@ func TestCurrentPeriodKey_Monthly(t *testing.T) {
 
 // U15: currentPeriodKey("weekly") returns a week-number key (YYYY-WNN).
 func TestCurrentPeriodKey_Weekly(t *testing.T) {
-	got := currentPeriodKey("weekly", time.UTC)
+	got := currentPeriodKey("weekly", time.UTC, time.Now())
 	yearStr := time.Now().UTC().Format("2006")
 	if !strings.HasPrefix(got, yearStr+"-W") {
 		t.Errorf("weekly key has unexpected format: %q (want prefix %q)", got, yearStr+"-W")
@@ -103,8 +103,9 @@ func TestSetBudget_MonthlyPeriod_CorrectDocKey(t *testing.T) {
 		t.Fatalf("SetBudget (monthly): %v", err)
 	}
 
-	monthlyKey := currentPeriodKey("monthly", time.UTC)
-	dailyKey := currentPeriodKey("daily", time.UTC)
+	now := time.Now()
+	monthlyKey := currentPeriodKey("monthly", time.UTC, now)
+	dailyKey := currentPeriodKey("daily", time.UTC, now)
 	if monthlyKey == dailyKey {
 		t.Skip("monthly and daily keys identical — skipping (first day of month)")
 	}
@@ -146,7 +147,7 @@ func TestResetSpend_IdempotentOnMissingPeriodDoc(t *testing.T) {
 	}
 
 	// Delete the period doc to simulate a fresh day (no spend doc yet).
-	periodKey := currentPeriodKey("daily", time.UTC)
+	periodKey := currentPeriodKey("daily", time.UTC, time.Now())
 	_, _ = s.client.Collection(usersCol).Doc(sanitizeID(uid)).
 		Collection(budgetsCol).Doc(periodKey).Delete(ctx)
 

--- a/pkg/storage/firestoredb/timezone_test.go
+++ b/pkg/storage/firestoredb/timezone_test.go
@@ -1,0 +1,63 @@
+package firestoredb
+
+import (
+	"testing"
+	"time"
+)
+
+// ── Timezone-aware period key tests (#136) ───────────────────────────
+
+func TestCurrentPeriodKey_UTC(t *testing.T) {
+	key := currentPeriodKey("daily", time.UTC)
+	expected := time.Now().UTC().Format("2006-01-02")
+	if key != expected {
+		t.Errorf("got %q, want %q", key, expected)
+	}
+}
+
+func TestCurrentPeriodKey_CustomTimezone(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("failed to load timezone: %v", err)
+	}
+	key := currentPeriodKey("daily", loc)
+	expected := time.Now().In(loc).Format("2006-01-02")
+	if key != expected {
+		t.Errorf("got %q, want %q", key, expected)
+	}
+}
+
+func TestCurrentPeriodKey_MonthlyWithTimezone(t *testing.T) {
+	key := currentPeriodKey("monthly", time.UTC)
+	expected := time.Now().UTC().Format("2006-01")
+	if key != expected {
+		t.Errorf("got %q, want %q", key, expected)
+	}
+}
+
+func TestCurrentPeriodKey_NilLocationDefaultsToUTC(t *testing.T) {
+	key := currentPeriodKey("daily", nil)
+	expected := time.Now().UTC().Format("2006-01-02")
+	if key != expected {
+		t.Errorf("nil loc: got %q, want %q", key, expected)
+	}
+}
+
+func TestSetBudgetLocation(t *testing.T) {
+	s := &Store{budgetLocation: time.UTC}
+
+	loc, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("failed to load timezone: %v", err)
+	}
+	s.SetBudgetLocation(loc)
+	if s.budgetLocation != loc {
+		t.Errorf("budgetLocation = %v, want Asia/Tokyo", s.budgetLocation)
+	}
+
+	// nil resets to UTC.
+	s.SetBudgetLocation(nil)
+	if s.budgetLocation != time.UTC {
+		t.Errorf("budgetLocation after nil = %v, want UTC", s.budgetLocation)
+	}
+}

--- a/pkg/storage/firestoredb/timezone_test.go
+++ b/pkg/storage/firestoredb/timezone_test.go
@@ -7,9 +7,14 @@ import (
 
 // ── Timezone-aware period key tests (#136) ───────────────────────────
 
+// refTime is a fixed point in time used across all period key tests.
+// Using a fixed time eliminates midnight-boundary flakiness when the
+// date rolls over between currentPeriodKey and the expected value.
+var refTime = time.Date(2026, 6, 13, 14, 30, 0, 0, time.UTC)
+
 func TestCurrentPeriodKey_UTC(t *testing.T) {
-	key := currentPeriodKey("daily", time.UTC)
-	expected := time.Now().UTC().Format("2006-01-02")
+	key := currentPeriodKey("daily", time.UTC, refTime)
+	expected := "2026-06-13"
 	if key != expected {
 		t.Errorf("got %q, want %q", key, expected)
 	}
@@ -20,24 +25,40 @@ func TestCurrentPeriodKey_CustomTimezone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load timezone: %v", err)
 	}
-	key := currentPeriodKey("daily", loc)
-	expected := time.Now().In(loc).Format("2006-01-02")
+	key := currentPeriodKey("daily", loc, refTime)
+	// 14:30 UTC = 10:30 EDT, still June 13
+	expected := "2026-06-13"
+	if key != expected {
+		t.Errorf("got %q, want %q", key, expected)
+	}
+}
+
+func TestCurrentPeriodKey_CustomTimezone_DateShift(t *testing.T) {
+	// Use a time near midnight UTC so that a far-east timezone shifts to the next day.
+	nearMidnight := time.Date(2026, 6, 13, 23, 30, 0, 0, time.UTC)
+	loc, err := time.LoadLocation("Asia/Tokyo") // UTC+9
+	if err != nil {
+		t.Fatalf("failed to load timezone: %v", err)
+	}
+	key := currentPeriodKey("daily", loc, nearMidnight)
+	// 23:30 UTC = 08:30 JST next day
+	expected := "2026-06-14"
 	if key != expected {
 		t.Errorf("got %q, want %q", key, expected)
 	}
 }
 
 func TestCurrentPeriodKey_MonthlyWithTimezone(t *testing.T) {
-	key := currentPeriodKey("monthly", time.UTC)
-	expected := time.Now().UTC().Format("2006-01")
+	key := currentPeriodKey("monthly", time.UTC, refTime)
+	expected := "2026-06"
 	if key != expected {
 		t.Errorf("got %q, want %q", key, expected)
 	}
 }
 
 func TestCurrentPeriodKey_NilLocationDefaultsToUTC(t *testing.T) {
-	key := currentPeriodKey("daily", nil)
-	expected := time.Now().UTC().Format("2006-01-02")
+	key := currentPeriodKey("daily", nil, refTime)
+	expected := "2026-06-13"
 	if key != expected {
 		t.Errorf("nil loc: got %q, want %q", key, expected)
 	}


### PR DESCRIPTION
## Problem
Budgets reset at midnight UTC = mid-afternoon for US teams.

## Solution
Add `budget.timezone` config option (IANA timezone string, e.g. `"America/New_York"`).

- Default: UTC (backward compatible)
- Validates timezone on startup (fails fast on invalid value)
- Affects daily, monthly, and weekly period key computation
- `currentPeriodKey()` now accepts `*time.Location`
- `Store` struct holds `budgetLocation` field, set via `SetBudgetLocation()`

## Testing
- 5 new unit tests in `timezone_test.go`
- All existing `TestCurrentPeriodKey_*` tests updated and passing

Closes #136