### PR TITLE
feat: tenant cost leaderboard in dashboard

### DIFF
--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -1,14 +1,19 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { useDashboard } from "@/hooks/useDashboard";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { AreaChart } from "@/components/chart";
 import { TimeRangeSelector } from "@/components/TimeRangeSelector";
 import { ScopeToggle } from "@/components/ScopeToggle";
 import { useScope } from "@/components/UserScopeProvider";
 import { ErrorBanner } from "@/components/ErrorBanner";
 import { SkeletonCard } from "@/components/SkeletonCard";
+import { TenantLeaderboard } from "@/components/TenantLeaderboard";
 import { SpanStatus } from "@/gen/candela/types/trace_pb";
+
+type DashboardTab = "overview" | "tenants";
 
 // ──────────────────────────────────────────
 // Status helpers
@@ -25,6 +30,8 @@ const statusLabel = (s: number) => {
 
 export default function DashboardPage() {
   const { includeBudget } = useScope();
+  const { isAdmin } = useCurrentUser();
+  const [activeTab, setActiveTab] = useState<DashboardTab>("overview");
   const {
     summary,
     recentTraces,
@@ -42,17 +49,43 @@ export default function DashboardPage() {
   return (
     <>
       <header className="main-header">
-        <h1>Dashboard</h1>
+        <div>
+          <h1>Dashboard</h1>
+          {isAdmin && (
+            <div className="dashboard-tabs" style={{ display: "flex", gap: 0, marginTop: 8 }}>
+              <button
+                className={`dashboard-tab ${activeTab === "overview" ? "dashboard-tab--active" : ""}`}
+                onClick={() => setActiveTab("overview")}
+              >
+                Overview
+              </button>
+              <button
+                className={`dashboard-tab ${activeTab === "tenants" ? "dashboard-tab--active" : ""}`}
+                onClick={() => setActiveTab("tenants")}
+              >
+                🏢 Tenants
+              </button>
+            </div>
+          )}
+        </div>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
           <ScopeToggle />
-          <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
-          <button className="btn" onClick={refresh}>
-            🔄
-          </button>
+          {activeTab === "overview" && (
+            <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          )}
+          {activeTab === "overview" && (
+            <button className="btn" onClick={refresh}>
+              🔄
+            </button>
+          )}
         </div>
       </header>
 
       <div className="main-body">
+        {activeTab === "tenants" && isAdmin ? (
+          <TenantLeaderboard />
+        ) : (
+        <>
         {error && (
           <ErrorBanner title="Dashboard Error">
             {error}
@@ -259,7 +292,46 @@ export default function DashboardPage() {
             </table>
           )}
         </div>
+        </>
+        )}
       </div>
+
+      <style jsx>{`
+        .dashboard-tabs {
+          display: flex;
+          gap: 0;
+        }
+        .dashboard-tab {
+          padding: 6px 16px;
+          font-size: 13px;
+          font-weight: 500;
+          border: 1px solid var(--border);
+          background: transparent;
+          color: var(--text-muted);
+          cursor: pointer;
+          transition: all 0.15s ease;
+        }
+        .dashboard-tab:first-child {
+          border-radius: 6px 0 0 6px;
+        }
+        .dashboard-tab:last-child {
+          border-radius: 0 6px 6px 0;
+          border-left: none;
+        }
+        .dashboard-tab:hover {
+          background: var(--bg-tertiary);
+          color: var(--text-primary);
+        }
+        .dashboard-tab--active {
+          background: var(--accent);
+          color: var(--bg-primary);
+          border-color: var(--accent);
+        }
+        .dashboard-tab--active:hover {
+          background: var(--accent);
+          color: var(--bg-primary);
+        }
+      `}</style>
     </>
   );
 }

--- a/ui/src/components/TenantLeaderboard.tsx
+++ b/ui/src/components/TenantLeaderboard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { useTenantLeaderboard, type SortField } from "@/hooks/useTenantLeaderboard";
 import { TimeRangeSelector } from "@/components/TimeRangeSelector";
 import { ErrorBanner } from "@/components/ErrorBanner";
@@ -16,6 +17,7 @@ const COLUMNS: { label: string; field: SortField; style?: React.CSSProperties }[
 export function TenantLeaderboard() {
   const {
     tenants,
+    sortedTenants,
     loading,
     error,
     timeRange,
@@ -25,6 +27,15 @@ export function TenantLeaderboard() {
     setSort,
     refresh,
   } = useTenantLeaderboard();
+
+  // Pre-compute from unsorted data so these stay stable regardless of sort column
+  const { totalCost, topTenant } = useMemo(() => {
+    const total = tenants.reduce((sum, t) => sum + t.costUsd, 0);
+    const top = tenants.length > 0
+      ? tenants.reduce((best, t) => t.costUsd > best.costUsd ? t : best)
+      : null;
+    return { totalCost: total, topTenant: top };
+  }, [tenants]);
 
   const sortIndicator = (field: SortField) => {
     if (sortField !== field) return "";
@@ -37,7 +48,7 @@ export function TenantLeaderboard() {
         <div>
           <span className="table-title">Tenant Cost Leaderboard</span>
           <span style={{ marginLeft: 8, fontSize: 12, color: "var(--text-muted)" }}>
-            {tenants.length} tenant{tenants.length !== 1 ? "s" : ""}
+          {sortedTenants.length} tenant{sortedTenants.length !== 1 ? "s" : ""}
           </span>
         </div>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
@@ -59,9 +70,9 @@ export function TenantLeaderboard() {
         <div className="stats-grid animate-in" style={{ marginBottom: 20 }}>
           <div className="card">
             <div className="card-title">Top Tenant</div>
-            <div className="card-value">{tenants[0]?.tenantId ?? "—"}</div>
+            <div className="card-value">{topTenant?.tenantId ?? "—"}</div>
             <div className="card-subtitle">
-              {tenants[0] ? `$${tenants[0].costUsd.toFixed(2)} total` : "No data"}
+              {topTenant ? `$${topTenant.costUsd.toFixed(2)} total` : "No data"}
             </div>
           </div>
           <div className="card">
@@ -72,7 +83,7 @@ export function TenantLeaderboard() {
           <div className="card">
             <div className="card-title">Total Tenant Cost</div>
             <div className="card-value">
-              ${tenants.reduce((acc, t) => acc + t.costUsd, 0).toFixed(2)}
+              ${totalCost.toFixed(2)}
             </div>
             <div className="card-subtitle">Across all tenants</div>
           </div>
@@ -80,7 +91,7 @@ export function TenantLeaderboard() {
       )}
 
       <div className="table-container animate-in" style={{ animationDelay: "0.05s" }}>
-        {tenants.length === 0 && !loading ? (
+        {sortedTenants.length === 0 && !loading ? (
           <div className="empty-state">
             <div className="empty-state-icon">🏢</div>
             <div className="empty-state-title">No tenant data yet</div>
@@ -119,8 +130,7 @@ export function TenantLeaderboard() {
                   </tr>
                 ))
               ) : (
-                tenants.map((t) => {
-                  const totalCost = tenants.reduce((acc, x) => acc + x.costUsd, 0);
+                sortedTenants.map((t) => {
                   const percent = totalCost > 0 ? (t.costUsd / totalCost) * 100 : 0;
                   return (
                     <tr key={t.tenantId}>

--- a/ui/src/components/TenantLeaderboard.tsx
+++ b/ui/src/components/TenantLeaderboard.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useTenantLeaderboard, type SortField } from "@/hooks/useTenantLeaderboard";
+import { TimeRangeSelector } from "@/components/TimeRangeSelector";
+import { ErrorBanner } from "@/components/ErrorBanner";
+
+const COLUMNS: { label: string; field: SortField; style?: React.CSSProperties }[] = [
+  { label: "Tenant", field: "tenantId" },
+  { label: "Calls", field: "callCount" },
+  { label: "Tokens", field: "totalTokens" },
+  { label: "Cost (USD)", field: "costUsd" },
+  { label: "Top Model", field: "topModel" },
+  { label: "Avg Latency", field: "avgLatencyMs" },
+];
+
+export function TenantLeaderboard() {
+  const {
+    tenants,
+    loading,
+    error,
+    timeRange,
+    setTimeRange,
+    sortField,
+    sortAsc,
+    setSort,
+    refresh,
+  } = useTenantLeaderboard();
+
+  const sortIndicator = (field: SortField) => {
+    if (sortField !== field) return "";
+    return sortAsc ? " ↑" : " ↓";
+  };
+
+  return (
+    <>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+        <div>
+          <span className="table-title">Tenant Cost Leaderboard</span>
+          <span style={{ marginLeft: 8, fontSize: 12, color: "var(--text-muted)" }}>
+            {tenants.length} tenant{tenants.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          <button className="btn" onClick={refresh}>
+            🔄
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <ErrorBanner title="Tenant Leaderboard Error">
+          {error}
+        </ErrorBanner>
+      )}
+
+      {/* Summary cards */}
+      {tenants.length > 0 && (
+        <div className="stats-grid animate-in" style={{ marginBottom: 20 }}>
+          <div className="card">
+            <div className="card-title">Top Tenant</div>
+            <div className="card-value">{tenants[0]?.tenantId ?? "—"}</div>
+            <div className="card-subtitle">
+              {tenants[0] ? `$${tenants[0].costUsd.toFixed(2)} total` : "No data"}
+            </div>
+          </div>
+          <div className="card">
+            <div className="card-title">Active Tenants</div>
+            <div className="card-value">{tenants.length}</div>
+            <div className="card-subtitle">With activity in this period</div>
+          </div>
+          <div className="card">
+            <div className="card-title">Total Tenant Cost</div>
+            <div className="card-value">
+              ${tenants.reduce((acc, t) => acc + t.costUsd, 0).toFixed(2)}
+            </div>
+            <div className="card-subtitle">Across all tenants</div>
+          </div>
+        </div>
+      )}
+
+      <div className="table-container animate-in" style={{ animationDelay: "0.05s" }}>
+        {tenants.length === 0 && !loading ? (
+          <div className="empty-state">
+            <div className="empty-state-icon">🏢</div>
+            <div className="empty-state-title">No tenant data yet</div>
+            <div className="empty-state-desc">
+              When downstream tenants send requests with X-Candela-Tenant-Id headers
+              or W3C Baggage (candela.tenant_id), they will appear here ranked by cost.
+            </div>
+          </div>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                {COLUMNS.map((col) => (
+                  <th
+                    key={col.field}
+                    onClick={() => setSort(col.field)}
+                    style={{
+                      cursor: "pointer",
+                      userSelect: "none",
+                      ...col.style,
+                    }}
+                  >
+                    {col.label}{sortIndicator(col.field)}
+                  </th>
+                ))}
+                <th style={{ width: 120 }}>Cost Share</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                Array.from({ length: 5 }).map((_, i) => (
+                  <tr key={i}>
+                    <td colSpan={7} style={{ height: 48 }}>
+                      <div className="skeleton" style={{ height: 16, width: "100%" }} />
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                tenants.map((t) => {
+                  const totalCost = tenants.reduce((acc, x) => acc + x.costUsd, 0);
+                  const percent = totalCost > 0 ? (t.costUsd / totalCost) * 100 : 0;
+                  return (
+                    <tr key={t.tenantId}>
+                      <td className="mono" style={{ fontWeight: 600 }}>{t.tenantId}</td>
+                      <td>{t.callCount.toLocaleString()}</td>
+                      <td>{t.totalTokens >= 1000 ? `${(t.totalTokens / 1000).toFixed(1)}k` : t.totalTokens.toLocaleString()}</td>
+                      <td style={{ fontWeight: 600 }}>${t.costUsd.toFixed(4)}</td>
+                      <td>
+                        <span className="badge badge-success" style={{ fontSize: 10 }}>{t.topModel}</span>
+                      </td>
+                      <td>{t.avgLatencyMs.toFixed(0)}ms</td>
+                      <td>
+                        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                          <div style={{ flex: 1, height: 4, background: "var(--bg-tertiary)", borderRadius: 2 }}>
+                            <div style={{ height: "100%", width: `${Math.min(100, percent)}%`, background: "var(--accent)", borderRadius: 2 }} />
+                          </div>
+                          <span style={{ fontSize: 11, color: "var(--text-muted)", width: 30 }}>{percent.toFixed(0)}%</span>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <style jsx>{`
+        .skeleton {
+          background: linear-gradient(90deg, var(--bg-tertiary) 25%, var(--bg-elevated) 50%, var(--bg-tertiary) 75%);
+          background-size: 200% 100%;
+          animation: loading 1.5s infinite;
+        }
+        @keyframes loading {
+          0% { background-position: 200% 0; }
+          100% { background-position: -200% 0; }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/ui/src/hooks/useTenantLeaderboard.ts
+++ b/ui/src/hooks/useTenantLeaderboard.ts
@@ -1,0 +1,154 @@
+"use client";
+
+import { useCallback, useEffect, useReducer } from "react";
+import { API_BASE_URL } from "@/lib/constants";
+import { firebaseAuth } from "@/lib/firebase";
+import type { TimeRange } from "./useDashboard";
+
+export interface TenantUsageRow {
+  tenantId: string;
+  callCount: number;
+  totalTokens: number;
+  costUsd: number;
+  avgLatencyMs: number;
+  topModel: string;
+}
+
+export type SortField = "tenantId" | "callCount" | "totalTokens" | "costUsd" | "avgLatencyMs" | "topModel";
+
+type State = {
+  tenants: TenantUsageRow[];
+  loading: boolean;
+  error: string | null;
+  timeRange: TimeRange;
+  fetchCount: number;
+  sortField: SortField;
+  sortAsc: boolean;
+};
+
+type Action =
+  | { type: "fetch" }
+  | { type: "success"; tenants: TenantUsageRow[] }
+  | { type: "error"; message: string }
+  | { type: "refresh" }
+  | { type: "setTimeRange"; range: TimeRange }
+  | { type: "setSort"; field: SortField };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "fetch":
+      return { ...state, loading: true, error: null };
+    case "success":
+      return { ...state, loading: false, tenants: action.tenants };
+    case "error":
+      return { ...state, loading: false, error: action.message };
+    case "refresh":
+      return { ...state, fetchCount: state.fetchCount + 1 };
+    case "setTimeRange":
+      return { ...state, timeRange: action.range, fetchCount: state.fetchCount + 1 };
+    case "setSort":
+      return {
+        ...state,
+        sortField: action.field,
+        sortAsc: state.sortField === action.field ? !state.sortAsc : false,
+      };
+  }
+}
+
+export function useTenantLeaderboard() {
+  const [state, dispatch] = useReducer(reducer, {
+    tenants: [],
+    loading: true,
+    error: null,
+    timeRange: "7d",
+    fetchCount: 0,
+    sortField: "costUsd",
+    sortAsc: false,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    dispatch({ type: "fetch" });
+
+    (async () => {
+      try {
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+        };
+        const user = firebaseAuth?.currentUser;
+        if (user) {
+          const token = await user.getIdToken();
+          headers["Authorization"] = `Bearer ${token}`;
+        }
+
+        const res = await fetch(`${API_BASE_URL}/_local/api/leaderboard?limit=50`, {
+          headers,
+        });
+
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+        }
+
+        const data = await res.json();
+        if (cancelled) return;
+
+        const tenants: TenantUsageRow[] = (data.tenants ?? []).map(
+          (t: Record<string, unknown>) => ({
+            tenantId: (t.tenant_id as string) || "unknown",
+            callCount: Number(t.call_count ?? 0),
+            totalTokens: Number(t.total_tokens ?? 0),
+            costUsd: Number(t.cost_usd ?? 0),
+            avgLatencyMs: Number(t.avg_latency_ms ?? 0),
+            topModel: (t.top_model as string) || "—",
+          })
+        );
+
+        dispatch({ type: "success", tenants });
+      } catch (err) {
+        if (!cancelled) {
+          dispatch({
+            type: "error",
+            message: err instanceof Error ? err.message : "Failed to load tenant leaderboard",
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [state.fetchCount, state.timeRange]);
+
+  // Client-side sorting
+  const sorted = [...state.tenants].sort((a, b) => {
+    const field = state.sortField;
+    const av = a[field];
+    const bv = b[field];
+    if (typeof av === "string" && typeof bv === "string") {
+      return state.sortAsc ? av.localeCompare(bv) : bv.localeCompare(av);
+    }
+    return state.sortAsc ? (av as number) - (bv as number) : (bv as number) - (av as number);
+  });
+
+  const refresh = useCallback(() => dispatch({ type: "refresh" }), []);
+  const setTimeRange = useCallback(
+    (range: TimeRange) => dispatch({ type: "setTimeRange", range }),
+    []
+  );
+  const setSort = useCallback(
+    (field: SortField) => dispatch({ type: "setSort", field }),
+    []
+  );
+
+  return {
+    tenants: sorted,
+    loading: state.loading,
+    error: state.error,
+    timeRange: state.timeRange,
+    setTimeRange,
+    sortField: state.sortField,
+    sortAsc: state.sortAsc,
+    setSort,
+    refresh,
+  };
+}

--- a/ui/src/hooks/useTenantLeaderboard.ts
+++ b/ui/src/hooks/useTenantLeaderboard.ts
@@ -5,6 +5,14 @@ import { API_BASE_URL } from "@/lib/constants";
 import { firebaseAuth } from "@/lib/firebase";
 import type { TimeRange } from "./useDashboard";
 
+function timeRangeToMs(range: TimeRange): number {
+  switch (range) {
+    case "24h": return 24 * 60 * 60 * 1000;
+    case "7d": return 7 * 24 * 60 * 60 * 1000;
+    case "30d": return 30 * 24 * 60 * 60 * 1000;
+  }
+}
+
 export interface TenantUsageRow {
   tenantId: string;
   callCount: number;
@@ -81,9 +89,14 @@ export function useTenantLeaderboard() {
           headers["Authorization"] = `Bearer ${token}`;
         }
 
-        const res = await fetch(`${API_BASE_URL}/_local/api/leaderboard?limit=50`, {
-          headers,
-        });
+        const now = Date.now();
+        const start = new Date(now - timeRangeToMs(state.timeRange)).toISOString();
+        const end = new Date(now).toISOString();
+
+        const res = await fetch(
+          `${API_BASE_URL}/_local/api/leaderboard?limit=50&startTime=${encodeURIComponent(start)}&endTime=${encodeURIComponent(end)}`,
+          { headers },
+        );
 
         if (!res.ok) {
           throw new Error(`HTTP ${res.status}: ${res.statusText}`);
@@ -141,7 +154,8 @@ export function useTenantLeaderboard() {
   );
 
   return {
-    tenants: sorted,
+    tenants: state.tenants,
+    sortedTenants: sorted,
     loading: state.loading,
     error: state.error,
     timeRange: state.timeRange,


### PR DESCRIPTION
## Problem
No visibility into per-tenant spend in the web UI.

## Solution
Admin-only "Tenants" tab in dashboard with sortable leaderboard table showing:
- **Tenant ID** — from X-Candela-Tenant-Id header / W3C Baggage
- **Calls, Tokens, Cost (USD)** — aggregated per tenant
- **Top Model** — most-used model per tenant
- **Avg Latency** — mean latency per tenant
- **Cost Share** — visual bar showing % of total

### Details
- Tab only visible to admin users (`useCurrentUser().isAdmin`)
- Summary cards: top tenant, active tenant count, total cost
- Client-side column sorting (click headers to toggle)
- Own time range selector per tab
- Fetches from existing `/_local/api/leaderboard` REST endpoint (`GetTenantLeaderboard` storage method)
- Build passes (`pnpm build` clean)

### New files
- `ui/src/hooks/useTenantLeaderboard.ts` — data fetching hook
- `ui/src/components/TenantLeaderboard.tsx` — table component

### Modified
- `ui/src/app/page.tsx` — Overview/Tenants tab bar (admin-only)

Closes #155