### PR TITLE
test: useDashboard + useModels hook tests

### DIFF
--- a/ui/src/hooks/__tests__/useDashboard.test.ts
+++ b/ui/src/hooks/__tests__/useDashboard.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useDashboard } from '../useDashboard';
+
+// ---------------------------------------------------------------------------
+// Mock RPC clients — useDashboard imports dashboardClient + traceClient
+// from "@/lib/api".
+// ---------------------------------------------------------------------------
+
+const mockGetDashboardData = vi.fn();
+const mockListTraces = vi.fn();
+const mockGetJobLeaderboard = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  dashboardClient: {
+    getDashboardData: (...args: unknown[]) => mockGetDashboardData(...args),
+    getJobLeaderboard: (...args: unknown[]) => mockGetJobLeaderboard(...args),
+  },
+  traceClient: {
+    listTraces: (...args: unknown[]) => mockListTraces(...args),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal successful dashboard RPC response. */
+function dashboardResponse(overrides?: {
+  summary?: Record<string, unknown>;
+  models?: Array<Record<string, unknown>>;
+  budgetContext?: Record<string, unknown> | null;
+}) {
+  return {
+    summary: {
+      totalTraces: BigInt(42),
+      totalSpans: BigInt(100),
+      totalLlmCalls: BigInt(10),
+      totalInputTokens: BigInt(5000),
+      totalOutputTokens: BigInt(3000),
+      totalCostUsd: 1.5,
+      avgLatencyMs: 200,
+      errorRate: 0.02,
+      totalCacheReadTokens: BigInt(1000),
+      totalCacheCreationTokens: BigInt(500),
+      tracesOverTime: [],
+      costOverTime: [],
+      tokensOverTime: [],
+      ...(overrides?.summary ?? {}),
+    },
+    models: overrides?.models ?? [
+      {
+        model: 'gemini-2.5-pro',
+        provider: 'google',
+        callCount: BigInt(8),
+        inputTokens: BigInt(4000),
+        outputTokens: BigInt(2000),
+        costUsd: 1.2,
+        avgLatencyMs: 180,
+        cacheReadTokens: BigInt(800),
+        cacheCreationTokens: BigInt(400),
+      },
+    ],
+    budgetContext: overrides?.budgetContext !== undefined
+      ? overrides.budgetContext
+      : null,
+  };
+}
+
+function tracesResponse(traces?: Array<Record<string, unknown>>) {
+  return {
+    traces: traces ?? [
+      {
+        traceId: 'trace-1',
+        rootSpanName: 'my-span',
+        primaryModel: 'gemini-2.5-pro',
+        spanCount: 3,
+        totalTokens: BigInt(1000),
+        totalCostUsd: 0.5,
+        duration: { seconds: BigInt(1), nanos: 500_000_000 },
+        status: 0,
+        startTime: { seconds: BigInt(1718000000), nanos: 0 },
+      },
+    ],
+  };
+}
+
+function jobLeaderboardResponse(
+  jobs?: Array<Record<string, unknown>>,
+) {
+  return {
+    jobs: jobs ?? [],
+  };
+}
+
+/** Wire up all three mocks with valid defaults. */
+function mockAllSuccess(
+  dashOverrides?: Parameters<typeof dashboardResponse>[0],
+) {
+  mockGetDashboardData.mockResolvedValue(dashboardResponse(dashOverrides));
+  mockListTraces.mockResolvedValue(tracesResponse());
+  mockGetJobLeaderboard.mockResolvedValue(jobLeaderboardResponse());
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useDashboard', () => {
+  beforeEach(() => {
+    mockGetDashboardData.mockReset();
+    mockListTraces.mockReset();
+    mockGetJobLeaderboard.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── 1. Loading state on mount ────────────────────────────────────────
+
+  it('starts in loading state', () => {
+    // Never resolve — we just want to check initial state.
+    mockGetDashboardData.mockReturnValue(new Promise(() => {}));
+    mockListTraces.mockReturnValue(new Promise(() => {}));
+    mockGetJobLeaderboard.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useDashboard());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(result.current.models).toEqual([]);
+    expect(result.current.summary).toBeNull();
+  });
+
+  // ── 2. Success transition ────────────────────────────────────────────
+
+  it('fetches data and transitions to success', async () => {
+    mockAllSuccess();
+
+    const { result } = renderHook(() => useDashboard());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.models).toHaveLength(1);
+    expect(result.current.models[0].model).toBe('gemini-2.5-pro');
+    expect(result.current.models[0].callCount).toBe(8);
+    expect(result.current.summary).not.toBeNull();
+    expect(result.current.summary!.totalTraces).toBe(42);
+    expect(result.current.summary!.totalCostUsd).toBe(1.5);
+    expect(result.current.recentTraces).toHaveLength(1);
+    expect(result.current.recentTraces[0].traceId).toBe('trace-1');
+  });
+
+  // ── 3. Error state ──────────────────────────────────────────────────
+
+  it('sets error state on RPC failure', async () => {
+    mockGetDashboardData.mockRejectedValue(new Error('server exploded'));
+    mockListTraces.mockResolvedValue(tracesResponse());
+    mockGetJobLeaderboard.mockResolvedValue(jobLeaderboardResponse());
+
+    const { result } = renderHook(() => useDashboard());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('server exploded');
+  });
+
+  // ── 4. AbortController on unmount ───────────────────────────────────
+
+  it('aborts in-flight requests on unmount', async () => {
+    let capturedSignal: AbortSignal | null = null;
+    mockGetDashboardData.mockImplementation(
+      (_req: unknown, opts: { signal: AbortSignal }) => {
+        capturedSignal = opts?.signal ?? null;
+        return new Promise(() => {}); // Never resolves
+      },
+    );
+    mockListTraces.mockReturnValue(new Promise(() => {}));
+    mockGetJobLeaderboard.mockReturnValue(new Promise(() => {}));
+
+    const { unmount } = renderHook(() => useDashboard());
+    await waitFor(() => expect(mockGetDashboardData).toHaveBeenCalled());
+
+    unmount();
+
+    expect(capturedSignal).not.toBeNull();
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+
+  // ── 5. Time range change triggers refetch ───────────────────────────
+
+  it('refetches when time range changes', async () => {
+    mockAllSuccess();
+
+    const { result } = renderHook(() => useDashboard());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockGetDashboardData).toHaveBeenCalledTimes(1);
+
+    // Change time range — should trigger another fetch
+    act(() => {
+      result.current.setTimeRange('7d');
+    });
+
+    await waitFor(() => {
+      expect(mockGetDashboardData).toHaveBeenCalledTimes(2);
+    });
+
+    expect(result.current.timeRange).toBe('7d');
+  });
+
+  // ── 6. Nullish coalescing — partial response with null fields ───────
+
+  it('applies nullish coalescing defaults for partial response', async () => {
+    mockGetDashboardData.mockResolvedValue({
+      summary: {
+        // All fields null / undefined — should fall back to 0
+        totalTraces: null,
+        totalSpans: null,
+        totalLlmCalls: null,
+        totalInputTokens: null,
+        totalOutputTokens: null,
+        totalCostUsd: null,
+        avgLatencyMs: null,
+        errorRate: null,
+        totalCacheReadTokens: null,
+        totalCacheCreationTokens: null,
+        tracesOverTime: undefined,
+        costOverTime: undefined,
+        tokensOverTime: undefined,
+      },
+      models: [],
+      budgetContext: null,
+    });
+    mockListTraces.mockResolvedValue({ traces: [] });
+    mockGetJobLeaderboard.mockResolvedValue({ jobs: [] });
+
+    const { result } = renderHook(() => useDashboard());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const s = result.current.summary!;
+    expect(s.totalTraces).toBe(0);
+    expect(s.totalSpans).toBe(0);
+    expect(s.totalLlmCalls).toBe(0);
+    expect(s.totalInputTokens).toBe(0);
+    expect(s.totalOutputTokens).toBe(0);
+    expect(s.totalCostUsd).toBe(0);
+    expect(s.avgLatencyMs).toBe(0);
+    expect(s.errorRate).toBe(0);
+    expect(s.totalCacheReadTokens).toBe(0);
+    expect(s.totalCacheCreationTokens).toBe(0);
+    expect(s.tracesOverTime).toEqual([]);
+    expect(s.costOverTime).toEqual([]);
+    expect(s.tokensOverTime).toEqual([]);
+    expect(result.current.models).toEqual([]);
+  });
+});

--- a/ui/src/hooks/__tests__/useModels.test.ts
+++ b/ui/src/hooks/__tests__/useModels.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { ModelUsageRow } from '../useDashboard';
+import type { CacheEfficiency } from '@/lib/cacheUtils';
+
+// ---------------------------------------------------------------------------
+// Mock useDashboard — useModels consumes it internally.
+// ---------------------------------------------------------------------------
+
+const mockSetTimeRange = vi.fn();
+const mockRefresh = vi.fn();
+
+/** Default useDashboard return value — overridden per-test. */
+let dashboardReturn: {
+  models: ModelUsageRow[];
+  summary: null;
+  recentTraces: never[];
+  budgetContext: null;
+  loading: boolean;
+  error: string | null;
+  timeRange: '24h' | '7d' | '30d';
+  setTimeRange: typeof mockSetTimeRange;
+  refresh: typeof mockRefresh;
+};
+
+function resetDashboard(overrides?: Partial<typeof dashboardReturn>) {
+  dashboardReturn = {
+    models: [],
+    summary: null,
+    recentTraces: [],
+    budgetContext: null,
+    loading: false,
+    error: null,
+    timeRange: '24h',
+    setTimeRange: mockSetTimeRange,
+    refresh: mockRefresh,
+    ...overrides,
+  };
+}
+
+vi.mock('@/hooks/useDashboard', () => ({
+  useDashboard: vi.fn(() => dashboardReturn),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock useCatalog — useModels enriches rows with getPricing.
+// ---------------------------------------------------------------------------
+
+type PricingResult = { inputPerMillion: number; outputPerMillion: number } | null;
+let pricingMap: Map<string, PricingResult>;
+
+function resetCatalog(overrides?: {
+  loading?: boolean;
+  error?: string | null;
+  source?: string;
+}) {
+  pricingMap = new Map();
+  catalogReturn = {
+    getPricing: vi.fn((provider: string, model: string) => {
+      const key = `${provider.toLowerCase()}:${model.toLowerCase()}`;
+      return pricingMap.get(key) ?? null;
+    }),
+    loading: overrides?.loading ?? false,
+    error: overrides?.error ?? null,
+    source: overrides?.source ?? 'config',
+    models: [],
+    adminEditable: false,
+    refresh: vi.fn(),
+  };
+}
+
+let catalogReturn: {
+  getPricing: ReturnType<typeof vi.fn>;
+  loading: boolean;
+  error: string | null;
+  source: string;
+  models: unknown[];
+  adminEditable: boolean;
+  refresh: ReturnType<typeof vi.fn>;
+};
+
+vi.mock('@/hooks/useCatalog', () => ({
+  useCatalog: vi.fn(() => catalogReturn),
+}));
+
+// ---------------------------------------------------------------------------
+// Import useModels *after* vi.mock so mocks are in place.
+// ---------------------------------------------------------------------------
+
+import { useModels } from '../useModels';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function modelRow(overrides: Partial<ModelUsageRow> & { model: string; provider: string }): ModelUsageRow {
+  return {
+    callCount: 10,
+    inputTokens: 5000,
+    outputTokens: 3000,
+    costUsd: 1.0,
+    avgLatencyMs: 150,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useModels', () => {
+  beforeEach(() => {
+    resetDashboard();
+    resetCatalog();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── 1. Enriches models with pricing ─────────────────────────────────
+
+  it('enriches models with pricing from catalog', () => {
+    const models = [
+      modelRow({ model: 'gemini-2.5-pro', provider: 'google' }),
+    ];
+    resetDashboard({ models });
+    pricingMap.set('google:gemini-2.5-pro', {
+      inputPerMillion: 1.25,
+      outputPerMillion: 10,
+    });
+
+    const { result } = renderHook(() => useModels());
+
+    expect(result.current.models).toHaveLength(1);
+    expect(result.current.models[0].inputPricePerMillion).toBe(1.25);
+    expect(result.current.models[0].outputPricePerMillion).toBe(10);
+  });
+
+  // ── 2. Returns null pricing for unknown model ───────────────────────
+
+  it('returns null pricing for a model not in catalog', () => {
+    const models = [
+      modelRow({ model: 'mystery-model', provider: 'unknown-provider' }),
+    ];
+    resetDashboard({ models });
+    // pricingMap is empty — no catalog entry
+
+    const { result } = renderHook(() => useModels());
+
+    expect(result.current.models).toHaveLength(1);
+    expect(result.current.models[0].inputPricePerMillion).toBeNull();
+    expect(result.current.models[0].outputPricePerMillion).toBeNull();
+  });
+
+  // ── 3. Search filter ────────────────────────────────────────────────
+
+  it('filters models by search term', () => {
+    const models = [
+      modelRow({ model: 'gemini-2.5-pro', provider: 'google', costUsd: 2 }),
+      modelRow({ model: 'claude-sonnet-4', provider: 'anthropic', costUsd: 3 }),
+      modelRow({ model: 'gpt-4o', provider: 'openai', costUsd: 1 }),
+    ];
+    resetDashboard({ models });
+
+    const { result } = renderHook(() => useModels());
+    expect(result.current.models).toHaveLength(3);
+
+    act(() => {
+      result.current.setSearch('claude');
+    });
+
+    expect(result.current.models).toHaveLength(1);
+    expect(result.current.models[0].model).toBe('claude-sonnet-4');
+  });
+
+  // ── 4. Sort toggle ─────────────────────────────────────────────────
+
+  it('toggles sort order', () => {
+    const models = [
+      modelRow({ model: 'alpha', provider: 'google', costUsd: 1 }),
+      modelRow({ model: 'bravo', provider: 'google', costUsd: 3 }),
+      modelRow({ model: 'charlie', provider: 'google', costUsd: 2 }),
+    ];
+    resetDashboard({ models });
+
+    const { result } = renderHook(() => useModels());
+
+    // Default sort is costUsd desc
+    expect(result.current.sort).toEqual({ key: 'costUsd', desc: true });
+    expect(result.current.models[0].model).toBe('bravo');
+    expect(result.current.models[2].model).toBe('alpha');
+
+    // Toggle same key — should flip to asc
+    act(() => {
+      result.current.toggleSort('costUsd');
+    });
+
+    expect(result.current.sort).toEqual({ key: 'costUsd', desc: false });
+    expect(result.current.models[0].model).toBe('alpha');
+    expect(result.current.models[2].model).toBe('bravo');
+
+    // Toggle different key — should reset to desc
+    act(() => {
+      result.current.toggleSort('model');
+    });
+
+    expect(result.current.sort).toEqual({ key: 'model', desc: true });
+    expect(result.current.models[0].model).toBe('charlie');
+  });
+
+  // ── 5. Cache efficiency ─────────────────────────────────────────────
+
+  it('populates cacheEfficiency for model with cache tokens', () => {
+    const models = [
+      modelRow({
+        model: 'gemini-2.5-pro',
+        provider: 'google',
+        cacheReadTokens: 3000,
+        inputTokens: 5000,
+      }),
+    ];
+    resetDashboard({ models });
+
+    const { result } = renderHook(() => useModels());
+
+    const eff: CacheEfficiency | null = result.current.models[0].cacheEfficiency;
+    expect(eff).not.toBeNull();
+    expect(eff!.rate).toBeCloseTo(0.6);
+    expect(eff!.tier).toBe('excellent');
+  });
+
+  // ── 6. Combined loading state ───────────────────────────────────────
+
+  it('returns loading=true when dashboard is loading', () => {
+    resetDashboard({ loading: true });
+    resetCatalog({ loading: false });
+
+    const { result } = renderHook(() => useModels());
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('returns loading=true when catalog is loading', () => {
+    resetDashboard({ loading: false });
+    resetCatalog({ loading: true });
+
+    const { result } = renderHook(() => useModels());
+    expect(result.current.loading).toBe(true);
+  });
+
+  // ── 7. Combined error state ─────────────────────────────────────────
+
+  it('surfaces dashboard error preferentially', () => {
+    resetDashboard({ error: 'dashboard failure' });
+    resetCatalog({ error: 'catalog failure' });
+
+    const { result } = renderHook(() => useModels());
+    expect(result.current.error).toBe('dashboard failure');
+  });
+
+  it('surfaces catalog error when dashboard has none', () => {
+    resetDashboard({ error: null });
+    resetCatalog({ error: 'catalog failure' });
+
+    const { result } = renderHook(() => useModels());
+    expect(result.current.error).toBe('catalog failure');
+  });
+});

--- a/ui/src/hooks/__tests__/useModels.test.ts
+++ b/ui/src/hooks/__tests__/useModels.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import type { ModelUsageRow } from '../useDashboard';
+import type { ModelUsageRow, TimeRange, DashboardSummary, RecentTrace, BudgetContext } from '../useDashboard';
 import type { CacheEfficiency } from '@/lib/cacheUtils';
 
 // ---------------------------------------------------------------------------
@@ -13,12 +13,12 @@ const mockRefresh = vi.fn();
 /** Default useDashboard return value — overridden per-test. */
 let dashboardReturn: {
   models: ModelUsageRow[];
-  summary: null;
-  recentTraces: never[];
-  budgetContext: null;
+  summary: DashboardSummary | null;
+  recentTraces: RecentTrace[];
+  budgetContext: BudgetContext | null;
   loading: boolean;
   error: string | null;
-  timeRange: '24h' | '7d' | '30d';
+  timeRange: TimeRange;
   setTimeRange: typeof mockSetTimeRange;
   refresh: typeof mockRefresh;
 };
@@ -57,7 +57,7 @@ function resetCatalog(overrides?: {
   pricingMap = new Map();
   catalogReturn = {
     getPricing: vi.fn((provider: string, model: string) => {
-      const key = `${provider.toLowerCase()}:${model.toLowerCase()}`;
+      const key = `${provider.toLowerCase()}/${model.toLowerCase()}`;
       return pricingMap.get(key) ?? null;
     }),
     loading: overrides?.loading ?? false,
@@ -127,7 +127,7 @@ describe('useModels', () => {
       modelRow({ model: 'gemini-2.5-pro', provider: 'google' }),
     ];
     resetDashboard({ models });
-    pricingMap.set('google:gemini-2.5-pro', {
+    pricingMap.set('google/gemini-2.5-pro', {
       inputPerMillion: 1.25,
       outputPerMillion: 10,
     });


### PR DESCRIPTION
## Coverage
- useDashboard: 6 tests (loading, success, error, abort, time range refetch, nullish coalescing)
- useModels: 9 tests (pricing enrichment, unknown model, search filter, sort toggle, cache efficiency, combined loading x2, combined error x2)
- Total frontend tests: 38 (up from 23)