### PR TITLE
feat: model allowlist/blocklist policy gate

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -738,13 +738,17 @@ func main() {
 		}
 
 		if len(activeProviders) > 0 {
-			llmProxy = proxy.New(proxy.Config{
+			llmProxy, err = proxy.New(proxy.Config{
 				Providers:      activeProviders,
 				ProjectID:      cfg.Proxy.ProjectID,
 				MaxRequestCost: cfg.Proxy.MaxRequestCost,
 				DailyLimits:    cfg.Proxy.DailyLimits,
 				Policy:         cfg.Proxy.Policy,
 			}, proc, calc)
+			if err != nil {
+				slog.Error("invalid proxy configuration", "error", err)
+				os.Exit(1)
+			}
 
 			// Wire team-mode features if Firestore is available.
 			if userStore != nil {

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -87,6 +87,7 @@ type Config struct {
 		Providers      []string                 `yaml:"providers"`            // e.g. ["openai", "google", "anthropic", "anthropic-direct", "gemini-oai"]
 		MaxRequestCost float64                  `yaml:"max_request_cost_usd"` // Per-request cost cap (0 = disabled)
 		DailyLimits    []proxy.SpendLimitConfig `yaml:"daily_limits"`         // Per-model daily spend limits
+		Policy         *proxy.PolicyConfig      `yaml:"policy"`               // Model allowlist policy (#207)
 		VertexAI       struct {
 			ProjectID     string `yaml:"project_id"`     // GCP project for Vertex AI
 			Region        string `yaml:"region"`         // default region (e.g. "us-central1")
@@ -742,6 +743,7 @@ func main() {
 				ProjectID:      cfg.Proxy.ProjectID,
 				MaxRequestCost: cfg.Proxy.MaxRequestCost,
 				DailyLimits:    cfg.Proxy.DailyLimits,
+				Policy:         cfg.Proxy.Policy,
 			}, proc, calc)
 
 			// Wire team-mode features if Firestore is available.

--- a/cmd/candela-sidecar/main.go
+++ b/cmd/candela-sidecar/main.go
@@ -198,10 +198,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	llmProxy := proxy.New(proxy.Config{
+	llmProxy, err := proxy.New(proxy.Config{
 		Providers: activeProviders,
 		ProjectID: projectID,
 	}, proc, calc)
+	if err != nil {
+		slog.Error("invalid proxy configuration", "error", err)
+		os.Exit(1)
+	}
 
 	// ── HTTP server ──
 	mux := http.NewServeMux()

--- a/cmd/candela/lm_handler_test.go
+++ b/cmd/candela/lm_handler_test.go
@@ -539,12 +539,15 @@ func TestLMHandler_CloudChatRouting(t *testing.T) {
 
 	// Create a proxy.Proxy with the mock upstream.
 	calc := costcalc.New()
-	cp := proxy.New(proxy.Config{
+	cp, err := proxy.New(proxy.Config{
 		Providers: []proxy.Provider{
 			{Name: "gemini-oai", UpstreamURL: cloudUpstream.URL},
 		},
 		ProjectID: "local",
 	}, nil, calc)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	h := newLMHandler(nil, nil, nil, nil, cp, cloudModels, calc)
 	srv := httptest.NewServer(h)
@@ -919,10 +922,13 @@ func TestLMHandler_ModelAlias_CloudModel(t *testing.T) {
 		Provider: "gemini-oai", Model: "gemini-2.5-pro-preview-05-06",
 		InputPerMillion: 1.25, OutputPerMillion: 10.00,
 	})
-	cp := proxy.New(proxy.Config{
+	cp, err := proxy.New(proxy.Config{
 		Providers: []proxy.Provider{{Name: "gemini-oai", UpstreamURL: cloudUpstream.URL}},
 		ProjectID: "local",
 	}, nil, calc)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	h := newLMHandler(nil, nil, nil, nil, cp, cloudModels, calc)
 	srv := httptest.NewServer(h)

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -1237,12 +1237,16 @@ func buildCloudProxy(cfg Config, submitter *processor.SpanProcessor) (*proxy.Pro
 	}
 
 	calc := costcalc.New()
-	cloudProxy := proxy.New(proxy.Config{
+	cloudProxy, err := proxy.New(proxy.Config{
 		Providers:      providers,
 		ProjectID:      "local",
 		MaxRequestCost: cfg.MaxRequestCost,
 		DailyLimits:    cfg.DailyLimits,
 	}, submitter, calc)
+	if err != nil {
+		slog.Error("invalid proxy configuration", "error", err)
+		return nil, nil
+	}
 
 	var names []string
 	for _, p := range providers {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -91,6 +91,20 @@ proxy:
   # max_idle_conns_per_host: 50 # Idle connections per upstream host
   # max_conns_per_host: 100     # Hard cap per upstream host
 
+  # Model allowlist policy (#207) — restrict which models users can access.
+  # When configured, only models matching the allowlist are permitted.
+  # Requests to unlisted models get 403 Forbidden with an audit log entry.
+  # Supports glob patterns (e.g. "claude-sonnet-4-*" matches all dated variants).
+  # Omit or leave empty to allow all models (backward compatible).
+  # policy:
+  #   allowed_models:
+  #     - provider: openai
+  #       models: ["gpt-4o", "gpt-4o-mini"]
+  #     - provider: anthropic
+  #       models: ["claude-sonnet-4-*"]
+  #     - provider: gemini-oai
+  #       models: ["gemini-2.5-flash-*", "gemini-2.5-pro-*"]
+
 # Model catalog configuration.
 # Controls how the server discovers available models and their pricing.
 catalog:

--- a/pkg/proxy/anthropic_direct_test.go
+++ b/pkg/proxy/anthropic_direct_test.go
@@ -48,7 +48,7 @@ func TestAnthropicDirect_EndToEnd_Passthrough(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic-direct", UpstreamURL: upstream.URL}},
 		ProjectID: "test-project",
 	}, submitter, calc)
@@ -164,7 +164,7 @@ func TestAnthropicDirect_NoADCInjection(t *testing.T) {
 	calc := costcalc.New()
 
 	// No TokenSource — that's the point.
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic-direct", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -222,7 +222,7 @@ func TestAnthropicDirect_StreamingPassthrough(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic-direct", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -321,7 +321,7 @@ func TestAnthropicDirect_UserAttribution(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic-direct", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -506,7 +506,7 @@ func TestAnthropicDirect_CountTokens_NoSpan(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic-direct", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)

--- a/pkg/proxy/bedrock_integration_test.go
+++ b/pkg/proxy/bedrock_integration_test.go
@@ -80,7 +80,7 @@ func TestBedrockProxyIntegration(t *testing.T) {
 		Provider: "anthropic", Model: "anthropic.claude-3-5-sonnet-20241022-v2:0",
 		InputPerMillion: 3.00, OutputPerMillion: 15.00,
 	})
-	p := New(Config{
+	p, _ := New(Config{
 		ProjectID: "test",
 		Providers: []Provider{
 			{
@@ -176,7 +176,7 @@ func TestBedrockProxyIntegration_SignerError(t *testing.T) {
 		Provider: "anthropic", Model: "anthropic.claude-3-5-sonnet-20241022-v2:0",
 		InputPerMillion: 3.00, OutputPerMillion: 15.00,
 	})
-	p := New(Config{
+	p, _ := New(Config{
 		ProjectID: "test",
 		Providers: []Provider{
 			{
@@ -234,7 +234,7 @@ func TestBedrockProxyIntegration_StreamingPath(t *testing.T) {
 		Provider: "anthropic", Model: "anthropic.claude-3-5-sonnet-20241022-v2:0",
 		InputPerMillion: 3.00, OutputPerMillion: 15.00,
 	})
-	p := New(Config{
+	p, _ := New(Config{
 		ProjectID: "test",
 		Providers: []Provider{
 			{

--- a/pkg/proxy/billing_coverage_test.go
+++ b/pkg/proxy/billing_coverage_test.go
@@ -260,7 +260,7 @@ func TestProxy_CostCalculation_E2E(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -335,7 +335,7 @@ func TestProxy_ServiceAccountBypassesBudget(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -400,7 +400,7 @@ func TestProxy_PricingGate_PrefixMatch(t *testing.T) {
 			submitter := &mockSubmitter{}
 			calc := costcalc.New()
 
-			p := New(Config{
+			p, _ := New(Config{
 				Providers: []Provider{{Name: tt.provider, UpstreamURL: upstream.URL}},
 				ProjectID: "test",
 			}, submitter, calc)
@@ -444,7 +444,7 @@ func TestDeductBudget_SkipsZeroCostZeroTokens(t *testing.T) {
 		},
 	}
 	calc := costcalc.New()
-	p := New(Config{ProjectID: "test"}, &mockSubmitter{}, calc)
+	p, _ := New(Config{ProjectID: "test"}, &mockSubmitter{}, calc)
 	p.SetUserStore(store)
 
 	// Zero tokens + zero cost → should skip DeductSpend.
@@ -462,7 +462,7 @@ func TestDeductBudget_CallsForPositiveTokens(t *testing.T) {
 		},
 	}
 	calc := costcalc.New()
-	p := New(Config{ProjectID: "test"}, &mockSubmitter{}, calc)
+	p, _ := New(Config{ProjectID: "test"}, &mockSubmitter{}, calc)
 	p.SetUserStore(store)
 
 	// Positive tokens → should call DeductSpend.
@@ -480,7 +480,7 @@ func TestDeductBudget_SkipsServiceAccount(t *testing.T) {
 		},
 	}
 	calc := costcalc.New()
-	p := New(Config{ProjectID: "test"}, &mockSubmitter{}, calc)
+	p, _ := New(Config{ProjectID: "test"}, &mockSubmitter{}, calc)
 	p.SetUserStore(store)
 
 	p.deductBudget(context.Background(), Provider{Name: "anthropic"}, "claude-sonnet-4-20250514",
@@ -498,7 +498,7 @@ func TestDeductBudget_SkipsEmptyUserID(t *testing.T) {
 		},
 	}
 	calc := costcalc.New()
-	p := New(Config{ProjectID: "test"}, &mockSubmitter{}, calc)
+	p, _ := New(Config{ProjectID: "test"}, &mockSubmitter{}, calc)
 	p.SetUserStore(store)
 
 	p.deductBudget(context.Background(), Provider{Name: "anthropic"}, "claude-sonnet-4-20250514", "", 1000, 500)

--- a/pkg/proxy/billing_test.go
+++ b/pkg/proxy/billing_test.go
@@ -66,7 +66,7 @@ func TestPricingGate_BlocksUnknownCloudModel(t *testing.T) {
 	calc := costcalc.New()
 	// "anthropic" has default pricing, but "mystery-model" is not registered.
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -129,7 +129,7 @@ func TestPricingGate_AllowsLocalProvider(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "local", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -181,7 +181,7 @@ func TestBudgetFloor_ExhaustedUserBlocked(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -234,7 +234,7 @@ func TestProxy_PricingGate_KnownModelAllowed(t *testing.T) {
 	calc := costcalc.New()
 	// claude-sonnet-4-20250514 is in the default pricing table.
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -282,7 +282,7 @@ func TestProxy_BudgetFloor_ZeroBalance_Blocked(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)

--- a/pkg/proxy/budget_gate_test.go
+++ b/pkg/proxy/budget_gate_test.go
@@ -89,7 +89,7 @@ func TestBudgetGate_BlocksExhaustedBudget(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -152,7 +152,7 @@ func TestBudgetGate_AllowsWhenBudgetRemains(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -199,7 +199,7 @@ func TestBudgetGate_CheckErrorBlocksRequest(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -243,7 +243,7 @@ func TestBudgetGate_SkippedForServiceAccount(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)

--- a/pkg/proxy/compat_test.go
+++ b/pkg/proxy/compat_test.go
@@ -83,7 +83,7 @@ func TestCompatRoutes_GetModels(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: "http://unused"}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -147,7 +147,7 @@ func TestCompatRoutes_ChatCompletions_RoutesToProvider(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -215,7 +215,7 @@ func TestCompatRoutes_ChatCompletions_UnknownModel(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: "http://unused"}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -255,7 +255,7 @@ func TestCompatRoutes_ChatCompletions_MissingModel(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: "http://unused"}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -291,7 +291,7 @@ func TestCompatRoutes_ChatCompletions_InvalidJSON(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: "http://unused"}},
 		ProjectID: "test",
 	}, submitter, calc)

--- a/pkg/proxy/cors_test.go
+++ b/pkg/proxy/cors_test.go
@@ -38,7 +38,7 @@ func TestCORS_ModelsEndpointReturnsJSON(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: "http://localhost:1"}},
 		ProjectID: "test",
 	}, submitter, calc)

--- a/pkg/proxy/hardening_v5_integration_test.go
+++ b/pkg/proxy/hardening_v5_integration_test.go
@@ -29,7 +29,7 @@ func TestIntegration_BudgetGateBlocksViaCompatRoute(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test-budget-compat-v5",
 	}, submitter, calc)
@@ -94,7 +94,7 @@ func TestIntegration_StreamingResponseForwarding(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test-stream",
 	}, submitter, calc)
@@ -161,7 +161,7 @@ func TestIntegration_CircuitBreakerTrips(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test-cb-v5",
 	}, submitter, calc)
@@ -197,7 +197,7 @@ func TestIntegration_CircuitBreakerTrips(t *testing.T) {
 
 func TestIntegration_CompatModelsEndpoint(t *testing.T) {
 	calc := newCalcWithTestModels()
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: "http://localhost:1"}},
 		ProjectID: "test-models",
 	}, nil, calc)
@@ -246,7 +246,7 @@ func TestIntegration_ServiceAccountSkipsBudget(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test-sa-v5",
 	}, submitter, calc)
@@ -325,7 +325,7 @@ func TestIntegration_ProxyCallsTouchLastActive(t *testing.T) {
 		},
 	}
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test-touch-active",
 	}, submitter, calc)

--- a/pkg/proxy/hardening_v5_test.go
+++ b/pkg/proxy/hardening_v5_test.go
@@ -57,7 +57,7 @@ func TestUpstreamError_DoesNotLeakURL(t *testing.T) {
 	// C-2: Error response should not contain internal URLs.
 	// Set up a proxy with a provider that has an unreachable upstream.
 	calc := newTestCalc()
-	proxy := New(Config{
+	proxy, _ := New(Config{
 		Providers: []Provider{
 			{Name: "openai", UpstreamURL: "http://192.168.0.1:99999"},
 		},

--- a/pkg/proxy/observability_test.go
+++ b/pkg/proxy/observability_test.go
@@ -47,7 +47,7 @@ func TestSASpend_TracksAtomicCounter(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -114,7 +114,7 @@ func TestDroppedSpans_IncrementedWhenSemaphoreFull(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -186,7 +186,7 @@ func TestDeductBudget_EnqueuesToOutboxOnFailure(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -258,7 +258,7 @@ func TestDeductBudget_EnqueuesToOutboxOnFailure(t *testing.T) {
 func TestProxyMetrics_Accessors(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: "http://localhost"}},
 		ProjectID: "test",
 	}, submitter, calc)

--- a/pkg/proxy/policy.go
+++ b/pkg/proxy/policy.go
@@ -1,0 +1,55 @@
+package proxy
+
+import (
+	"path"
+	"strings"
+)
+
+// PolicyConfig defines model access rules.
+type PolicyConfig struct {
+	AllowedModels []ProviderModels `yaml:"allowed_models" json:"allowed_models"`
+}
+
+// ProviderModels defines allowed model patterns for a specific provider.
+type ProviderModels struct {
+	Provider string   `yaml:"provider" json:"provider"`
+	Models   []string `yaml:"models" json:"models"`
+}
+
+// ModelPolicy evaluates model access rules against an allowlist.
+// A nil ModelPolicy allows all models (no restrictions).
+type ModelPolicy struct {
+	rules map[string][]string // provider (lowercase) → model glob patterns
+}
+
+// NewModelPolicy creates a policy from config.
+// Returns nil if config is nil or has no rules (all models allowed).
+func NewModelPolicy(cfg *PolicyConfig) *ModelPolicy {
+	if cfg == nil || len(cfg.AllowedModels) == 0 {
+		return nil // no restrictions
+	}
+	p := &ModelPolicy{rules: make(map[string][]string)}
+	for _, pm := range cfg.AllowedModels {
+		p.rules[strings.ToLower(pm.Provider)] = pm.Models
+	}
+	return p
+}
+
+// IsAllowed checks if a model is permitted by the policy.
+// Returns true if no policy is set (nil receiver).
+// Uses path.Match for glob pattern support (e.g. "claude-sonnet-4-*").
+func (p *ModelPolicy) IsAllowed(provider, model string) bool {
+	if p == nil {
+		return true // no policy = all allowed
+	}
+	patterns, ok := p.rules[strings.ToLower(provider)]
+	if !ok {
+		return false // provider not in allowlist
+	}
+	for _, pattern := range patterns {
+		if matched, _ := path.Match(pattern, model); matched {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/proxy/policy.go
+++ b/pkg/proxy/policy.go
@@ -1,7 +1,7 @@
 package proxy
 
 import (
-	"path"
+	"fmt"
 	"strings"
 )
 
@@ -23,21 +23,25 @@ type ModelPolicy struct {
 }
 
 // NewModelPolicy creates a policy from config.
-// Returns nil if config is nil or has no rules (all models allowed).
-func NewModelPolicy(cfg *PolicyConfig) *ModelPolicy {
+// Returns (nil, nil) if config is nil or has no rules (all models allowed).
+// Returns an error if a provider has an empty models list.
+func NewModelPolicy(cfg *PolicyConfig) (*ModelPolicy, error) {
 	if cfg == nil || len(cfg.AllowedModels) == 0 {
-		return nil // no restrictions
+		return nil, nil // no restrictions
 	}
 	p := &ModelPolicy{rules: make(map[string][]string)}
 	for _, pm := range cfg.AllowedModels {
+		if len(pm.Models) == 0 {
+			return nil, fmt.Errorf("policy: provider %q has empty models list — use [\"*\"] to allow all", pm.Provider)
+		}
 		p.rules[strings.ToLower(pm.Provider)] = pm.Models
 	}
-	return p
+	return p, nil
 }
 
 // IsAllowed checks if a model is permitted by the policy.
 // Returns true if no policy is set (nil receiver).
-// Uses path.Match for glob pattern support (e.g. "claude-sonnet-4-*").
+// Uses matchGlob for glob pattern support (e.g. "claude-sonnet-4-*", "deepseek-ai/*").
 func (p *ModelPolicy) IsAllowed(provider, model string) bool {
 	if p == nil {
 		return true // no policy = all allowed
@@ -46,10 +50,36 @@ func (p *ModelPolicy) IsAllowed(provider, model string) bool {
 	if !ok {
 		return false // provider not in allowlist
 	}
+	model = strings.ToLower(model)
 	for _, pattern := range patterns {
-		if matched, _ := path.Match(pattern, model); matched {
+		if matchGlob(strings.ToLower(pattern), model) {
 			return true
 		}
 	}
 	return false
+}
+
+// matchGlob performs glob matching where * matches any characters including /.
+// This differs from path.Match which treats / as a separator.
+func matchGlob(pattern, name string) bool {
+	// Split pattern on * and check if name contains all parts in order.
+	parts := strings.Split(pattern, "*")
+	if len(parts) == 1 {
+		return pattern == name // no wildcards, exact match
+	}
+	// Check prefix.
+	if !strings.HasPrefix(name, parts[0]) {
+		return false
+	}
+	name = name[len(parts[0]):]
+	// Check middle parts.
+	for i := 1; i < len(parts)-1; i++ {
+		idx := strings.Index(name, parts[i])
+		if idx < 0 {
+			return false
+		}
+		name = name[idx+len(parts[i]):]
+	}
+	// Check suffix.
+	return strings.HasSuffix(name, parts[len(parts)-1])
 }

--- a/pkg/proxy/policy_test.go
+++ b/pkg/proxy/policy_test.go
@@ -1,0 +1,74 @@
+package proxy
+
+import "testing"
+
+func TestModelPolicy_NoPolicy(t *testing.T) {
+	p := NewModelPolicy(nil)
+	if !p.IsAllowed("openai", "gpt-4o") {
+		t.Error("nil policy should allow all")
+	}
+}
+
+func TestModelPolicy_AllowedModel(t *testing.T) {
+	p := NewModelPolicy(&PolicyConfig{
+		AllowedModels: []ProviderModels{{
+			Provider: "openai",
+			Models:   []string{"gpt-4o", "gpt-4o-mini"},
+		}},
+	})
+	if !p.IsAllowed("openai", "gpt-4o") {
+		t.Error("should be allowed")
+	}
+	if p.IsAllowed("openai", "gpt-3.5-turbo") {
+		t.Error("should be blocked")
+	}
+}
+
+func TestModelPolicy_GlobPattern(t *testing.T) {
+	p := NewModelPolicy(&PolicyConfig{
+		AllowedModels: []ProviderModels{{
+			Provider: "anthropic",
+			Models:   []string{"claude-sonnet-4-*"},
+		}},
+	})
+	if !p.IsAllowed("anthropic", "claude-sonnet-4-20250514") {
+		t.Error("glob should match")
+	}
+	if p.IsAllowed("anthropic", "claude-opus-4") {
+		t.Error("should not match")
+	}
+}
+
+func TestModelPolicy_UnknownProvider(t *testing.T) {
+	p := NewModelPolicy(&PolicyConfig{
+		AllowedModels: []ProviderModels{{
+			Provider: "openai",
+			Models:   []string{"*"},
+		}},
+	})
+	if p.IsAllowed("anthropic", "claude-sonnet-4") {
+		t.Error("unlisted provider should be blocked")
+	}
+}
+
+func TestModelPolicy_EmptyRules(t *testing.T) {
+	p := NewModelPolicy(&PolicyConfig{})
+	if !p.IsAllowed("openai", "gpt-4o") {
+		t.Error("empty rules should allow all")
+	}
+}
+
+func TestModelPolicy_CaseInsensitiveProvider(t *testing.T) {
+	p := NewModelPolicy(&PolicyConfig{
+		AllowedModels: []ProviderModels{{
+			Provider: "OpenAI",
+			Models:   []string{"gpt-4o"},
+		}},
+	})
+	if !p.IsAllowed("openai", "gpt-4o") {
+		t.Error("provider match should be case-insensitive")
+	}
+	if !p.IsAllowed("OPENAI", "gpt-4o") {
+		t.Error("provider match should be case-insensitive")
+	}
+}

--- a/pkg/proxy/policy_test.go
+++ b/pkg/proxy/policy_test.go
@@ -3,19 +3,25 @@ package proxy
 import "testing"
 
 func TestModelPolicy_NoPolicy(t *testing.T) {
-	p := NewModelPolicy(nil)
+	p, err := NewModelPolicy(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !p.IsAllowed("openai", "gpt-4o") {
 		t.Error("nil policy should allow all")
 	}
 }
 
 func TestModelPolicy_AllowedModel(t *testing.T) {
-	p := NewModelPolicy(&PolicyConfig{
+	p, err := NewModelPolicy(&PolicyConfig{
 		AllowedModels: []ProviderModels{{
 			Provider: "openai",
 			Models:   []string{"gpt-4o", "gpt-4o-mini"},
 		}},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !p.IsAllowed("openai", "gpt-4o") {
 		t.Error("should be allowed")
 	}
@@ -25,12 +31,15 @@ func TestModelPolicy_AllowedModel(t *testing.T) {
 }
 
 func TestModelPolicy_GlobPattern(t *testing.T) {
-	p := NewModelPolicy(&PolicyConfig{
+	p, err := NewModelPolicy(&PolicyConfig{
 		AllowedModels: []ProviderModels{{
 			Provider: "anthropic",
 			Models:   []string{"claude-sonnet-4-*"},
 		}},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !p.IsAllowed("anthropic", "claude-sonnet-4-20250514") {
 		t.Error("glob should match")
 	}
@@ -40,35 +49,109 @@ func TestModelPolicy_GlobPattern(t *testing.T) {
 }
 
 func TestModelPolicy_UnknownProvider(t *testing.T) {
-	p := NewModelPolicy(&PolicyConfig{
+	p, err := NewModelPolicy(&PolicyConfig{
 		AllowedModels: []ProviderModels{{
 			Provider: "openai",
 			Models:   []string{"*"},
 		}},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if p.IsAllowed("anthropic", "claude-sonnet-4") {
 		t.Error("unlisted provider should be blocked")
 	}
 }
 
 func TestModelPolicy_EmptyRules(t *testing.T) {
-	p := NewModelPolicy(&PolicyConfig{})
+	p, err := NewModelPolicy(&PolicyConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !p.IsAllowed("openai", "gpt-4o") {
 		t.Error("empty rules should allow all")
 	}
 }
 
 func TestModelPolicy_CaseInsensitiveProvider(t *testing.T) {
-	p := NewModelPolicy(&PolicyConfig{
+	p, err := NewModelPolicy(&PolicyConfig{
 		AllowedModels: []ProviderModels{{
 			Provider: "OpenAI",
 			Models:   []string{"gpt-4o"},
 		}},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !p.IsAllowed("openai", "gpt-4o") {
 		t.Error("provider match should be case-insensitive")
 	}
 	if !p.IsAllowed("OPENAI", "gpt-4o") {
 		t.Error("provider match should be case-insensitive")
+	}
+}
+
+func TestModelPolicy_SlashedModelID(t *testing.T) {
+	p, err := NewModelPolicy(&PolicyConfig{
+		AllowedModels: []ProviderModels{{
+			Provider: "huggingface",
+			Models:   []string{"deepseek-ai/*"},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.IsAllowed("huggingface", "deepseek-ai/deepseek-chat") {
+		t.Error("glob should match across slashes")
+	}
+}
+
+func TestModelPolicy_CaseInsensitive(t *testing.T) {
+	p, err := NewModelPolicy(&PolicyConfig{
+		AllowedModels: []ProviderModels{{
+			Provider: "OpenAI",
+			Models:   []string{"GPT-4o"},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.IsAllowed("openai", "gpt-4o") {
+		t.Error("should be case-insensitive")
+	}
+}
+
+func TestModelPolicy_EmptyModelsErrors(t *testing.T) {
+	_, err := NewModelPolicy(&PolicyConfig{
+		AllowedModels: []ProviderModels{{
+			Provider: "openai",
+			Models:   []string{},
+		}},
+	})
+	if err == nil {
+		t.Error("empty models list should error")
+	}
+}
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		pattern, name string
+		want          bool
+	}{
+		{"gpt-4o", "gpt-4o", true},
+		{"gpt-4o", "gpt-4o-mini", false},
+		{"claude-sonnet-4-*", "claude-sonnet-4-20250514", true},
+		{"claude-sonnet-4-*", "claude-opus-4", false},
+		{"deepseek-ai/*", "deepseek-ai/deepseek-chat", true},
+		{"*", "anything", true},
+		{"*", "org/model", true},
+		{"prefix-*-suffix", "prefix-middle-suffix", true},
+		{"prefix-*-suffix", "prefix-middle-other", false},
+	}
+	for _, tt := range tests {
+		got := matchGlob(tt.pattern, tt.name)
+		if got != tt.want {
+			t.Errorf("matchGlob(%q, %q) = %v, want %v", tt.pattern, tt.name, got, tt.want)
+		}
 	}
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -379,7 +379,7 @@ func newUpstreamHTTPClient(cfg Config) *http.Client {
 }
 
 // New creates a new LLM proxy.
-func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) *Proxy {
+func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) (*Proxy, error) {
 	providers := make(map[string]Provider)
 	breakers := make(map[string]*CircuitBreaker)
 	cbCfg := DefaultCircuitBreakerConfig()
@@ -408,9 +408,13 @@ func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) *Proxy 
 	}
 
 	// #207: Initialize model allowlist policy.
-	p.policy = NewModelPolicy(cfg.Policy)
+	policy, err := NewModelPolicy(cfg.Policy)
+	if err != nil {
+		return nil, fmt.Errorf("proxy: %w", err)
+	}
+	p.policy = policy
 
-	return p
+	return p, nil
 }
 
 // SetUserStore sets the optional UserStore for budget deduction.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -259,6 +259,9 @@ type Proxy struct {
 	config       Config        // retained for limit config access
 	spendTracker *SpendTracker // per-user per-model daily spend tracker (nil if no limits)
 
+	// #207: Model allowlist policy gate.
+	policy *ModelPolicy
+
 	// HIGH-2: Service account spend tracking (micro-USD for precision).
 	saSpendMicroUSD atomic.Int64
 
@@ -284,6 +287,7 @@ type Config struct {
 	ProjectID      string             `yaml:"project_id"`
 	MaxRequestCost float64            `yaml:"max_request_cost_usd"` // Per-request cost cap (0 = disabled)
 	DailyLimits    []SpendLimitConfig `yaml:"daily_limits"`         // Per-model daily spend limits
+	Policy         *PolicyConfig      `yaml:"policy"`               // Model allowlist policy (nil = all allowed)
 
 	// HTTP transport tuning for upstream LLM provider connections.
 	MaxIdleConns        int `yaml:"max_idle_conns"`          // default: 200
@@ -402,6 +406,9 @@ func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) *Proxy 
 	if len(cfg.DailyLimits) > 0 {
 		p.spendTracker = NewSpendTracker()
 	}
+
+	// #207: Initialize model allowlist policy.
+	p.policy = NewModelPolicy(cfg.Policy)
 
 	return p
 }
@@ -891,6 +898,25 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(errBody)
 		slog.Warn("blocked request: no pricing for model",
 			"user_id", effectiveUserID, "provider", providerName, "model", requestModel)
+		return
+	}
+
+	// ── Model allowlist policy gate (#207) ──
+	// Blocks models not in the configured allowlist. Runs after pricing gate
+	// and before budget checks. Empty/missing policy = all models allowed.
+	if requestModel != "" && !p.policy.IsAllowed(providerName, requestModel) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		errBody, _ := json.Marshal(map[string]any{
+			"error": map[string]any{
+				"message": "model not allowed by policy",
+				"type":    "forbidden",
+				"code":    403,
+			},
+		})
+		_, _ = w.Write(errBody)
+		slog.Warn("model blocked by policy",
+			"provider", providerName, "model", requestModel, "user", effectiveUserID)
 		return
 	}
 

--- a/pkg/proxy/proxy_error_test.go
+++ b/pkg/proxy/proxy_error_test.go
@@ -46,7 +46,7 @@ func TestADCTokenInjection(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{
 			Name:        "anthropic",
 			UpstreamURL: upstream.URL,
@@ -93,7 +93,7 @@ func TestADCTokenFailure(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{
 			Name:        "anthropic",
 			UpstreamURL: upstream.URL,
@@ -144,7 +144,7 @@ func TestUpstream429_SurfacedToClient(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -193,7 +193,7 @@ func TestUpstream500_SurfacedToClient(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -239,7 +239,7 @@ func TestUpstreamUnreachable_502(t *testing.T) {
 	calc := newCalcWithTestModels()
 
 	// Point to a guaranteed-closed port.
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: "http://127.0.0.1:1"}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -282,7 +282,7 @@ func TestUpstream500_TracksErrorInSpan(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -373,7 +373,7 @@ func TestStreamingSSE_EndToEnd_WithTranslation(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{
 			Name:             "anthropic",
 			UpstreamURL:      upstream.URL,
@@ -463,7 +463,7 @@ func TestStreamingSSE_Passthrough_NoTranslation(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)

--- a/pkg/proxy/proxy_integration_test.go
+++ b/pkg/proxy/proxy_integration_test.go
@@ -49,7 +49,7 @@ func TestProxy_EndToEnd_OpenAI(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test-project",
 	}, submitter, calc)
@@ -125,7 +125,7 @@ func TestProxy_EndToEnd_CompatBudgetExhausted(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test-budget-compat",
 	}, submitter, calc)
@@ -181,7 +181,7 @@ func TestProxy_EndToEnd_W3CTraceContext(t *testing.T) {
 
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test-trace",
 	}, submitter, calc)

--- a/pkg/proxy/proxy_security_test.go
+++ b/pkg/proxy/proxy_security_test.go
@@ -22,7 +22,7 @@ func TestCompatRoute_ModelNameInjection(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -78,7 +78,7 @@ func TestHandleProxy_MaxBytesError413(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -113,7 +113,7 @@ func TestHandleProxy_UnknownProviderSanitized(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: "http://localhost:1"}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -163,7 +163,7 @@ func TestRequestID_UsesTraceIDFormat(t *testing.T) {
 
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -196,7 +196,7 @@ func TestRequestID_UsesTraceIDFormat(t *testing.T) {
 func TestHandleProxy_EmptyPath(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: "http://localhost:1"}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -216,7 +216,7 @@ func TestHandleProxy_GETModelsRoute(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: "http://localhost:1"}},
 		ProjectID: "test",
 	}, submitter, calc)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -167,7 +167,7 @@ func TestProxyEndToEndAnthropic(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test-project",
 	}, submitter, calc)
@@ -272,7 +272,7 @@ func TestRequestID_GeneratedWhenAbsent(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -338,7 +338,7 @@ func TestRequestID_AcceptedWhenProvided(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -397,7 +397,7 @@ func TestCircuitBreaker_SkipsSpanOnOpen(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -457,7 +457,7 @@ func TestUserID_FromAuthContext(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -517,7 +517,7 @@ func TestUserID_XUserIdHeaderIgnored(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -575,7 +575,7 @@ func TestUserID_EmptyWithoutAuthContext(t *testing.T) {
 	submitter := &mockSubmitter{}
 	calc := costcalc.New()
 
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)

--- a/pkg/proxy/tenant_test.go
+++ b/pkg/proxy/tenant_test.go
@@ -179,7 +179,7 @@ func TestProxy_TenantID_HeaderPropagatedToSpan(t *testing.T) {
 	defer upstream.Close()
 
 	sub := &mockSubmitter{}
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "proj-test",
 	}, sub, newCalcWithTestModels())
@@ -226,7 +226,7 @@ func TestProxy_TenantID_BaggageWinsOverHeader(t *testing.T) {
 	defer upstream.Close()
 
 	sub := &mockSubmitter{}
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "proj-test",
 	}, sub, newCalcWithTestModels())
@@ -273,7 +273,7 @@ func TestProxy_TenantID_AbsentHeaderLeavesEmpty(t *testing.T) {
 	defer upstream.Close()
 
 	sub := &mockSubmitter{}
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "proj-test",
 	}, sub, newCalcWithTestModels())
@@ -319,7 +319,7 @@ func TestProxy_TenantID_InvalidHeaderRejected(t *testing.T) {
 	defer upstream.Close()
 
 	sub := &mockSubmitter{}
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "proj-test",
 	}, sub, newCalcWithTestModels())
@@ -367,7 +367,7 @@ func TestProxy_TenantID_MultiBaggageHeaders(t *testing.T) {
 	defer upstream.Close()
 
 	sub := &mockSubmitter{}
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "proj-test",
 	}, sub, newCalcWithTestModels())
@@ -412,7 +412,7 @@ func TestProxy_TenantID_Precedence(t *testing.T) {
 	defer upstream.Close()
 
 	sub := &mockSubmitter{}
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "proj-test",
 	}, sub, newCalcWithTestModels())
@@ -447,7 +447,7 @@ func TestProxy_TenantID_Streaming(t *testing.T) {
 	defer upstream.Close()
 
 	sub := &mockSubmitter{}
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "proj-test",
 	}, sub, newCalcWithTestModels())


### PR DESCRIPTION
## Problem
No way to restrict which models users can access through the proxy.

## Solution
New `policy.allowed_models` config section for model governance:
- Per-provider model allowlists with glob pattern support (e.g. `claude-sonnet-4-*`)
- 403 Forbidden with structured JSON error for blocked models
- Audit logging via `slog.Warn` for every blocked request
- Nil-safe design: empty/missing config = all models allowed (backward compatible)

## Changes
- `pkg/proxy/policy.go` — `ModelPolicy` engine with `NewModelPolicy()` and `IsAllowed()`
- `pkg/proxy/policy_test.go` — 6 tests (nil, exact, glob, unknown provider, empty, case-insensitive)
- `pkg/proxy/proxy.go` — Wire policy into `Config`, `Proxy` struct, `New()`, and `handleProxy`
- `cmd/candela-server/main.go` — Pass policy config through to proxy
- `config.example.yaml` — Documented example with commented config

## Config Example
```yaml
proxy:
  policy:
    allowed_models:
      - provider: openai
        models: ["gpt-4o", "gpt-4o-mini"]
      - provider: anthropic
        models: ["claude-sonnet-4-*"]
```

Closes #207