### PR TITLE
refactor: extract pricing to pricing.yaml

### DIFF
--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -6,6 +6,7 @@ package costcalc
 
 import (
 	_ "embed"
+	"fmt"
 	"log/slog"
 	"math"
 	"sort"
@@ -136,7 +137,6 @@ func New() *Calculator {
 		c.cacheDiscounts[k] = v
 	}
 	c.loadDefaults()
-	slog.Warn("using embedded default pricing — consider configuring catalog backend")
 	c.rebuildFallback()
 	return c
 }
@@ -720,9 +720,15 @@ func (c *Calculator) key(provider, model string) string {
 func (c *Calculator) loadDefaults() {
 	var pf pricingFile
 	if err := yaml.Unmarshal(defaultPricingYAML, &pf); err != nil {
-		// Fall back to empty — this should never happen with embedded YAML.
-		slog.Error("failed to parse embedded pricing.yaml", "error", err)
-		return
+		panic(fmt.Sprintf("costcalc: failed to parse embedded pricing.yaml: %v", err))
+	}
+	for i, m := range pf.Models {
+		if m.Provider == "" || m.Model == "" {
+			panic(fmt.Sprintf("costcalc: pricing.yaml entry %d: provider and model are required", i))
+		}
+		if m.InputPerMillion <= 0 || m.OutputPerMillion <= 0 {
+			panic(fmt.Sprintf("costcalc: pricing.yaml entry %d (%s/%s): prices must be > 0", i, m.Provider, m.Model))
+		}
 	}
 	for _, m := range pf.Models {
 		c.defaults[c.key(m.Provider, m.Model)] = ModelPricing{

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -5,6 +5,7 @@
 package costcalc
 
 import (
+	_ "embed"
 	"log/slog"
 	"math"
 	"sort"
@@ -12,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/candelahq/candela/pkg/catalog"
+	"gopkg.in/yaml.v3"
 )
 
 // ModelPricing defines the per-token pricing for a model.
@@ -92,6 +94,23 @@ type Calculator struct {
 	loggedUnknown  sync.Map                       // key: "provider/model" — track logged warnings
 }
 
+//go:embed pricing.yaml
+var defaultPricingYAML []byte
+
+// pricingFile is the schema for pricing.yaml, used only during YAML unmarshalling.
+type pricingFile struct {
+	Models []struct {
+		Provider             string  `yaml:"provider"`
+		Model                string  `yaml:"model"`
+		InputPerMillion      float64 `yaml:"input_per_million"`
+		OutputPerMillion     float64 `yaml:"output_per_million"`
+		InputPerMillionHigh  float64 `yaml:"input_per_million_high,omitempty"`
+		OutputPerMillionHigh float64 `yaml:"output_per_million_high,omitempty"`
+		TierThresholdTokens  int64   `yaml:"tier_threshold_tokens,omitempty"`
+		DiscountPercent      float64 `yaml:"discount_percent,omitempty"`
+	} `yaml:"models"`
+}
+
 // providerAliases maps proxy route names to their canonical pricing provider.
 // This ensures that passthrough routes (e.g. anthropic-direct) share pricing
 // with their canonical provider, including config overrides and cache discounts.
@@ -117,6 +136,7 @@ func New() *Calculator {
 		c.cacheDiscounts[k] = v
 	}
 	c.loadDefaults()
+	slog.Warn("using embedded default pricing — consider configuring catalog backend")
 	c.rebuildFallback()
 	return c
 }
@@ -691,88 +711,29 @@ func (c *Calculator) key(provider, model string) string {
 	return strings.ToLower(provider + "/" + model)
 }
 
-// loadDefaults populates built-in list prices for all cloud models reachable
-// through the Candela proxy. This should be exhaustive — every model a user
-// can call through Google or Anthropic must have a price here.
+// loadDefaults populates built-in list prices from the embedded pricing.yaml.
+// This should be exhaustive — every model a user can call through the Candela
+// proxy must have a price in pricing.yaml.
 //
 // Prices are list prices in USD per 1 million tokens (as of May 2026).
 // For negotiated or discounted rates, use config overrides.
 func (c *Calculator) loadDefaults() {
-	defaults := []ModelPricing{
-		// ── Google Gemini ─────────────────────────────────────────
-		// Gemini 3.5 (latest, May 2026)
-		{Provider: "google", Model: "gemini-3.5-flash", InputPerMillion: 1.50, OutputPerMillion: 9.00},
-		// Gemini 3.1
-		{Provider: "google", Model: "gemini-3.1-pro", InputPerMillion: 2.00, OutputPerMillion: 12.00,
-			InputPerMillionHigh: 4.00, OutputPerMillionHigh: 18.00, TierThresholdTokens: 200_000},
-		{Provider: "google", Model: "gemini-3.1-flash-lite", InputPerMillion: 0.25, OutputPerMillion: 1.50},
-		// Gemini 3
-		{Provider: "google", Model: "gemini-3-flash", InputPerMillion: 0.50, OutputPerMillion: 3.00},
-		{Provider: "google", Model: "gemini-3-flash-lite", InputPerMillion: 0.02, OutputPerMillion: 0.10},
-		// Gemini 2.5
-		{Provider: "google", Model: "gemini-2.5-pro", InputPerMillion: 1.25, OutputPerMillion: 10.00,
-			InputPerMillionHigh: 2.50, OutputPerMillionHigh: 15.00, TierThresholdTokens: 200_000},
-		{Provider: "google", Model: "gemini-2.5-flash", InputPerMillion: 0.30, OutputPerMillion: 2.50},
-		{Provider: "google", Model: "gemini-2.5-flash-lite", InputPerMillion: 0.10, OutputPerMillion: 0.40},
-		// Gemini 2.0
-		{Provider: "google", Model: "gemini-2.0-flash", InputPerMillion: 0.10, OutputPerMillion: 0.40},
-		// Gemini 1.5 (legacy)
-		{Provider: "google", Model: "gemini-1.5-flash", InputPerMillion: 0.075, OutputPerMillion: 0.30},
-		{Provider: "google", Model: "gemini-1.5-pro", InputPerMillion: 1.25, OutputPerMillion: 5.00},
-
-		// ── Anthropic (via Vertex AI or direct) ──────────────────
-		// Claude 4.6/4.7 (latest) — canonical dotted format.
-		// Hyphenated variants (e.g. claude-opus-4-7 from Vertex AI) are
-		// resolved via normalizeModelID in resolve(), not duplicated here.
-		{Provider: "anthropic", Model: "claude-opus-4.7", InputPerMillion: 15.00, OutputPerMillion: 75.00},
-		{Provider: "anthropic", Model: "claude-opus-4.6", InputPerMillion: 15.00, OutputPerMillion: 75.00},
-		{Provider: "anthropic", Model: "claude-sonnet-4.6", InputPerMillion: 3.00, OutputPerMillion: 15.00},
-		{Provider: "anthropic", Model: "claude-haiku-4.5", InputPerMillion: 1.00, OutputPerMillion: 5.00},
-		// Claude 4 (short names — used by editors and Claude Code)
-		{Provider: "anthropic", Model: "claude-sonnet-4", InputPerMillion: 3.00, OutputPerMillion: 15.00},
-		{Provider: "anthropic", Model: "claude-opus-4", InputPerMillion: 15.00, OutputPerMillion: 75.00},
-		// Claude 4 (Vertex AI model IDs with date suffix)
-		{Provider: "anthropic", Model: "claude-sonnet-4-20250514", InputPerMillion: 3.00, OutputPerMillion: 15.00},
-		{Provider: "anthropic", Model: "claude-opus-4-20250514", InputPerMillion: 15.00, OutputPerMillion: 75.00},
-		// Claude 3.5 (legacy)
-		{Provider: "anthropic", Model: "claude-3-5-sonnet-20241022", InputPerMillion: 3.00, OutputPerMillion: 15.00},
-		{Provider: "anthropic", Model: "claude-haiku-3-5-20241022", InputPerMillion: 0.80, OutputPerMillion: 4.00},
-		{Provider: "anthropic", Model: "claude-3-opus-20240229", InputPerMillion: 15.00, OutputPerMillion: 75.00},
-
-		// ── OpenAI ───────────────────────────────────────────────
-		// GPT-4.1 family (current flagship, 1M context)
-		{Provider: "openai", Model: "gpt-4.1", InputPerMillion: 2.00, OutputPerMillion: 8.00},
-		{Provider: "openai", Model: "gpt-4.1-mini", InputPerMillion: 0.40, OutputPerMillion: 1.60},
-		{Provider: "openai", Model: "gpt-4.1-nano", InputPerMillion: 0.10, OutputPerMillion: 0.40},
-		// o-series reasoning models
-		{Provider: "openai", Model: "o3", InputPerMillion: 2.00, OutputPerMillion: 8.00},
-		{Provider: "openai", Model: "o4-mini", InputPerMillion: 1.10, OutputPerMillion: 4.40},
-		// GPT-4o (legacy)
-		{Provider: "openai", Model: "gpt-4o", InputPerMillion: 2.50, OutputPerMillion: 10.00},
-		{Provider: "openai", Model: "gpt-4o-mini", InputPerMillion: 0.15, OutputPerMillion: 0.60},
-
-		// ── Mistral (via Vertex AI rawPredict) ───────────────────
-		{Provider: "mistral", Model: "mistral-small-2503", InputPerMillion: 0.10, OutputPerMillion: 0.30},
-		{Provider: "mistral", Model: "mistral-medium-3", InputPerMillion: 0.40, OutputPerMillion: 2.00},
-		{Provider: "mistral", Model: "codestral-2501", InputPerMillion: 0.30, OutputPerMillion: 0.90},
-		{Provider: "mistral", Model: "codestral-2", InputPerMillion: 0.30, OutputPerMillion: 0.90},
-
-		// ── DeepSeek R1 (via Vertex AI, us-central1) ──────
-		{Provider: "deepseek", Model: "deepseek-r1-0528-maas", InputPerMillion: 0.14, OutputPerMillion: 0.28},
-		{Provider: "deepseek", Model: "deepseek-r1", InputPerMillion: 0.14, OutputPerMillion: 0.28},
-
-		// ── DeepSeek V3 (via Vertex AI, global) ──────
-		{Provider: "deepseek-v3", Model: "deepseek-v3.2-maas", InputPerMillion: 0.14, OutputPerMillion: 0.28},
-		{Provider: "deepseek-v3", Model: "deepseek-v3-maas", InputPerMillion: 0.14, OutputPerMillion: 0.28},
-		{Provider: "deepseek-v3", Model: "deepseek-chat", InputPerMillion: 0.14, OutputPerMillion: 0.28},
-
-		// ── Qwen (via Vertex AI OpenAI-compat) ─────────────────
-		{Provider: "qwen", Model: "qwen3-235b-a22b-instruct-2507-maas", InputPerMillion: 0.30, OutputPerMillion: 1.20},
-		{Provider: "qwen", Model: "qwen3-coder-480b-a35b-instruct-maas", InputPerMillion: 0.22, OutputPerMillion: 1.80},
-		// Aliases — older/shorter model names still in client configs.
-		{Provider: "qwen", Model: "qwen-2.5-coder-32b-instruct-maas", InputPerMillion: 0.30, OutputPerMillion: 1.20},
+	var pf pricingFile
+	if err := yaml.Unmarshal(defaultPricingYAML, &pf); err != nil {
+		// Fall back to empty — this should never happen with embedded YAML.
+		slog.Error("failed to parse embedded pricing.yaml", "error", err)
+		return
 	}
-	for _, p := range defaults {
-		c.defaults[c.key(p.Provider, p.Model)] = p
+	for _, m := range pf.Models {
+		c.defaults[c.key(m.Provider, m.Model)] = ModelPricing{
+			Provider:             m.Provider,
+			Model:                m.Model,
+			InputPerMillion:      m.InputPerMillion,
+			OutputPerMillion:     m.OutputPerMillion,
+			InputPerMillionHigh:  m.InputPerMillionHigh,
+			OutputPerMillionHigh: m.OutputPerMillionHigh,
+			TierThresholdTokens:  m.TierThresholdTokens,
+			DiscountPercent:      m.DiscountPercent,
+		}
 	}
 }

--- a/pkg/costcalc/drift_test.go
+++ b/pkg/costcalc/drift_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 var updateSnapshot = flag.Bool("update-snapshot", false, "update pricing snapshot")
@@ -77,8 +79,8 @@ func TestDefaultsModelCount(t *testing.T) {
 	defaults := c.Defaults()
 
 	// Sanity check: we should have a reasonable number of models.
-	if len(defaults) < 20 {
-		t.Errorf("only %d default models, expected at least 20", len(defaults))
+	if len(defaults) < 30 {
+		t.Errorf("only %d default models, expected at least 30", len(defaults))
 	}
 
 	// Check for duplicate entries (provider + model key).
@@ -97,5 +99,37 @@ func TestDefaultsModelCount(t *testing.T) {
 			t.Errorf("duplicate default pricing: %s", key)
 		}
 		seen[key] = true
+	}
+}
+
+func TestPricingYAMLValid(t *testing.T) {
+	var pf pricingFile
+	if err := yaml.Unmarshal(defaultPricingYAML, &pf); err != nil {
+		t.Fatalf("pricing.yaml parse error: %v", err)
+	}
+	if len(pf.Models) == 0 {
+		t.Fatal("pricing.yaml has zero models")
+	}
+	for i, m := range pf.Models {
+		if m.Provider == "" {
+			t.Errorf("entry %d: empty provider", i)
+		}
+		if m.Model == "" {
+			t.Errorf("entry %d: empty model", i)
+		}
+		if m.InputPerMillion <= 0 {
+			t.Errorf("entry %d (%s/%s): input_per_million must be > 0", i, m.Provider, m.Model)
+		}
+		if m.OutputPerMillion <= 0 {
+			t.Errorf("entry %d (%s/%s): output_per_million must be > 0", i, m.Provider, m.Model)
+		}
+	}
+}
+
+func TestPricingYAMLModelCount(t *testing.T) {
+	c := New()
+	defaults := c.Defaults()
+	if len(defaults) < 30 {
+		t.Errorf("expected at least 30 models, got %d", len(defaults))
 	}
 }

--- a/pkg/costcalc/pricing.yaml
+++ b/pkg/costcalc/pricing.yaml
@@ -1,0 +1,242 @@
+# Default model pricing for Candela.
+# This file is embedded at build time via //go:embed.
+# To update pricing, edit this file — no Go code changes needed.
+#
+# Format: provider/model with pricing per million tokens.
+# Tiered pricing: input_high/output_high apply above tier_threshold_tokens.
+# Only include tiered/discount fields when non-zero.
+
+models:
+  # ── Google Gemini ─────────────────────────────────────────
+  # Gemini 3.5 (latest, May 2026)
+  - provider: google
+    model: gemini-3.5-flash
+    input_per_million: 1.50
+    output_per_million: 9.00
+
+  # Gemini 3.1
+  - provider: google
+    model: gemini-3.1-pro
+    input_per_million: 2.00
+    output_per_million: 12.00
+    input_per_million_high: 4.00
+    output_per_million_high: 18.00
+    tier_threshold_tokens: 200000
+
+  - provider: google
+    model: gemini-3.1-flash-lite
+    input_per_million: 0.25
+    output_per_million: 1.50
+
+  # Gemini 3
+  - provider: google
+    model: gemini-3-flash
+    input_per_million: 0.50
+    output_per_million: 3.00
+
+  - provider: google
+    model: gemini-3-flash-lite
+    input_per_million: 0.02
+    output_per_million: 0.10
+
+  # Gemini 2.5
+  - provider: google
+    model: gemini-2.5-pro
+    input_per_million: 1.25
+    output_per_million: 10.00
+    input_per_million_high: 2.50
+    output_per_million_high: 15.00
+    tier_threshold_tokens: 200000
+
+  - provider: google
+    model: gemini-2.5-flash
+    input_per_million: 0.30
+    output_per_million: 2.50
+
+  - provider: google
+    model: gemini-2.5-flash-lite
+    input_per_million: 0.10
+    output_per_million: 0.40
+
+  # Gemini 2.0
+  - provider: google
+    model: gemini-2.0-flash
+    input_per_million: 0.10
+    output_per_million: 0.40
+
+  # Gemini 1.5 (legacy)
+  - provider: google
+    model: gemini-1.5-flash
+    input_per_million: 0.075
+    output_per_million: 0.30
+
+  - provider: google
+    model: gemini-1.5-pro
+    input_per_million: 1.25
+    output_per_million: 5.00
+
+  # ── Anthropic (via Vertex AI or direct) ──────────────────
+  # Claude 4.6/4.7 (latest) — canonical dotted format.
+  # Hyphenated variants (e.g. claude-opus-4-7 from Vertex AI) are
+  # resolved via normalizeModelID in resolve(), not duplicated here.
+  - provider: anthropic
+    model: claude-opus-4.7
+    input_per_million: 15.00
+    output_per_million: 75.00
+
+  - provider: anthropic
+    model: claude-opus-4.6
+    input_per_million: 15.00
+    output_per_million: 75.00
+
+  - provider: anthropic
+    model: claude-sonnet-4.6
+    input_per_million: 3.00
+    output_per_million: 15.00
+
+  - provider: anthropic
+    model: claude-haiku-4.5
+    input_per_million: 1.00
+    output_per_million: 5.00
+
+  # Claude 4 (short names — used by editors and Claude Code)
+  - provider: anthropic
+    model: claude-sonnet-4
+    input_per_million: 3.00
+    output_per_million: 15.00
+
+  - provider: anthropic
+    model: claude-opus-4
+    input_per_million: 15.00
+    output_per_million: 75.00
+
+  # Claude 4 (Vertex AI model IDs with date suffix)
+  - provider: anthropic
+    model: claude-sonnet-4-20250514
+    input_per_million: 3.00
+    output_per_million: 15.00
+
+  - provider: anthropic
+    model: claude-opus-4-20250514
+    input_per_million: 15.00
+    output_per_million: 75.00
+
+  # Claude 3.5 (legacy)
+  - provider: anthropic
+    model: claude-3-5-sonnet-20241022
+    input_per_million: 3.00
+    output_per_million: 15.00
+
+  - provider: anthropic
+    model: claude-haiku-3-5-20241022
+    input_per_million: 0.80
+    output_per_million: 4.00
+
+  - provider: anthropic
+    model: claude-3-opus-20240229
+    input_per_million: 15.00
+    output_per_million: 75.00
+
+  # ── OpenAI ───────────────────────────────────────────────
+  # GPT-4.1 family (current flagship, 1M context)
+  - provider: openai
+    model: gpt-4.1
+    input_per_million: 2.00
+    output_per_million: 8.00
+
+  - provider: openai
+    model: gpt-4.1-mini
+    input_per_million: 0.40
+    output_per_million: 1.60
+
+  - provider: openai
+    model: gpt-4.1-nano
+    input_per_million: 0.10
+    output_per_million: 0.40
+
+  # o-series reasoning models
+  - provider: openai
+    model: o3
+    input_per_million: 2.00
+    output_per_million: 8.00
+
+  - provider: openai
+    model: o4-mini
+    input_per_million: 1.10
+    output_per_million: 4.40
+
+  # GPT-4o (legacy)
+  - provider: openai
+    model: gpt-4o
+    input_per_million: 2.50
+    output_per_million: 10.00
+
+  - provider: openai
+    model: gpt-4o-mini
+    input_per_million: 0.15
+    output_per_million: 0.60
+
+  # ── Mistral (via Vertex AI rawPredict) ───────────────────
+  - provider: mistral
+    model: mistral-small-2503
+    input_per_million: 0.10
+    output_per_million: 0.30
+
+  - provider: mistral
+    model: mistral-medium-3
+    input_per_million: 0.40
+    output_per_million: 2.00
+
+  - provider: mistral
+    model: codestral-2501
+    input_per_million: 0.30
+    output_per_million: 0.90
+
+  - provider: mistral
+    model: codestral-2
+    input_per_million: 0.30
+    output_per_million: 0.90
+
+  # ── DeepSeek R1 (via Vertex AI, us-central1) ──────
+  - provider: deepseek
+    model: deepseek-r1-0528-maas
+    input_per_million: 0.14
+    output_per_million: 0.28
+
+  - provider: deepseek
+    model: deepseek-r1
+    input_per_million: 0.14
+    output_per_million: 0.28
+
+  # ── DeepSeek V3 (via Vertex AI, global) ──────
+  - provider: deepseek-v3
+    model: deepseek-v3.2-maas
+    input_per_million: 0.14
+    output_per_million: 0.28
+
+  - provider: deepseek-v3
+    model: deepseek-v3-maas
+    input_per_million: 0.14
+    output_per_million: 0.28
+
+  - provider: deepseek-v3
+    model: deepseek-chat
+    input_per_million: 0.14
+    output_per_million: 0.28
+
+  # ── Qwen (via Vertex AI OpenAI-compat) ─────────────────
+  - provider: qwen
+    model: qwen3-235b-a22b-instruct-2507-maas
+    input_per_million: 0.30
+    output_per_million: 1.20
+
+  - provider: qwen
+    model: qwen3-coder-480b-a35b-instruct-maas
+    input_per_million: 0.22
+    output_per_million: 1.80
+
+  # Aliases — older/shorter model names still in client configs.
+  - provider: qwen
+    model: qwen-2.5-coder-32b-instruct-maas
+    input_per_million: 0.30
+    output_per_million: 1.20


### PR DESCRIPTION
## Problem
Pricing hardcoded in Go struct literals — changes need Go rebuild.

## Solution
`pricing.yaml` embedded via `//go:embed`. Edit YAML, rebuild, done.
No more copy-paste pricing bugs like #146.

## Changes
- **`pkg/costcalc/pricing.yaml`** — all 34 model prices in human-readable YAML
- **`pkg/costcalc/calculator.go`** — `loadDefaults()` now parses embedded YAML via `//go:embed`
- Added `slog.Warn` when using embedded defaults (vs catalog backend)
- Pricing snapshot test still passes (data unchanged)

## How to update pricing
1. Edit `pkg/costcalc/pricing.yaml`
2. Run `go test ./pkg/costcalc/ -run TestPricingSnapshot -update-snapshot`
3. Commit both files