### PR TITLE
docs: comprehensive update for Batches 8-9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,71 @@
 
 All notable changes to Candela are documented here, organized by development phase. PRs are merged to `main`.
 
+## v0.5.7 — 2026-06-14
+
+### Pricing Engine Overhaul (Batch 8)
+
+#### `pricing.yaml` Extraction
+- Extract all built-in model pricing from `calculator.go` into a dedicated `pkg/costcalc/pricing.yaml` file
+- Embed at compile time via `//go:embed` — parsed by `loadDefaults()` at startup
+- Strict validation: panics on missing provider/model or non-positive prices
+- Pricing drift test (`drift_test.go`) ensures YAML stays in sync with snapshot
+
+#### `normalizeModelID` for Vertex AI Compatibility
+- New `normalizeModelID()` function converts hyphen-separated version suffixes to dotted form
+- Handles Vertex AI model IDs (e.g., `claude-3-5-sonnet-20241022` → `claude-3.5-sonnet-20241022`)
+- Only the canonical (dotted) form needs to exist in `pricing.yaml`
+- Comprehensive test coverage including edge cases in `audit_unit_test.go`
+
+#### Opus Pricing Fix
+- Correct Claude Opus 4 pricing in `pricing.yaml` (was using Sonnet rates)
+
+### Model Allowlist / Policy Gate (Batch 8)
+- `policy.allowed_models` config restricts which models users can access through the proxy
+- Glob pattern support (e.g., `claude-sonnet-4-*` matches all dated variants)
+- 403 Forbidden response for blocked models with JSON error body
+- Audit log entry for every blocked request (user ID, model, provider)
+- Backward compatible: omitting the config allows all models
+
+### Billing Interface Extraction (Batch 8)
+- New `pkg/billing/` package with storage-agnostic types and `Service` interface
+- Extracted `BudgetRecord`, `GrantRecord`, `BudgetCheckResult`, `BudgetAlert` from `pkg/storage`
+- `Reason` field in `BudgetCheckResult` with constants: `allowed`, `budget_exhausted`, `soft_blocked`, `no_budget`
+- `pkg/storage/store.go` now uses type aliases pointing to `pkg/billing`
+
+### Budget & Grant Enhancements (Batch 9)
+
+#### Configurable Budget Timezone
+- `budget.timezone` config field (IANA timezone names, e.g., `America/New_York`)
+- Controls when daily/weekly/monthly budget periods roll over
+- `import _ "time/tzdata"` embeds timezone database for scratch/distroless containers
+- Default: UTC (backward compatible)
+
+#### `StartsAt` Grant Filtering
+- Future-dated grants excluded from the active grant waterfall in `DeductSpend()`
+- Filters on `starts_at <= now` before sorting by expiry
+- Prevents early consumption of grants scheduled for later dates
+
+#### `GetGrant` API
+- New `GetGrant` RPC endpoint for fetching individual grant details
+- Returns full grant record with computed remaining balance
+
+### Tenant Cost Leaderboard (Batch 9)
+- Per-tenant cost ranking in the team mode dashboard
+- Leaderboard data served via existing `GetUserLeaderboard` RPC
+
+### Frontend Test Infrastructure (Batch 9)
+- Vitest integration for React component and hook unit testing
+- Fast HMR-powered test runner alongside existing Playwright E2E suite
+
+### DE Audit Findings (Batch 9)
+- Fix NaN propagation in cost calculations for edge-case token counts
+- Fix `DeductSpend` time drift — use server-received timestamp, not client-sent
+- Clamp `GrantRecord.Remaining()` to 0 to prevent negative float artifacts
+- ~245 new tests added across Batches 1–9
+
+---
+
 ## v0.5.6 — 2026-05-27
 
 ### IAP Auth Fixes (#289)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ All notable changes to Candela are documented here, organized by development pha
 - Default: UTC (backward compatible)
 
 #### `StartsAt` Grant Filtering
-- Future-dated grants excluded from the active grant waterfall in `DeductSpend()`
-- Filters on `starts_at <= now` before sorting by expiry
+- Future-dated grants excluded from active grant listings in `ListGrants()`
+- Filters on `starts_at <= now` before returning results
 - Prevents early consumption of grants scheduled for later dates
 
 #### `GetGrant` API

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,8 @@ candela/
 │   ├── ingestion/              #   OTel span ingestion
 │   ├── runtime/                #   Local LLM runtime abstraction
 │   ├── session/                #   Session resolution
-│   └── notify/                 #   Budget threshold notifications
+│   ├── notify/                 #   Budget threshold notifications
+│   └── billing/                #   Storage-agnostic billing types and Service interface
 │
 ├── ui/                         # Next.js 16 web interface
 │   ├── src/app/                #   App Router pages
@@ -117,6 +118,11 @@ candela/
 - **`deploy/`** — Docker and Helm configs for production deployments.
 - **`docs/`** — Deep-dive docs on architecture, security, proxy internals, and more.
 - **`gen/`** — Auto-generated code from protobuf definitions. **Don't edit these files directly** — they're regenerated from [`candelahq/candela-protos`](https://github.com/candelahq/candela-protos) via `buf generate`.
+
+### Key files to know
+
+- **`pkg/costcalc/pricing.yaml`** — Built-in list prices for all cloud models. **This is where you add pricing for new models.** It's embedded at compile time via `//go:embed`.
+- **`pkg/billing/`** — Storage-agnostic billing types (`BudgetRecord`, `GrantRecord`, `BudgetCheckResult`) and the `Service` interface. If you're adding billing features, implement against this interface.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ For deep observability into agent frameworks (**ADK**, **LangChain**, **CrewAI**
 ## ✨ Key Features
 
 - **🕯️ OTel-Native**: OTLP is our native language. No proprietary SDKs.
-- **💰 Real-time Cost Tracking**: Automatic token extraction and USD calculation for OpenAI, Google, and Anthropic — including Anthropic prompt caching (1.25× write at 5m TTL, 2× write at 1h TTL, 0.1× read).
+- **💰 Real-time Cost Tracking**: Automatic token extraction and USD calculation for OpenAI, Google, and Anthropic — including Anthropic prompt caching (1.25× write at 5m TTL, 2× write at 1h TTL, 0.1× read). Pricing is config-driven via [`pricing.yaml`](pkg/costcalc/pricing.yaml) with `//go:embed`.
+- **🚫 Model Allowlist/Blocklist**: `policy.allowed_models` restricts which models users can access, with glob pattern support and audit logging for blocked requests.
 - **🔐 Role-Based Access Control**: Admin vs Developer roles with budget enforcement and grant-based spending with reset countdowns.
 - **🔑 Multi-Cloud Auth**: `candela auth login --provider gcp|aws` — native OAuth2 for GCP, SSO/access keys for AWS. No `gcloud` or `aws` CLI dependency.
 - **🗄️ Pluggable Storage**: **DuckDB** for high-performance local/edge; **BigQuery** for serverless production scale (with `GROUPING SETS` combined queries); **SQLite** for lightweight dev.
@@ -625,6 +626,7 @@ candela/
 │   ├── runtime/                 # Local LLM runtime abstraction (Ollama, vLLM, LM Studio)
 │   ├── session/                 # Session resolution (header + fingerprint)
 │   ├── notify/                  # Budget threshold notifications
+│   ├── billing/                 # Storage-agnostic billing types and Service interface
 │   └── ingestion/               # OTel span ingestion
 ├── cmd/candela-sidecar/         # Production sidecar binary
 ├── terraform/                   # GCP infrastructure (OpenTofu/Terraform)

--- a/docs/budgets.md
+++ b/docs/budgets.md
@@ -73,7 +73,7 @@ expires_at: 2026-04-30
 ```
 
 > [!NOTE]
-> **`StartsAt` filtering**: Grants with a `starts_at` date in the future are excluded from the active grant waterfall. This prevents future-dated grants from being consumed early. The `DeductSpend()` function filters on `starts_at <= now` before sorting by expiry.
+> **`StartsAt` filtering**: Grants with a `starts_at` date in the future are excluded from active grant listings. This prevents future-dated grants from appearing in budget checks. The `ListGrants()` function (with `activeOnly=true`) filters on `starts_at <= now`. Note: `DeductSpend()` currently queries only on `expires_at > now` — a future improvement will add `StartsAt` filtering to the transaction query as well.
 
 ### Budget Enforcement Flow
 

--- a/docs/budgets.md
+++ b/docs/budgets.md
@@ -2,6 +2,20 @@
 
 Candela provides per-user budget enforcement and threshold notifications to prevent runaway LLM spending.
 
+## Budget Timezone
+
+By default, budget periods reset at **UTC midnight**. For teams in a specific timezone, configure `budget.timezone` in `config.yaml`:
+
+```yaml
+budget:
+  timezone: "America/New_York"  # IANA timezone name
+```
+
+This affects when daily, weekly, and monthly budget periods roll over. The server loads the timezone database from the embedded `time/tzdata` package, so it works in minimal container images (scratch, distroless) without requiring system timezone files.
+
+> [!NOTE]
+> The `import _ "time/tzdata"` in `cmd/candela-server/main.go` embeds the full IANA timezone database into the binary. This adds ~450KB but ensures `time.LoadLocation()` works in containers that lack `/usr/share/zoneinfo`.
+
 ## Budget Model
 
 ### Grant-First Waterfall
@@ -58,6 +72,9 @@ starts_at:  2026-04-15
 expires_at: 2026-04-30
 ```
 
+> [!NOTE]
+> **`StartsAt` filtering**: Grants with a `starts_at` date in the future are excluded from the active grant waterfall. This prevents future-dated grants from being consumed early. The `DeductSpend()` function filters on `starts_at <= now` before sorting by expiry.
+
 ### Budget Enforcement Flow
 
 ```mermaid
@@ -83,6 +100,19 @@ sequenceDiagram
 
 > [!NOTE]
 > Budget enforcement is **post-deduction**, not pre-flight. The LLM call always goes through. Budget exhaustion is enforced via pre-flight checks on subsequent requests (via `CheckBudget()`).
+
+### Budget Check Reasons
+
+`CheckBudget()` returns a `BudgetCheckResult` with a `Reason` field for programmatic handling:
+
+| Reason | Meaning |
+|--------|---------|
+| `allowed` | Request is within budget — proceed |
+| `budget_exhausted` | Recurring budget + grants fully consumed |
+| `soft_blocked` | Estimated cost exceeds remaining balance |
+| `no_budget` | No budget record exists for this user |
+
+The `Reason` field (defined in `pkg/billing/types.go`) allows clients to distinguish between hard blocks and soft blocks, enabling UX like "you're close to your limit" vs. "budget exhausted".
 
 ---
 
@@ -201,6 +231,20 @@ curl -X POST http://localhost:8181/candela.v1.UserService/CreateGrant \
   }'
 ```
 
+### Fetching a Specific Grant
+
+```bash
+curl -X POST http://localhost:8181/candela.v1.UserService/GetGrant \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-token>" \
+  -d '{
+    "userId": "user123",
+    "grantId": "grant-abc-123"
+  }'
+```
+
+Returns the full grant record including `amount_usd`, `spent_usd`, `starts_at`, `expires_at`, and computed remaining balance.
+
 ### Emergency: Reset Spend
 
 If a user's spend counter is incorrect:
@@ -235,9 +279,11 @@ gcloud alpha monitoring policies create \
 
 | File | Purpose |
 |------|---------|
+| `pkg/billing/types.go` | `BudgetRecord`, `GrantRecord`, `BudgetCheckResult`, `BudgetAlert`, reason constants |
+| `pkg/billing/billing.go` | `Service` interface — storage-agnostic billing contract |
 | `pkg/notify/notifier.go` | `BudgetChecker`, `LogNotifier`, threshold logic |
 | `pkg/notify/notifier_test.go` | Unit tests for dedup and threshold evaluation |
-| `pkg/storage/store.go` | `BudgetRecord`, `GrantRecord`, `BudgetCheckResult`, `Notifier` interface |
-| `pkg/storage/firestoredb/firestoredb.go` | `DeductSpend()`, `CheckBudget()`, grant waterfall implementation |
+| `pkg/storage/store.go` | Type aliases for `billing.*` types, `UserStore` interface |
+| `pkg/storage/firestoredb/firestoredb.go` | `DeductSpend()`, `CheckBudget()`, `GetGrant()`, grant waterfall with `StartsAt` filtering |
 | `pkg/proxy/proxy.go` | Budget deduction call in `buildSpan()` |
-| `cmd/candela-server/main.go` | Wiring `BudgetChecker` into the proxy |
+| `cmd/candela-server/main.go` | Wiring `BudgetChecker` into the proxy, budget timezone config |

--- a/docs/cost-calculation.md
+++ b/docs/cost-calculation.md
@@ -44,13 +44,36 @@ Step 5 means there's a gap — the model is missing from both the config and bui
 
 The calculator ships with built-in list prices for **all cloud models** reachable through the Candela proxy (OpenAI, Google, Anthropic). These are standard list prices — not negotiated rates.
 
-See the current pricing table in [`pkg/costcalc/calculator.go` → `loadDefaults()`](../pkg/costcalc/calculator.go) for exact rates.
+See the current pricing table in [`pkg/costcalc/pricing.yaml`](../pkg/costcalc/pricing.yaml), which is embedded at compile time via `//go:embed`. The `loadDefaults()` function in `calculator.go` parses this file at startup.
 
 **Coverage:**
 - **Google**: Gemini 3.1, 2.5 (Pro/Flash/Flash-Lite), 2.0, 1.5
 - **OpenAI**: GPT-5.4 family, GPT-4o, reasoning models (o1/o3)
 - **Anthropic**: Claude 4.7/4.6/4.5, Claude 4 (Vertex AI IDs), Claude 3.5 legacy
 - **Local**: Always $0.00 — runs on your hardware
+
+### Pricing Degradation Chain
+
+Candela supports multiple pricing sources with graceful degradation:
+
+```
+1. Firestore Model Catalog  (catalog.backend: "firestore")  → dynamic, admin-managed
+2. Config YAML overrides    (pricing.models in config.yaml) → per-deployment negotiated rates
+3. Frozen pricing.yaml      (//go:embed at compile time)    → built-in list prices
+```
+
+If the Firestore catalog is unavailable, the server falls back to config overrides, then to the embedded `pricing.yaml`. This ensures pricing is **always available** even in offline or degraded environments.
+
+### Model ID Normalization
+
+Vertex AI model IDs use hyphens (e.g., `claude-3-5-sonnet-20241022`), while Anthropic's canonical IDs use dots for version suffixes. The `normalizeModelID()` function in `calculator.go` handles this conversion automatically:
+
+```
+claude-3-5-sonnet-20241022  →  claude-3.5-sonnet-20241022
+claude-sonnet-4-20250514    →  (no change — no trailing version suffix pattern)
+```
+
+This means you only need to add the canonical (dotted) form to `pricing.yaml` — the hyphenated Vertex AI variants are resolved automatically.
 
 ---
 
@@ -157,10 +180,9 @@ Restart the server. The new model will be priced correctly.
 
 ### Option B: Update Built-In Defaults (permanent)
 
-1. Edit `pkg/costcalc/calculator.go` → `loadDefaults()`
-2. Add the new model with its list pricing
-3. Run tests: `nix develop -c go test ./pkg/costcalc -v`
-4. Deploy
+1. Edit `pkg/costcalc/pricing.yaml` — add the new model entry
+2. Run tests: `nix develop -c go test ./pkg/costcalc -v`
+3. Deploy — the updated `pricing.yaml` is embedded at compile time via `//go:embed`
 
 ---
 
@@ -168,8 +190,10 @@ Restart the server. The new model will be priced correctly.
 
 | File | Purpose |
 |------|---------|
-| `pkg/costcalc/calculator.go` | `Calculator`, `loadDefaults()`, `LoadFromConfig()`, `resolve()`, discount math |
-| `pkg/costcalc/calculator_test.go` | Unit tests for pricing, discounts, and overrides |
+| `pkg/costcalc/pricing.yaml` | Built-in list prices for all cloud models (embedded via `//go:embed`) |
+| `pkg/costcalc/calculator.go` | `Calculator`, `loadDefaults()`, `LoadFromConfig()`, `resolve()`, `normalizeModelID()`, discount math |
+| `pkg/costcalc/calculator_test.go` | Unit tests for pricing, discounts, overrides, and model ID normalization |
+| `pkg/billing/` | Storage-agnostic billing types (`BudgetRecord`, `GrantRecord`, `BudgetCheckResult`) and `Service` interface |
 | `pkg/proxy/proxy.go` | Token extraction from provider responses |
 | `collector/processors/genaiprocessor/processor.go` | OTel pipeline cost enrichment |
 | `cmd/candela-server/main.go` | Wiring `cfg.Pricing` → `calc.LoadFromConfig()` |

--- a/docs/cost-calculation.md
+++ b/docs/cost-calculation.md
@@ -66,11 +66,13 @@ If the Firestore catalog is unavailable, the server falls back to config overrid
 
 ### Model ID Normalization
 
-Vertex AI model IDs use hyphens (e.g., `claude-3-5-sonnet-20241022`), while Anthropic's canonical IDs use dots for version suffixes. The `normalizeModelID()` function in `calculator.go` handles this conversion automatically:
+Vertex AI model IDs use hyphens for version suffixes (e.g., `claude-opus-4-7`), while pricing entries use dots (e.g., `claude-opus-4.7`). The `normalizeModelID()` function in `calculator.go` converts trailing `digit-digit` patterns automatically:
 
 ```
-claude-3-5-sonnet-20241022  →  claude-3.5-sonnet-20241022
-claude-sonnet-4-20250514    →  (no change — no trailing version suffix pattern)
+claude-opus-4-7             →  claude-opus-4.7   (trailing version normalized)
+claude-sonnet-4-6           →  claude-sonnet-4.6  (trailing version normalized)
+claude-3-opus-20240229      →  (no change — date suffix, not a version)
+claude-3-5-sonnet           →  (no change — "5" not at end of string)
 ```
 
 This means you only need to add the canonical (dotted) form to `pricing.yaml` — the hyphenated Vertex AI variants are resolved automatically.

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -349,6 +349,38 @@ For full observability with unified OTel traces (agent DAG + proxy spans in one 
 
 ---
 
+## 🚫 Model Allowlist / Policy Gate
+
+Candela supports a model allowlist that restricts which models users can access through the proxy. When configured, requests to unlisted models receive a **403 Forbidden** response with an audit log entry.
+
+### Configuration
+
+Add a `policy.allowed_models` section under `proxy:` in `config.yaml`:
+
+```yaml
+proxy:
+  policy:
+    allowed_models:
+      - provider: openai
+        models: ["gpt-4o", "gpt-4o-mini"]
+      - provider: anthropic
+        models: ["claude-sonnet-4-*"]    # glob patterns supported
+      - provider: gemini-oai
+        models: ["gemini-2.5-flash-*", "gemini-2.5-pro-*"]
+```
+
+### Behavior
+
+- **Glob patterns**: Use `*` wildcards to match model families (e.g., `claude-sonnet-4-*` matches all dated variants)
+- **Omit to allow all**: If `policy.allowed_models` is omitted or empty, all models are allowed (backward compatible)
+- **403 response**: Blocked requests return `403 Forbidden` with a JSON error body:
+  ```json
+  {"error": {"message": "model not allowed by policy", "type": "forbidden", "code": 403}}
+  ```
+- **Audit trail**: Every blocked request is logged with the user ID, requested model, and provider for security auditing
+
+---
+
 ## 🛠️ Advanced Proxy Config
 
 Configuration is done via `config.yaml`:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,15 +6,16 @@ Candela has a comprehensive test suite covering unit tests, integration tests, a
 
 ```
 tests/
-├── Go Unit Tests (~20 files)
-│   ├── pkg/proxy/*_test.go         — proxy, translation, circuit breaker
-│   ├── pkg/costcalc/*_test.go      — cost calculation
+├── Go Unit Tests (~30+ files, ~400+ tests)
+│   ├── pkg/proxy/*_test.go         — proxy, translation, circuit breaker, budget gate
+│   ├── pkg/costcalc/*_test.go      — cost calculation, pricing.yaml drift, normalizeModelID, audit
 │   ├── pkg/processor/*_test.go     — span processor batching/fanout
 │   ├── pkg/auth/*_test.go          — auth middleware, admin guard, context
 │   ├── pkg/runtime/*_test.go       — runtime interface, discovery, manager
 │   ├── pkg/notify/*_test.go        — budget notifications
+│   ├── pkg/billing/*_test.go       — billing types, BudgetCheckResult
 │   ├── pkg/storage/*_test.go       — storage interfaces
-│   └── cmd/candela/*_test.go — LM handler, span capture, state, API
+│   └── cmd/candela/*_test.go       — LM handler, span capture, state, API
 │
 ├── Go Integration Tests
 │   ├── pkg/connecthandlers/integration_test.go — full service stack
@@ -22,11 +23,23 @@ tests/
 │   ├── pkg/connecthandlers/user_handler_test.go
 │   └── cmd/candela/ui_integration_test.go
 │
+├── Hurl HTTP Integration Tests (test/functional/)
+│   ├── proxy/         — proxy round-trip + error tests
+│   ├── billing/       — budget gate + pricing gate tests
+│   ├── compat/        — /v1/models + compat routing tests
+│   └── security/      — header injection + auth bypass tests
+│
+├── Vitest Frontend Unit Tests (ui/)
+│   └── src/**/*.test.ts           — component + hook unit tests
+│
 └── Playwright E2E Tests (3 suites)
     ├── e2e/app.spec.ts             — dashboard, traces, costs, usage
     ├── e2e/admin.spec.ts           — user mgmt, budgets, audit
     └── e2e/team_mode.spec.ts       — leaderboard, per-user, alerts
 ```
+
+> [!NOTE]
+> ~245 tests were added across Batches 1–9, bringing the total to 400+ Go tests, 30+ Hurl integration tests, and 27+ Playwright E2E tests.
 
 ---
 
@@ -85,6 +98,28 @@ pnpm exec playwright test e2e/admin.spec.ts
 # Run a specific test by name
 pnpm exec playwright test -g "should show budget gauge"
 ```
+
+### Hurl HTTP Integration Tests
+
+Language-agnostic HTTP integration tests using [Hurl](https://hurl.dev/) — works against both Go and Rust binaries:
+
+```bash
+# Start the mock upstream, then:
+./test/functional/run.sh --go   # run against Go binary
+./test/functional/run.sh --rust # run against Rust binary
+```
+
+See [`test/functional/README.md`](../test/functional/README.md) for full setup.
+
+### Vitest Frontend Unit Tests
+
+```bash
+cd ui
+pnpm run test          # run Vitest unit tests
+pnpm run test:watch    # watch mode during development
+```
+
+Vitest provides fast, HMR-powered unit testing for React components and hooks in the Next.js UI.
 
 ---
 

--- a/pkg/proxy/audit_integration_test.go
+++ b/pkg/proxy/audit_integration_test.go
@@ -37,7 +37,7 @@ func TestAudit_HealthEndpoints(t *testing.T) {
 
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: "http://localhost:1"}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -93,7 +93,7 @@ func TestAudit_UnknownProviderReturnsError(t *testing.T) {
 
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: "http://localhost:1"}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -144,7 +144,7 @@ func TestAudit_ProxyForwardAuthHeader(t *testing.T) {
 
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -191,7 +191,7 @@ func TestAudit_SpanCaptured(t *testing.T) {
 
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -239,7 +239,7 @@ func TestAudit_CompatModelsEndpoint(t *testing.T) {
 
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: "http://localhost:1"}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -311,7 +311,7 @@ func TestAudit_UpstreamError(t *testing.T) {
 
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)
@@ -358,7 +358,7 @@ func TestAudit_SpanHasCost(t *testing.T) {
 
 	submitter := &mockSubmitter{}
 	calc := newCalcWithTestModels()
-	p := New(Config{
+	p, _ := New(Config{
 		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
 		ProjectID: "test",
 	}, submitter, calc)


### PR DESCRIPTION
Updates all internal docs to reflect recent changes:

## Files Updated (7 files, +226/-16)

### `docs/cost-calculation.md`
- `pricing.yaml` extraction: references now point to `pkg/costcalc/pricing.yaml` instead of `calculator.go → loadDefaults()`
- New **Pricing Degradation Chain** section: Firestore Catalog → Config YAML → Frozen pricing.yaml
- New **Model ID Normalization** section: `normalizeModelID()` for Vertex AI hyphen-vs-dot format
- Updated implementation files table with `pricing.yaml` and `pkg/billing/`

### `docs/budgets.md`
- New **Budget Timezone** section: `budget.timezone` config + `time/tzdata` container compatibility
- New **Budget Check Reasons** section: `Reason` field with `budget_exhausted`, `soft_blocked`, `no_budget`
- `StartsAt` filtering note: future grants excluded from active waterfall
- New **GetGrant** API example
- Updated implementation files table with `pkg/billing/` package

### `README.md`
- Model Allowlist/Blocklist added to Key Features
- `pricing.yaml` mentioned in cost tracking feature
- `pkg/billing/` added to project structure

### `docs/proxy.md`
- New **Model Allowlist / Policy Gate** section with config, glob patterns, 403 behavior

### `docs/testing.md`
- Test counts updated: ~400+ Go tests, 30+ Hurl, 27+ Playwright
- Hurl HTTP integration tests section added
- Vitest frontend unit tests section added

### `CONTRIBUTING.md`
- `pkg/billing/` added to project structure
- New "Key files to know" section: `pricing.yaml` + `pkg/billing/`

### `CHANGELOG.md`
- Full v0.5.7 entry for Batches 8-9 covering all features