### PR TITLE
feat(catalog): add ProviderModelID and Region to catalog entries

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -527,6 +527,13 @@ func main() {
 					allProviders[i].PathRewriter = &proxy.VertexAIPathRewriter{
 						ProjectID: cfg.Proxy.VertexAI.ProjectID,
 						Region:    region,
+						ModelResolver: func(model string) (string, string) {
+							entry, err := catalogStore.Get(context.Background(), "anthropic", model)
+							if err != nil || entry == nil {
+								return "", ""
+							}
+							return entry.ProviderModelID, entry.Region
+						},
 					}
 					if tokenSource != nil {
 						allProviders[i].TokenSource = tokenSource

--- a/cmd/seed-catalog/main.go
+++ b/cmd/seed-catalog/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"strings"
 
 	"cloud.google.com/go/firestore"
 
@@ -43,7 +44,7 @@ func main() {
 	// Convert ModelPricing → catalog.Entry.
 	entries := make([]catalog.Entry, 0, len(defaults))
 	for _, p := range defaults {
-		entries = append(entries, catalog.Entry{
+		e := catalog.Entry{
 			ModelID:              p.Model,
 			Provider:             p.Provider,
 			InputPerMillion:      p.InputPerMillion,
@@ -53,7 +54,19 @@ func main() {
 			TierThresholdTokens:  p.TierThresholdTokens,
 			DiscountPercent:      p.DiscountPercent,
 			Enabled:              true,
-		})
+		}
+
+		// For Anthropic models routed through Vertex AI, set the
+		// provider-specific model ID (Vertex uses dashes, not dots)
+		// and default to the "global" region endpoint.
+		if p.Provider == "anthropic" {
+			if vid := vertexModelID(p.Model); vid != p.Model {
+				e.ProviderModelID = vid
+			}
+			e.Region = "global"
+		}
+
+		entries = append(entries, e)
 	}
 
 	fmt.Printf("🕯️  seed-catalog (project=%s database=%s collection=%s dry-run=%v)\n\n",
@@ -111,4 +124,13 @@ func main() {
 	}
 
 	fmt.Printf("\n✅ Done — %d entries seeded, %d errors.\n", seeded, errCount)
+}
+
+// vertexModelID converts an Anthropic model name to its Vertex AI equivalent.
+// Vertex AI uses dashes where Anthropic uses dots in version numbers.
+// e.g. "claude-opus-4.7" → "claude-opus-4-7"
+//
+// If no dots are present, returns the input unchanged.
+func vertexModelID(model string) string {
+	return strings.ReplaceAll(model, ".", "-")
 }

--- a/cmd/seed-catalog/main_test.go
+++ b/cmd/seed-catalog/main_test.go
@@ -156,3 +156,57 @@ func TestOutputFormatIncludesDatabaseID(t *testing.T) {
 		t.Errorf("output should include project ID: %s", got)
 	}
 }
+
+func TestVertexModelID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"claude-opus-4.7", "claude-opus-4-7"},
+		{"claude-opus-4.8", "claude-opus-4-8"},
+		{"claude-haiku-4.5", "claude-haiku-4-5"},
+		{"claude-sonnet-4.6", "claude-sonnet-4-6"},
+		{"claude-sonnet-4", "claude-sonnet-4"},                       // no dots — unchanged
+		{"claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022"}, // no dots
+	}
+	for _, tt := range tests {
+		got := vertexModelID(tt.input)
+		if got != tt.want {
+			t.Errorf("vertexModelID(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestAnthropicEntriesHaveProviderModelID(t *testing.T) {
+	calc := costcalc.New()
+	defaults := calc.Defaults()
+
+	for _, p := range defaults {
+		if p.Provider != "anthropic" {
+			continue
+		}
+		e := catalog.Entry{
+			ModelID:  p.Model,
+			Provider: p.Provider,
+		}
+		if vid := vertexModelID(p.Model); vid != p.Model {
+			e.ProviderModelID = vid
+		}
+		e.Region = "global"
+
+		// Models with dots must have a ProviderModelID set.
+		if strings.Contains(p.Model, ".") {
+			if e.ProviderModelID == "" {
+				t.Errorf("anthropic model %q has dots but no ProviderModelID", p.Model)
+			}
+			if strings.Contains(e.ProviderModelID, ".") {
+				t.Errorf("ProviderModelID %q should not contain dots", e.ProviderModelID)
+			}
+		}
+
+		// All Anthropic models should have region = "global".
+		if e.Region != "global" {
+			t.Errorf("anthropic model %q should have region=global, got %q", p.Model, e.Region)
+		}
+	}
+}

--- a/pkg/catalog/firestore_store.go
+++ b/pkg/catalog/firestore_store.go
@@ -33,6 +33,8 @@ type firestoreEntry struct {
 	AllowedTenants       []string  `firestore:"allowed_tenants,omitempty"`
 	DiscountPercent      float64   `firestore:"discount_percent,omitempty"`
 	UpdatedAt            time.Time `firestore:"updated_at,serverTimestamp"`
+	ProviderModelID      string    `firestore:"provider_model_id,omitempty"`
+	Region               string    `firestore:"region,omitempty"`
 }
 
 func entryToFirestore(e *Entry) *firestoreEntry {
@@ -52,6 +54,8 @@ func entryToFirestore(e *Entry) *firestoreEntry {
 		AllowedTenants:       e.AllowedTenants,
 		DiscountPercent:      e.DiscountPercent,
 		UpdatedAt:            e.UpdatedAt,
+		ProviderModelID:      e.ProviderModelID,
+		Region:               e.Region,
 	}
 }
 
@@ -72,6 +76,8 @@ func firestoreToEntry(fe *firestoreEntry) Entry {
 		AllowedTenants:       fe.AllowedTenants,
 		DiscountPercent:      fe.DiscountPercent,
 		UpdatedAt:            fe.UpdatedAt,
+		ProviderModelID:      fe.ProviderModelID,
+		Region:               fe.Region,
 	}
 }
 

--- a/pkg/catalog/firestore_store_test.go
+++ b/pkg/catalog/firestore_store_test.go
@@ -48,10 +48,11 @@ func TestFirestoreStore_FieldMapping(t *testing.T) {
 	// field count. If Entry gains a field and firestoreEntry doesn't, the
 	// conformance test will catch data loss. This test guards the field count.
 	entryType := reflect.TypeOf(catalog.Entry{})
-	expectedFields := 15 // ModelID, Provider, DisplayName, InputPerMillion,
+	expectedFields := 17 // ModelID, Provider, DisplayName, InputPerMillion,
 	// OutputPerMillion, Enabled, Category, ContextWindow,
 	// InputPerMillionHigh, OutputPerMillionHigh, TierThresholdTokens,
-	// Aliases, AllowedTenants, DiscountPercent, UpdatedAt
+	// Aliases, AllowedTenants, DiscountPercent, UpdatedAt,
+	// ProviderModelID, Region
 
 	if got := entryType.NumField(); got != expectedFields {
 		t.Errorf("Entry has %d fields, expected %d — "+

--- a/pkg/catalog/store.go
+++ b/pkg/catalog/store.go
@@ -60,6 +60,17 @@ type Entry struct {
 	// DiscountPercent is a model-specific discount (0.0–1.0).
 	DiscountPercent float64   `json:"discount_percent,omitempty"`
 	UpdatedAt       time.Time `json:"updated_at,omitempty"` // last modification timestamp
+
+	// ProviderModelID is the upstream provider's model identifier when it
+	// differs from ModelID. For example, Anthropic uses "claude-opus-4.7"
+	// but Vertex AI requires "claude-opus-4-7" (dashes instead of dots).
+	// If empty, ModelID is used as-is for upstream requests.
+	ProviderModelID string `json:"provider_model_id,omitempty"`
+
+	// Region is the cloud region to use for this specific model.
+	// For Vertex AI, this determines the endpoint (e.g. "global", "us-east5").
+	// If empty, falls back to the deployment-wide CANDELA_VERTEX_REGION setting.
+	Region string `json:"region,omitempty"`
 }
 
 // ModelCatalogStore is the core abstraction for the model catalog.

--- a/pkg/proxy/translate.go
+++ b/pkg/proxy/translate.go
@@ -565,18 +565,46 @@ func (t *AnthropicFormatTranslator) TranslateStreamChunk(data []byte, model stri
 // VertexAIPathRewriter rewrites URL paths for Vertex AI's publisher model endpoints.
 type VertexAIPathRewriter struct {
 	ProjectID string // GCP project ID
-	Region    string // GCP region (e.g. "us-central1")
+	Region    string // GCP region (e.g. "us-central1") — used as default
+
+	// ModelResolver optionally resolves a model name to its provider-specific
+	// model ID and region from the catalog. If nil or the lookup returns empty
+	// strings, the raw model name and default Region are used.
+	ModelResolver func(model string) (providerModelID, region string)
 }
 
 func (r *VertexAIPathRewriter) RewritePath(model string, streaming bool) string {
 	info := ParseModelName(model)
+
+	// Resolve provider-specific model ID and region from catalog.
+	region := r.Region
+	vertexModel := info.VertexAI
+	if r.ModelResolver != nil {
+		// Look up by Display name (base name without date suffix) since the
+		// catalog is seeded with base names like "claude-opus-4.7", not
+		// "claude-opus-4.7-20250514".
+		if pmID, reg := r.ModelResolver(info.Display); pmID != "" || reg != "" {
+			if pmID != "" {
+				// Re-attach any date suffix from the original model name
+				// so ParseModelName produces the correct @version format.
+				resolvedModel := pmID
+				if matches := dateVersionRe.FindStringSubmatch(model); len(matches) == 2 {
+					resolvedModel = pmID + "-" + matches[1]
+				}
+				vertexModel = ParseModelName(resolvedModel).VertexAI
+			}
+			if reg != "" {
+				region = reg
+			}
+		}
+	}
 
 	method := "rawPredict"
 	if streaming {
 		method = "streamRawPredict"
 	}
 	return fmt.Sprintf("/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:%s",
-		r.ProjectID, r.Region, info.VertexAI, method)
+		r.ProjectID, region, vertexModel, method)
 }
 
 // ====================================================================

--- a/pkg/proxy/translate_test.go
+++ b/pkg/proxy/translate_test.go
@@ -596,6 +596,91 @@ func TestVertexAIPathRewriter(t *testing.T) {
 	}
 }
 
+func TestVertexAIPathRewriterWithModelResolver(t *testing.T) {
+	rewriter := &VertexAIPathRewriter{
+		ProjectID: "my-project",
+		Region:    "us-east5", // default region
+		ModelResolver: func(model string) (string, string) {
+			switch model {
+			case "claude-opus-4.7":
+				return "claude-opus-4-7", "global"
+			case "claude-haiku-4.5":
+				return "claude-haiku-4-5", "global"
+			case "claude-sonnet-4":
+				return "", "global" // no ID override, only region
+			default:
+				return "", ""
+			}
+		},
+	}
+
+	tests := []struct {
+		name      string
+		model     string
+		streaming bool
+		want      string
+	}{
+		{
+			name:  "dots to dashes with region override",
+			model: "claude-opus-4.7",
+			want:  "/v1/projects/my-project/locations/global/publishers/anthropic/models/claude-opus-4-7:rawPredict",
+		},
+		{
+			name:  "haiku dots to dashes",
+			model: "claude-haiku-4.5",
+			want:  "/v1/projects/my-project/locations/global/publishers/anthropic/models/claude-haiku-4-5:rawPredict",
+		},
+		{
+			name:  "region override only — no model ID change",
+			model: "claude-sonnet-4",
+			want:  "/v1/projects/my-project/locations/global/publishers/anthropic/models/claude-sonnet-4:rawPredict",
+		},
+		{
+			name:  "unknown model — uses defaults",
+			model: "claude-unknown-99",
+			want:  "/v1/projects/my-project/locations/us-east5/publishers/anthropic/models/claude-unknown-99:rawPredict",
+		},
+		{
+			name:      "streaming with resolver",
+			model:     "claude-opus-4.7",
+			streaming: true,
+			want:      "/v1/projects/my-project/locations/global/publishers/anthropic/models/claude-opus-4-7:streamRawPredict",
+		},
+		{
+			name:  "date-suffixed model resolves via Display name",
+			model: "claude-opus-4.7-20250514",
+			want:  "/v1/projects/my-project/locations/global/publishers/anthropic/models/claude-opus-4-7@20250514:rawPredict",
+		},
+		{
+			name:  "date-suffixed sonnet — region only, suffix preserved",
+			model: "claude-sonnet-4-20250514",
+			want:  "/v1/projects/my-project/locations/global/publishers/anthropic/models/claude-sonnet-4@20250514:rawPredict",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rewriter.RewritePath(tt.model, tt.streaming)
+			if got != tt.want {
+				t.Errorf("RewritePath = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVertexAIPathRewriterNilResolver(t *testing.T) {
+	// Without a resolver, behavior is unchanged from the original.
+	rewriter := &VertexAIPathRewriter{
+		ProjectID: "my-project",
+		Region:    "global",
+	}
+	got := rewriter.RewritePath("claude-opus-4.7", false)
+	want := "/v1/projects/my-project/locations/global/publishers/anthropic/models/claude-opus-4.7:rawPredict"
+	if got != want {
+		t.Errorf("RewritePath = %q, want %q", got, want)
+	}
+}
+
 func TestVertexAIUpstreamURL(t *testing.T) {
 	tests := []struct {
 		region string


### PR DESCRIPTION
Vertex AI uses different model IDs than Anthropic's direct API (dashes not dots):

| User sends | Vertex needs |
|-----------|-------------|
| `claude-opus-4.7` | `claude-opus-4-7` |
| `claude-opus-4.8` | `claude-opus-4-8` |
| `claude-haiku-4.5` | `claude-haiku-4-5` |
| `claude-sonnet-4` | `claude-sonnet-4` (unchanged) |

## Changes

### `catalog.Entry` — 2 new fields
- `ProviderModelID`: upstream model ID when it differs from `ModelID`
- `Region`: per-model region override (e.g. `"global"`)

### `VertexAIPathRewriter` — catalog-aware
- Optional `ModelResolver` function looks up `ProviderModelID` and `Region`
- Falls back to raw model name + default region when resolver is nil or returns empty

### `seed-catalog` — populates new fields
- All Anthropic models get `Region: "global"`
- Models with dots get `ProviderModelID` with dots→dashes conversion

### Proto — intentionally NOT updated
These are server-side routing details. Clients send the user-facing `ModelID` and the proxy handles the translation.

## Tests
- `TestVertexModelID` — 6 cases for dot→dash conversion
- `TestAnthropicEntriesHaveProviderModelID` — validates all Anthropic entries
- `TestVertexAIPathRewriterWithModelResolver` — 5 cases including streaming
- `TestVertexAIPathRewriterNilResolver` — backward compatibility

Closes #394