### PR TITLE
feat: dynamic model list from catalog + team-mode server-authoritative models

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -863,22 +863,30 @@ func main() {
 			// updated models to the proxy.  This lets admins add/remove
 			// models in Firestore without restarting the server.
 			if catalogStore != nil && catalogStore.Source() != "config" {
+				catalogDone := make(chan struct{})
 				go func() {
 					ticker := time.NewTicker(60 * time.Second)
 					defer ticker.Stop()
-					for range ticker.C {
-						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-						entries, err := catalogStore.List(ctx, false)
-						cancel()
-						if err != nil {
-							slog.Warn("catalog refresh failed", "error", err)
-							continue
+					for {
+						select {
+						case <-ticker.C:
+							ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+							entries, err := catalogStore.List(ctx, false)
+							cancel()
+							if err != nil {
+								slog.Warn("catalog refresh failed", "error", err)
+								continue
+							}
+							calc.LoadFromCatalog(entries)
+							refreshed := buildCompatModels()
+							llmProxy.RefreshModels(refreshed)
+						case <-catalogDone:
+							return
 						}
-						calc.LoadFromCatalog(entries)
-						refreshed := buildCompatModels()
-						llmProxy.RefreshModels(refreshed)
 					}
 				}()
+				// Ensure the goroutine is stopped when the server exits.
+				defer close(catalogDone)
 				slog.Info("🔄 catalog refresh goroutine started", "interval", "60s")
 			}
 

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -830,27 +830,56 @@ func main() {
 			// (e.g. "claude-sonnet-4") and dated variants ("claude-sonnet-4-20250514")
 			// that resolve to the same underlying model. Keep all of them — the
 			// compat layer's prefix-based alias resolution handles short→long mapping.
-			seen := make(map[string]bool)
-			var compatModels []proxy.CompatModel
-			for _, m := range calc.Models() {
-				compatProvider, ok := pricingToCompat[m.Provider]
-				if !ok || !activeSet[compatProvider] {
-					continue
+			buildCompatModels := func() []proxy.CompatModel {
+				seen := make(map[string]bool)
+				var models []proxy.CompatModel
+				for _, m := range calc.Models() {
+					compatProvider, ok := pricingToCompat[m.Provider]
+					if !ok || !activeSet[compatProvider] {
+						continue
+					}
+					key := compatProvider + "/" + m.Model
+					if seen[key] {
+						continue
+					}
+					seen[key] = true
+					models = append(models, proxy.CompatModel{
+						ID:       m.Model,
+						Provider: compatProvider,
+					})
 				}
-				key := compatProvider + "/" + m.Model
-				if seen[key] {
-					continue
-				}
-				seen[key] = true
-				compatModels = append(compatModels, proxy.CompatModel{
-					ID:       m.Model,
-					Provider: compatProvider,
-				})
+				return models
 			}
+
+			compatModels := buildCompatModels()
 
 			if len(compatModels) > 0 {
 				llmProxy.RegisterCompatRoutes(mux, compatModels)
 				slog.Info("📋 /v1/models endpoint registered", "models", len(compatModels))
+			}
+
+			// Periodic catalog refresh: when backed by Firestore (or any
+			// non-config store), reload the catalog every 60s and push
+			// updated models to the proxy.  This lets admins add/remove
+			// models in Firestore without restarting the server.
+			if catalogStore != nil && catalogStore.Source() != "config" {
+				go func() {
+					ticker := time.NewTicker(60 * time.Second)
+					defer ticker.Stop()
+					for range ticker.C {
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+						entries, err := catalogStore.List(ctx, false)
+						cancel()
+						if err != nil {
+							slog.Warn("catalog refresh failed", "error", err)
+							continue
+						}
+						calc.LoadFromCatalog(entries)
+						refreshed := buildCompatModels()
+						llmProxy.RefreshModels(refreshed)
+					}
+				}()
+				slog.Info("🔄 catalog refresh goroutine started", "interval", "60s")
 			}
 
 			var names []string

--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/candelahq/candela/pkg/costcalc"
@@ -31,23 +32,28 @@ type lmHandler struct {
 	cloudProxy   *proxy.Proxy           // direct cloud proxy (solo + cloud mode)
 	cloudModels  map[string]string      // model ID → provider name
 	calc         *costcalc.Calculator   // pricing calculator (for filtering unpriced models)
+	soloMode     bool                   // true = solo mode (use embedded cloud models), false = team mode
 
 	localModels  sync.Map // model ID string → bool (cached for fast routing)
 	remoteModels sync.Map // model ID string → bool (cached from remote /v1/models)
 
 	remoteFetchGroup singleflight.Group // deduplicates concurrent lazy fetches
+
+	// Remote model cache TTL: tracks when we last refreshed so periodic
+	// callers don't hammer the server on every /v1/models request.
+	lastRemoteFetch atomic.Int64 // unix timestamp of last successful fetch
 }
 
 // newLMHandler creates a smart LM compat handler that merges local + remote + cloud
 // models and routes chat completions to the correct backend.
-func newLMHandler(mgr *runtime.Manager, remoteProxy, localProxy *httputil.ReverseProxy, localHandler http.Handler, cloudProxy *proxy.Proxy, cloudModels map[string]string, calc *costcalc.Calculator) *lmHandler {
+func newLMHandler(mgr *runtime.Manager, remoteProxy, localProxy *httputil.ReverseProxy, localHandler http.Handler, cloudProxy *proxy.Proxy, cloudModels map[string]string, calc *costcalc.Calculator, soloMode bool) *lmHandler {
 	if localHandler == nil && localProxy != nil {
 		localHandler = localProxy
 	}
 	if cloudModels == nil {
 		cloudModels = make(map[string]string)
 	}
-	return &lmHandler{
+	h := &lmHandler{
 		mgr:          mgr,
 		remoteProxy:  remoteProxy,
 		localProxy:   localProxy,
@@ -55,6 +61,52 @@ func newLMHandler(mgr *runtime.Manager, remoteProxy, localProxy *httputil.Revers
 		cloudProxy:   cloudProxy,
 		cloudModels:  cloudModels,
 		calc:         calc,
+		soloMode:     soloMode,
+	}
+
+	// In team mode, pre-fetch remote models and start a background refresh.
+	if !soloMode && remoteProxy != nil {
+		go h.startRemoteRefresh()
+	}
+
+	return h
+}
+
+// startRemoteRefresh periodically refreshes the remote model cache.
+func (h *lmHandler) startRemoteRefresh() {
+	// Initial fetch with a short delay to let the server come up.
+	time.Sleep(2 * time.Second)
+	h.refreshRemoteModels()
+
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		h.refreshRemoteModels()
+	}
+}
+
+// refreshRemoteModels fetches the model list from the remote server
+// and updates the cache.
+func (h *lmHandler) refreshRemoteModels() {
+	req, err := http.NewRequest(http.MethodGet, "/v1/models", nil)
+	if err != nil {
+		return
+	}
+	models := h.fetchRemoteModels(req)
+	if len(models) > 0 {
+		newSet := make(map[string]bool, len(models))
+		for _, m := range models {
+			newSet[m.ID] = true
+			h.remoteModels.Store(m.ID, true)
+		}
+		h.remoteModels.Range(func(key, _ any) bool {
+			if !newSet[key.(string)] {
+				h.remoteModels.Delete(key)
+			}
+			return true
+		})
+		h.lastRemoteFetch.Store(time.Now().Unix())
+		slog.Info("lm handler: remote model cache refreshed", "models", len(models))
 	}
 }
 
@@ -120,18 +172,20 @@ func (h *lmHandler) serveModels(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 2. Add direct cloud models (only if priced).
-	for modelID, providerName := range h.cloudModels {
-		if h.calc != nil && !h.calc.HasPricing(providerName, modelID) {
-			slog.Warn("⚠️ hiding cloud model from /v1/models — no pricing configured",
-				"model", modelID, "provider", providerName)
-			continue
+	// 2. Add direct cloud models (only in solo mode, and only if priced).
+	if h.soloMode {
+		for modelID, providerName := range h.cloudModels {
+			if h.calc != nil && !h.calc.HasPricing(providerName, modelID) {
+				slog.Warn("⚠️ hiding cloud model from /v1/models — no pricing configured",
+					"model", modelID, "provider", providerName)
+				continue
+			}
+			merged = append(merged, openaiModel{
+				ID:      modelID,
+				Object:  "model",
+				OwnedBy: providerName,
+			})
 		}
-		merged = append(merged, openaiModel{
-			ID:      modelID,
-			Object:  "model",
-			OwnedBy: providerName,
-		})
 	}
 
 	// 3. Fetch remote models by proxying to the remote Candela server.

--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -114,21 +114,25 @@ func (h *lmHandler) startRemoteRefresh() {
 
 // refreshRemoteModels fetches the model list from the remote server
 // and atomically swaps the cache.
+// Distinguishes fetch failure (nil → keep stale cache) from a valid
+// empty response ([] → clear the cache).
 func (h *lmHandler) refreshRemoteModels() {
 	req, err := http.NewRequest(http.MethodGet, "/v1/models", nil)
 	if err != nil {
 		return
 	}
 	models := h.fetchRemoteModels(req)
-	if len(models) > 0 {
-		newSet := make(map[string]bool, len(models))
-		for _, m := range models {
-			newSet[m.ID] = true
-		}
-		h.remoteModels.Store(newSet)
-		h.lastRemoteFetch.Store(time.Now().Unix())
-		slog.Info("lm handler: remote model cache refreshed", "models", len(models))
+	if models == nil {
+		return // fetch failed — keep stale cache
 	}
+	// models may be empty (all disabled) — that's valid, clear the cache.
+	newSet := make(map[string]bool, len(models))
+	for _, m := range models {
+		newSet[m.ID] = true
+	}
+	h.remoteModels.Store(newSet)
+	h.lastRemoteFetch.Store(time.Now().Unix())
+	slog.Info("lm handler: remote model cache refreshed", "models", len(models))
 }
 
 // loadLocalModels returns the current local model cache.
@@ -223,7 +227,8 @@ func (h *lmHandler) serveModels(w http.ResponseWriter, r *http.Request) {
 	merged = append(merged, remoteModels...)
 
 	// Cache remote model IDs atomically for alias resolution.
-	if len(remoteModels) > 0 {
+	// Only update if we got a valid response (non-nil), even if empty.
+	if remoteModels != nil {
 		newRemoteSet := make(map[string]bool, len(remoteModels))
 		for _, m := range remoteModels {
 			newRemoteSet[m.ID] = true
@@ -300,13 +305,16 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 2. Cloud model → direct cloud proxy (solo + cloud mode).
-	if providerName, ok := h.cloudModels[req.Model]; ok && h.cloudProxy != nil {
-		slog.Debug("lm handler: routing to cloud provider", "model", req.Model, "provider", providerName)
-		// Rewrite path for the proxy package: /proxy/{provider}/v1/chat/completions
-		r.URL.Path = fmt.Sprintf("/proxy/%s/v1/chat/completions", providerName)
-		h.cloudProxy.ServeHTTP(w, r)
-		return
+	// 2. Cloud model → direct cloud proxy (solo mode only).
+	// In team mode, all cloud traffic must go through the remote server
+	// so the server catalog remains the single source of truth.
+	if h.soloMode {
+		if providerName, ok := h.cloudModels[req.Model]; ok && h.cloudProxy != nil {
+			slog.Debug("lm handler: routing to cloud provider", "model", req.Model, "provider", providerName)
+			r.URL.Path = fmt.Sprintf("/proxy/%s/v1/chat/completions", providerName)
+			h.cloudProxy.ServeHTTP(w, r)
+			return
+		}
 	}
 
 	// 3. Remote server → team mode proxy.

--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httputil"
 	"regexp"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -34,14 +33,18 @@ type lmHandler struct {
 	calc         *costcalc.Calculator   // pricing calculator (for filtering unpriced models)
 	soloMode     bool                   // true = solo mode (use embedded cloud models), false = team mode
 
-	localModels  sync.Map // model ID string → bool (cached for fast routing)
-	remoteModels sync.Map // model ID string → bool (cached from remote /v1/models)
+	// Model caches stored as atomic.Value holding map[string]bool.
+	// Updated atomically by swapping the entire map — no in-place mutation.
+	localModels  atomic.Value // map[string]bool (cached for fast routing)
+	remoteModels atomic.Value // map[string]bool (cached from remote /v1/models)
 
 	remoteFetchGroup singleflight.Group // deduplicates concurrent lazy fetches
 
 	// Remote model cache TTL: tracks when we last refreshed so periodic
 	// callers don't hammer the server on every /v1/models request.
 	lastRemoteFetch atomic.Int64 // unix timestamp of last successful fetch
+
+	stopCh chan struct{} // closed by Close() to stop background goroutines
 }
 
 // newLMHandler creates a smart LM compat handler that merges local + remote + cloud
@@ -62,7 +65,12 @@ func newLMHandler(mgr *runtime.Manager, remoteProxy, localProxy *httputil.Revers
 		cloudModels:  cloudModels,
 		calc:         calc,
 		soloMode:     soloMode,
+		stopCh:       make(chan struct{}),
 	}
+
+	// Initialize empty maps in atomic values.
+	h.localModels.Store(make(map[string]bool))
+	h.remoteModels.Store(make(map[string]bool))
 
 	// In team mode, pre-fetch remote models and start a background refresh.
 	if !soloMode && remoteProxy != nil {
@@ -72,21 +80,40 @@ func newLMHandler(mgr *runtime.Manager, remoteProxy, localProxy *httputil.Revers
 	return h
 }
 
+// Close stops background goroutines. Safe to call multiple times.
+func (h *lmHandler) Close() {
+	select {
+	case <-h.stopCh:
+		// already closed
+	default:
+		close(h.stopCh)
+	}
+}
+
 // startRemoteRefresh periodically refreshes the remote model cache.
 func (h *lmHandler) startRemoteRefresh() {
 	// Initial fetch with a short delay to let the server come up.
-	time.Sleep(2 * time.Second)
+	select {
+	case <-time.After(2 * time.Second):
+	case <-h.stopCh:
+		return
+	}
 	h.refreshRemoteModels()
 
 	ticker := time.NewTicker(60 * time.Second)
 	defer ticker.Stop()
-	for range ticker.C {
-		h.refreshRemoteModels()
+	for {
+		select {
+		case <-ticker.C:
+			h.refreshRemoteModels()
+		case <-h.stopCh:
+			return
+		}
 	}
 }
 
 // refreshRemoteModels fetches the model list from the remote server
-// and updates the cache.
+// and atomically swaps the cache.
 func (h *lmHandler) refreshRemoteModels() {
 	req, err := http.NewRequest(http.MethodGet, "/v1/models", nil)
 	if err != nil {
@@ -97,17 +124,27 @@ func (h *lmHandler) refreshRemoteModels() {
 		newSet := make(map[string]bool, len(models))
 		for _, m := range models {
 			newSet[m.ID] = true
-			h.remoteModels.Store(m.ID, true)
 		}
-		h.remoteModels.Range(func(key, _ any) bool {
-			if !newSet[key.(string)] {
-				h.remoteModels.Delete(key)
-			}
-			return true
-		})
+		h.remoteModels.Store(newSet)
 		h.lastRemoteFetch.Store(time.Now().Unix())
 		slog.Info("lm handler: remote model cache refreshed", "models", len(models))
 	}
+}
+
+// loadLocalModels returns the current local model cache.
+func (h *lmHandler) loadLocalModels() map[string]bool {
+	if m, ok := h.localModels.Load().(map[string]bool); ok {
+		return m
+	}
+	return nil
+}
+
+// loadRemoteModels returns the current remote model cache.
+func (h *lmHandler) loadRemoteModels() map[string]bool {
+	if m, ok := h.remoteModels.Load().(map[string]bool); ok {
+		return m
+	}
+	return nil
 }
 
 func (h *lmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -151,7 +188,7 @@ func (h *lmHandler) serveModels(w http.ResponseWriter, r *http.Request) {
 			slog.Warn("lm handler: failed to list local models", "error", err)
 		} else {
 			backendName := h.mgr.Runtime().Name()
-			// Refresh the cached model set.
+			// Build new set and atomically swap.
 			newSet := make(map[string]bool, len(models))
 			for _, m := range models {
 				merged = append(merged, openaiModel{
@@ -160,15 +197,8 @@ func (h *lmHandler) serveModels(w http.ResponseWriter, r *http.Request) {
 					OwnedBy: backendName,
 				})
 				newSet[m.ID] = true
-				h.localModels.Store(m.ID, true)
 			}
-			// Remove stale entries.
-			h.localModels.Range(func(key, _ any) bool {
-				if !newSet[key.(string)] {
-					h.localModels.Delete(key)
-				}
-				return true
-			})
+			h.localModels.Store(newSet)
 		}
 	}
 
@@ -192,19 +222,14 @@ func (h *lmHandler) serveModels(w http.ResponseWriter, r *http.Request) {
 	remoteModels := h.fetchRemoteModels(r)
 	merged = append(merged, remoteModels...)
 
-	// Cache remote model IDs for alias resolution.
-	newRemoteSet := make(map[string]bool, len(remoteModels))
-	for _, m := range remoteModels {
-		newRemoteSet[m.ID] = true
-		h.remoteModels.Store(m.ID, true)
-	}
-	// Remove stale remote entries.
-	h.remoteModels.Range(func(key, _ any) bool {
-		if !newRemoteSet[key.(string)] {
-			h.remoteModels.Delete(key)
+	// Cache remote model IDs atomically for alias resolution.
+	if len(remoteModels) > 0 {
+		newRemoteSet := make(map[string]bool, len(remoteModels))
+		for _, m := range remoteModels {
+			newRemoteSet[m.ID] = true
 		}
-		return true
-	})
+		h.remoteModels.Store(newRemoteSet)
+	}
 
 	// 4. Return merged OpenAI-format response.
 	w.Header().Set("Content-Type", "application/json")
@@ -301,14 +326,13 @@ func (h *lmHandler) isLocalModel(model string) bool {
 	if model == "" || h.mgr == nil || h.localProxy == nil {
 		return false
 	}
-	_, ok := h.localModels.Load(model)
-	if ok {
+	locals := h.loadLocalModels()
+	if locals[model] {
 		return true
 	}
 	// Also check without tag (e.g., "llama3.2" → "llama3.2:latest").
 	if !strings.Contains(model, ":") {
-		_, ok = h.localModels.Load(model + ":latest")
-		return ok
+		return locals[model+":latest"]
 	}
 	return false
 }
@@ -322,40 +346,40 @@ func (h *lmHandler) resolveModel(model string) string {
 		return model
 	}
 
-	// Collect all known model IDs.
+	// Collect all known model IDs from atomic caches.
 	var allModels []string
-	h.localModels.Range(func(key, _ any) bool {
-		allModels = append(allModels, key.(string))
-		return true
-	})
+	for id := range h.loadLocalModels() {
+		allModels = append(allModels, id)
+	}
 	for id := range h.cloudModels {
 		allModels = append(allModels, id)
 	}
 
 	// Lazy-populate remote models if cache is empty and we have a remote proxy.
 	// Uses singleflight to prevent thundering herd on concurrent first requests.
-	remoteEmpty := true
-	h.remoteModels.Range(func(_, _ any) bool {
-		remoteEmpty = false
-		return false // stop after first entry
-	})
-	if remoteEmpty && h.remoteProxy != nil {
+	remoteCache := h.loadRemoteModels()
+	if len(remoteCache) == 0 && h.remoteProxy != nil {
 		_, _, _ = h.remoteFetchGroup.Do("fetch-remote-models", func() (any, error) {
 			req, _ := http.NewRequest(http.MethodGet, "/v1/models", nil)
 			if req != nil {
 				remote := h.fetchRemoteModels(req)
-				for _, m := range remote {
-					h.remoteModels.Store(m.ID, true)
+				if len(remote) > 0 {
+					newSet := make(map[string]bool, len(remote))
+					for _, m := range remote {
+						newSet[m.ID] = true
+					}
+					h.remoteModels.Store(newSet)
 				}
 			}
 			return nil, nil
 		})
+		// Re-read after potential update.
+		remoteCache = h.loadRemoteModels()
 	}
 
-	h.remoteModels.Range(func(key, _ any) bool {
-		allModels = append(allModels, key.(string))
-		return true
-	})
+	for id := range remoteCache {
+		allModels = append(allModels, id)
+	}
 
 	// Exact match → no resolution needed.
 	for _, id := range allModels {

--- a/cmd/candela/lm_handler_test.go
+++ b/cmd/candela/lm_handler_test.go
@@ -1137,3 +1137,134 @@ func TestAtomicModelCache(t *testing.T) {
 		t.Error("gemini-2.5-pro should still be present")
 	}
 }
+
+// TestTeamMode_ChatRejectsCloudRouting verifies that in team mode,
+// chat completions do NOT route to the cloud proxy — they must go
+// through the remote server to enforce the server catalog.
+func TestTeamMode_ChatRejectsCloudRouting(t *testing.T) {
+	cloudHit := false
+	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cloudHit = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"from cloud"}}]}`))
+	}))
+	t.Cleanup(cloudSrv.Close)
+
+	remoteHit := false
+	remoteSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/models" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+			return
+		}
+		remoteHit = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"from remote"}}]}`))
+	}))
+	t.Cleanup(remoteSrv.Close)
+
+	cloudModels := map[string]string{"claude-sonnet-4": "anthropic"}
+
+	// Team mode: soloMode=false — cloud routing should be bypassed.
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, cloudModels, nil, false)
+	t.Cleanup(h.Close)
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	// Send a chat completion for a cloud model.
+	resp, err := http.Post(srv.URL+"/v1/chat/completions", "application/json",
+		strings.NewReader(`{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hi"}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	_, _ = io.ReadAll(resp.Body)
+
+	if cloudHit {
+		t.Error("team mode should NOT route to cloud proxy")
+	}
+	if !remoteHit {
+		t.Error("team mode should route to remote server")
+	}
+}
+
+// TestRemoteEmptyResponse_ClearsCache verifies that when the remote
+// server returns a valid but empty model list, the cache is cleared
+// (not left stale).
+func TestRemoteEmptyResponse_ClearsCache(t *testing.T) {
+	callCount := 0
+	remoteSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		if callCount == 1 {
+			// First call: return a model.
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"model-a","object":"model","owned_by":"test"}]}`))
+		} else {
+			// Second call: return empty list (all models disabled).
+			_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+		}
+	}))
+	t.Cleanup(remoteSrv.Close)
+
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
+	t.Cleanup(h.Close)
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	// First request: should populate cache with model-a.
+	resp, _ := http.Get(srv.URL + "/v1/models")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close() //nolint:errcheck
+	if !strings.Contains(string(body), "model-a") {
+		t.Fatal("expected model-a in first response")
+	}
+
+	// Verify cache is populated.
+	if remotes := h.loadRemoteModels(); !remotes["model-a"] {
+		t.Fatal("expected model-a in remote cache after first request")
+	}
+
+	// Second request: remote returns empty list.
+	resp, _ = http.Get(srv.URL + "/v1/models")
+	_, _ = io.ReadAll(resp.Body)
+	resp.Body.Close() //nolint:errcheck
+
+	// Cache should now be empty (not stale).
+	if remotes := h.loadRemoteModels(); remotes["model-a"] {
+		t.Error("model-a should be cleared from cache when remote returns empty list")
+	}
+}
+
+// TestRemoteDown_PreservesStaleCache verifies that when the remote
+// server is down, the stale cache is preserved (not cleared).
+func TestRemoteDown_PreservesStaleCache(t *testing.T) {
+	remoteSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"model-a","object":"model","owned_by":"test"}]}`))
+	}))
+	t.Cleanup(remoteSrv.Close)
+
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
+	t.Cleanup(h.Close)
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	// First request: populate cache.
+	resp, _ := http.Get(srv.URL + "/v1/models")
+	_, _ = io.ReadAll(resp.Body)
+	resp.Body.Close() //nolint:errcheck
+
+	if remotes := h.loadRemoteModels(); !remotes["model-a"] {
+		t.Fatal("expected model-a in cache")
+	}
+
+	// Now call refreshRemoteModels directly with the server stopped
+	// to simulate the remote being down.
+	remoteSrv.Close()
+	h.refreshRemoteModels()
+
+	// Cache should still have model-a (stale cache preserved on failure).
+	if remotes := h.loadRemoteModels(); !remotes["model-a"] {
+		t.Error("model-a should be preserved in cache when remote is down")
+	}
+}

--- a/cmd/candela/lm_handler_test.go
+++ b/cmd/candela/lm_handler_test.go
@@ -98,7 +98,7 @@ func setupLMHandler(t *testing.T, localModels []runtime.Model, remoteModels []op
 	}
 	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
 
-	h := newLMHandler(mgr, proxyTo(remoteSrv.URL), proxyTo(localSrv.URL), nil, nil, nil, nil)
+	h := newLMHandler(mgr, proxyTo(remoteSrv.URL), proxyTo(localSrv.URL), nil, nil, nil, nil, false)
 
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
@@ -160,7 +160,7 @@ func TestLMHandler_Models_NoRuntime(t *testing.T) {
 
 	remoteSrv := mockRemoteServer(t, remoteModels)
 
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -197,7 +197,7 @@ func TestLMHandler_Models_RemoteDown(t *testing.T) {
 	_ = mgr.Start(context.Background())
 	defer func() { _ = mgr.Stop(context.Background()) }()
 
-	h := newLMHandler(mgr, proxyTo(failSrv.URL), proxyTo(localSrv.URL), nil, nil, nil, nil)
+	h := newLMHandler(mgr, proxyTo(failSrv.URL), proxyTo(localSrv.URL), nil, nil, nil, nil, false)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -304,7 +304,7 @@ func TestLMHandler_Passthrough(t *testing.T) {
 	}))
 	defer remoteSrv.Close()
 
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -382,7 +382,7 @@ func setupSoloLMHandler(t *testing.T, localModels []runtime.Model) *httptest.Ser
 	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
 
 	// Solo mode: nil remote proxy.
-	h := newLMHandler(mgr, nil, proxyTo(localSrv.URL), nil, nil, nil, nil)
+	h := newLMHandler(mgr, nil, proxyTo(localSrv.URL), nil, nil, nil, nil, true)
 
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
@@ -484,7 +484,7 @@ func TestLMHandler_CloudModelsIncluded(t *testing.T) {
 		"claude-sonnet-4-20250514": "anthropic",
 	}
 
-	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New())
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New(), true)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -549,7 +549,7 @@ func TestLMHandler_CloudChatRouting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := newLMHandler(nil, nil, nil, nil, cp, cloudModels, calc)
+	h := newLMHandler(nil, nil, nil, nil, cp, cloudModels, calc, true)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -594,7 +594,7 @@ func TestLMHandler_LocalPreference(t *testing.T) {
 	defer func() { _ = mgr.Stop(context.Background()) }()
 
 	localProxy := proxyTo(localSrv.URL)
-	h := newLMHandler(mgr, nil, localProxy, localProxy, nil, cloudModels, costcalc.New())
+	h := newLMHandler(mgr, nil, localProxy, localProxy, nil, cloudModels, costcalc.New(), true)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -637,7 +637,7 @@ func TestLMHandler_CloudAndLocalModelsMerged(t *testing.T) {
 	defer func() { _ = mgr.Stop(context.Background()) }()
 
 	localProxy := proxyTo(localSrv.URL)
-	h := newLMHandler(mgr, nil, localProxy, nil, nil, cloudModels, costcalc.New())
+	h := newLMHandler(mgr, nil, localProxy, nil, nil, cloudModels, costcalc.New(), true)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -671,7 +671,7 @@ func TestLMHandler_CloudModelWhenProxyNil(t *testing.T) {
 	// models should still appear in /v1/models but chat should 404.
 	cloudModels := map[string]string{"gemini-2.5-pro": "gemini-oai"}
 
-	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New()) // no cloudProxy
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New(), true) // no cloudProxy
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -703,7 +703,7 @@ func TestLMHandler_UnknownModelSoloCloudMode(t *testing.T) {
 	// cloudModels should return 404 (not panic or route incorrectly).
 	cloudModels := map[string]string{"gemini-2.5-pro": "gemini-oai"}
 
-	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New())
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New(), true)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -781,7 +781,7 @@ func TestLMHandler_ModelAlias_PrefixResolvesRemote(t *testing.T) {
 	}
 
 	remoteSrv := mockRemoteServer(t, remoteModels)
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -832,7 +832,7 @@ func TestLMHandler_ModelAlias_BodyRewritten(t *testing.T) {
 	}))
 	defer remoteSrv.Close()
 
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -856,7 +856,7 @@ func TestLMHandler_ModelAlias_AmbiguousPrefixNoResolve(t *testing.T) {
 	}
 
 	remoteSrv := mockRemoteServer(t, remoteModels)
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -882,7 +882,7 @@ func TestLMHandler_ModelAlias_ExactMatchSkipsResolution(t *testing.T) {
 	}
 
 	remoteSrv := mockRemoteServer(t, remoteModels)
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -930,7 +930,7 @@ func TestLMHandler_ModelAlias_CloudModel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := newLMHandler(nil, nil, nil, nil, cp, cloudModels, calc)
+	h := newLMHandler(nil, nil, nil, nil, cp, cloudModels, calc, true)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 

--- a/cmd/candela/lm_handler_test.go
+++ b/cmd/candela/lm_handler_test.go
@@ -1001,3 +1001,139 @@ func TestRewriteModelInBody_DoesNotCorruptUserContent(t *testing.T) {
 		t.Errorf("user content corrupted: %q", result.Messages[0].Content)
 	}
 }
+
+// TestTeamMode_ExcludesCloudModels verifies that in team mode (soloMode=false),
+// cloud models are NOT included in the /v1/models response.
+func TestTeamMode_ExcludesCloudModels(t *testing.T) {
+	remoteModels := []openaiModel{
+		{ID: "gemini-2.5-pro", Object: "model", OwnedBy: "google"},
+	}
+	remoteSrv := mockRemoteServer(t, remoteModels)
+	t.Cleanup(remoteSrv.Close)
+
+	cloudModels := map[string]string{
+		"claude-sonnet-4": "anthropic",
+		"gpt-4o":          "openai",
+	}
+
+	// Team mode: soloMode=false
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, cloudModels, costcalc.New(), false)
+	t.Cleanup(h.Close)
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, _ := io.ReadAll(resp.Body)
+	var result openaiModelList
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should only contain remote models, not cloud models.
+	for _, m := range result.Data {
+		if m.ID == "claude-sonnet-4" || m.ID == "gpt-4o" {
+			t.Errorf("team mode should not include cloud model %q", m.ID)
+		}
+	}
+	// Should contain the remote model.
+	found := false
+	for _, m := range result.Data {
+		if m.ID == "gemini-2.5-pro" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected remote model gemini-2.5-pro in team mode response")
+	}
+}
+
+// TestSoloMode_IncludesCloudModels verifies that in solo mode (soloMode=true),
+// cloud models ARE included in the /v1/models response.
+func TestSoloMode_IncludesCloudModels(t *testing.T) {
+	cloudModels := map[string]string{
+		"claude-sonnet-4": "anthropic",
+	}
+
+	// Solo mode: soloMode=true, no remote
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New(), true)
+	t.Cleanup(h.Close)
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, _ := io.ReadAll(resp.Body)
+	var result openaiModelList
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, m := range result.Data {
+		if m.ID == "claude-sonnet-4" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected cloud model claude-sonnet-4 in solo mode response")
+	}
+}
+
+// TestLMHandler_Close stops the background goroutine without blocking.
+func TestLMHandler_Close(t *testing.T) {
+	remoteSrv := mockRemoteServer(t, []openaiModel{
+		{ID: "test-model", Object: "model", OwnedBy: "test"},
+	})
+	t.Cleanup(remoteSrv.Close)
+
+	// Team mode starts a background goroutine.
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
+	// Close should not block or panic.
+	h.Close()
+	// Calling Close again should be safe.
+	h.Close()
+}
+
+// TestAtomicModelCache verifies that the atomic model caches work correctly.
+func TestAtomicModelCache(t *testing.T) {
+	h := newLMHandler(nil, nil, nil, nil, nil, nil, nil, true)
+	t.Cleanup(h.Close)
+
+	// Initially empty.
+	if locals := h.loadLocalModels(); len(locals) != 0 {
+		t.Errorf("expected empty local models, got %d", len(locals))
+	}
+	if remotes := h.loadRemoteModels(); len(remotes) != 0 {
+		t.Errorf("expected empty remote models, got %d", len(remotes))
+	}
+
+	// Store and verify local models.
+	h.localModels.Store(map[string]bool{"llama3.2:latest": true})
+	if locals := h.loadLocalModels(); !locals["llama3.2:latest"] {
+		t.Error("expected llama3.2:latest in local models")
+	}
+
+	// Store and verify remote models.
+	h.remoteModels.Store(map[string]bool{"claude-sonnet-4": true, "gemini-2.5-pro": true})
+	remotes := h.loadRemoteModels()
+	if !remotes["claude-sonnet-4"] || !remotes["gemini-2.5-pro"] {
+		t.Errorf("expected claude-sonnet-4 and gemini-2.5-pro in remote models, got %v", remotes)
+	}
+
+	// Overwrite atomically — old entries should be gone.
+	h.remoteModels.Store(map[string]bool{"gemini-2.5-pro": true})
+	remotes = h.loadRemoteModels()
+	if remotes["claude-sonnet-4"] {
+		t.Error("claude-sonnet-4 should be gone after atomic swap")
+	}
+	if !remotes["gemini-2.5-pro"] {
+		t.Error("gemini-2.5-pro should still be present")
+	}
+}

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -862,7 +862,7 @@ func runForeground() {
 		cloudCalc = costcalc.New()
 	}
 
-	lmH := newLMHandler(mgr, remoteProxy, runtimeLocalProxy, localHandler, cloudProxy, cloudModels, cloudCalc)
+	lmH := newLMHandler(mgr, remoteProxy, runtimeLocalProxy, localHandler, cloudProxy, cloudModels, cloudCalc, soloMode)
 	lmAddr := fmt.Sprintf("127.0.0.1:%d", lmPort)
 
 	// ── Graceful shutdown ──

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"math"
 	"net"
 	"net/http"
@@ -24,10 +25,9 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
-
-	"log/slog"
 
 	"golang.org/x/oauth2"
 
@@ -250,7 +250,9 @@ type Proxy struct {
 	users    storage.UserStore     // Budget deduction (nil = no budget tracking)
 	budgetCk *notify.BudgetChecker // Budget threshold notifications (nil = no alerts)
 
-	compatModels []CompatModel // configured models for per-provider /models responses
+	compatModels  []CompatModel // configured models for per-provider /models responses
+	modelListJSON atomic.Value  // cached []byte JSON response for /v1/models
+	compatMu      sync.RWMutex  // guards compatModels reads during refresh
 
 	// CRIT-3: Durable outbox for failed DeductSpend calls.
 	spendOutbox *spendoutbox.Outbox
@@ -515,45 +517,41 @@ type CompatModel struct {
 // GET /v1/models returns the configured model list.
 // POST /v1/chat/completions routes to the correct provider based on the model name.
 func (p *Proxy) RegisterCompatRoutes(mux *http.ServeMux, models []CompatModel) {
-	// Filter models: only surface models with known pricing.
-	// This ensures clients never discover a model that would show $0.00 cost.
-	var pricedModels []CompatModel
-	for _, m := range models {
-		if p.calc != nil && !p.calc.HasPricing(m.Provider, m.ID) {
-			slog.Warn("⚠️ hiding model from /v1/models — no pricing configured",
-				"model", m.ID, "provider", m.Provider)
-			continue
-		}
-		pricedModels = append(pricedModels, m)
-	}
-
-	if dropped := len(models) - len(pricedModels); dropped > 0 {
-		slog.Info("model list filtered by pricing availability",
-			"total", len(models), "visible", len(pricedModels), "hidden", dropped)
-	}
-
-	// Build the /v1/models response once at startup.
-	modelList := buildModelsResponse(pricedModels)
-
-	// Store models for per-provider /models responses in handleProxy.
-	p.compatModels = pricedModels
+	// Initial model list build.
+	p.setModels(models)
 
 	// GET /v1/models — return the configured model list (OpenAI-compatible).
 	mux.HandleFunc("GET /v1/models", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(modelList)
+		if data, ok := p.modelListJSON.Load().([]byte); ok {
+			_, _ = w.Write(data)
+		} else {
+			_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+		}
 	})
 
 	// GET /api/v0/models — LM Studio native API (used by IntelliJ's "Test Connection").
 	mux.HandleFunc("GET /api/v0/models", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(modelList)
+		if data, ok := p.modelListJSON.Load().([]byte); ok {
+			_, _ = w.Write(data)
+		} else {
+			_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+		}
 	})
 
-	// Build model→provider lookup.
-	modelToProvider := make(map[string]string, len(pricedModels))
-	for _, m := range pricedModels {
-		modelToProvider[m.ID] = m.Provider
+	// POST /v1/chat/completions — route to provider based on model name in body.
+	// The model→provider lookup reads from the live compatModels list so it
+	// stays current after RefreshModels() calls.
+	lookupProvider := func(modelID string) (string, bool) {
+		p.compatMu.RLock()
+		defer p.compatMu.RUnlock()
+		for _, m := range p.compatModels {
+			if m.ID == modelID {
+				return m.Provider, true
+			}
+		}
+		return "", false
 	}
 
 	// POST /v1/chat/completions — route to provider based on model name in body.
@@ -580,19 +578,21 @@ func (p *Proxy) RegisterCompatRoutes(mux *http.ServeMux, models []CompatModel) {
 			return
 		}
 
-		providerName, ok := modelToProvider[req.Model]
+		providerName, ok := lookupProvider(req.Model)
 		if !ok {
 			// Try prefix-based alias resolution (e.g. "claude-sonnet-4" → "claude-sonnet-4-20250514").
+			p.compatMu.RLock()
 			var matches []string
-			for id := range modelToProvider {
-				if strings.HasPrefix(id, req.Model) {
-					matches = append(matches, id)
+			for _, m := range p.compatModels {
+				if strings.HasPrefix(m.ID, req.Model) {
+					matches = append(matches, m.ID)
 				}
 			}
+			p.compatMu.RUnlock()
 			if len(matches) == 1 {
 				resolved := matches[0]
 				slog.Info("compat: resolved model alias", "from", req.Model, "to", resolved)
-				providerName = modelToProvider[resolved]
+				providerName, _ = lookupProvider(resolved)
 				ok = true
 				// Rewrite the model field in the body so upstream gets the canonical ID.
 				body = rewriteModelField(body, resolved)
@@ -617,6 +617,40 @@ func (p *Proxy) RegisterCompatRoutes(mux *http.ServeMux, models []CompatModel) {
 		r.ContentLength = int64(len(body))
 		p.handleProxy(w, r)
 	})
+}
+
+// setModels filters models by pricing availability, stores them, and rebuilds
+// the cached JSON response. Thread-safe for concurrent reads.
+func (p *Proxy) setModels(models []CompatModel) {
+	// Filter models: only surface models with known pricing.
+	var pricedModels []CompatModel
+	for _, m := range models {
+		if p.calc != nil && !p.calc.HasPricing(m.Provider, m.ID) {
+			slog.Warn("⚠️ hiding model from /v1/models — no pricing configured",
+				"model", m.ID, "provider", m.Provider)
+			continue
+		}
+		pricedModels = append(pricedModels, m)
+	}
+
+	if dropped := len(models) - len(pricedModels); dropped > 0 {
+		slog.Info("model list filtered by pricing availability",
+			"total", len(models), "visible", len(pricedModels), "hidden", dropped)
+	}
+
+	p.compatMu.Lock()
+	p.compatModels = pricedModels
+	p.compatMu.Unlock()
+
+	p.modelListJSON.Store(buildModelsResponse(pricedModels))
+	slog.Info("📋 model list updated", "models", len(pricedModels))
+}
+
+// RefreshModels replaces the current model list with a new set of models.
+// This is intended to be called periodically when the catalog changes
+// (e.g. Firestore catalog refresh) without restarting the server.
+func (p *Proxy) RefreshModels(models []CompatModel) {
+	p.setModels(models)
 }
 
 func buildModelsResponse(models []CompatModel) []byte {
@@ -845,12 +879,14 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// Build per-provider model list from the proxy's registered providers/models.
 	if r.Method == http.MethodGet && strings.HasSuffix(upstreamPath, "/models") {
 		// Collect models configured for this specific provider.
+		p.compatMu.RLock()
 		var providerModels []CompatModel
 		for _, m := range p.compatModels {
 			if m.Provider == providerName {
 				providerModels = append(providerModels, m)
 			}
 		}
+		p.compatMu.RUnlock()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(buildModelsResponse(providerModels))
 		return

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -250,9 +250,10 @@ type Proxy struct {
 	users    storage.UserStore     // Budget deduction (nil = no budget tracking)
 	budgetCk *notify.BudgetChecker // Budget threshold notifications (nil = no alerts)
 
-	compatModels  []CompatModel // configured models for per-provider /models responses
-	modelListJSON atomic.Value  // cached []byte JSON response for /v1/models
-	compatMu      sync.RWMutex  // guards compatModels reads during refresh
+	compatModels     []CompatModel // configured models for per-provider /models responses
+	modelListJSON    atomic.Value  // cached []byte JSON response for /v1/models
+	modelProviderMap atomic.Value  // cached map[string]string (model→provider) for O(1) lookups
+	compatMu         sync.RWMutex  // guards compatModels reads during refresh
 
 	// CRIT-3: Durable outbox for failed DeductSpend calls.
 	spendOutbox *spendoutbox.Outbox
@@ -541,15 +542,11 @@ func (p *Proxy) RegisterCompatRoutes(mux *http.ServeMux, models []CompatModel) {
 	})
 
 	// POST /v1/chat/completions — route to provider based on model name in body.
-	// The model→provider lookup reads from the live compatModels list so it
-	// stays current after RefreshModels() calls.
+	// The model→provider lookup uses an atomic map for O(1) lock-free lookups.
 	lookupProvider := func(modelID string) (string, bool) {
-		p.compatMu.RLock()
-		defer p.compatMu.RUnlock()
-		for _, m := range p.compatModels {
-			if m.ID == modelID {
-				return m.Provider, true
-			}
+		if m, ok := p.modelProviderMap.Load().(map[string]string); ok {
+			prov, found := m[modelID]
+			return prov, found
 		}
 		return "", false
 	}
@@ -567,7 +564,6 @@ func (p *Proxy) RegisterCompatRoutes(mux *http.ServeMux, models []CompatModel) {
 			return
 		}
 		_ = r.Body.Close()
-
 		var req struct {
 			Model string `json:"model"`
 		}
@@ -581,21 +577,22 @@ func (p *Proxy) RegisterCompatRoutes(mux *http.ServeMux, models []CompatModel) {
 		providerName, ok := lookupProvider(req.Model)
 		if !ok {
 			// Try prefix-based alias resolution (e.g. "claude-sonnet-4" → "claude-sonnet-4-20250514").
-			p.compatMu.RLock()
-			var matches []string
-			for _, m := range p.compatModels {
-				if strings.HasPrefix(m.ID, req.Model) {
-					matches = append(matches, m.ID)
+			// Use the atomic map for lock-free iteration.
+			if provMap, loaded := p.modelProviderMap.Load().(map[string]string); loaded {
+				var matches []string
+				for id := range provMap {
+					if strings.HasPrefix(id, req.Model) {
+						matches = append(matches, id)
+					}
 				}
-			}
-			p.compatMu.RUnlock()
-			if len(matches) == 1 {
-				resolved := matches[0]
-				slog.Info("compat: resolved model alias", "from", req.Model, "to", resolved)
-				providerName, _ = lookupProvider(resolved)
-				ok = true
-				// Rewrite the model field in the body so upstream gets the canonical ID.
-				body = rewriteModelField(body, resolved)
+				if len(matches) == 1 {
+					resolved := matches[0]
+					slog.Info("compat: resolved model alias", "from", req.Model, "to", resolved)
+					providerName = provMap[resolved]
+					ok = true
+					// Rewrite the model field in the body so upstream gets the canonical ID.
+					body = rewriteModelField(body, resolved)
+				}
 			}
 		}
 		if !ok {
@@ -641,6 +638,13 @@ func (p *Proxy) setModels(models []CompatModel) {
 	p.compatMu.Lock()
 	p.compatModels = pricedModels
 	p.compatMu.Unlock()
+
+	// Build O(1) lookup map for the chat completions hot path.
+	providerMap := make(map[string]string, len(pricedModels))
+	for _, m := range pricedModels {
+		providerMap[m.ID] = m.Provider
+	}
+	p.modelProviderMap.Store(providerMap)
 
 	p.modelListJSON.Store(buildModelsResponse(pricedModels))
 	slog.Info("📋 model list updated", "models", len(pricedModels))

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -686,3 +686,46 @@ func TestPricingProvider(t *testing.T) {
 		}
 	}
 }
+
+// TestRefreshModels verifies that RefreshModels dynamically updates the /v1/models
+// response without restarting.
+func TestRefreshModels(t *testing.T) {
+	p, err := New(Config{
+		Providers: []Provider{{Name: "test", UpstreamURL: "http://localhost:9999"}},
+	}, &mockSubmitter{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	initial := []CompatModel{
+		{ID: "model-a", Provider: "test"},
+	}
+	p.RegisterCompatRoutes(mux, initial)
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Initial: should have model-a.
+	resp, _ := http.Get(srv.URL + "/v1/models")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close() //nolint:errcheck
+	if !strings.Contains(string(body), "model-a") {
+		t.Error("expected model-a in initial response")
+	}
+
+	// Refresh with model-b.
+	p.RefreshModels([]CompatModel{
+		{ID: "model-b", Provider: "test"},
+	})
+
+	resp, _ = http.Get(srv.URL + "/v1/models")
+	body, _ = io.ReadAll(resp.Body)
+	resp.Body.Close() //nolint:errcheck
+	if strings.Contains(string(body), "model-a") {
+		t.Error("model-a should be gone after refresh")
+	}
+	if !strings.Contains(string(body), "model-b") {
+		t.Error("expected model-b after refresh")
+	}
+}

--- a/scratch/test_models.sh
+++ b/scratch/test_models.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Test all models from the LM Studio endpoint
+
+curl -s http://127.0.0.1:1234/v1/models | jq -r '.data[].id' > /tmp/candela_models.txt
+total=$(wc -l < /tmp/candela_models.txt | tr -d ' ')
+echo "Testing $total models..."
+echo ""
+
+pass=0
+fail=0
+
+while IFS= read -r model; do
+  printf "%-45s " "$model"
+  result=$(curl -s --max-time 30 http://127.0.0.1:1234/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{"model":"'"$model"'","messages":[{"role":"user","content":"reply with exactly one word: ok"}],"max_tokens":5}' 2>&1)
+  
+  has_choices=$(echo "$result" | jq -e '.choices[0]' 2>/dev/null)
+  if [ $? -eq 0 ]; then
+    content=$(echo "$result" | jq -r '.choices[0].message.content // "empty"' | tr -d '\n' | head -c 30)
+    echo "✅ $content"
+    pass=$((pass + 1))
+  else
+    errMsg=$(echo "$result" | jq -r '
+      if .error.message then .error.message
+      elif type == "array" and .[0].error.message then .[0].error.message  
+      elif .error then (.error | tostring)
+      else "unknown error"
+      end' 2>/dev/null | head -c 100)
+    echo "❌ $errMsg"
+    fail=$((fail + 1))
+  fi
+done < /tmp/candela_models.txt
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Results: $pass ✅  $fail ❌  (total: $total)"


### PR DESCRIPTION
## Problem

In team mode, the CLI proxy's `/v1/models` returns models from the **locally embedded** `pricing.yaml` — including broken/retired models like `claude-fable-5`. The server has a Firestore catalog with the correct model list, but the CLI doesn't use it exclusively.

Additionally, the server's `/v1/models` response was computed **once at startup** and never refreshed, so adding models to Firestore required a server restart.

Closes #402 (Milestone 1)

## Changes

### Server-side: Dynamic `/v1/models`

- **`pkg/proxy/proxy.go`**: Replace the static `[]byte` model list with `atomic.Value` + `sync.RWMutex`
  - New `setModels()` method: filters by pricing, stores models, rebuilds JSON atomically
  - New `RefreshModels()` public method: allows external callers to push updated model lists
  - Per-provider `/v1/models` handler now reads under `RLock`
  - Chat completions model→provider lookup reads from live list via closure
- **`cmd/candela-server/main.go`**: Extract model-building into `buildCompatModels()` helper
  - Start a 60s periodic goroutine (Firestore backend only) that reloads catalog entries and calls `RefreshModels()`
  - Admins can now add/remove models in Firestore without restarting the server

### CLI-side: Server-authoritative in team mode

- **`cmd/candela/lm_handler.go`**: Add `soloMode` flag
  - In team mode (`soloMode=false`): `serveModels()` skips embedded cloud models, returns only local runtime + remote server models
  - Background goroutine pre-fetches remote models on startup (2s delay) and refreshes every 60s
  - `lastRemoteFetch` atomic timestamp for TTL tracking
- **`cmd/candela/main.go`**: Pass existing `soloMode` variable to `newLMHandler()`

## Testing

- All pre-commit hooks pass (gofmt, go-vet, golangci-lint, go-test)
- All 40+ test packages pass including `cmd/candela` (11.9s) and `pkg/proxy` (4.1s)
- Updated all 16 `newLMHandler()` call sites in `lm_handler_test.go` with correct `soloMode` values