### PR TITLE
fix: disable dev_mode in production, fail-closed on Cloud Run

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -906,9 +906,11 @@ func main() {
 	// Wrap the mux with Firebase Auth middleware.
 	devMode := cfg.Auth.DevMode
 	// Guard: never allow dev mode on Cloud Run (K_SERVICE is always set by Cloud Run).
+	// Fail-closed: refuse to start rather than silently correcting.
 	if devMode && os.Getenv("K_SERVICE") != "" {
-		slog.Error("auth.dev_mode=true is not allowed on Cloud Run — disabling")
-		devMode = false
+		slog.Error("FATAL: auth.dev_mode=true is not allowed on Cloud Run — refusing to start",
+			"K_SERVICE", os.Getenv("K_SERVICE"))
+		os.Exit(1)
 	}
 
 	// Initialize Firebase Admin SDK for token verification.

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -902,14 +902,14 @@ func main() {
 	}
 
 	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
-
 	// Wrap the mux with Firebase Auth middleware.
 	devMode := cfg.Auth.DevMode
-	// Guard: never allow dev mode on Cloud Run (K_SERVICE is always set by Cloud Run).
-	// Fail-closed: refuse to start rather than silently correcting.
-	if devMode && os.Getenv("K_SERVICE") != "" {
-		slog.Error("FATAL: auth.dev_mode=true is not allowed on Cloud Run — refusing to start",
-			"K_SERVICE", os.Getenv("K_SERVICE"))
+	// Cloud Run service URL is the audience for Google ID tokens (candela-local).
+	cloudRunURL := os.Getenv("CLOUD_RUN_URL")
+
+	// Guard: never allow dev mode on Cloud Run. Fail-closed.
+	if err := validateAuthConfig(devMode, os.Getenv("K_SERVICE"), cloudRunURL); err != nil {
+		slog.Error("FATAL: " + err.Error())
 		os.Exit(1)
 	}
 
@@ -928,9 +928,6 @@ func main() {
 		}
 		slog.Info("🔐 Firebase Auth initialized")
 	}
-
-	// Cloud Run service URL is the audience for Google ID tokens (candela-local).
-	cloudRunURL := os.Getenv("CLOUD_RUN_URL")
 
 	// Build a UserAuthorizer from the Firestore UserStore (if available).
 	// This restricts access to only registered users.
@@ -1148,4 +1145,16 @@ func corsMiddleware(next http.Handler, origins []string) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// validateAuthConfig checks that the auth configuration is safe for the runtime environment.
+// Returns an error if the configuration would be insecure.
+func validateAuthConfig(devMode bool, kService, cloudRunURL string) error {
+	if devMode && kService != "" {
+		return fmt.Errorf("auth.dev_mode=true is not allowed on Cloud Run (K_SERVICE=%s)", kService)
+	}
+	if kService != "" && cloudRunURL == "" {
+		slog.Warn("CLOUD_RUN_URL not set on Cloud Run — Google ID token validation (Strategy 2) will be skipped; tokens will fall through to OAuth2 userinfo (slower)")
+	}
+	return nil
 }

--- a/cmd/candela-server/main_test.go
+++ b/cmd/candela-server/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestValidateAuthConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		devMode     bool
+		kService    string
+		cloudRunURL string
+		wantErr     bool
+	}{
+		{"dev mode on Cloud Run is rejected", true, "candela-server", "https://candela.run.app", true},
+		{"dev mode locally is allowed", true, "", "", false},
+		{"prod mode on Cloud Run is allowed", false, "candela-server", "https://candela.run.app", false},
+		{"prod mode locally is allowed", false, "", "", false},
+		{"dev mode on Cloud Run without CLOUD_RUN_URL is rejected", true, "candela-server", "", true},
+		{"prod mode on Cloud Run without CLOUD_RUN_URL warns but succeeds", false, "candela-server", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAuthConfig(tt.devMode, tt.kService, tt.cloudRunURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateAuthConfig(devMode=%v, kService=%q, cloudRunURL=%q) error = %v, wantErr %v",
+					tt.devMode, tt.kService, tt.cloudRunURL, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/deploy/config.production.example.yaml
+++ b/deploy/config.production.example.yaml
@@ -46,8 +46,9 @@ cors:
   allowed_origins: []
 
 auth:
-  dev_mode: true  # Cloud Run invoker IAM handles access control.
-  # TODO: replace with Firebase Auth / Cloud Run ID token validation.
+  dev_mode: false  # Firebase Auth + Google ID token validation (no IAP).
+  # allowed_service_accounts:  # SAs allowed to proxy — deny all if empty.
+  #   - "your-sa@your-project.iam.gserviceaccount.com"
 
 firestore:
   enabled: true

--- a/pkg/auth/firebase_test.go
+++ b/pkg/auth/firebase_test.go
@@ -600,3 +600,126 @@ func TestFirebaseAuthMiddleware_DevMode_IgnoresAllowlist(t *testing.T) {
 		t.Fatalf("dev mode with SA allowlist status = %d, want 200", rr2.Code)
 	}
 }
+
+// --- Production auth path tests (dev_mode=false, no IAP) ---
+
+func TestFirebaseAuthMiddleware_ProdMode_NoBearerToken_Returns401(t *testing.T) {
+	// In production mode with no Firebase client and no Cloud Run audience,
+	// requests without any Authorization header must get 401.
+	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", nil, false, nil)
+
+	req := httptest.NewRequest("POST", "/candela.v1.SpanService/ListSpans", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+
+	var errResp map[string]string
+	body, _ := io.ReadAll(rr.Body)
+	_ = json.Unmarshal(body, &errResp)
+	if errResp["error"] != "missing authentication" {
+		t.Errorf("error = %q, want %q", errResp["error"], "missing authentication")
+	}
+}
+
+func TestFirebaseAuthMiddleware_ProdMode_InvalidBearerToken_Returns401(t *testing.T) {
+	// In production mode, an invalid Bearer token should be rejected with 401
+	// after all strategies (Firebase, Google ID token, OAuth2) fail.
+	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", nil, false, nil)
+
+	req := httptest.NewRequest("POST", "/candela.v1.SpanService/ListSpans", nil)
+	req.Header.Set("Authorization", "Bearer bogus-token-12345")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+
+	var errResp map[string]string
+	body, _ := io.ReadAll(rr.Body)
+	_ = json.Unmarshal(body, &errResp)
+	if errResp["error"] != "invalid authentication token" {
+		t.Errorf("error = %q, want %q", errResp["error"], "invalid authentication token")
+	}
+}
+
+func TestFirebaseAuthMiddleware_ProdMode_XCandelaAuth_Preferred(t *testing.T) {
+	// When behind IAP, X-Candela-Auth carries the original user identity token
+	// and should take priority over the IAP-replaced Authorization header.
+	// With no validators configured, both tokens will fail, but this tests
+	// that extractBearerToken returns the X-Candela-Auth token.
+	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", nil, false, nil)
+
+	req := httptest.NewRequest("GET", "/api/data", nil)
+	req.Header.Set("X-Candela-Auth", "Bearer custom-token")
+	req.Header.Set("Authorization", "Bearer iap-replaced-token")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// Both tokens are invalid, so we get 401 — but the important thing is
+	// that it didn't crash and the middleware ran through all strategies.
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestExtractBearerToken_XCandelaAuth_Priority(t *testing.T) {
+	// X-Candela-Auth should take priority over Authorization.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Candela-Auth", "Bearer candela-token")
+	req.Header.Set("Authorization", "Bearer auth-token")
+	got := extractBearerToken(req)
+	if got != "candela-token" {
+		t.Errorf("extractBearerToken() = %q, want %q (X-Candela-Auth should take priority)", got, "candela-token")
+	}
+}
+
+func TestFirebaseAuthMiddleware_ProdMode_HealthzBypassesAuth(t *testing.T) {
+	// Health checks must bypass auth even in production mode with no
+	// validators configured. This is critical for Cloud Run health probes.
+	healthHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	handler := FirebaseAuthMiddleware(healthHandler, nil, "", nil, false, nil)
+
+	for _, path := range []string{"/healthz", "/readyz"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest("GET", path, nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("%s status = %d, want 200", path, rr.Code)
+			}
+			body, _ := io.ReadAll(rr.Body)
+			if string(body) != "ok" {
+				t.Errorf("%s body = %q, want %q", path, string(body), "ok")
+			}
+		})
+	}
+}
+
+func TestFirebaseAuthMiddleware_ProdMode_SelfServicePath_StillRequiresToken(t *testing.T) {
+	// Self-service paths bypass the registration gate but still require
+	// a valid auth token. Without a token, they should return 401.
+	handler := FirebaseAuthMiddleware(echoHandler(), nil, "", nil, false, nil)
+
+	for _, path := range []string{
+		"/candela.v1.UserService/GetCurrentUser",
+		"/candela.v1.UserService/GetMyBudget",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest("POST", path, nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusUnauthorized {
+				t.Fatalf("self-service path %s without token: status = %d, want 401", path, rr.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the `dev_mode: true` security issue in production deployment config.

### Key Finding
The server already had proper Cloud Run OIDC auth via `FirebaseAuthMiddleware` — it validates Firebase ID tokens, Google ID tokens, and OAuth2 access tokens. No new auth mode was needed. The config was just set wrong.

### Changes

1. **`deploy/config.production.yaml`** — `dev_mode: false`
2. **`deploy/config.production.example.yaml`** — Set `dev_mode: false`, removed stale TODO
3. **`cmd/candela-server/main.go`** — K_SERVICE guard upgraded to `os.Exit(1)` (fail-closed). If someone deploys with `dev_mode: true` to Cloud Run, the server refuses to start instead of silently correcting.
4. **`pkg/auth/firebase_test.go`** — 6 new tests covering production auth paths:
   - No bearer token → 401
   - Invalid bearer token → 401
   - X-Candela-Auth header priority
   - Health check auth bypass
   - Self-service paths still require auth

### Testing
- `go test ./pkg/auth/...` — all 34 tests pass
- `go build ./cmd/candela-server/...` — builds clean
- All pre-commit hooks pass