### PR TITLE
ci: add buf registry whoami workflow

### DIFF
--- a/.github/workflows/buf_whoami.yaml
+++ b/.github/workflows/buf_whoami.yaml
@@ -25,7 +25,21 @@ jobs:
       - name: Fix git ownership for Nix flake
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Buf registry whoami
+      - name: Check BUF_TOKEN is set
+        run: |
+          if [ -z "$BUF_TOKEN" ]; then
+            echo "::warning::BUF_TOKEN secret is not set or empty"
+          else
+            echo "BUF_TOKEN is configured (${#BUF_TOKEN} chars)"
+          fi
         env:
           BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
-        run: nix develop . --command buf registry whoami
+
+      - name: Buf registry whoami
+        run: |
+          nix develop . --command buf registry whoami || {
+            echo "::error::buf registry whoami failed — check that BUF_TOKEN secret is configured"
+            exit 1
+          }
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/buf_whoami.yaml
+++ b/.github/workflows/buf_whoami.yaml
@@ -1,0 +1,31 @@
+name: Buf Whoami
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  buf-whoami:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/candelahq/candela-dev:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Fix git ownership for Nix flake
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Buf registry whoami
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+        run: nix develop . --command buf registry whoami


### PR DESCRIPTION
Adds a standalone CI workflow (`buf_whoami.yaml`) that authenticates with `BUF_TOKEN` and runs `buf registry whoami` to verify which Buf registry identity is used in CI.

**Triggers:** push/PR to main, manual dispatch

This helps diagnose BSR authentication issues in CI.