### PR TITLE
ci(buf_whoami): drop pull_request trigger — secrets unavailable on PRs

### DIFF
--- a/.github/workflows/buf_whoami.yaml
+++ b/.github/workflows/buf_whoami.yaml
@@ -3,8 +3,6 @@ name: Buf Whoami
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Fixes the `buf_whoami` workflow that was failing on PRs because GitHub Actions does not expose secrets on `pull_request` events.

**Change:** Remove `pull_request` trigger, keep `push` (main) and `workflow_dispatch`.

Follow-up to #407.