### PR TITLE
fix(catalog): scope AdminEditable to caller role, not just store writability

### DIFF
--- a/pkg/connecthandlers/catalog_handler.go
+++ b/pkg/connecthandlers/catalog_handler.go
@@ -32,8 +32,11 @@ func (h *CatalogHandler) ListModelCatalog(
 ) (*connect.Response[v1.ListModelCatalogResponse], error) {
 	includeDisabled := req.Msg.IncludeDisabled
 
+	// Resolve caller scope once — empty string means admin (full access).
+	callerScope := scopeUserID(ctx, h.users)
+
 	// Non-admin callers cannot see disabled models.
-	if uid := scopeUserID(ctx, h.users); uid != "" {
+	if callerScope != "" {
 		includeDisabled = false
 	}
 
@@ -50,7 +53,7 @@ func (h *CatalogHandler) ListModelCatalog(
 	return connect.NewResponse(&v1.ListModelCatalogResponse{
 		Models:        pbModels,
 		Source:        h.store.Source(),
-		AdminEditable: h.store.Writable() && scopeUserID(ctx, h.users) == "",
+		AdminEditable: h.store.Writable() && callerScope == "",
 	}), nil
 }
 

--- a/pkg/connecthandlers/catalog_handler.go
+++ b/pkg/connecthandlers/catalog_handler.go
@@ -50,7 +50,7 @@ func (h *CatalogHandler) ListModelCatalog(
 	return connect.NewResponse(&v1.ListModelCatalogResponse{
 		Models:        pbModels,
 		Source:        h.store.Source(),
-		AdminEditable: h.store.Writable(),
+		AdminEditable: h.store.Writable() && scopeUserID(ctx, h.users) == "",
 	}), nil
 }
 

--- a/pkg/connecthandlers/catalog_handler_test.go
+++ b/pkg/connecthandlers/catalog_handler_test.go
@@ -180,6 +180,40 @@ func TestCatalogHandler_ListDisabled_NonAdmin(t *testing.T) {
 	}
 }
 
+// TestCatalogHandler_ListAdminEditable_Developer verifies that developers
+// do NOT receive admin_editable=true even on a writable store.
+func TestCatalogHandler_ListAdminEditable_Developer(t *testing.T) {
+	store := newMockWritableCatalogStore(testCatalogEntries) // Writable() = true
+	handler := NewCatalogHandler(store, newDeveloperUserStore())
+
+	resp, err := handler.ListModelCatalog(developerContext(),
+		connect.NewRequest(&v1.ListModelCatalogRequest{}))
+	if err != nil {
+		t.Fatalf("ListModelCatalog: %v", err)
+	}
+
+	if resp.Msg.AdminEditable {
+		t.Error("expected admin_editable=false for developer caller on writable store")
+	}
+}
+
+// TestCatalogHandler_ListAdminEditable_Admin verifies that admins
+// receive admin_editable=true on a writable store.
+func TestCatalogHandler_ListAdminEditable_Admin(t *testing.T) {
+	store := newMockWritableCatalogStore(testCatalogEntries) // Writable() = true
+	handler := NewCatalogHandler(store, newAdminUserStore())
+
+	resp, err := handler.ListModelCatalog(adminContext(),
+		connect.NewRequest(&v1.ListModelCatalogRequest{}))
+	if err != nil {
+		t.Fatalf("ListModelCatalog: %v", err)
+	}
+
+	if !resp.Msg.AdminEditable {
+		t.Error("expected admin_editable=true for admin caller on writable store")
+	}
+}
+
 // TestCatalogHandler_UpdateReadOnly tests that update returns Unimplemented
 // when the store is read-only.
 func TestCatalogHandler_UpdateReadOnly(t *testing.T) {


### PR DESCRIPTION
## Problem

`AdminEditable` in the `ListModelCatalogResponse` was set solely based on `h.store.Writable()` — a property of the **storage backend**, not the **caller's role**.

Any developer on a Firestore-backed catalog received `adminEditable: true`, causing the Flutter client to show admin UI controls (enable/disable toggles, delete buttons, Admin badge) they couldn't use. Not a privilege escalation (server mutations are correctly guarded), but confusing UX.

## Fix

```diff
- AdminEditable: h.store.Writable(),
+ AdminEditable: h.store.Writable() && scopeUserID(ctx, h.users) == "",
```

## Tests

- `TestCatalogHandler_ListAdminEditable_Developer` — developer + writable store → `adminEditable=false`
- `TestCatalogHandler_ListAdminEditable_Admin` — admin + writable store → `adminEditable=true`