### PR TITLE
fix(security): add auth guard to GetJobLeaderboard, close UpdateUser role escalation gap

### DIFF
--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -405,6 +405,12 @@ func (h *DashboardHandler) GetTenantLeaderboard(
 }
 
 func (h *DashboardHandler) GetJobLeaderboard(ctx context.Context, req *connect.Request[v1.GetJobLeaderboardRequest]) (*connect.Response[v1.GetJobLeaderboardResponse], error) {
+	// Admin-only: non-admin users (non-empty scopeUserID) are denied.
+	if uid := scopeUserID(ctx, h.users); uid != "" {
+		return nil, connect.NewError(connect.CodePermissionDenied,
+			fmt.Errorf("job leaderboard is admin-only"))
+	}
+
 	q, limit := parseLeaderboardParams(req.Msg)
 	jobs, err := h.store.GetJobLeaderboard(ctx, q, limit)
 	if err != nil {

--- a/pkg/connecthandlers/dashboard_handler_test.go
+++ b/pkg/connecthandlers/dashboard_handler_test.go
@@ -245,3 +245,92 @@ func TestGetDashboardData_FallbackReader(t *testing.T) {
 		t.Errorf("Models count = %d, want 1", len(resp.Msg.Models))
 	}
 }
+
+// ── Leaderboard authorization tests ─────────────────────────────────────────
+
+// mockUserStoreForDashboard is a minimal mock that returns user records by email.
+type mockUserStoreForDashboard struct {
+	storage.UserStore // embed to satisfy interface; unused methods panic
+	users             map[string]*storage.UserRecord
+}
+
+func (m *mockUserStoreForDashboard) GetUserByEmail(_ context.Context, email string) (*storage.UserRecord, error) {
+	if u, ok := m.users[email]; ok {
+		return u, nil
+	}
+	return nil, storage.ErrNotFound
+}
+
+// startDashboardServerWithAuth creates a test server with a specific user store
+// and injects the given auth user into every request.
+func startDashboardServerWithAuth(t *testing.T, spanStore storage.SpanReader, userStore storage.UserStore, user *auth.User) candelav1connect.DashboardServiceClient {
+	t.Helper()
+	mux := http.NewServeMux()
+	path, handler := candelav1connect.NewDashboardServiceHandler(
+		connecthandlers.NewDashboardHandler(spanStore, userStore),
+	)
+	mux.Handle(path, handler)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.NewContext(r.Context(), user)
+		mux.ServeHTTP(w, r.WithContext(ctx))
+	}))
+	t.Cleanup(server.Close)
+
+	return candelav1connect.NewDashboardServiceClient(http.DefaultClient, server.URL)
+}
+
+// TestGetJobLeaderboard_DeveloperDenied verifies that non-admin callers
+// are rejected from GetJobLeaderboard with PermissionDenied.
+func TestGetJobLeaderboard_DeveloperDenied(t *testing.T) {
+	userStore := &mockUserStoreForDashboard{
+		users: map[string]*storage.UserRecord{
+			"dev@example.com": {
+				ID:    "dev@example.com",
+				Email: "dev@example.com",
+				Role:  storage.RoleDeveloper,
+			},
+		},
+	}
+	spanStore := &fallbackStore{}
+
+	client := startDashboardServerWithAuth(t, spanStore, userStore,
+		&auth.User{ID: "dev-uid", Email: "dev@example.com"})
+
+	_, err := client.GetJobLeaderboard(context.Background(),
+		connect.NewRequest(&v1.GetJobLeaderboardRequest{}))
+	if err == nil {
+		t.Fatal("expected permission denied for developer calling GetJobLeaderboard")
+	}
+	connectErr, ok := err.(*connect.Error)
+	if !ok {
+		t.Fatalf("expected *connect.Error, got %T", err)
+	}
+	if connectErr.Code() != connect.CodePermissionDenied {
+		t.Errorf("expected CodePermissionDenied, got %v", connectErr.Code())
+	}
+}
+
+// TestGetJobLeaderboard_AdminAllowed verifies that admin callers
+// can access GetJobLeaderboard successfully.
+func TestGetJobLeaderboard_AdminAllowed(t *testing.T) {
+	userStore := &mockUserStoreForDashboard{
+		users: map[string]*storage.UserRecord{
+			"admin@example.com": {
+				ID:    "admin@example.com",
+				Email: "admin@example.com",
+				Role:  storage.RoleAdmin,
+			},
+		},
+	}
+	spanStore := &fallbackStore{}
+
+	client := startDashboardServerWithAuth(t, spanStore, userStore,
+		&auth.User{ID: "admin-uid", Email: "admin@example.com"})
+
+	_, err := client.GetJobLeaderboard(context.Background(),
+		connect.NewRequest(&v1.GetJobLeaderboardRequest{}))
+	if err != nil {
+		t.Fatalf("expected admin to access GetJobLeaderboard, got: %v", err)
+	}
+}

--- a/pkg/connecthandlers/user_handler.go
+++ b/pkg/connecthandlers/user_handler.go
@@ -218,12 +218,14 @@ func (h *UserHandler) UpdateUser(
 	for _, p := range paths {
 		if p == "role" {
 			caller := auth.FromContext(ctx)
-			if caller != nil {
-				callerRecord, err := h.store.GetUserByEmail(ctx, caller.Email)
-				if err != nil || callerRecord.Role != storage.RoleAdmin {
-					return nil, connect.NewError(connect.CodePermissionDenied,
-						fmt.Errorf("only admins can modify user roles"))
-				}
+			if caller == nil {
+				return nil, connect.NewError(connect.CodeUnauthenticated,
+					fmt.Errorf("authentication required to modify roles"))
+			}
+			callerRecord, err := h.store.GetUserByEmail(ctx, caller.Email)
+			if err != nil || callerRecord.Role != storage.RoleAdmin {
+				return nil, connect.NewError(connect.CodePermissionDenied,
+					fmt.Errorf("only admins can modify user roles"))
 			}
 			break
 		}

--- a/pkg/connecthandlers/user_handler.go
+++ b/pkg/connecthandlers/user_handler.go
@@ -223,7 +223,14 @@ func (h *UserHandler) UpdateUser(
 					fmt.Errorf("authentication required to modify roles"))
 			}
 			callerRecord, err := h.store.GetUserByEmail(ctx, caller.Email)
-			if err != nil || callerRecord.Role != storage.RoleAdmin {
+			if err != nil {
+				if errors.Is(err, storage.ErrNotFound) {
+					return nil, connect.NewError(connect.CodePermissionDenied,
+						fmt.Errorf("only admins can modify user roles"))
+				}
+				return nil, internalError("failed to look up caller", err)
+			}
+			if callerRecord.Role != storage.RoleAdmin {
 				return nil, connect.NewError(connect.CodePermissionDenied,
 					fmt.Errorf("only admins can modify user roles"))
 			}

--- a/pkg/connecthandlers/user_handler_test.go
+++ b/pkg/connecthandlers/user_handler_test.go
@@ -787,6 +787,49 @@ func TestUserHandler_UpdateUser_FieldMask(t *testing.T) {
 	}
 }
 
+// TestUserHandler_UpdateUser_RoleChange_Unauthenticated verifies that
+// unauthenticated callers (nil auth context) are denied role changes.
+// This is a defense-in-depth test — production uses AdminInterceptor,
+// but the handler should be independently secure.
+func TestUserHandler_UpdateUser_RoleChange_Unauthenticated(t *testing.T) {
+	store := newMockUserStore()
+	handler := NewUserHandler(store, 0)
+
+	// Create a target user as admin first.
+	adminCtx := authedCtx("admin@example.com")
+	_, _ = handler.CreateUser(adminCtx, connect.NewRequest(&v1.CreateUserRequest{
+		Email: "admin@example.com",
+		Role:  typespb.UserRole_USER_ROLE_ADMIN,
+	}))
+	createResp, _ := handler.CreateUser(adminCtx, connect.NewRequest(&v1.CreateUserRequest{
+		Email: "target@example.com",
+		Role:  typespb.UserRole_USER_ROLE_DEVELOPER,
+	}))
+	userID := createResp.Msg.User.Id
+
+	// Attempt role escalation with no auth context (context.Background()).
+	_, err := handler.UpdateUser(context.Background(), connect.NewRequest(&v1.UpdateUserRequest{
+		Id:   userID,
+		Role: typespb.UserRole_USER_ROLE_ADMIN,
+	}))
+	if err == nil {
+		t.Fatal("expected error for unauthenticated role change")
+	}
+	connectErr, ok := err.(*connect.Error)
+	if !ok {
+		t.Fatalf("expected *connect.Error, got %T", err)
+	}
+	if connectErr.Code() != connect.CodeUnauthenticated {
+		t.Errorf("expected CodeUnauthenticated, got %v", connectErr.Code())
+	}
+
+	// Verify the role was NOT changed.
+	u, _ := store.GetUser(context.Background(), userID)
+	if u.Role != "developer" {
+		t.Errorf("role should still be developer, got %q", u.Role)
+	}
+}
+
 func TestUserHandler_GetMyBudget_Unauthenticated(t *testing.T) {
 	store := newMockUserStore()
 	handler := NewUserHandler(store, 0)


### PR DESCRIPTION
## Two authorization fixes

### 1. GetJobLeaderboard missing auth guard (HIGH)

`GetJobLeaderboard` had **no `scopeUserID` check**, unlike its siblings `GetTeamLeaderboard` and `GetTenantLeaderboard`. Any authenticated developer could query cross-user job cost/usage data.

**Fix:** Added the same admin-only guard.

### 2. UpdateUser role escalation bypass (MEDIUM-HIGH)

The role-mutation guard used `if caller != nil` which **silently skipped** the admin check when `auth.FromContext` returned nil (dev mode / unauthenticated). A nil auth context allowed unrestricted role changes.

**Fix:** Inverted to deny-by-default — nil caller now returns `CodeUnauthenticated`.

## Tests

- `TestGetJobLeaderboard_DeveloperDenied` — developer gets `PermissionDenied`
- `TestGetJobLeaderboard_AdminAllowed` — admin succeeds
- `TestUserHandler_UpdateUser_RoleChange_Unauthenticated` — nil auth context gets `Unauthenticated`, role unchanged