### PR TITLE
ci: disable Docker build cache to prevent stale binaries

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -102,5 +102,5 @@ jobs:
           platforms: ${{ inputs.platforms || '' }}
           tags: ${{ steps.version.outputs.tags || steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Cache disabled: GHA cache caused stale binaries to ship without
+          # security fixes (v0.7.1 incident). Build time (~2 min) is acceptable.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,5 +98,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Cache disabled: GHA cache caused stale binaries to ship without
+          # security fixes (v0.7.1 incident). Build time (~2 min) is acceptable.


### PR DESCRIPTION
## Problem

GHA Docker layer cache (`cache-from/cache-to: type=gha`) caused the v0.7.1 security fixes to NOT be compiled into the published server image. The `COPY . .` and `go build` layers were cache-hit from a pre-fix build, shipping the old binary under the new `91e6b68` tag.

This meant the AdminEditable, GetJobLeaderboard, and UpdateUser security fixes were never actually deployed despite the tag and image appearing correct.

## Fix

Remove Docker build caching entirely from both:
- `publish.yml` (server image publish)
- `docker-build-push.yml` (shared reusable workflow)

Build time (~2 min) is acceptable for correctness guarantees.

## Impact

- Prevents future incidents where security fixes silently fail to deploy
- Affects: `publish.yml`, `docker-build-push.yml`