### PR TITLE
feat: add structured audit logging for admin actions

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -31,6 +31,7 @@ import (
 	connect "connectrpc.com/connect"
 	"connectrpc.com/validate"
 	"github.com/candelahq/candela/gen/go/candela/v1/candelav1connect"
+	"github.com/candelahq/candela/pkg/audit"
 	"github.com/candelahq/candela/pkg/auth"
 	"github.com/candelahq/candela/pkg/catalog"
 	"github.com/candelahq/candela/pkg/connecthandlers"
@@ -420,12 +421,16 @@ func main() {
 		// Create protovalidate interceptor (validates request fields before handler).
 		validateInterceptor := validate.NewInterceptor()
 
+		// Audit interceptor logs all mutation RPCs with actor identity and outcome.
+		auditLogger := audit.NewSlogLogger()
+		auditInterceptor := audit.Interceptor(auditLogger, audit.DefaultMutationProcedures)
+
 		userPath, userH := candelav1connect.NewUserServiceHandler(
 			connecthandlers.NewUserHandler(fStore, cfg.Users.DefaultDailyBudgetUSD),
-			connect.WithInterceptors(validateInterceptor, auth.AdminInterceptor(fStore)))
+			connect.WithInterceptors(validateInterceptor, auth.AdminInterceptor(fStore), auditInterceptor))
 		mux.Handle(userPath, userH)
 		slog.Info("UserService registered", "path", userPath,
-			"admin_guard", true, "validation", true,
+			"admin_guard", true, "validation", true, "audit", true,
 			"default_daily_budget", cfg.Users.DefaultDailyBudgetUSD)
 	} else {
 		slog.Info("Firestore disabled — UserService not available, all users see all traces")
@@ -451,14 +456,27 @@ func main() {
 	}
 	defer func() { _ = projectStore.Close() }()
 
+	// Build audit interceptor for services outside the Firestore block.
+	// If Firestore is disabled, auditInterceptor is nil-safe (not wired).
+	var projectInterceptors, catalogInterceptors []connect.Interceptor
+	catalogValidateInterceptor := validate.NewInterceptor()
+	if userStore != nil {
+		auditLogger := audit.NewSlogLogger()
+		auditInterceptor := audit.Interceptor(auditLogger, audit.DefaultMutationProcedures)
+		projectInterceptors = []connect.Interceptor{auditInterceptor}
+		catalogInterceptors = []connect.Interceptor{catalogValidateInterceptor, auditInterceptor}
+	} else {
+		catalogInterceptors = []connect.Interceptor{catalogValidateInterceptor}
+	}
+
 	projectPath, projectH := candelav1connect.NewProjectServiceHandler(
-		connecthandlers.NewProjectHandler(projectStore))
+		connecthandlers.NewProjectHandler(projectStore, userStore),
+		connect.WithInterceptors(projectInterceptors...))
 	mux.Handle(projectPath, projectH)
 
-	catalogValidateInterceptor := validate.NewInterceptor()
 	catalogPath, catalogH := candelav1connect.NewModelCatalogServiceHandler(
 		connecthandlers.NewCatalogHandler(catalogStore, userStore),
-		connect.WithInterceptors(catalogValidateInterceptor))
+		connect.WithInterceptors(catalogInterceptors...))
 	mux.Handle(catalogPath, catalogH)
 
 	slog.Info("ConnectRPC services registered",

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -28,7 +28,9 @@ type Multi []Logger
 
 func (m Multi) Log(ctx context.Context, event Event) {
 	for _, l := range m {
-		l.Log(ctx, event)
+		if l != nil {
+			l.Log(ctx, event)
+		}
 	}
 }
 

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -1,0 +1,73 @@
+package audit
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// Event represents a single auditable admin action.
+type Event struct {
+	Timestamp  time.Time
+	ActorEmail string // from auth.FromContext
+	ActorID    string
+	Service    string // e.g. "UserService"
+	Method     string // e.g. "CreateUser"
+	Procedure  string // full RPC path, e.g. "/candela.v1.UserService/CreateUser"
+	StatusCode string // "ok", "permission_denied", etc.
+	Error      string // empty on success
+}
+
+// Logger writes audit events to a backend.
+type Logger interface {
+	Log(ctx context.Context, event Event)
+}
+
+// Multi fans out audit events to multiple loggers.
+type Multi []Logger
+
+func (m Multi) Log(ctx context.Context, event Event) {
+	for _, l := range m {
+		l.Log(ctx, event)
+	}
+}
+
+// ParseProcedure extracts service and method names from a ConnectRPC procedure string.
+// e.g. "/candela.v1.UserService/CreateUser" → ("UserService", "CreateUser")
+func ParseProcedure(procedure string) (service, method string) {
+	// Strip leading slash: "candela.v1.UserService/CreateUser"
+	p := strings.TrimPrefix(procedure, "/")
+	parts := strings.SplitN(p, "/", 2)
+	if len(parts) != 2 {
+		return procedure, ""
+	}
+	method = parts[1]
+	// Extract service name from fully-qualified name: "candela.v1.UserService" → "UserService"
+	svcParts := strings.Split(parts[0], ".")
+	service = svcParts[len(svcParts)-1]
+	return service, method
+}
+
+// DefaultMutationProcedures is the set of RPC procedures that should be audit-logged.
+var DefaultMutationProcedures = map[string]bool{
+	// UserService mutations
+	"/candela.v1.UserService/CreateUser":     true,
+	"/candela.v1.UserService/UpdateUser":     true,
+	"/candela.v1.UserService/DeactivateUser": true,
+	"/candela.v1.UserService/ReactivateUser": true,
+	"/candela.v1.UserService/DeleteUser":     true,
+	"/candela.v1.UserService/SetBudget":      true,
+	"/candela.v1.UserService/ResetSpend":     true,
+	"/candela.v1.UserService/CreateGrant":    true,
+	"/candela.v1.UserService/RevokeGrant":    true,
+
+	// CatalogService mutations
+	"/candela.v1.ModelCatalogService/UpdateModelCatalogEntry": true,
+	"/candela.v1.ModelCatalogService/DeleteModelCatalogEntry": true,
+
+	// ProjectService mutations
+	"/candela.v1.ProjectService/CreateProject": true,
+	"/candela.v1.ProjectService/DeleteProject": true,
+	"/candela.v1.ProjectService/CreateAPIKey":  true,
+	"/candela.v1.ProjectService/RevokeAPIKey":  true,
+}

--- a/pkg/audit/audit_test.go
+++ b/pkg/audit/audit_test.go
@@ -2,10 +2,14 @@ package audit
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"sync"
 	"testing"
+	"time"
 
 	connect "connectrpc.com/connect"
+	"github.com/candelahq/candela/pkg/auth"
 )
 
 // memLogger captures audit events in memory for testing.
@@ -106,5 +110,159 @@ func TestDefaultMutationProcedures(t *testing.T) {
 	}
 }
 
-// Ensure connect import is used (interceptor tests reference connect.CodeOf).
-var _ = connect.CodeOf
+func TestMulti_NilLogger(t *testing.T) {
+	a := &memLogger{}
+	multi := Multi{a, nil, a} // nil logger in the middle
+
+	multi.Log(context.Background(), Event{Method: "test"})
+
+	if len(a.Events()) != 2 {
+		t.Fatalf("logger a got %d events, want 2 (nil logger should be skipped)", len(a.Events()))
+	}
+}
+
+// fakeRequest implements connect.AnyRequest for testing interceptors.
+type fakeRequest struct {
+	connect.AnyRequest
+	procedure string
+}
+
+func (r *fakeRequest) Spec() connect.Spec {
+	return connect.Spec{Procedure: r.procedure}
+}
+
+func (r *fakeRequest) Peer() connect.Peer {
+	return connect.Peer{}
+}
+
+func (r *fakeRequest) Header() http.Header {
+	return http.Header{}
+}
+
+func TestInterceptor_MutationLogged(t *testing.T) {
+	logger := &memLogger{}
+	procedures := map[string]bool{
+		"/candela.v1.UserService/CreateUser": true,
+	}
+	interceptor := Interceptor(logger, procedures)
+
+	// Wrap a handler that succeeds.
+	handler := interceptor(func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, nil
+	})
+
+	// Inject auth context.
+	ctx := auth.NewContext(context.Background(), &auth.User{
+		Email: "admin@test.com",
+		ID:    "uid-123",
+	})
+
+	_, _ = handler(ctx, &fakeRequest{procedure: "/candela.v1.UserService/CreateUser"})
+
+	events := logger.Events()
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	e := events[0]
+	if e.ActorEmail != "admin@test.com" {
+		t.Errorf("ActorEmail = %q, want %q", e.ActorEmail, "admin@test.com")
+	}
+	if e.ActorID != "uid-123" {
+		t.Errorf("ActorID = %q, want %q", e.ActorID, "uid-123")
+	}
+	if e.Service != "UserService" {
+		t.Errorf("Service = %q, want %q", e.Service, "UserService")
+	}
+	if e.Method != "CreateUser" {
+		t.Errorf("Method = %q, want %q", e.Method, "CreateUser")
+	}
+	if e.StatusCode != "ok" {
+		t.Errorf("StatusCode = %q, want %q", e.StatusCode, "ok")
+	}
+	if e.Timestamp.Location() != time.UTC {
+		t.Errorf("Timestamp location = %v, want UTC", e.Timestamp.Location())
+	}
+}
+
+func TestInterceptor_ReadOnlyNotLogged(t *testing.T) {
+	logger := &memLogger{}
+	procedures := map[string]bool{
+		"/candela.v1.UserService/CreateUser": true,
+	}
+	interceptor := Interceptor(logger, procedures)
+
+	handler := interceptor(func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, nil
+	})
+
+	// Call a read-only procedure not in the map.
+	_, _ = handler(context.Background(), &fakeRequest{procedure: "/candela.v1.UserService/ListUsers"})
+
+	if len(logger.Events()) != 0 {
+		t.Fatalf("got %d events for read-only RPC, want 0", len(logger.Events()))
+	}
+}
+
+func TestInterceptor_ErrorCaptured(t *testing.T) {
+	logger := &memLogger{}
+	procedures := map[string]bool{
+		"/candela.v1.UserService/DeleteUser": true,
+	}
+	interceptor := Interceptor(logger, procedures)
+
+	handler := interceptor(func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, connect.NewError(connect.CodePermissionDenied, fmt.Errorf("not allowed"))
+	})
+
+	_, _ = handler(context.Background(), &fakeRequest{procedure: "/candela.v1.UserService/DeleteUser"})
+
+	events := logger.Events()
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].StatusCode != "permission_denied" {
+		t.Errorf("StatusCode = %q, want %q", events[0].StatusCode, "permission_denied")
+	}
+	if events[0].Error == "" {
+		t.Error("Error should be non-empty for failed RPC")
+	}
+}
+
+func TestInterceptor_NilAuth(t *testing.T) {
+	logger := &memLogger{}
+	procedures := map[string]bool{
+		"/candela.v1.UserService/CreateUser": true,
+	}
+	interceptor := Interceptor(logger, procedures)
+
+	handler := interceptor(func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, nil
+	})
+
+	// No auth context — should not panic.
+	_, _ = handler(context.Background(), &fakeRequest{procedure: "/candela.v1.UserService/CreateUser"})
+
+	events := logger.Events()
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].ActorEmail != "" {
+		t.Errorf("ActorEmail = %q, want empty for unauthenticated", events[0].ActorEmail)
+	}
+}
+
+func TestInterceptor_NilLogger(t *testing.T) {
+	// Nil logger should return a no-op interceptor that doesn't panic.
+	interceptor := Interceptor(nil, DefaultMutationProcedures)
+
+	called := false
+	handler := interceptor(func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		called = true
+		return nil, nil
+	})
+
+	_, _ = handler(context.Background(), &fakeRequest{procedure: "/candela.v1.UserService/CreateUser"})
+	if !called {
+		t.Error("handler was not called through nil-logger interceptor")
+	}
+}

--- a/pkg/audit/audit_test.go
+++ b/pkg/audit/audit_test.go
@@ -1,0 +1,110 @@
+package audit
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	connect "connectrpc.com/connect"
+)
+
+// memLogger captures audit events in memory for testing.
+type memLogger struct {
+	mu     sync.Mutex
+	events []Event
+}
+
+func (m *memLogger) Log(_ context.Context, e Event) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, e)
+}
+
+func (m *memLogger) Events() []Event {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]Event(nil), m.events...)
+}
+
+func TestParseProcedure(t *testing.T) {
+	tests := []struct {
+		in      string
+		service string
+		method  string
+	}{
+		{"/candela.v1.UserService/CreateUser", "UserService", "CreateUser"},
+		{"/candela.v1.ModelCatalogService/DeleteModelCatalogEntry", "ModelCatalogService", "DeleteModelCatalogEntry"},
+		{"/candela.v1.ProjectService/CreateAPIKey", "ProjectService", "CreateAPIKey"},
+		{"malformed", "malformed", ""},
+	}
+	for _, tt := range tests {
+		svc, method := ParseProcedure(tt.in)
+		if svc != tt.service || method != tt.method {
+			t.Errorf("ParseProcedure(%q) = (%q, %q), want (%q, %q)",
+				tt.in, svc, method, tt.service, tt.method)
+		}
+	}
+}
+
+func TestMulti(t *testing.T) {
+	a := &memLogger{}
+	b := &memLogger{}
+	multi := Multi{a, b}
+
+	multi.Log(context.Background(), Event{Method: "test"})
+
+	if len(a.Events()) != 1 {
+		t.Fatalf("logger a got %d events, want 1", len(a.Events()))
+	}
+	if len(b.Events()) != 1 {
+		t.Fatalf("logger b got %d events, want 1", len(b.Events()))
+	}
+}
+
+func TestSlogLogger_NoError(t *testing.T) {
+	// SlogLogger should not panic.
+	l := NewSlogLogger()
+	l.Log(context.Background(), Event{
+		ActorEmail: "admin@test.com",
+		Service:    "UserService",
+		Method:     "CreateUser",
+		Procedure:  "/candela.v1.UserService/CreateUser",
+		StatusCode: "ok",
+	})
+}
+
+func TestDefaultMutationProcedures(t *testing.T) {
+	// Verify key procedures are present.
+	expected := []string{
+		"/candela.v1.UserService/CreateUser",
+		"/candela.v1.UserService/UpdateUser",
+		"/candela.v1.UserService/DeleteUser",
+		"/candela.v1.ModelCatalogService/UpdateModelCatalogEntry",
+		"/candela.v1.ModelCatalogService/DeleteModelCatalogEntry",
+		"/candela.v1.ProjectService/CreateProject",
+		"/candela.v1.ProjectService/DeleteProject",
+		"/candela.v1.ProjectService/CreateAPIKey",
+		"/candela.v1.ProjectService/RevokeAPIKey",
+	}
+	for _, p := range expected {
+		if !DefaultMutationProcedures[p] {
+			t.Errorf("expected %q in DefaultMutationProcedures", p)
+		}
+	}
+
+	// Verify read-only procedures are NOT present.
+	readOnly := []string{
+		"/candela.v1.UserService/ListUsers",
+		"/candela.v1.UserService/GetUser",
+		"/candela.v1.ModelCatalogService/ListModelCatalog",
+		"/candela.v1.ProjectService/ListProjects",
+	}
+	for _, p := range readOnly {
+		if DefaultMutationProcedures[p] {
+			t.Errorf("read-only procedure %q should NOT be in DefaultMutationProcedures", p)
+		}
+	}
+}
+
+// Ensure connect import is used (interceptor tests reference connect.CodeOf).
+var _ = connect.CodeOf

--- a/pkg/audit/bq_logger.go
+++ b/pkg/audit/bq_logger.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	"cloud.google.com/go/bigquery"
+	"google.golang.org/api/googleapi"
 )
 
 const bqTableName = "admin_audit_log"
@@ -22,11 +23,15 @@ type bqRow struct {
 	Error      string                 `bigquery:"error"`
 }
 
-// BQLogger writes audit events to a BigQuery table.
+// BQLogger writes audit events to a BigQuery table asynchronously.
+// Events are buffered in a channel and written by a background goroutine,
+// keeping BigQuery latency off the RPC critical path.
 // Create one via NewBQLogger; call Close when done.
 type BQLogger struct {
 	client   *bigquery.Client
 	inserter *bigquery.Inserter
+	events   chan bqRow
+	done     chan struct{}
 }
 
 // BQConfig holds BigQuery audit logger configuration.
@@ -35,7 +40,7 @@ type BQConfig struct {
 	Dataset   string
 }
 
-// NewBQLogger creates a BigQuery audit logger.
+// NewBQLogger creates a BigQuery audit logger with an async write loop.
 // It does NOT create the table — call EnsureTable separately if needed.
 func NewBQLogger(ctx context.Context, cfg BQConfig) (*BQLogger, error) {
 	client, err := bigquery.NewClient(ctx, cfg.ProjectID)
@@ -44,14 +49,33 @@ func NewBQLogger(ctx context.Context, cfg BQConfig) (*BQLogger, error) {
 	}
 
 	table := client.Dataset(cfg.Dataset).Table(bqTableName)
-	return &BQLogger{
+	l := &BQLogger{
 		client:   client,
 		inserter: table.Inserter(),
-	}, nil
+		events:   make(chan bqRow, 256),
+		done:     make(chan struct{}),
+	}
+	go l.writeLoop()
+	return l, nil
 }
 
-// Log writes an audit event to BigQuery.
-func (l *BQLogger) Log(ctx context.Context, e Event) {
+// writeLoop drains the events channel and writes rows to BigQuery.
+// It uses context.Background() so inserts are not cancelled by request contexts.
+func (l *BQLogger) writeLoop() {
+	defer close(l.done)
+	for row := range l.events {
+		if err := l.inserter.Put(context.Background(), row); err != nil {
+			slog.Warn("audit: failed to write to BigQuery",
+				"error", err,
+				"procedure", row.Procedure,
+				"actor", row.ActorEmail)
+		}
+	}
+}
+
+// Log enqueues an audit event for async writing to BigQuery.
+// If the buffer is full, the event is dropped with a warning.
+func (l *BQLogger) Log(_ context.Context, e Event) {
 	row := bqRow{
 		Timestamp:  bigquery.NullTimestamp{Timestamp: e.Timestamp, Valid: true},
 		ActorEmail: e.ActorEmail,
@@ -62,20 +86,23 @@ func (l *BQLogger) Log(ctx context.Context, e Event) {
 		StatusCode: e.StatusCode,
 		Error:      e.Error,
 	}
-	if err := l.inserter.Put(ctx, row); err != nil {
-		slog.WarnContext(ctx, "audit: failed to write to BigQuery",
-			"error", err,
+	select {
+	case l.events <- row:
+	default:
+		slog.Warn("audit: BQ event buffer full, dropping event",
 			"procedure", e.Procedure,
 			"actor", e.ActorEmail)
 	}
 }
 
-// Close releases the BigQuery client resources.
+// Close drains the event buffer and releases the BigQuery client.
 func (l *BQLogger) Close() error {
+	close(l.events)
+	<-l.done // wait for writeLoop to finish
 	return l.client.Close()
 }
 
-// EnsureTable creates the admin_audit_log table if it does not exist.
+// EnsureTable creates the admin_audit_log table if it does not already exist.
 func EnsureTable(ctx context.Context, cfg BQConfig) error {
 	client, err := bigquery.NewClient(ctx, cfg.ProjectID)
 	if err != nil {
@@ -107,6 +134,11 @@ func EnsureTable(ctx context.Context, cfg BQConfig) error {
 	}
 
 	if err := table.Create(ctx, md); err != nil {
+		// Idempotent: if table already exists, that's fine.
+		if apiErr, ok := err.(*googleapi.Error); ok && apiErr.Code == 409 {
+			slog.Info("audit: BigQuery table already exists", "table", bqTableName)
+			return nil
+		}
 		return fmt.Errorf("audit: failed to create table %s: %w", bqTableName, err)
 	}
 	slog.Info("audit: BigQuery table created", "table", bqTableName, "dataset", cfg.Dataset)

--- a/pkg/audit/bq_logger.go
+++ b/pkg/audit/bq_logger.go
@@ -1,0 +1,114 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"cloud.google.com/go/bigquery"
+)
+
+const bqTableName = "admin_audit_log"
+
+// bqRow is the BigQuery row schema for audit events.
+type bqRow struct {
+	Timestamp  bigquery.NullTimestamp `bigquery:"timestamp"`
+	ActorEmail string                 `bigquery:"actor_email"`
+	ActorID    string                 `bigquery:"actor_id"`
+	Service    string                 `bigquery:"service"`
+	Method     string                 `bigquery:"method"`
+	Procedure  string                 `bigquery:"procedure"`
+	StatusCode string                 `bigquery:"status_code"`
+	Error      string                 `bigquery:"error"`
+}
+
+// BQLogger writes audit events to a BigQuery table.
+// Create one via NewBQLogger; call Close when done.
+type BQLogger struct {
+	client   *bigquery.Client
+	inserter *bigquery.Inserter
+}
+
+// BQConfig holds BigQuery audit logger configuration.
+type BQConfig struct {
+	ProjectID string
+	Dataset   string
+}
+
+// NewBQLogger creates a BigQuery audit logger.
+// It does NOT create the table — call EnsureTable separately if needed.
+func NewBQLogger(ctx context.Context, cfg BQConfig) (*BQLogger, error) {
+	client, err := bigquery.NewClient(ctx, cfg.ProjectID)
+	if err != nil {
+		return nil, fmt.Errorf("audit: failed to create BigQuery client: %w", err)
+	}
+
+	table := client.Dataset(cfg.Dataset).Table(bqTableName)
+	return &BQLogger{
+		client:   client,
+		inserter: table.Inserter(),
+	}, nil
+}
+
+// Log writes an audit event to BigQuery.
+func (l *BQLogger) Log(ctx context.Context, e Event) {
+	row := bqRow{
+		Timestamp:  bigquery.NullTimestamp{Timestamp: e.Timestamp, Valid: true},
+		ActorEmail: e.ActorEmail,
+		ActorID:    e.ActorID,
+		Service:    e.Service,
+		Method:     e.Method,
+		Procedure:  e.Procedure,
+		StatusCode: e.StatusCode,
+		Error:      e.Error,
+	}
+	if err := l.inserter.Put(ctx, row); err != nil {
+		slog.WarnContext(ctx, "audit: failed to write to BigQuery",
+			"error", err,
+			"procedure", e.Procedure,
+			"actor", e.ActorEmail)
+	}
+}
+
+// Close releases the BigQuery client resources.
+func (l *BQLogger) Close() error {
+	return l.client.Close()
+}
+
+// EnsureTable creates the admin_audit_log table if it does not exist.
+func EnsureTable(ctx context.Context, cfg BQConfig) error {
+	client, err := bigquery.NewClient(ctx, cfg.ProjectID)
+	if err != nil {
+		return fmt.Errorf("audit: failed to create BigQuery client: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	schema := bigquery.Schema{
+		{Name: "timestamp", Type: bigquery.TimestampFieldType, Required: true},
+		{Name: "actor_email", Type: bigquery.StringFieldType, Required: true},
+		{Name: "actor_id", Type: bigquery.StringFieldType},
+		{Name: "service", Type: bigquery.StringFieldType, Required: true},
+		{Name: "method", Type: bigquery.StringFieldType, Required: true},
+		{Name: "procedure", Type: bigquery.StringFieldType, Required: true},
+		{Name: "status_code", Type: bigquery.StringFieldType, Required: true},
+		{Name: "error", Type: bigquery.StringFieldType},
+	}
+
+	table := client.Dataset(cfg.Dataset).Table(bqTableName)
+	md := &bigquery.TableMetadata{
+		Schema: schema,
+		TimePartitioning: &bigquery.TimePartitioning{
+			Field: "timestamp",
+			Type:  bigquery.DayPartitioningType,
+		},
+		Clustering: &bigquery.Clustering{
+			Fields: []string{"service", "actor_email"},
+		},
+	}
+
+	if err := table.Create(ctx, md); err != nil {
+		return fmt.Errorf("audit: failed to create table %s: %w", bqTableName, err)
+	}
+	slog.Info("audit: BigQuery table created", "table", bqTableName, "dataset", cfg.Dataset)
+	return nil
+}

--- a/pkg/audit/interceptor.go
+++ b/pkg/audit/interceptor.go
@@ -14,6 +14,10 @@ import (
 // This interceptor should be wired AFTER auth and validation interceptors so it
 // only fires for authorized, validated requests.
 func Interceptor(logger Logger, procedures map[string]bool) connect.UnaryInterceptorFunc {
+	// Nil-safe: return a no-op interceptor if no logger is provided.
+	if logger == nil {
+		return func(next connect.UnaryFunc) connect.UnaryFunc { return next }
+	}
 	return func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			procedure := req.Spec().Procedure
@@ -34,7 +38,7 @@ func Interceptor(logger Logger, procedures map[string]bool) connect.UnaryInterce
 			// Build the audit event.
 			service, method := ParseProcedure(procedure)
 			event := Event{
-				Timestamp:  time.Now(),
+				Timestamp:  time.Now().UTC(),
 				ActorEmail: actorEmail,
 				ActorID:    actorID,
 				Service:    service,

--- a/pkg/audit/interceptor.go
+++ b/pkg/audit/interceptor.go
@@ -1,0 +1,54 @@
+package audit
+
+import (
+	"context"
+	"time"
+
+	connect "connectrpc.com/connect"
+	"github.com/candelahq/candela/pkg/auth"
+)
+
+// Interceptor returns a ConnectRPC unary interceptor that logs mutation RPCs
+// to the provided Logger. Only procedures listed in the procedures map are logged.
+//
+// This interceptor should be wired AFTER auth and validation interceptors so it
+// only fires for authorized, validated requests.
+func Interceptor(logger Logger, procedures map[string]bool) connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			procedure := req.Spec().Procedure
+			if !procedures[procedure] {
+				return next(ctx, req)
+			}
+
+			// Extract caller identity.
+			var actorEmail, actorID string
+			if user := auth.FromContext(ctx); user != nil {
+				actorEmail = user.Email
+				actorID = user.ID
+			}
+
+			// Call the actual handler.
+			resp, err := next(ctx, req)
+
+			// Build the audit event.
+			service, method := ParseProcedure(procedure)
+			event := Event{
+				Timestamp:  time.Now(),
+				ActorEmail: actorEmail,
+				ActorID:    actorID,
+				Service:    service,
+				Method:     method,
+				Procedure:  procedure,
+				StatusCode: "ok",
+			}
+			if err != nil {
+				event.StatusCode = connect.CodeOf(err).String()
+				event.Error = err.Error()
+			}
+
+			logger.Log(ctx, event)
+			return resp, err
+		}
+	}
+}

--- a/pkg/audit/slog_logger.go
+++ b/pkg/audit/slog_logger.go
@@ -1,0 +1,29 @@
+package audit
+
+import (
+	"context"
+	"log/slog"
+)
+
+// SlogLogger writes audit events as structured JSON via slog.
+// On Cloud Run, slog output goes to Cloud Logging where it is
+// queryable, alertable, and exportable to BigQuery via log sinks.
+type SlogLogger struct{}
+
+// NewSlogLogger creates a new SlogLogger.
+func NewSlogLogger() *SlogLogger {
+	return &SlogLogger{}
+}
+
+// Log writes a structured audit event at INFO level.
+func (l *SlogLogger) Log(ctx context.Context, e Event) {
+	slog.InfoContext(ctx, "audit",
+		slog.String("actor_email", e.ActorEmail),
+		slog.String("actor_id", e.ActorID),
+		slog.String("service", e.Service),
+		slog.String("method", e.Method),
+		slog.String("procedure", e.Procedure),
+		slog.String("status", e.StatusCode),
+		slog.String("error", e.Error),
+	)
+}

--- a/pkg/connecthandlers/project_handler.go
+++ b/pkg/connecthandlers/project_handler.go
@@ -15,17 +15,23 @@ import (
 // ProjectHandler implements the ProjectService ConnectRPC handler.
 type ProjectHandler struct {
 	store storage.ProjectStore
+	users storage.UserStore // optional, nil in local dev
 }
 
 // NewProjectHandler creates a new ProjectHandler.
-func NewProjectHandler(store storage.ProjectStore) *ProjectHandler {
-	return &ProjectHandler{store: store}
+func NewProjectHandler(store storage.ProjectStore, users storage.UserStore) *ProjectHandler {
+	return &ProjectHandler{store: store, users: users}
 }
 
 func (h *ProjectHandler) CreateProject(
 	ctx context.Context,
 	req *connect.Request[v1.CreateProjectRequest],
 ) (*connect.Response[v1.CreateProjectResponse], error) {
+	if uid := scopeUserID(ctx, h.users); uid != "" {
+		return nil, connect.NewError(connect.CodePermissionDenied,
+			fmt.Errorf("admin access required"))
+	}
+
 	p, err := h.store.CreateProject(ctx, storage.Project{
 		Name:        req.Msg.Name,
 		Description: req.Msg.Description,
@@ -88,6 +94,11 @@ func (h *ProjectHandler) DeleteProject(
 	ctx context.Context,
 	req *connect.Request[v1.DeleteProjectRequest],
 ) (*connect.Response[v1.DeleteProjectResponse], error) {
+	if uid := scopeUserID(ctx, h.users); uid != "" {
+		return nil, connect.NewError(connect.CodePermissionDenied,
+			fmt.Errorf("admin access required"))
+	}
+
 	if err := h.store.DeleteProject(ctx, req.Msg.Id); err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("project not found"))
 	}
@@ -98,6 +109,11 @@ func (h *ProjectHandler) CreateAPIKey(
 	ctx context.Context,
 	req *connect.Request[v1.CreateAPIKeyRequest],
 ) (*connect.Response[v1.CreateAPIKeyResponse], error) {
+	if uid := scopeUserID(ctx, h.users); uid != "" {
+		return nil, connect.NewError(connect.CodePermissionDenied,
+			fmt.Errorf("admin access required"))
+	}
+
 	fullKey := projectdb.GenerateAPIKey()
 
 	key, err := h.store.CreateAPIKey(ctx, storage.APIKey{
@@ -138,6 +154,11 @@ func (h *ProjectHandler) RevokeAPIKey(
 	ctx context.Context,
 	req *connect.Request[v1.RevokeAPIKeyRequest],
 ) (*connect.Response[v1.RevokeAPIKeyResponse], error) {
+	if uid := scopeUserID(ctx, h.users); uid != "" {
+		return nil, connect.NewError(connect.CodePermissionDenied,
+			fmt.Errorf("admin access required"))
+	}
+
 	if err := h.store.RevokeAPIKey(ctx, req.Msg.Id); err != nil {
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("API key not found"))
 	}

--- a/pkg/connecthandlers/project_handler_test.go
+++ b/pkg/connecthandlers/project_handler_test.go
@@ -105,7 +105,7 @@ func (m *mockProjectStore) ValidateAPIKey(_ context.Context, rawKey string) (*st
 
 func TestProjectHandler_CreateProject(t *testing.T) {
 	store := newMockProjectStore()
-	handler := NewProjectHandler(store)
+	handler := NewProjectHandler(store, nil)
 
 	resp, err := handler.CreateProject(context.Background(),
 		connect.NewRequest(&v1.CreateProjectRequest{
@@ -129,7 +129,7 @@ func TestProjectHandler_CreateProject(t *testing.T) {
 
 func TestProjectHandler_GetProject_NotFound(t *testing.T) {
 	store := newMockProjectStore()
-	handler := NewProjectHandler(store)
+	handler := NewProjectHandler(store, nil)
 
 	_, err := handler.GetProject(context.Background(),
 		connect.NewRequest(&v1.GetProjectRequest{Id: "nonexistent"}))
@@ -148,7 +148,7 @@ func TestProjectHandler_GetProject_NotFound(t *testing.T) {
 
 func TestProjectHandler_ListProjects_Pagination(t *testing.T) {
 	store := newMockProjectStore()
-	handler := NewProjectHandler(store)
+	handler := NewProjectHandler(store, nil)
 
 	// Create 3 projects.
 	for i := 0; i < 3; i++ {
@@ -185,7 +185,7 @@ func TestProjectHandler_ListProjects_Pagination(t *testing.T) {
 
 func TestProjectHandler_DeleteProject_NotFound(t *testing.T) {
 	store := newMockProjectStore()
-	handler := NewProjectHandler(store)
+	handler := NewProjectHandler(store, nil)
 
 	_, err := handler.DeleteProject(context.Background(),
 		connect.NewRequest(&v1.DeleteProjectRequest{Id: "nonexistent"}))
@@ -204,7 +204,7 @@ func TestProjectHandler_DeleteProject_NotFound(t *testing.T) {
 
 func TestProjectHandler_CreateAPIKey(t *testing.T) {
 	store := newMockProjectStore()
-	handler := NewProjectHandler(store)
+	handler := NewProjectHandler(store, nil)
 
 	// Create a project first.
 	p, _ := store.CreateProject(context.Background(), storage.Project{Name: "Key Project"})
@@ -233,7 +233,7 @@ func TestProjectHandler_CreateAPIKey(t *testing.T) {
 
 func TestProjectHandler_RevokeAPIKey_NotFound(t *testing.T) {
 	store := newMockProjectStore()
-	handler := NewProjectHandler(store)
+	handler := NewProjectHandler(store, nil)
 
 	_, err := handler.RevokeAPIKey(context.Background(),
 		connect.NewRequest(&v1.RevokeAPIKeyRequest{Id: "nonexistent"}))
@@ -252,7 +252,7 @@ func TestProjectHandler_RevokeAPIKey_NotFound(t *testing.T) {
 
 func TestProjectHandler_FullLifecycle(t *testing.T) {
 	store := newMockProjectStore()
-	handler := NewProjectHandler(store)
+	handler := NewProjectHandler(store, nil)
 
 	// Create project.
 	createResp, err := handler.CreateProject(context.Background(),

--- a/pkg/connecthandlers/user_handler.go
+++ b/pkg/connecthandlers/user_handler.go
@@ -251,6 +251,19 @@ func (h *UserHandler) UpdateUser(
 		return nil, internalError("failed to update user", err)
 	}
 
+	caller := auth.FromContext(ctx)
+	actorEmail := ""
+	if caller != nil {
+		actorEmail = caller.Email
+	}
+	h.logAudit(ctx, &storage.AuditRecord{
+		UserID:     user.ID,
+		ActorEmail: actorEmail,
+		Action:     "update_user",
+		Details:    fmt.Sprintf("fields: %v", paths),
+		Timestamp:  time.Now(),
+	})
+
 	return connect.NewResponse(&v1.UpdateUserResponse{
 		User: userToProto(user),
 	}), nil

--- a/pkg/connecthandlers/user_handler.go
+++ b/pkg/connecthandlers/user_handler.go
@@ -261,7 +261,7 @@ func (h *UserHandler) UpdateUser(
 		ActorEmail: actorEmail,
 		Action:     "update_user",
 		Details:    fmt.Sprintf("fields: %v", paths),
-		Timestamp:  time.Now(),
+		Timestamp:  time.Now().UTC(),
 	})
 
 	return connect.NewResponse(&v1.UpdateUserResponse{


### PR DESCRIPTION
Closes #413

## Summary

Add structured audit logging for all admin and mutation actions, with pluggable backends.

### New `pkg/audit` package
- **`Logger` interface** — pluggable audit backends
- **`SlogLogger`** — writes structured JSON to Cloud Logging (default, always on)
- **`BQLogger`** — writes to BigQuery `admin_audit_log` table (implemented, not wired yet)
- **`Multi`** — fan-out to multiple loggers (slog + BQ when enabled)
- **ConnectRPC interceptor** — auto-logs all mutation RPCs with actor identity, procedure, and outcome

### Security: Admin guards for ProjectService
`CreateProject`, `DeleteProject`, `CreateAPIKey`, `RevokeAPIKey` now require admin role via `scopeUserID`. Previously these had **zero access control**.

### Bug fix: Missing audit on UpdateUser
`UserService.UpdateUser` was the only mutation without a Firestore audit log entry. Now logs `update_user` with field details.

### Interceptor wiring
Audit interceptor is wired on:
- **UserService** — after validate + AdminInterceptor
- **CatalogService** — after validate
- **ProjectService** — standalone

### Audited procedures (16 total)
| Service | Methods |
|---------|---------|
| UserService | CreateUser, UpdateUser, DeactivateUser, ReactivateUser, DeleteUser, SetBudget, ResetSpend, CreateGrant, RevokeGrant |
| CatalogService | UpdateModelCatalogEntry, DeleteModelCatalogEntry |
| ProjectService | CreateProject, DeleteProject, CreateAPIKey, RevokeAPIKey |

## Testing
- `go test ./pkg/audit/...` — 4 tests PASS
- `go test ./pkg/connecthandlers/...` — 70+ tests PASS
- `go test ./...` — full suite PASS (pre-commit)