### PR TITLE
feat: add Z.AI GLM-5 provider (zai)

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -644,11 +644,11 @@ func main() {
 		} else {
 			// Without a project ID, Vertex AI providers can't route.
 			// Remove them from allProviders to prevent broken defaults.
-			slog.Warn("⚠️ Vertex AI providers require vertex_ai.project_id — gemini-oai, google, gemini-vertex, mistral, deepseek, deepseek-v3, qwen providers will be disabled")
+			slog.Warn("⚠️ Vertex AI providers require vertex_ai.project_id — gemini-oai, google, gemini-vertex, mistral, deepseek, deepseek-v3, qwen, zai providers will be disabled")
 			var filtered []proxy.Provider
 			for _, p := range allProviders {
 				switch p.Name {
-				case "gemini-oai", "google", "gemini-vertex", "mistral", "deepseek", "deepseek-v3", "qwen":
+				case "gemini-oai", "google", "gemini-vertex", "mistral", "deepseek", "deepseek-v3", "qwen", "zai":
 					// Skip — these need Vertex AI project ID
 				default:
 					filtered = append(filtered, p)
@@ -734,7 +734,7 @@ func main() {
 		// Validate provider_overrides keys — warn on unknown providers.
 		if len(cfg.Proxy.VertexAI.ProviderOverrides) > 0 {
 			validOverrideProviders := map[string]bool{
-				"mistral": true, "deepseek": true, "deepseek-v3": true, "qwen": true,
+				"mistral": true, "deepseek": true, "deepseek-v3": true, "qwen": true, "zai": true,
 				"anthropic": true, "anthropic-vertex": true,
 				"gemini-oai": true, "gemini-vertex": true, "google": true,
 			}
@@ -838,6 +838,7 @@ func main() {
 				"deepseek":    "deepseek",    // DeepSeek R1 via Vertex AI OpenAI-compat
 				"deepseek-v3": "deepseek-v3", // DeepSeek V3 via Vertex AI OpenAI-compat
 				"qwen":        "qwen",        // Qwen via Vertex AI OpenAI-compat
+				"zai":         "zai",         // Z.AI GLM via Vertex AI OpenAI-compat
 			}
 
 			// Build set of active provider names for quick lookup.

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -704,6 +704,8 @@ func main() {
 					defaultRegion = "global"
 				case "qwen":
 					defaultRegion = "us-south1"
+				case "zai":
+					defaultRegion = "global"
 				default:
 					continue
 				}

--- a/deploy/entrypoint-server.sh
+++ b/deploy/entrypoint-server.sh
@@ -37,6 +37,8 @@ proxy:
         region: "${CANDELA_DEEPSEEK_V3_REGION:-global}"
       qwen:
         region: "${CANDELA_QWEN_REGION:-us-south1}"
+      zai:
+        region: "${CANDELA_ZAI_REGION:-global}"
   providers:
     - openai
     - google
@@ -50,6 +52,7 @@ proxy:
     - deepseek
     - deepseek-v3
     - qwen
+    - zai
 
 cors:
   allowed_origins: []

--- a/pkg/costcalc/pricing.yaml
+++ b/pkg/costcalc/pricing.yaml
@@ -178,3 +178,9 @@ models:
     model: qwen3-coder-480b-a35b-instruct-maas
     input_per_million: 0.22
     output_per_million: 1.80
+
+  # ── Z.AI GLM (via Vertex AI OpenAI-compat) ────────────────
+  - provider: zai
+    model: glm-5-maas
+    input_per_million: 1.00
+    output_per_million: 3.20

--- a/pkg/costcalc/testdata/pricing_snapshot.json
+++ b/pkg/costcalc/testdata/pricing_snapshot.json
@@ -178,5 +178,11 @@
     "provider": "qwen",
     "input_per_million": 0.22,
     "output_per_million": 1.8
+  },
+  {
+    "model": "glm-5-maas",
+    "provider": "zai",
+    "input_per_million": 1,
+    "output_per_million": 3.2
   }
 ]

--- a/pkg/proxy/coverage_boost_test.go
+++ b/pkg/proxy/coverage_boost_test.go
@@ -313,3 +313,152 @@ func TestIsUtilityEndpoint(t *testing.T) {
 		}
 	}
 }
+
+// ====================================================================
+// MaaS provider integration tests — prefix injection, parser registry,
+// model extraction, and stream usage injection.
+// ====================================================================
+
+// TestMaaSProviders_InDefaultProviders verifies all MaaS providers
+// are registered in DefaultProviders.
+func TestMaaSProviders_InDefaultProviders(t *testing.T) {
+	providers := DefaultProviders()
+	names := make(map[string]bool)
+	for _, p := range providers {
+		names[p.Name] = true
+	}
+
+	want := []string{"deepseek", "deepseek-v3", "qwen", "zai"}
+	for _, name := range want {
+		if !names[name] {
+			t.Errorf("MaaS provider %q not found in DefaultProviders()", name)
+		}
+	}
+}
+
+// TestMaaSProviders_ParserRegistry verifies all MaaS providers have
+// parsers registered and they return openaiParser (not fallback).
+func TestMaaSProviders_ParserRegistry(t *testing.T) {
+	maas := []string{"deepseek", "deepseek-v3", "qwen", "zai"}
+	for _, name := range maas {
+		p := getParser(name)
+		if _, ok := p.(*openaiParser); !ok {
+			t.Errorf("getParser(%q) = %T, want *openaiParser", name, p)
+		}
+	}
+
+	// Verify unknown provider falls back.
+	p := getParser("unknown-provider")
+	if _, ok := p.(*fallbackParser); !ok {
+		t.Errorf("getParser(\"unknown-provider\") = %T, want *fallbackParser", p)
+	}
+}
+
+// TestMaaSProviders_ModelPrefixRewrite verifies that rewriteModelField
+// correctly prepends publisher prefixes for each MaaS provider.
+func TestMaaSProviders_ModelPrefixRewrite(t *testing.T) {
+	tests := []struct {
+		provider string
+		model    string
+		prefix   string
+		want     string
+	}{
+		{"deepseek", "deepseek-r1-0528-maas", "deepseek-ai/", "deepseek-ai/deepseek-r1-0528-maas"},
+		{"deepseek-v3", "deepseek-v3.2-maas", "deepseek-ai/", "deepseek-ai/deepseek-v3.2-maas"},
+		{"qwen", "qwen3-235b-a22b-instruct-2507-maas", "qwen/", "qwen/qwen3-235b-a22b-instruct-2507-maas"},
+		{"zai", "glm-5-maas", "zai-org/", "zai-org/glm-5-maas"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider+"/"+tt.model, func(t *testing.T) {
+			body := []byte(`{"model":"` + tt.model + `","messages":[]}`)
+			result := rewriteModelField(body, tt.prefix+tt.model)
+
+			var req struct {
+				Model string `json:"model"`
+			}
+			if err := json.Unmarshal(result, &req); err != nil {
+				t.Fatalf("failed to parse: %v", err)
+			}
+			if req.Model != tt.want {
+				t.Errorf("model = %q, want %q", req.Model, tt.want)
+			}
+		})
+	}
+}
+
+// TestMaaSProviders_ModelPrefixIdempotent verifies that if the model
+// already has the publisher prefix, rewrite is not double-applied.
+func TestMaaSProviders_ModelPrefixIdempotent(t *testing.T) {
+	tests := []struct {
+		provider string
+		prefix   string
+		model    string
+	}{
+		{"deepseek", "deepseek-ai/", "deepseek-ai/deepseek-r1-0528-maas"},
+		{"qwen", "qwen/", "qwen/qwen3-235b-a22b-instruct-2507-maas"},
+		{"zai", "zai-org/", "zai-org/glm-5-maas"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			// When prefix already present, the model should not change.
+			if !strings.HasPrefix(tt.model, tt.prefix) {
+				t.Fatalf("test setup: model %q should start with prefix %q", tt.model, tt.prefix)
+			}
+		})
+	}
+}
+
+// TestMaaSProviders_ExtractModel verifies that extractModelFromResponse
+// strips publisher prefixes for MaaS providers.
+func TestMaaSProviders_ExtractModel(t *testing.T) {
+	tests := []struct {
+		provider string
+		response string
+		want     string
+	}{
+		{"deepseek", `{"model":"deepseek-ai/deepseek-r1-0528-maas"}`, "deepseek-r1-0528-maas"},
+		{"deepseek-v3", `{"model":"deepseek-ai/deepseek-v3.2-maas"}`, "deepseek-v3.2-maas"},
+		{"qwen", `{"model":"qwen/qwen3-235b-a22b-instruct-2507-maas"}`, "qwen3-235b-a22b-instruct-2507-maas"},
+		{"zai", `{"model":"zai-org/glm-5-maas"}`, "glm-5-maas"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			got := extractModelFromResponse(tt.provider, []byte(tt.response))
+			if got != tt.want {
+				t.Errorf("extractModelFromResponse(%q) = %q, want %q", tt.provider, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMaaSProviders_InjectStreamUsage verifies that injectStreamUsageOption
+// adds stream_options for all MaaS providers.
+func TestMaaSProviders_InjectStreamUsage(t *testing.T) {
+	maas := []string{"deepseek", "deepseek-v3", "qwen", "zai"}
+	body := []byte(`{"model":"test","stream":true}`)
+
+	for _, provider := range maas {
+		t.Run(provider, func(t *testing.T) {
+			result := injectStreamUsageOption(provider, body)
+			if !strings.Contains(string(result), "stream_options") {
+				t.Errorf("injectStreamUsageOption(%q) did not add stream_options", provider)
+			}
+			if !strings.Contains(string(result), "include_usage") {
+				t.Errorf("injectStreamUsageOption(%q) did not add include_usage", provider)
+			}
+		})
+	}
+
+	// Verify non-OpenAI providers don't get injection.
+	for _, provider := range []string{"anthropic", "google"} {
+		t.Run(provider+"_no_inject", func(t *testing.T) {
+			result := injectStreamUsageOption(provider, body)
+			if strings.Contains(string(result), "stream_options") {
+				t.Errorf("injectStreamUsageOption(%q) should not inject for non-OpenAI provider", provider)
+			}
+		})
+	}
+}

--- a/pkg/proxy/parsers.go
+++ b/pkg/proxy/parsers.go
@@ -104,6 +104,7 @@ var parserRegistry = map[string]ProviderParser{
 	"deepseek":          &openaiParser{}, // DeepSeek R1 via Vertex AI OpenAI-compat (us-central1).
 	"deepseek-v3":       &openaiParser{}, // DeepSeek V3.x via Vertex AI OpenAI-compat (global).
 	"qwen":              &openaiParser{}, // Qwen via Vertex AI OpenAI-compat endpoint.
+	"zai":               &openaiParser{}, // Z.AI GLM via Vertex AI OpenAI-compat endpoint.
 	"anthropic":         &anthropicParser{},
 	"anthropic-direct":  &anthropicParser{}, // Same wire format, just no Vertex AI translation.
 	"anthropic-vertex":  &anthropicParser{}, // Native Anthropic format routed via Vertex AI.
@@ -482,7 +483,7 @@ func extractModelFromResponse(provider string, body []byte) string {
 		if m, ok := resp["model"].(string); ok && m != "" {
 			return m
 		}
-	case "mistral", "deepseek", "deepseek-v3", "qwen":
+	case "mistral", "deepseek", "deepseek-v3", "qwen", "zai":
 		if m, ok := resp["model"].(string); ok && m != "" {
 			return stripPublisherPrefix(m)
 		}
@@ -519,7 +520,7 @@ func extractModelFromStreamingResponse(provider string, data []byte) string {
 
 	default:
 		// OpenAI/Anthropic SSE: scan for "model" in any data line.
-		isMaaS := provider == "mistral" || provider == "deepseek" || provider == "deepseek-v3" || provider == "qwen"
+		isMaaS := provider == "mistral" || provider == "deepseek" || provider == "deepseek-v3" || provider == "qwen" || provider == "zai"
 		for _, line := range strings.Split(string(data), "\n") {
 			line = strings.TrimSpace(line)
 			if !strings.HasPrefix(line, "data: ") {
@@ -570,7 +571,7 @@ func extractCacheTokens(provider string, body []byte) CacheTokens {
 			}
 		}
 
-	case "openai", "gemini-oai", "mistral", "deepseek", "deepseek-v3", "qwen":
+	case "openai", "gemini-oai", "mistral", "deepseek", "deepseek-v3", "qwen", "zai":
 		// OpenAI reports cached tokens inside usage.prompt_tokens_details.cached_tokens
 		if usage, ok := resp["usage"].(map[string]interface{}); ok {
 			if details, ok := usage["prompt_tokens_details"].(map[string]interface{}); ok {
@@ -598,7 +599,7 @@ func extractStreamingCacheTokens(provider string, data []byte) CacheTokens {
 	case "anthropic", "anthropic-direct", "anthropic-vertex", "anthropic-bedrock":
 		return extractAnthropicStreamingCache(data)
 
-	case "openai", "gemini-oai", "mistral", "deepseek", "deepseek-v3", "qwen":
+	case "openai", "gemini-oai", "mistral", "deepseek", "deepseek-v3", "qwen", "zai":
 		return extractOpenAIStreamingCache(data)
 
 	case "google", "gemini-vertex":
@@ -707,7 +708,7 @@ func extractGoogleStreamingCache(data []byte) CacheTokens {
 // This is a no-op if stream_options is already set or if the body is not valid JSON.
 func injectStreamUsageOption(provider string, body []byte) []byte {
 	switch provider {
-	case "openai", "gemini-oai", "mistral", "deepseek", "deepseek-v3", "qwen":
+	case "openai", "gemini-oai", "mistral", "deepseek", "deepseek-v3", "qwen", "zai":
 		// Only inject for OpenAI-compatible providers.
 	default:
 		return body

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -331,6 +331,8 @@ func DefaultProviders() []Provider {
 		{Name: "deepseek-v3", UpstreamURL: "https://aiplatform.googleapis.com"},
 		// Qwen via Vertex AI OpenAI-compat endpoint (global). Model prefix: qwen/
 		{Name: "qwen", UpstreamURL: "https://aiplatform.googleapis.com"},
+		// Z.AI GLM via Vertex AI OpenAI-compat endpoint (global). Model prefix: zai-org/
+		{Name: "zai", UpstreamURL: "https://aiplatform.googleapis.com"},
 	}
 }
 
@@ -1204,6 +1206,10 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		case "qwen":
 			if !strings.HasPrefix(requestModel, "qwen/") {
 				upstreamBody = rewriteModelField(upstreamBody, "qwen/"+requestModel)
+			}
+		case "zai":
+			if !strings.HasPrefix(requestModel, "zai-org/") {
+				upstreamBody = rewriteModelField(upstreamBody, "zai-org/"+requestModel)
 			}
 		}
 	}


### PR DESCRIPTION
Add Z.AI (formerly Zhipu AI) as a new MaaS provider routed through Vertex AI's OpenAI-compatible endpoint on the global region.

## Changes
- Add `zai` to DefaultProviders with `zai-org/` model prefix injection
- Add MaaS routing in server config (default region: global)
- Add `zai` to entrypoint-server.sh providers + provider_overrides
- Add GLM-5 pricing to pricing.yaml ($1.00/$3.20 per M tokens)
- Update pricing snapshot

## Verified
- **Publisher**: `zai-org` (confirmed via `gcloud ai model-garden models list`)
- **Model**: `glm-5-maas` → HTTP 200 on global endpoint
- **Endpoint**: OpenAI-compat chat/completions
- **Staging Firestore**: entry added to `candela-stg` → `model_catalog/zai_glm-5-maas`

## Testing
- All pre-commit hooks passed (11/11)
- Full test suite passed (42 packages)