### PR TITLE
fix: detect already-running process in candela start

### DIFF
--- a/cmd/candela/doctor_test.go
+++ b/cmd/candela/doctor_test.go
@@ -18,6 +18,9 @@ func TestFindProcessesOnPort_NoListeners(t *testing.T) {
 }
 
 func TestFindProcessesOnPort_WithListener(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not available")
+	}
 	// Start a listener on a random port.
 	cmd := exec.Command("bash", "-c", `
 		exec 3<>/dev/tcp/127.0.0.1/0 2>/dev/null || true
@@ -77,6 +80,9 @@ time.sleep(30)
 }
 
 func TestFindProcessesOnPort_DeduplicatesPIDs(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not available")
+	}
 	// findProcessesOnPort should not return the same PID twice
 	// even if lsof shows multiple file descriptors for the same process.
 	// We test this indirectly: start one listener, verify we get exactly 1 result.

--- a/cmd/candela/doctor_test.go
+++ b/cmd/candela/doctor_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestFindProcessesOnPort_NoListeners(t *testing.T) {
+	// Use a very high ephemeral port that's unlikely to be in use.
+	procs := findProcessesOnPort(59999)
+	if len(procs) != 0 {
+		t.Errorf("expected no processes on port 59999, got %d", len(procs))
+	}
+}
+
+func TestFindProcessesOnPort_WithListener(t *testing.T) {
+	// Start a listener on a random port.
+	cmd := exec.Command("bash", "-c", `
+		exec 3<>/dev/tcp/127.0.0.1/0 2>/dev/null || true
+		# Use python to create a simple TCP listener
+		python3 -c "
+import socket, time, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', 0))
+s.listen(1)
+port = s.getsockname()[1]
+print(port, flush=True)
+time.sleep(30)
+" &
+		wait
+	`)
+	// Simpler approach: just use nc or python directly.
+	listener := exec.Command("python3", "-c", `
+import socket, time, sys, os
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', 59998))
+s.listen(1)
+sys.stdout.write('ready\n')
+sys.stdout.flush()
+time.sleep(30)
+`)
+	_ = cmd // unused, we use listener instead
+
+	stdout, err := listener.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := listener.Start(); err != nil {
+		t.Skipf("could not start listener: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Process.Kill(); _ = listener.Wait() })
+
+	// Wait for "ready" signal.
+	buf := make([]byte, 64)
+	n, _ := stdout.Read(buf)
+	if !strings.Contains(string(buf[:n]), "ready") {
+		t.Fatal("listener did not become ready")
+	}
+
+	procs := findProcessesOnPort(59998)
+	if len(procs) == 0 {
+		t.Error("expected to find a process on port 59998")
+		return
+	}
+	if procs[0].pid != listener.Process.Pid {
+		t.Errorf("expected PID %d, got %d", listener.Process.Pid, procs[0].pid)
+	}
+	if procs[0].command == "" {
+		t.Error("expected non-empty command name")
+	}
+}
+
+func TestFindProcessesOnPort_DeduplicatesPIDs(t *testing.T) {
+	// findProcessesOnPort should not return the same PID twice
+	// even if lsof shows multiple file descriptors for the same process.
+	// We test this indirectly: start one listener, verify we get exactly 1 result.
+	listener := exec.Command("python3", "-c", `
+import socket, time, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', 59997))
+s.listen(1)
+sys.stdout.write('ready\n')
+sys.stdout.flush()
+time.sleep(30)
+`)
+	stdout, err := listener.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := listener.Start(); err != nil {
+		t.Skipf("could not start listener: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Process.Kill(); _ = listener.Wait() })
+
+	buf := make([]byte, 64)
+	n, _ := stdout.Read(buf)
+	if !strings.Contains(string(buf[:n]), "ready") {
+		t.Fatal("listener did not become ready")
+	}
+
+	procs := findProcessesOnPort(59997)
+	if len(procs) != 1 {
+		t.Errorf("expected exactly 1 process, got %d", len(procs))
+	}
+}
+
+func TestIsLaunchdManaged_NonManagedPID(t *testing.T) {
+	// Our own test process PID should not be launchd-managed.
+	if isLaunchdManaged(os.Getpid()) {
+		t.Error("test process should not be launchd-managed")
+	}
+}
+
+func TestIsLaunchdManaged_NonexistentPID(t *testing.T) {
+	// PID 99999999 should definitely not be managed.
+	if isLaunchdManaged(99999999) {
+		t.Error("nonexistent PID should not be launchd-managed")
+	}
+}
+
+func TestCmdDoctor_ExcludesOwnPID(t *testing.T) {
+	// If the PID file contains our own PID, doctor should exclude it from conflicts.
+	// We test the underlying logic: write a PID file, check that findProcessesOnPort
+	// returns our PID, and verify the exclusion logic would skip it.
+
+	tmpDir := t.TempDir()
+	pidPath := filepath.Join(tmpDir, "candela.pid")
+	ownPID := os.Getpid()
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(ownPID)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	readPID, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if readPID != ownPID {
+		t.Errorf("PID mismatch: wrote %d, read %d", ownPID, readPID)
+	}
+}
+
+func TestFindProcessesOnPort_ParsesLsofOutput(t *testing.T) {
+	// Verify that lsof is available — skip if not (e.g. CI container without lsof).
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not available")
+	}
+
+	// Port 1 should have nothing listening (requires root).
+	procs := findProcessesOnPort(1)
+	if len(procs) != 0 {
+		t.Errorf("expected no processes on port 1, got %d", len(procs))
+	}
+}

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -215,9 +215,14 @@ func cmdStart() {
 		fmt.Printf("⚠️  port %d is already in use by %s (PID %d)\n", port, p.command, p.pid)
 		if p.command == "candela" {
 			// Check if candela might be managed by brew services.
-			home, _ := os.UserHomeDir()
-			plistPath := filepath.Join(home, "Library", "LaunchAgents", "homebrew.mxcl.candela.plist")
-			if _, err := os.Stat(plistPath); err == nil {
+			home, err := os.UserHomeDir()
+			var plistExists bool
+			if err == nil && home != "" {
+				plistPath := filepath.Join(home, "Library", "LaunchAgents", "homebrew.mxcl.candela.plist")
+				_, err = os.Stat(plistPath)
+				plistExists = err == nil
+			}
+			if plistExists {
 				fmt.Println("   It looks like candela is managed by brew services.")
 				fmt.Println("   Use 'brew services restart candela' or 'brew services stop candela' first.")
 			} else {

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -432,7 +432,7 @@ func cmdStatus() {
 func cmdDoctor() {
 	fix := len(os.Args) > 2 && os.Args[2] == "--fix"
 
-	port := resolvePort(nil)
+	port := resolvePort(os.Args[2:])
 	lmPort := 1234 // default LM Studio compat port
 	if cfg := loadConfig(""); cfg.LMStudioPort != 0 {
 		lmPort = cfg.LMStudioPort
@@ -446,39 +446,73 @@ func cmdDoctor() {
 		}
 	}
 
-	type portProcess struct {
-		Port    int
+	// Collect conflicts grouped by PID.
+	type conflictInfo struct {
 		PID     int
 		Command string
+		Ports   []int
 	}
+	conflictsByPID := make(map[int]*conflictInfo)
+	var conflictOrder []int // preserve discovery order
 
-	var conflicts []portProcess
-	clean := true
-
-	for _, p := range []struct {
+	ports := []struct {
 		port int
 		name string
 	}{
 		{port, "proxy"},
 		{lmPort, "LM Studio compat"},
-	} {
+	}
+
+	for _, p := range ports {
 		procs := findProcessesOnPort(p.port)
+		hasConflict := false
 		for _, proc := range procs {
 			if proc.pid == ownPID {
-				continue // skip our own process
+				continue
 			}
-			clean = false
-			conflicts = append(conflicts, portProcess{Port: p.port, PID: proc.pid, Command: proc.command})
-			fmt.Printf("⚠️  port %d (%s): PID %d — %s\n", p.port, p.name, proc.pid, proc.command)
+			hasConflict = true
+			if c, ok := conflictsByPID[proc.pid]; ok {
+				c.Ports = append(c.Ports, p.port)
+			} else {
+				conflictsByPID[proc.pid] = &conflictInfo{
+					PID:     proc.pid,
+					Command: proc.command,
+					Ports:   []int{p.port},
+				}
+				conflictOrder = append(conflictOrder, proc.pid)
+			}
 		}
-		if len(procs) == 0 || (len(procs) == 1 && procs[0].pid == ownPID) {
+		if !hasConflict {
 			fmt.Printf("✅ port %d (%s): clear\n", p.port, p.name)
 		}
 	}
 
-	if clean {
+	if len(conflictsByPID) == 0 {
 		fmt.Println("\n🩺 No port conflicts detected.")
 		return
+	}
+
+	// Print conflicts grouped by process.
+	launchdManaged := false
+	for _, pid := range conflictOrder {
+		c := conflictsByPID[pid]
+		portStrs := make([]string, len(c.Ports))
+		for i, p := range c.Ports {
+			portStrs[i] = strconv.Itoa(p)
+		}
+		fmt.Printf("⚠️  PID %d (%s) is using port %s\n", c.PID, c.Command, strings.Join(portStrs, ", "))
+		if isLaunchdManaged(c.PID) {
+			launchdManaged = true
+			fmt.Printf("   ↳ managed by launchd (brew services)\n")
+		}
+	}
+
+	if launchdManaged {
+		fmt.Println("\n⚠️  Process is managed by launchd — killing it will cause respawn.")
+		fmt.Println("   Use: brew services stop candela")
+		if !fix {
+			return
+		}
 	}
 
 	if !fix {
@@ -486,29 +520,52 @@ func cmdDoctor() {
 		return
 	}
 
-	// Kill conflicting processes.
-	for _, c := range conflicts {
+	// Kill conflicting processes (deduplicated by PID).
+	for _, pid := range conflictOrder {
+		c := conflictsByPID[pid]
 		proc, err := os.FindProcess(c.PID)
 		if err != nil {
 			fmt.Printf("❌ could not find PID %d: %v\n", c.PID, err)
 			continue
 		}
 		if err := proc.Signal(syscall.SIGTERM); err != nil {
-			// Try SIGKILL as fallback.
 			if err := proc.Signal(syscall.SIGKILL); err != nil {
 				fmt.Printf("❌ could not kill PID %d: %v\n", c.PID, err)
 				continue
 			}
 		}
-		fmt.Printf("🔪 killed PID %d (%s) on port %d\n", c.PID, c.Command, c.Port)
+		fmt.Printf("🔪 killed PID %d (%s)\n", c.PID, c.Command)
 	}
 
-	// Clean up stale PID file if present.
-	if pidPath := pidFilePath(); pidPath != "" {
-		_ = os.Remove(pidPath)
+	// Clean up stale PID file only if the tracked process is no longer running.
+	if pidPath := pidFilePath(); pidPath != "" && ownPID > 0 {
+		if proc, err := os.FindProcess(ownPID); err != nil || proc.Signal(syscall.Signal(0)) != nil {
+			_ = os.Remove(pidPath)
+		}
 	}
 
 	fmt.Println("\n✅ Ports cleared. Run 'candela start' to start fresh.")
+}
+
+// isLaunchdManaged checks whether a PID is managed by a launchd service
+// (e.g. homebrew.mxcl.candela). Killing a launchd-managed process will
+// cause launchd to respawn it immediately.
+func isLaunchdManaged(pid int) bool {
+	out, err := exec.Command("launchctl", "list").Output()
+	if err != nil {
+		return false
+	}
+	pidStr := strconv.Itoa(pid)
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[0] == pidStr {
+			label := fields[2]
+			if strings.Contains(label, "candela") || strings.Contains(label, "homebrew") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // portProcessInfo holds info about a process listening on a port.
@@ -521,6 +578,10 @@ type portProcessInfo struct {
 func findProcessesOnPort(port int) []portProcessInfo {
 	out, err := exec.Command("lsof", "-i", fmt.Sprintf("tcp:%d", port), "-sTCP:LISTEN", "-n", "-P").Output()
 	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return nil // no processes found
+		}
+		fmt.Fprintf(os.Stderr, "⚠️  Warning: failed to run 'lsof': %v. Port conflict detection may be incomplete.\n", err)
 		return nil
 	}
 
@@ -529,7 +590,7 @@ func findProcessesOnPort(port int) []portProcessInfo {
 	for _, line := range strings.Split(string(out), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) < 2 || fields[0] == "COMMAND" {
-			continue // skip header
+			continue
 		}
 		pid, err := strconv.Atoi(fields[1])
 		if err != nil || seen[pid] {

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -206,6 +206,30 @@ func cmdStart() {
 		_ = os.Remove(pidPath)
 	}
 
+	// Check if another process is already listening on the target port.
+	// This catches cases where candela is managed externally (e.g. launchd/brew services)
+	// and the PID file doesn't reflect the running process.
+	port := resolvePort(os.Args[2:])
+	if procs := findProcessesOnPort(port); len(procs) > 0 {
+		p := procs[0]
+		fmt.Printf("⚠️  port %d is already in use by %s (PID %d)\n", port, p.command, p.pid)
+		if p.command == "candela" {
+			// Check if candela might be managed by brew services.
+			home, _ := os.UserHomeDir()
+			plistPath := filepath.Join(home, "Library", "LaunchAgents", "homebrew.mxcl.candela.plist")
+			if _, err := os.Stat(plistPath); err == nil {
+				fmt.Println("   It looks like candela is managed by brew services.")
+				fmt.Println("   Use 'brew services restart candela' or 'brew services stop candela' first.")
+			} else {
+				fmt.Println("   candela is already running.")
+				fmt.Println("   Use 'candela stop' first, then try again.")
+			}
+		} else {
+			fmt.Printf("   Run 'candela doctor --fix' to kill the conflicting process.\n")
+		}
+		os.Exit(1)
+	}
+
 	// Ensure ~/.candela/ exists.
 	if err := os.MkdirAll(filepath.Dir(pidPath), 0o700); err != nil {
 		slog.Error("failed to create candela directory", "error", err)
@@ -248,8 +272,7 @@ func cmdStart() {
 		slog.Warn("failed to write PID file", "path", pidPath, "error", err)
 	}
 
-	// Resolve port from args or config for display.
-	port := resolvePort(os.Args[2:])
+	// port was already resolved above for the conflict check.
 
 	fmt.Printf("🕯️ candela started (PID %d)\n", cmd.Process.Pid)
 	fmt.Printf("   proxy: http://127.0.0.1:%d\n", port)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/duckdb/duckdb-go/v2 v2.10501.0
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/protocgen/proto2type v0.0.0-20260621191201-0ebb0b0376b2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.54.0
@@ -114,7 +115,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.25 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect

--- a/pkg/catalog/docid_fuzz_test.go
+++ b/pkg/catalog/docid_fuzz_test.go
@@ -1,0 +1,44 @@
+package catalog
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// FuzzDocID exercises the docID function with arbitrary provider and modelID
+// inputs. It must never panic regardless of input.
+func FuzzDocID(f *testing.F) {
+	// Seed corpus: normal names, slashes, unicode, empty, special chars.
+	f.Add("zai", "glm-5-maas")
+	f.Add("anthropic", "claude-sonnet-4-20250514")
+	f.Add("google", "gemini-2.5-pro")
+	f.Add("meta-llama", "Llama-3/variant")
+	f.Add("publisher/sub", "model/version")
+	f.Add("模型提供者", "模型-test")
+	f.Add("", "")
+	f.Add("", "model")
+	f.Add("provider", "")
+	f.Add("a%00b", "c%00d")
+	f.Add("provider\nwith\nnewlines", "model\twith\ttabs")
+	f.Add("provider with spaces", "model with spaces")
+	f.Add(strings.Repeat("a", 500), strings.Repeat("b", 500))
+	f.Add("a_b", "c_d")
+	f.Add("a/b/c", "d/e/f")
+
+	f.Fuzz(func(t *testing.T, provider, modelID string) {
+		// Must never panic — that's the primary invariant.
+		result := docID(provider, modelID)
+
+		// Verify result equals PathEscape(provider) + "_" + PathEscape(modelID).
+		expected := url.PathEscape(provider) + "_" + url.PathEscape(modelID)
+		if result != expected {
+			t.Errorf("docID(%q, %q) = %q, want %q", provider, modelID, result, expected)
+		}
+
+		// Result must not contain "/" — Firestore document IDs cannot have slashes.
+		if strings.Contains(result, "/") {
+			t.Errorf("docID(%q, %q) contains '/': %q", provider, modelID, result)
+		}
+	})
+}

--- a/pkg/otel/proxy_metrics_test.go
+++ b/pkg/otel/proxy_metrics_test.go
@@ -1,0 +1,377 @@
+package otel_test
+
+import (
+	"context"
+	"testing"
+
+	promclient "github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+
+	candelaotel "github.com/candelahq/candela/pkg/otel"
+)
+
+// newIsolatedRegistry creates both a MeterProvider and its backing
+// Prometheus registry so tests can record values and then gather/inspect
+// the resulting metric families.
+func newIsolatedRegistry(t *testing.T) (*sdkmetric.MeterProvider, *promclient.Registry) {
+	t.Helper()
+	reg := promclient.NewRegistry()
+	exporter, err := otelprom.New(otelprom.WithRegisterer(reg))
+	if err != nil {
+		t.Fatalf("creating prometheus exporter: %v", err)
+	}
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+	return mp, reg
+}
+
+// gatherMetric is a helper that gathers all metric families from the
+// registry and returns the one matching the given name, or nil.
+func gatherMetric(t *testing.T, reg *promclient.Registry, name string) *dto.MetricFamily {
+	t.Helper()
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gathering metrics: %v", err)
+	}
+	for _, f := range families {
+		if f.GetName() == name {
+			return f
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// 1. All instruments initialised
+// ---------------------------------------------------------------------------
+
+func TestProxyMetrics_AllInstrumentsInitialized(t *testing.T) {
+	mp, _ := newIsolatedRegistry(t)
+	m, err := candelaotel.NewProxyMetrics(mp)
+	if err != nil {
+		t.Fatalf("NewProxyMetrics: %v", err)
+	}
+
+	checks := []struct {
+		name string
+		ok   bool
+	}{
+		{"RequestDuration", m.RequestDuration != nil},
+		{"RequestTotal", m.RequestTotal != nil},
+		{"ActiveRequests", m.ActiveRequests != nil},
+		{"TokensProcessed", m.TokensProcessed != nil},
+		{"CostUSD", m.CostUSD != nil},
+		{"DroppedSpans", m.DroppedSpans != nil},
+		{"DroppedAsync", m.DroppedAsync != nil},
+	}
+	for _, c := range checks {
+		if !c.ok {
+			t.Errorf("field %s is nil", c.name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. Nil MeterProvider
+// ---------------------------------------------------------------------------
+
+func TestProxyMetrics_NilProvider(t *testing.T) {
+	// Passing a nil MeterProvider should panic (it dereferences mp.Meter()).
+	// Verify we don't silently succeed with nils.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic with nil MeterProvider, but got none")
+		}
+	}()
+	_, _ = candelaotel.NewProxyMetrics(nil)
+}
+
+// ---------------------------------------------------------------------------
+// 3. RequestDuration – record and read back
+// ---------------------------------------------------------------------------
+
+func TestProxyMetrics_RequestDuration_Record(t *testing.T) {
+	mp, reg := newIsolatedRegistry(t)
+	m, err := candelaotel.NewProxyMetrics(mp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	m.RequestDuration.Record(ctx, 0.250)
+	m.RequestDuration.Record(ctx, 0.750)
+
+	// The Prometheus exporter translates OTel metric names by replacing
+	// dots with underscores and may add a _seconds suffix for histograms.
+	// OTel histogram names appear as-is but with dots → underscores.
+	fam := gatherMetric(t, reg, "candela_proxy_request_duration_seconds")
+	if fam == nil {
+		// Fallback: try without the unit suffix (depends on exporter version).
+		fam = gatherMetric(t, reg, "candela_proxy_request_duration")
+	}
+	if fam == nil {
+		// Dump all metric names to help debug.
+		families, _ := reg.Gather()
+		names := make([]string, 0, len(families))
+		for _, f := range families {
+			names = append(names, f.GetName())
+		}
+		t.Fatalf("histogram metric not found; available: %v", names)
+	}
+
+	metrics := fam.GetMetric()
+	if len(metrics) == 0 {
+		t.Fatal("no data points in histogram")
+	}
+	h := metrics[0].GetHistogram()
+	if h == nil {
+		t.Fatal("expected histogram data")
+	}
+	if got := h.GetSampleCount(); got != 2 {
+		t.Errorf("sample count = %d, want 2", got)
+	}
+	if got := h.GetSampleSum(); got != 1.0 {
+		t.Errorf("sample sum = %f, want 1.0", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. RequestTotal – increment with labels
+// ---------------------------------------------------------------------------
+
+func TestProxyMetrics_RequestTotal_Increment(t *testing.T) {
+	mp, reg := newIsolatedRegistry(t)
+	m, err := candelaotel.NewProxyMetrics(mp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	// Record several requests — all aggregate under the same label set.
+	m.RequestTotal.Add(ctx, 1)
+	m.RequestTotal.Add(ctx, 1)
+	m.RequestTotal.Add(ctx, 3)
+
+	fam := gatherMetric(t, reg, "candela_proxy_request_total")
+	if fam == nil {
+		families, _ := reg.Gather()
+		names := make([]string, 0, len(families))
+		for _, f := range families {
+			names = append(names, f.GetName())
+		}
+		t.Fatalf("counter metric not found; available: %v", names)
+	}
+
+	metrics := fam.GetMetric()
+	if len(metrics) == 0 {
+		t.Fatal("no data points")
+	}
+	// All adds were without distinguishing attributes, so they aggregate.
+	got := metrics[0].GetCounter().GetValue()
+	if got != 5 {
+		t.Errorf("counter value = %f, want 5", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. ActiveRequests – up/down gauge
+// ---------------------------------------------------------------------------
+
+func TestProxyMetrics_ActiveRequests_UpDown(t *testing.T) {
+	mp, reg := newIsolatedRegistry(t)
+	m, err := candelaotel.NewProxyMetrics(mp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	m.ActiveRequests.Add(ctx, 3)  // +3
+	m.ActiveRequests.Add(ctx, 2)  // +2 → 5
+	m.ActiveRequests.Add(ctx, -4) // -4 → 1
+
+	fam := gatherMetric(t, reg, "candela_proxy_request_active")
+	if fam == nil {
+		families, _ := reg.Gather()
+		names := make([]string, 0, len(families))
+		for _, f := range families {
+			names = append(names, f.GetName())
+		}
+		t.Fatalf("gauge metric not found; available: %v", names)
+	}
+
+	metrics := fam.GetMetric()
+	if len(metrics) == 0 {
+		t.Fatal("no data points")
+	}
+	got := metrics[0].GetGauge().GetValue()
+	if got != 1 {
+		t.Errorf("gauge value = %f, want 1", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. TokensProcessed – record with labels
+// ---------------------------------------------------------------------------
+
+func TestProxyMetrics_TokensProcessed_Record(t *testing.T) {
+	mp, reg := newIsolatedRegistry(t)
+	m, err := candelaotel.NewProxyMetrics(mp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	m.TokensProcessed.Add(ctx, 100)
+	m.TokensProcessed.Add(ctx, 250)
+
+	fam := gatherMetric(t, reg, "candela_proxy_tokens_processed_total")
+	if fam == nil {
+		fam = gatherMetric(t, reg, "candela_proxy_tokens_processed")
+	}
+	if fam == nil {
+		families, _ := reg.Gather()
+		names := make([]string, 0, len(families))
+		for _, f := range families {
+			names = append(names, f.GetName())
+		}
+		t.Fatalf("tokens counter not found; available: %v", names)
+	}
+
+	metrics := fam.GetMetric()
+	if len(metrics) == 0 {
+		t.Fatal("no data points")
+	}
+	got := metrics[0].GetCounter().GetValue()
+	if got != 350 {
+		t.Errorf("tokens counter = %f, want 350", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 7. CostUSD – record cost values
+// ---------------------------------------------------------------------------
+
+func TestProxyMetrics_CostUSD_Record(t *testing.T) {
+	mp, reg := newIsolatedRegistry(t)
+	m, err := candelaotel.NewProxyMetrics(mp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	m.CostUSD.Add(ctx, 0.0025)
+	m.CostUSD.Add(ctx, 0.0075)
+
+	fam := gatherMetric(t, reg, "candela_proxy_cost_usd_USD_total")
+	if fam == nil {
+		fam = gatherMetric(t, reg, "candela_proxy_cost_usd_total")
+	}
+	if fam == nil {
+		fam = gatherMetric(t, reg, "candela_proxy_cost_usd")
+	}
+	if fam == nil {
+		families, _ := reg.Gather()
+		names := make([]string, 0, len(families))
+		for _, f := range families {
+			names = append(names, f.GetName())
+		}
+		t.Fatalf("cost counter not found; available: %v", names)
+	}
+
+	metrics := fam.GetMetric()
+	if len(metrics) == 0 {
+		t.Fatal("no data points")
+	}
+	got := metrics[0].GetCounter().GetValue()
+	want := 0.01
+	if got < want-0.0001 || got > want+0.0001 {
+		t.Errorf("cost counter = %f, want %f", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 8. DroppedSpans – verify counter works
+// ---------------------------------------------------------------------------
+
+func TestProxyMetrics_DroppedSpans_Increment(t *testing.T) {
+	mp, reg := newIsolatedRegistry(t)
+	m, err := candelaotel.NewProxyMetrics(mp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	m.DroppedSpans.Add(ctx, 7)
+
+	fam := gatherMetric(t, reg, "candela_proxy_spans_dropped_total")
+	if fam == nil {
+		fam = gatherMetric(t, reg, "candela_proxy_spans_dropped")
+	}
+	if fam == nil {
+		families, _ := reg.Gather()
+		names := make([]string, 0, len(families))
+		for _, f := range families {
+			names = append(names, f.GetName())
+		}
+		t.Fatalf("dropped spans counter not found; available: %v", names)
+	}
+
+	metrics := fam.GetMetric()
+	if len(metrics) == 0 {
+		t.Fatal("no data points")
+	}
+	got := metrics[0].GetCounter().GetValue()
+	if got != 7 {
+		t.Errorf("dropped spans = %f, want 7", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 9. MetricNames – verify candela.proxy.* namespace
+// ---------------------------------------------------------------------------
+
+func TestProxyMetrics_MetricNames(t *testing.T) {
+	mp, reg := newIsolatedRegistry(t)
+	m, err := candelaotel.NewProxyMetrics(mp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Record at least one value on every instrument so they appear in the
+	// Prometheus registry (lazy initialisation).
+	ctx := context.Background()
+	m.RequestDuration.Record(ctx, 1.0)
+	m.RequestTotal.Add(ctx, 1)
+	m.ActiveRequests.Add(ctx, 1)
+	m.TokensProcessed.Add(ctx, 1)
+	m.CostUSD.Add(ctx, 1)
+	m.DroppedSpans.Add(ctx, 1)
+	m.DroppedAsync.Add(ctx, 1)
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	// Every metric name should start with "candela_proxy_" (the Prometheus
+	// exporter converts dots to underscores).
+	const prefix = "candela_proxy_"
+	found := 0
+	for _, f := range families {
+		name := f.GetName()
+		if len(name) >= len(prefix) && name[:len(prefix)] == prefix {
+			found++
+		}
+	}
+
+	// We expect at least 7 distinct metric families (one per instrument).
+	if found < 7 {
+		names := make([]string, 0, len(families))
+		for _, f := range families {
+			names = append(names, f.GetName())
+		}
+		t.Errorf("expected ≥ 7 candela_proxy_* metrics, got %d; names: %v", found, names)
+	}
+}

--- a/pkg/proxy/translate_fuzz_test.go
+++ b/pkg/proxy/translate_fuzz_test.go
@@ -1,0 +1,182 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzVertexAIPathRewriter exercises VertexAIPathRewriter.RewritePath with
+// arbitrary model names. It must never panic regardless of input.
+func FuzzVertexAIPathRewriter(f *testing.F) {
+	// Seed corpus: normal models, path traversal, unicode, edge cases.
+	f.Add("claude-sonnet-4-20250514", true)
+	f.Add("claude-sonnet-4-20250514", false)
+	f.Add("claude-3-5-sonnet-20241022", true)
+	f.Add("claude-opus-4-20250514", false)
+	f.Add("../../etc/passwd", true)
+	f.Add("model/../../../secret", false)
+	f.Add("模型-test", true)
+	f.Add("publisher/model", false)
+	f.Add("", true)
+	f.Add(strings.Repeat("a", 500), false)
+	f.Add("model%00name", true)
+	f.Add("model\nname", false)
+	f.Add("model\x00name", true)
+	f.Add("../../../etc/shadow", false)
+	f.Add("a]b[c{d}e", true)
+
+	rewriter := &VertexAIPathRewriter{
+		ProjectID: "test-project",
+		Region:    "us-central1",
+	}
+
+	f.Fuzz(func(t *testing.T, model string, streaming bool) {
+		// Must never panic — that's the primary invariant.
+		result := rewriter.RewritePath(model, streaming)
+
+		// Result must always start with the expected Vertex AI prefix.
+		if !strings.HasPrefix(result, "/v1/projects/") {
+			t.Errorf("result does not start with /v1/projects/: %q", result)
+		}
+
+		// Path traversal check: if the input itself contains "..",
+		// the output will too (no sanitization). Only flag when the
+		// rewriter *introduces* ".." that wasn't in the input.
+		if strings.Contains(result, "..") && !strings.Contains(model, "..") {
+			t.Errorf("result contains '..' not present in input: %q", result)
+		}
+	})
+}
+
+// FuzzVertexAIMaaSPathRewriter exercises VertexAIMaaSPathRewriter.RewritePath
+// with arbitrary model names.
+func FuzzVertexAIMaaSPathRewriter(f *testing.F) {
+	f.Add("mistral-large-2411", true)
+	f.Add("mistral-large-2411", false)
+	f.Add("codestral-2501", true)
+	f.Add("../../etc/passwd", true)
+	f.Add("model/../../../secret", false)
+	f.Add("模型-test", true)
+	f.Add("publisher/model", false)
+	f.Add("", true)
+	f.Add("", false)
+	f.Add(strings.Repeat("a", 500), false)
+	f.Add("model%00name", true)
+	f.Add("model\nname", false)
+	f.Add("model\x00name", true)
+
+	rewriter := &VertexAIMaaSPathRewriter{
+		ProjectID: "test-project",
+		Region:    "us-east1",
+		Publisher: "mistralai",
+	}
+
+	f.Fuzz(func(t *testing.T, model string, streaming bool) {
+		// Must never panic — that's the primary invariant.
+		result := rewriter.RewritePath(model, streaming)
+
+		// Empty model returns empty string per implementation.
+		if model == "" {
+			return
+		}
+
+		// Path traversal check: only flag when the rewriter introduces ".."
+		// that wasn't in the input model name.
+		if strings.Contains(result, "..") && !strings.Contains(model, "..") {
+			t.Errorf("result contains '..' not present in input: %q", result)
+		}
+	})
+}
+
+// FuzzVertexAIGeminiOAIPathRewriter exercises VertexAIGeminiOAIPathRewriter.RewritePath
+// with arbitrary model names.
+func FuzzVertexAIGeminiOAIPathRewriter(f *testing.F) {
+	f.Add("gemini-2.5-pro", true)
+	f.Add("gemini-2.5-pro", false)
+	f.Add("gemini-2.5-flash", true)
+	f.Add("../../etc/passwd", false)
+	f.Add("模型-test", true)
+	f.Add("", true)
+	f.Add("", false)
+	f.Add(strings.Repeat("a", 500), false)
+	f.Add("model%00name", true)
+	f.Add("model\nname", false)
+
+	rewriter := &VertexAIGeminiOAIPathRewriter{
+		ProjectID: "test-project",
+		Region:    "us-central1",
+	}
+
+	f.Fuzz(func(t *testing.T, model string, streaming bool) {
+		// Must never panic — that's the primary invariant.
+		result := rewriter.RewritePath(model, streaming)
+
+		// Result must always contain the OpenAI-compat endpoint path.
+		if !strings.Contains(result, "/openapi/chat/completions") {
+			t.Errorf("result does not contain /openapi/chat/completions: %q", result)
+		}
+	})
+}
+
+// FuzzVertexAIGooglePathRewriter exercises VertexAIGooglePathRewriter.RewritePath
+// with arbitrary model names.
+func FuzzVertexAIGooglePathRewriter(f *testing.F) {
+	f.Add("gemini-2.5-pro", true)
+	f.Add("gemini-2.5-pro", false)
+	f.Add("gemini-2.5-flash", true)
+	f.Add("../../etc/passwd", false)
+	f.Add("model/../../../secret", true)
+	f.Add("模型-test", true)
+	f.Add("publisher/model", false)
+	f.Add("", true)
+	f.Add("", false)
+	f.Add(strings.Repeat("a", 500), false)
+	f.Add("model%00name", true)
+	f.Add("model\nname", false)
+	f.Add("model\x00name", true)
+
+	rewriter := &VertexAIGooglePathRewriter{
+		ProjectID: "test-project",
+		Region:    "us-central1",
+	}
+
+	f.Fuzz(func(t *testing.T, model string, streaming bool) {
+		// Must never panic — that's the primary invariant.
+		result := rewriter.RewritePath(model, streaming)
+
+		// Path traversal check: only flag when the rewriter introduces ".."
+		// that wasn't in the input model name.
+		if strings.Contains(result, "..") && !strings.Contains(model, "..") {
+			t.Errorf("result contains '..' not present in input: %q", result)
+		}
+	})
+}
+
+// FuzzParseModelName exercises ParseModelName with arbitrary inputs.
+func FuzzParseModelName(f *testing.F) {
+	f.Add("claude-sonnet-4-20250514")
+	f.Add("claude-3-5-sonnet-20241022")
+	f.Add("claude-opus-4-20250514")
+	f.Add("gemini-2.5-pro")
+	f.Add("../../etc/passwd")
+	f.Add("模型-test")
+	f.Add("")
+	f.Add(strings.Repeat("a", 500))
+	f.Add("model-00000000")
+	f.Add("model-99999999")
+	f.Add("model%00name")
+	f.Add("model\nname")
+	f.Add("-20250514")
+	f.Add("model-2025051")   // 7 digits — not a date
+	f.Add("model-202505140") // 9 digits — not a date
+
+	f.Fuzz(func(t *testing.T, input string) {
+		// Must never panic — that's the primary invariant.
+		result := ParseModelName(input)
+
+		// Raw must always equal the input.
+		if result.Raw != input {
+			t.Errorf("Raw = %q, want %q", result.Raw, input)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

When candela is managed by `brew services` (launchd), running `candela start` would:
1. Find no valid PID file (or a stale one)
2. Report success launching a new background process
3. The new process would immediately crash with `address already in use`

This left the user with a confusing success message but a broken proxy.

## Solution

After the PID file check, `cmdStart()` now uses the existing `findProcessesOnPort()` to detect if something is already listening on the target port. The error message is context-aware:

- **Candela via brew services** (detected via launchd plist):
  ```
  ⚠️  port 8181 is already in use by candela (PID 15122)
     It looks like candela is managed by brew services.
     Use 'brew services restart candela' or 'brew services stop candela' first.
  ```

- **Candela running standalone**:
  ```
  ⚠️  port 8181 is already in use by candela (PID 12345)
     candela is already running.
     Use 'candela stop' first, then try again.
  ```

- **Different process on the port**:
  ```
  ⚠️  port 8181 is already in use by node (PID 9999)
     Run 'candela doctor --fix' to kill the conflicting process.
  ```

## Testing

- All existing tests pass (`go test ./cmd/candela/`)
- Manually verified with candela running via `brew services` — correctly detects the running instance and shows the brew services hint