### PR TITLE
feat(costcalc): add NewEmpty() constructor for database-driven pricing

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -228,8 +228,9 @@ func main() {
 	defer closeFn()
 	slog.Info("storage initialized", "backend", cfg.Storage.Backend, "sinks", len(writers))
 
-	// Initialize cost calculator with built-in defaults + config overrides.
-	calc := costcalc.New()
+	// Initialize cost calculator with no built-in defaults — pricing comes
+	// from the catalog database at runtime (or config overrides below).
+	calc := costcalc.NewEmpty()
 	if cfg.Pricing.DiscountPercent > 0 || len(cfg.Pricing.Models) > 0 {
 		calc.LoadFromConfig(cfg.Pricing)
 	}

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -228,9 +228,16 @@ func main() {
 	defer closeFn()
 	slog.Info("storage initialized", "backend", cfg.Storage.Backend, "sinks", len(writers))
 
-	// Initialize cost calculator with no built-in defaults — pricing comes
-	// from the catalog database at runtime (or config overrides below).
-	calc := costcalc.NewEmpty()
+	// Initialize cost calculator.
+	// Config backend relies on embedded pricing from New(); database-backed
+	// catalogs (e.g. Firestore) load pricing at runtime so start empty.
+	var calc *costcalc.Calculator
+	switch cfg.Catalog.Backend {
+	case "firestore":
+		calc = costcalc.NewEmpty()
+	default: // "config", "", or unrecognized (caught later)
+		calc = costcalc.New()
+	}
 	if cfg.Pricing.DiscountPercent > 0 || len(cfg.Pricing.Models) > 0 {
 		calc.LoadFromConfig(cfg.Pricing)
 	}
@@ -261,8 +268,9 @@ func main() {
 		}
 		if err != nil {
 			slog.Error("failed to create Firestore client for catalog", "error", err)
-			slog.Warn("falling back to config-based catalog")
-			catalogStore = catalog.NewConfigStore(nil) // falls back to built-in defaults
+			slog.Warn("falling back to config-based catalog with embedded pricing")
+			calc.LoadDefaults() // ensure embedded pricing is available for fallback
+			catalogStore = catalog.NewConfigStore(nil)
 		} else {
 			catalogStore = catalog.NewFirestoreStore(fsClient, collection)
 			catalogClosers = append(catalogClosers, func() { _ = fsClient.Close() })
@@ -286,7 +294,8 @@ func main() {
 		entries, err := catalogStore.List(ctx, false) // only enabled models needed for pricing
 		if err != nil {
 			slog.Error("failed to load catalog entries", "error", err)
-			slog.Warn("using built-in default pricing (catalog unavailable)")
+			calc.LoadDefaults() // fall back to embedded pricing
+			slog.Warn("catalog unavailable, fell back to embedded pricing")
 		} else {
 			calc.LoadFromCatalog(entries)
 		}

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -125,6 +125,23 @@ var providerAliases = map[string]string{
 
 // New creates a Calculator with default pricing for all supported cloud models.
 func New() *Calculator {
+	c := newBase()
+	c.loadDefaults()
+	c.rebuildFallback()
+	return c
+}
+
+// NewEmpty creates a Calculator with no built-in model pricing.
+// Use this when pricing will be loaded from a database or catalog at runtime
+// rather than from the embedded pricing.yaml. Cache discount defaults and
+// provider aliases are still initialized.
+func NewEmpty() *Calculator {
+	return newBase()
+}
+
+// newBase creates a Calculator with initialized maps, provider aliases, and
+// default cache discounts, but no model pricing loaded.
+func newBase() *Calculator {
 	c := &Calculator{
 		defaults:       make(map[string]ModelPricing),
 		overrides:      make(map[string]ModelPricing),
@@ -136,8 +153,6 @@ func New() *Calculator {
 	for k, v := range defaultCacheDiscounts {
 		c.cacheDiscounts[k] = v
 	}
-	c.loadDefaults()
-	c.rebuildFallback()
 	return c
 }
 

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -139,6 +139,17 @@ func NewEmpty() *Calculator {
 	return newBase()
 }
 
+// LoadDefaults loads embedded pricing from pricing.yaml into the calculator.
+// This is useful when a database-backed catalog is unavailable and the caller
+// needs to fall back to built-in list prices. Safe to call on a Calculator
+// created with NewEmpty(). Existing config overrides are preserved.
+func (c *Calculator) LoadDefaults() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.loadDefaults()
+	c.rebuildFallback()
+}
+
 // newBase creates a Calculator with initialized maps, provider aliases, and
 // default cache discounts, but no model pricing loaded.
 func newBase() *Calculator {

--- a/pkg/costcalc/calculator_test.go
+++ b/pkg/costcalc/calculator_test.go
@@ -69,6 +69,118 @@ func TestNewEmpty(t *testing.T) {
 	})
 }
 
+func TestLoadDefaults(t *testing.T) {
+	t.Run("recovers pricing on empty calculator", func(t *testing.T) {
+		calc := NewEmpty()
+		// Verify initially empty.
+		if calc.HasPricing("openai", "gpt-4o") {
+			t.Fatal("expected no pricing before LoadDefaults")
+		}
+		cost := calc.Calculate("openai", "gpt-4o", 1_000_000, 1_000_000)
+		if cost != 0 {
+			t.Fatalf("expected zero cost before LoadDefaults, got %f", cost)
+		}
+
+		// Load embedded pricing.
+		calc.LoadDefaults()
+
+		// Verify pricing is now available.
+		if !calc.HasPricing("openai", "gpt-4o") {
+			t.Error("expected pricing for gpt-4o after LoadDefaults")
+		}
+		cost = calc.Calculate("openai", "gpt-4o", 1_000_000, 1_000_000)
+		if cost <= 0 {
+			t.Errorf("expected non-zero cost after LoadDefaults, got %f", cost)
+		}
+	})
+
+	t.Run("preserves config overrides", func(t *testing.T) {
+		calc := NewEmpty()
+		// Apply a config override before LoadDefaults.
+		calc.LoadFromConfig(PricingConfig{
+			Models: []ModelPricing{{
+				Provider: "openai", Model: "gpt-4o",
+				InputPerMillion: 999.0, OutputPerMillion: 999.0,
+			}},
+		})
+
+		calc.LoadDefaults()
+
+		// The config override should take priority over embedded defaults.
+		p, ok := calc.Resolve("openai", "gpt-4o")
+		if !ok {
+			t.Fatal("expected gpt-4o to resolve")
+		}
+		if p.InputPerMillion != 999.0 {
+			t.Errorf("config override should take priority: got input rate %f, want 999.0", p.InputPerMillion)
+		}
+	})
+
+	t.Run("idempotent on New calculator", func(t *testing.T) {
+		calc := New()
+		defaultsBefore := calc.Defaults()
+
+		calc.LoadDefaults()
+
+		defaultsAfter := calc.Defaults()
+		if len(defaultsBefore) != len(defaultsAfter) {
+			t.Errorf("LoadDefaults on New() changed model count: %d → %d",
+				len(defaultsBefore), len(defaultsAfter))
+		}
+	})
+}
+
+func TestNewVsNewEmpty_ConfigBackendContract(t *testing.T) {
+	// This test verifies the core contract: config backend users must use
+	// New() (not NewEmpty()) to get embedded pricing. This is the exact
+	// scenario that broke when NewEmpty() was used unconditionally.
+
+	t.Run("New provides pricing for config backend", func(t *testing.T) {
+		calc := New()
+		// Config backend relies on embedded pricing — should work.
+		cost := calc.Calculate("openai", "gpt-4o", 1_000_000, 1_000_000)
+		if cost <= 0 {
+			t.Errorf("New() should have embedded pricing: got cost %f, want > 0", cost)
+		}
+		models := calc.Models()
+		if len(models) == 0 {
+			t.Error("New() should have models loaded")
+		}
+	})
+
+	t.Run("NewEmpty has no pricing without explicit loading", func(t *testing.T) {
+		calc := NewEmpty()
+		cost := calc.Calculate("openai", "gpt-4o", 1_000_000, 1_000_000)
+		if cost != 0 {
+			t.Errorf("NewEmpty() should have zero pricing: got cost %f, want 0", cost)
+		}
+		models := calc.Models()
+		if len(models) != 0 {
+			t.Errorf("NewEmpty() should have 0 models, got %d", len(models))
+		}
+	})
+
+	t.Run("NewEmpty with LoadDefaults matches New", func(t *testing.T) {
+		calcNew := New()
+		calcEmpty := NewEmpty()
+		calcEmpty.LoadDefaults()
+
+		newModels := calcNew.Models()
+		emptyModels := calcEmpty.Models()
+		if len(newModels) != len(emptyModels) {
+			t.Errorf("model count mismatch: New()=%d, NewEmpty()+LoadDefaults()=%d",
+				len(newModels), len(emptyModels))
+		}
+
+		// Spot-check a specific model cost.
+		costNew := calcNew.Calculate("openai", "gpt-4o", 1_000_000, 1_000_000)
+		costEmpty := calcEmpty.Calculate("openai", "gpt-4o", 1_000_000, 1_000_000)
+		if math.Abs(costNew-costEmpty) > 0.001 {
+			t.Errorf("costs differ: New()=%f, NewEmpty()+LoadDefaults()=%f", costNew, costEmpty)
+		}
+	})
+}
+
 func TestCalculate(t *testing.T) {
 	calc := New()
 

--- a/pkg/costcalc/calculator_test.go
+++ b/pkg/costcalc/calculator_test.go
@@ -6,6 +6,69 @@ import (
 	"testing"
 )
 
+func TestNewEmpty(t *testing.T) {
+	calc := NewEmpty()
+
+	t.Run("no models loaded", func(t *testing.T) {
+		models := calc.Models()
+		if len(models) != 0 {
+			t.Errorf("NewEmpty().Models() returned %d models, want 0", len(models))
+		}
+	})
+
+	t.Run("defaults empty", func(t *testing.T) {
+		defaults := calc.Defaults()
+		if len(defaults) != 0 {
+			t.Errorf("NewEmpty().Defaults() returned %d defaults, want 0", len(defaults))
+		}
+	})
+
+	t.Run("calculate returns zero for any model", func(t *testing.T) {
+		cost := calc.Calculate("openai", "gpt-4o", 1_000_000, 1_000_000)
+		if cost != 0 {
+			t.Errorf("NewEmpty().Calculate(gpt-4o) = %f, want 0", cost)
+		}
+	})
+
+	t.Run("local still free", func(t *testing.T) {
+		cost := calc.Calculate("local", "llama3:8b", 1_000_000, 1_000_000)
+		if cost != 0 {
+			t.Errorf("NewEmpty().Calculate(local) = %f, want 0", cost)
+		}
+	})
+
+	t.Run("cache discounts initialized", func(t *testing.T) {
+		_, ok := calc.GetCacheDiscount("openai")
+		if !ok {
+			t.Error("NewEmpty() should have default cache discounts for openai")
+		}
+		_, ok = calc.GetCacheDiscount("anthropic")
+		if !ok {
+			t.Error("NewEmpty() should have default cache discounts for anthropic")
+		}
+	})
+
+	t.Run("SetPricing works", func(t *testing.T) {
+		calc.SetPricing(ModelPricing{
+			Provider:         "custom",
+			Model:            "test-model",
+			InputPerMillion:  2.0,
+			OutputPerMillion: 4.0,
+		})
+		cost := calc.Calculate("custom", "test-model", 1_000_000, 1_000_000)
+		want := 6.0
+		if math.Abs(cost-want) > 0.001 {
+			t.Errorf("after SetPricing, Calculate = %f, want %f", cost, want)
+		}
+	})
+
+	t.Run("HasPricing false for unloaded model", func(t *testing.T) {
+		if calc.HasPricing("openai", "gpt-4o") {
+			t.Error("NewEmpty() should not have pricing for gpt-4o")
+		}
+	})
+}
+
 func TestCalculate(t *testing.T) {
 	calc := New()
 


### PR DESCRIPTION
## Problem
Server loads embedded `pricing.yaml` defaults via `costcalc.New()` only to immediately overwrite them from the catalog database.

## Changes
- Add `NewEmpty()` constructor that returns a Calculator with no built-in pricing
- Refactor `New()` to use shared `newBase()` helper
- Switch `candela-server` to `NewEmpty()` (CLI keeps `New()` for solo mode)
- 7 test subtests covering empty state, runtime `SetPricing()`, cache discounts

Closes #392