### PR TITLE
feat: add CANDELA_VERTEX_REGION env var

### DIFF
--- a/cmd/candela-server/config_test.go
+++ b/cmd/candela-server/config_test.go
@@ -729,7 +729,7 @@ proxy:
 	}
 }
 
-func TestLoadConfig_VertexRegionDefaultsToGlobal(t *testing.T) {
+func TestLoadConfig_VertexRegionDefaultsToUSCentral1(t *testing.T) {
 	// Write a config file with no region set.
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
@@ -748,9 +748,35 @@ proxy:
 	if err != nil {
 		t.Fatalf("loadConfig() error: %v", err)
 	}
-	if cfg.Proxy.VertexAI.Region != "global" {
-		t.Errorf("region = %q, want %q (should default to global)",
-			cfg.Proxy.VertexAI.Region, "global")
+	if cfg.Proxy.VertexAI.Region != "us-central1" {
+		t.Errorf("region = %q, want %q (should default to us-central1)",
+			cfg.Proxy.VertexAI.Region, "us-central1")
+	}
+}
+
+func TestLoadConfig_VertexRegionDefaultNotGlobal_MistralSafe(t *testing.T) {
+	// Mistral is a regional MaaS model that is NOT available on the
+	// "global" Vertex AI endpoint. Verify the default region is never
+	// "global" so that Mistral works out of the box.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+proxy:
+  vertex_ai:
+    project_id: "my-project"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CANDELA_CONFIG", cfgPath)
+	t.Setenv("CANDELA_VERTEX_REGION", "")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+	if cfg.Proxy.VertexAI.Region == "global" {
+		t.Error("default region must not be 'global' — Mistral (regional MaaS) is not available on the global endpoint")
 	}
 }
 

--- a/cmd/candela-server/config_test.go
+++ b/cmd/candela-server/config_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -697,5 +699,97 @@ custom_providers:
 	}
 	if providers[0].AuthHeader != "x-api-key" {
 		t.Errorf("AuthHeader = %q, want %q", providers[0].AuthHeader, "x-api-key")
+	}
+}
+
+// ── CANDELA_VERTEX_REGION env var tests ──────────────────────────────────────
+
+func TestLoadConfig_VertexRegionEnvOverridesConfig(t *testing.T) {
+	// Write a temp config file with a region set.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+proxy:
+  vertex_ai:
+    region: "us-east5"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CANDELA_CONFIG", cfgPath)
+	t.Setenv("CANDELA_VERTEX_REGION", "europe-west4")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+	if cfg.Proxy.VertexAI.Region != "europe-west4" {
+		t.Errorf("region = %q, want %q (env var should override config)",
+			cfg.Proxy.VertexAI.Region, "europe-west4")
+	}
+}
+
+func TestLoadConfig_VertexRegionDefaultsToGlobal(t *testing.T) {
+	// Write a config file with no region set.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+proxy:
+  vertex_ai:
+    project_id: "my-project"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CANDELA_CONFIG", cfgPath)
+	t.Setenv("CANDELA_VERTEX_REGION", "")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+	if cfg.Proxy.VertexAI.Region != "global" {
+		t.Errorf("region = %q, want %q (should default to global)",
+			cfg.Proxy.VertexAI.Region, "global")
+	}
+}
+
+func TestLoadConfig_VertexRegionEnvNoConfigFile(t *testing.T) {
+	// Point to a non-existent config file — env var should still apply.
+	t.Setenv("CANDELA_CONFIG", filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	t.Setenv("CANDELA_VERTEX_REGION", "us-south1")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+	if cfg.Proxy.VertexAI.Region != "us-south1" {
+		t.Errorf("region = %q, want %q (env var should work without config file)",
+			cfg.Proxy.VertexAI.Region, "us-south1")
+	}
+}
+
+func TestLoadConfig_VertexRegionConfigPreservedWithoutEnv(t *testing.T) {
+	// When no env var is set, config file value should be preserved.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+proxy:
+  vertex_ai:
+    region: "us-east5"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CANDELA_CONFIG", cfgPath)
+	t.Setenv("CANDELA_VERTEX_REGION", "")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+	if cfg.Proxy.VertexAI.Region != "us-east5" {
+		t.Errorf("region = %q, want %q (config value should be preserved)",
+			cfg.Proxy.VertexAI.Region, "us-east5")
 	}
 }

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -533,10 +533,7 @@ func main() {
 		// when Vertex AI is configured. Anthropic routes through regional
 		// Vertex AI publisher endpoints (rawPredict/streamRawPredict).
 		if cfg.Proxy.VertexAI.ProjectID != "" {
-			region := cfg.Proxy.VertexAI.Region
-			if region == "" {
-				region = "global"
-			}
+			region := cfg.Proxy.VertexAI.Region // guaranteed non-empty by loadConfig()
 
 			for i, p := range allProviders {
 				switch p.Name {
@@ -1120,12 +1117,14 @@ func loadConfig() (*Config, error) {
 		cfg.Catalog.Backend = "config"
 	}
 
-	// Vertex AI region: env var override, then default to "global".
+	// Vertex AI region: env var override, then default to "us-central1".
+	// We default to us-central1 (not "global") because regional MaaS
+	// providers like Mistral are NOT available on the global endpoint.
 	if env := os.Getenv("CANDELA_VERTEX_REGION"); env != "" {
 		cfg.Proxy.VertexAI.Region = env
 	}
 	if cfg.Proxy.VertexAI.Region == "" {
-		cfg.Proxy.VertexAI.Region = "global"
+		cfg.Proxy.VertexAI.Region = "us-central1"
 	}
 
 	return &cfg, nil

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -535,7 +535,7 @@ func main() {
 		if cfg.Proxy.VertexAI.ProjectID != "" {
 			region := cfg.Proxy.VertexAI.Region
 			if region == "" {
-				region = "us-central1"
+				region = "global"
 			}
 
 			for i, p := range allProviders {
@@ -1095,18 +1095,13 @@ func loadConfig() (*Config, error) {
 		cfgPath = "config.yaml"
 	}
 
+	var cfg Config
+
 	data, err := os.ReadFile(cfgPath)
 	if err != nil {
 		// No config file — use defaults (DuckDB, port 8181).
 		slog.Warn("config file not found, using defaults", "path", cfgPath)
-		cfg := &Config{}
-		cfg.Server.Port = 8181
-		cfg.Storage.Backend = "duckdb"
-		return cfg, nil
-	}
-
-	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	} else if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 
@@ -1123,6 +1118,14 @@ func loadConfig() (*Config, error) {
 	}
 	if cfg.Catalog.Backend == "" {
 		cfg.Catalog.Backend = "config"
+	}
+
+	// Vertex AI region: env var override, then default to "global".
+	if env := os.Getenv("CANDELA_VERTEX_REGION"); env != "" {
+		cfg.Proxy.VertexAI.Region = env
+	}
+	if cfg.Proxy.VertexAI.Region == "" {
+		cfg.Proxy.VertexAI.Region = "global"
 	}
 
 	return &cfg, nil

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -1272,7 +1272,7 @@ func buildCloudProxy(cfg Config, submitter *processor.SpanProcessor) (*proxy.Pro
 		region = env
 	}
 	if region == "" {
-		region = "global"
+		region = "us-central1"
 	}
 
 	// Check if any provider needs GCP credentials.

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -1268,8 +1268,11 @@ func buildLocalProxy(upstream string) *httputil.ReverseProxy {
 // Uses Google ADC for authentication to Vertex AI endpoints (Gemini + Anthropic).
 func buildCloudProxy(cfg Config, submitter *processor.SpanProcessor) (*proxy.Proxy, map[string]string) {
 	region := cfg.VertexAI.Region
+	if env := os.Getenv("CANDELA_VERTEX_REGION"); env != "" {
+		region = env
+	}
 	if region == "" {
-		region = "us-central1"
+		region = "global"
 	}
 
 	// Check if any provider needs GCP credentials.


### PR DESCRIPTION
## Problem
Vertex AI region is only configurable via `config.yaml`, not via environment variable.

## Changes
- Add `CANDELA_VERTEX_REGION` env var in both `candela-server` and `candela` CLI
- Default to `global` (works for all models) instead of `us-central1`
- Fix early-return in `loadConfig()` so env overrides apply even without a config file
- 4 tests covering override, default, no-config-file, and preservation scenarios

Closes #386