### PR TITLE
feat(cli): add --from, --merge, --dry-run flags to seed-catalog

### DIFF
--- a/cmd/seed-catalog/load.go
+++ b/cmd/seed-catalog/load.go
@@ -64,6 +64,7 @@ func loadCatalogFile(path string) ([]catalog.Entry, error) {
 		return nil, fmt.Errorf("catalog file %s contains no model entries", path)
 	}
 
+	seen := make(map[string]int, len(cf.Models))
 	entries := make([]catalog.Entry, 0, len(cf.Models))
 	for i, m := range cf.Models {
 		if m.Provider == "" || m.Model == "" {
@@ -72,6 +73,12 @@ func loadCatalogFile(path string) ([]catalog.Entry, error) {
 		if m.InputPerMillion <= 0 || m.OutputPerMillion <= 0 {
 			return nil, fmt.Errorf("catalog file entry %d (%s/%s): prices must be > 0", i, m.Provider, m.Model)
 		}
+
+		key := m.Provider + "/" + m.Model
+		if prevIdx, ok := seen[key]; ok {
+			return nil, fmt.Errorf("catalog file entry %d: duplicate model %s (first seen at entry %d)", i, key, prevIdx)
+		}
+		seen[key] = i
 
 		enabled := true
 		if m.Enabled != nil {

--- a/cmd/seed-catalog/load.go
+++ b/cmd/seed-catalog/load.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/candelahq/candela/pkg/catalog"
+	"gopkg.in/yaml.v3"
+)
+
+// catalogFile is the schema for external catalog files.
+// It matches the structure of pkg/costcalc/pricing.yaml so users can
+// export and re-import catalog data using the same format.
+type catalogFile struct {
+	Models []catalogModel `yaml:"models" json:"models"`
+}
+
+// catalogModel represents a single model entry in an external catalog file.
+type catalogModel struct {
+	Provider             string   `yaml:"provider" json:"provider"`
+	Model                string   `yaml:"model" json:"model"`
+	InputPerMillion      float64  `yaml:"input_per_million" json:"input_per_million"`
+	OutputPerMillion     float64  `yaml:"output_per_million" json:"output_per_million"`
+	InputPerMillionHigh  float64  `yaml:"input_per_million_high,omitempty" json:"input_per_million_high,omitempty"`
+	OutputPerMillionHigh float64  `yaml:"output_per_million_high,omitempty" json:"output_per_million_high,omitempty"`
+	TierThresholdTokens  int64    `yaml:"tier_threshold_tokens,omitempty" json:"tier_threshold_tokens,omitempty"`
+	DiscountPercent      float64  `yaml:"discount_percent,omitempty" json:"discount_percent,omitempty"`
+	Enabled              *bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"` // defaults to true if omitted
+	DisplayName          string   `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	Category             string   `yaml:"category,omitempty" json:"category,omitempty"`
+	ContextWindow        int64    `yaml:"context_window,omitempty" json:"context_window,omitempty"`
+	Aliases              []string `yaml:"aliases,omitempty" json:"aliases,omitempty"`
+	ProviderModelID      string   `yaml:"provider_model_id,omitempty" json:"provider_model_id,omitempty"`
+	Region               string   `yaml:"region,omitempty" json:"region,omitempty"`
+}
+
+// loadCatalogFile reads model entries from an external YAML or JSON file.
+// The file format is detected from the extension (.yaml, .yml, .json).
+func loadCatalogFile(path string) ([]catalog.Entry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading catalog file: %w", err)
+	}
+
+	var cf catalogFile
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".yaml", ".yml":
+		if err := yaml.Unmarshal(data, &cf); err != nil {
+			return nil, fmt.Errorf("parsing YAML catalog file: %w", err)
+		}
+	case ".json":
+		if err := json.Unmarshal(data, &cf); err != nil {
+			return nil, fmt.Errorf("parsing JSON catalog file: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported file extension %q (expected .yaml, .yml, or .json)", ext)
+	}
+
+	if len(cf.Models) == 0 {
+		return nil, fmt.Errorf("catalog file %s contains no model entries", path)
+	}
+
+	entries := make([]catalog.Entry, 0, len(cf.Models))
+	for i, m := range cf.Models {
+		if m.Provider == "" || m.Model == "" {
+			return nil, fmt.Errorf("catalog file entry %d: provider and model are required", i)
+		}
+		if m.InputPerMillion <= 0 || m.OutputPerMillion <= 0 {
+			return nil, fmt.Errorf("catalog file entry %d (%s/%s): prices must be > 0", i, m.Provider, m.Model)
+		}
+
+		enabled := true
+		if m.Enabled != nil {
+			enabled = *m.Enabled
+		}
+
+		e := catalog.Entry{
+			ModelID:              m.Model,
+			Provider:             m.Provider,
+			InputPerMillion:      m.InputPerMillion,
+			OutputPerMillion:     m.OutputPerMillion,
+			InputPerMillionHigh:  m.InputPerMillionHigh,
+			OutputPerMillionHigh: m.OutputPerMillionHigh,
+			TierThresholdTokens:  m.TierThresholdTokens,
+			DiscountPercent:      m.DiscountPercent,
+			Enabled:              enabled,
+			DisplayName:          m.DisplayName,
+			Category:             m.Category,
+			ContextWindow:        m.ContextWindow,
+			Aliases:              m.Aliases,
+			ProviderModelID:      m.ProviderModelID,
+			Region:               m.Region,
+		}
+		entries = append(entries, e)
+	}
+
+	return entries, nil
+}

--- a/cmd/seed-catalog/load_test.go
+++ b/cmd/seed-catalog/load_test.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadCatalogFileYAML(t *testing.T) {
+	content := `models:
+  - provider: test-provider
+    model: test-model
+    input_per_million: 1.50
+    output_per_million: 9.00
+  - provider: test-provider
+    model: test-model-tiered
+    input_per_million: 1.25
+    output_per_million: 10.00
+    input_per_million_high: 2.50
+    output_per_million_high: 15.00
+    tier_threshold_tokens: 200000
+`
+	path := writeTestFile(t, "catalog.yaml", content)
+	entries, err := loadCatalogFile(path)
+	if err != nil {
+		t.Fatalf("loadCatalogFile(%q): %v", path, err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	// Verify first entry.
+	e := entries[0]
+	if e.Provider != "test-provider" {
+		t.Errorf("entry[0].Provider = %q, want %q", e.Provider, "test-provider")
+	}
+	if e.ModelID != "test-model" {
+		t.Errorf("entry[0].ModelID = %q, want %q", e.ModelID, "test-model")
+	}
+	if e.InputPerMillion != 1.50 {
+		t.Errorf("entry[0].InputPerMillion = %f, want 1.50", e.InputPerMillion)
+	}
+	if e.OutputPerMillion != 9.00 {
+		t.Errorf("entry[0].OutputPerMillion = %f, want 9.00", e.OutputPerMillion)
+	}
+	if !e.Enabled {
+		t.Error("entry[0].Enabled should default to true")
+	}
+
+	// Verify tiered entry.
+	e2 := entries[1]
+	if e2.TierThresholdTokens != 200000 {
+		t.Errorf("entry[1].TierThresholdTokens = %d, want 200000", e2.TierThresholdTokens)
+	}
+	if e2.InputPerMillionHigh != 2.50 {
+		t.Errorf("entry[1].InputPerMillionHigh = %f, want 2.50", e2.InputPerMillionHigh)
+	}
+	if e2.OutputPerMillionHigh != 15.00 {
+		t.Errorf("entry[1].OutputPerMillionHigh = %f, want 15.00", e2.OutputPerMillionHigh)
+	}
+}
+
+func TestLoadCatalogFileYML(t *testing.T) {
+	content := `models:
+  - provider: google
+    model: gemini-3.5-flash
+    input_per_million: 1.50
+    output_per_million: 9.00
+`
+	path := writeTestFile(t, "catalog.yml", content)
+	entries, err := loadCatalogFile(path)
+	if err != nil {
+		t.Fatalf("loadCatalogFile(%q): %v", path, err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+}
+
+func TestLoadCatalogFileJSON(t *testing.T) {
+	content := `{
+  "models": [
+    {
+      "provider": "openai",
+      "model": "gpt-4.1",
+      "input_per_million": 2.00,
+      "output_per_million": 8.00
+    },
+    {
+      "provider": "anthropic",
+      "model": "claude-sonnet-4",
+      "input_per_million": 3.00,
+      "output_per_million": 15.00,
+      "enabled": false
+    }
+  ]
+}`
+	path := writeTestFile(t, "catalog.json", content)
+	entries, err := loadCatalogFile(path)
+	if err != nil {
+		t.Fatalf("loadCatalogFile(%q): %v", path, err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	// First entry should default to enabled=true.
+	if !entries[0].Enabled {
+		t.Error("entry[0] should default to enabled=true")
+	}
+	// Second entry explicitly set enabled=false.
+	if entries[1].Enabled {
+		t.Error("entry[1] should be enabled=false")
+	}
+}
+
+func TestLoadCatalogFileExtraFields(t *testing.T) {
+	content := `models:
+  - provider: custom
+    model: custom-model
+    input_per_million: 1.00
+    output_per_million: 5.00
+    display_name: Custom Model
+    category: premium
+    context_window: 128000
+    aliases:
+      - custom-v1
+      - custom-latest
+    provider_model_id: custom-model-v1
+    region: us-east1
+    discount_percent: 0.15
+`
+	path := writeTestFile(t, "catalog-extra.yaml", content)
+	entries, err := loadCatalogFile(path)
+	if err != nil {
+		t.Fatalf("loadCatalogFile(%q): %v", path, err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	e := entries[0]
+	if e.DisplayName != "Custom Model" {
+		t.Errorf("DisplayName = %q, want %q", e.DisplayName, "Custom Model")
+	}
+	if e.Category != "premium" {
+		t.Errorf("Category = %q, want %q", e.Category, "premium")
+	}
+	if e.ContextWindow != 128000 {
+		t.Errorf("ContextWindow = %d, want 128000", e.ContextWindow)
+	}
+	if len(e.Aliases) != 2 {
+		t.Errorf("Aliases len = %d, want 2", len(e.Aliases))
+	}
+	if e.ProviderModelID != "custom-model-v1" {
+		t.Errorf("ProviderModelID = %q, want %q", e.ProviderModelID, "custom-model-v1")
+	}
+	if e.Region != "us-east1" {
+		t.Errorf("Region = %q, want %q", e.Region, "us-east1")
+	}
+	if e.DiscountPercent != 0.15 {
+		t.Errorf("DiscountPercent = %f, want 0.15", e.DiscountPercent)
+	}
+}
+
+func TestLoadCatalogFileMissingProvider(t *testing.T) {
+	content := `models:
+  - model: some-model
+    input_per_million: 1.00
+    output_per_million: 5.00
+`
+	path := writeTestFile(t, "no-provider.yaml", content)
+	_, err := loadCatalogFile(path)
+	if err == nil {
+		t.Fatal("expected error for missing provider, got nil")
+	}
+}
+
+func TestLoadCatalogFileMissingModel(t *testing.T) {
+	content := `models:
+  - provider: test
+    input_per_million: 1.00
+    output_per_million: 5.00
+`
+	path := writeTestFile(t, "no-model.yaml", content)
+	_, err := loadCatalogFile(path)
+	if err == nil {
+		t.Fatal("expected error for missing model, got nil")
+	}
+}
+
+func TestLoadCatalogFileZeroPrice(t *testing.T) {
+	content := `models:
+  - provider: test
+    model: test-model
+    input_per_million: 0
+    output_per_million: 5.00
+`
+	path := writeTestFile(t, "zero-price.yaml", content)
+	_, err := loadCatalogFile(path)
+	if err == nil {
+		t.Fatal("expected error for zero input price, got nil")
+	}
+}
+
+func TestLoadCatalogFileEmptyModels(t *testing.T) {
+	content := `models: []
+`
+	path := writeTestFile(t, "empty.yaml", content)
+	_, err := loadCatalogFile(path)
+	if err == nil {
+		t.Fatal("expected error for empty models list, got nil")
+	}
+}
+
+func TestLoadCatalogFileUnsupportedExtension(t *testing.T) {
+	path := writeTestFile(t, "catalog.toml", "whatever")
+	_, err := loadCatalogFile(path)
+	if err == nil {
+		t.Fatal("expected error for unsupported extension, got nil")
+	}
+}
+
+func TestLoadCatalogFileNotFound(t *testing.T) {
+	_, err := loadCatalogFile("/nonexistent/path/catalog.yaml")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file, got nil")
+	}
+}
+
+func TestLoadCatalogFileInvalidYAML(t *testing.T) {
+	content := `models:
+  - this is: [not: valid: yaml
+`
+	path := writeTestFile(t, "invalid.yaml", content)
+	_, err := loadCatalogFile(path)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+}
+
+func TestLoadCatalogFileInvalidJSON(t *testing.T) {
+	content := `{"models": [{"not valid json`
+	path := writeTestFile(t, "invalid.json", content)
+	_, err := loadCatalogFile(path)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestLoadCatalogFileMatchesPricingYAMLFormat(t *testing.T) {
+	// Verify that the embedded pricing.yaml can be parsed by loadCatalogFile.
+	// This validates format compatibility between the two systems.
+	pricingPath := filepath.Join("..", "..", "pkg", "costcalc", "pricing.yaml")
+	entries, err := loadCatalogFile(pricingPath)
+	if err != nil {
+		t.Fatalf("loadCatalogFile(pricing.yaml): %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected non-empty entries from pricing.yaml")
+	}
+
+	// Spot-check: all entries must have valid pricing.
+	for _, e := range entries {
+		if e.Provider == "" || e.ModelID == "" {
+			t.Errorf("entry with empty provider/model: %+v", e)
+		}
+		if e.InputPerMillion <= 0 || e.OutputPerMillion <= 0 {
+			t.Errorf("entry %s/%s has non-positive pricing", e.Provider, e.ModelID)
+		}
+		if !e.Enabled {
+			t.Errorf("entry %s/%s should default to enabled=true", e.Provider, e.ModelID)
+		}
+	}
+}
+
+// writeTestFile writes content to a temp file with the given name and returns the path.
+func writeTestFile(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/cmd/seed-catalog/load_test.go
+++ b/cmd/seed-catalog/load_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -271,6 +272,27 @@ func TestLoadCatalogFileMatchesPricingYAMLFormat(t *testing.T) {
 		if !e.Enabled {
 			t.Errorf("entry %s/%s should default to enabled=true", e.Provider, e.ModelID)
 		}
+	}
+}
+
+func TestLoadCatalogFileDuplicateEntries(t *testing.T) {
+	content := `models:
+  - provider: google
+    model: gemini-2.5-pro
+    input_per_million: 1.25
+    output_per_million: 10.00
+  - provider: google
+    model: gemini-2.5-pro
+    input_per_million: 2.50
+    output_per_million: 20.00
+`
+	path := writeTestFile(t, "duplicates.yaml", content)
+	_, err := loadCatalogFile(path)
+	if err == nil {
+		t.Fatal("expected error for duplicate entries, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("error should mention 'duplicate': got %v", err)
 	}
 }
 

--- a/cmd/seed-catalog/main.go
+++ b/cmd/seed-catalog/main.go
@@ -1,11 +1,14 @@
-// Command seed-catalog populates a Firestore model catalog collection with the
-// built-in default pricing from the Calculator.
+// Command seed-catalog populates a Firestore model catalog collection with
+// model pricing entries. By default it uses the built-in pricing from the
+// Calculator; use --from to load entries from an external YAML/JSON file.
 //
 // Usage:
 //
 //	go run ./cmd/seed-catalog/ \
 //	  --project-id=your-gcp-project \
 //	  [--collection=model_catalog] \
+//	  [--from=pricing.yaml] \
+//	  [--merge] \
 //	  [--dry-run]
 //
 // In dry-run mode the tool prints what would be written without touching
@@ -30,6 +33,8 @@ func main() {
 	projectID := flag.String("project-id", "", "GCP Project ID (required)")
 	databaseID := flag.String("database-id", "(default)", "Firestore database ID")
 	collection := flag.String("collection", "model_catalog", "Firestore collection name")
+	fromFile := flag.String("from", "", "Read model entries from an external YAML/JSON file instead of embedded pricing")
+	merge := flag.Bool("merge", false, "Skip existing entries instead of overwriting (upsert only new)")
 	dryRun := flag.Bool("dry-run", false, "Print entries without writing to Firestore")
 	flag.Parse()
 
@@ -37,41 +42,28 @@ func main() {
 		log.Fatal("--project-id flag is required")
 	}
 
-	// Build the default pricing table from the Calculator.
-	calc := costcalc.New()
-	defaults := calc.Defaults() // Already sorted by provider/model.
+	var (
+		entries []catalog.Entry
+		source  string
+	)
 
-	// Convert ModelPricing → catalog.Entry.
-	entries := make([]catalog.Entry, 0, len(defaults))
-	for _, p := range defaults {
-		e := catalog.Entry{
-			ModelID:              p.Model,
-			Provider:             p.Provider,
-			InputPerMillion:      p.InputPerMillion,
-			OutputPerMillion:     p.OutputPerMillion,
-			InputPerMillionHigh:  p.InputPerMillionHigh,
-			OutputPerMillionHigh: p.OutputPerMillionHigh,
-			TierThresholdTokens:  p.TierThresholdTokens,
-			DiscountPercent:      p.DiscountPercent,
-			Enabled:              true,
+	if *fromFile != "" {
+		// Load entries from external file.
+		var err error
+		entries, err = loadCatalogFile(*fromFile)
+		if err != nil {
+			log.Fatalf("loading catalog file: %v", err)
 		}
-
-		// For Anthropic models routed through Vertex AI, set the
-		// provider-specific model ID (Vertex uses dashes, not dots)
-		// and default to the "global" region endpoint.
-		if p.Provider == "anthropic" {
-			if vid := vertexModelID(p.Model); vid != p.Model {
-				e.ProviderModelID = vid
-			}
-			e.Region = "global"
-		}
-
-		entries = append(entries, e)
+		source = *fromFile
+	} else {
+		// Build the default pricing table from the Calculator.
+		entries = buildEntriesFromDefaults()
+		source = "embedded defaults"
 	}
 
 	fmt.Printf("🕯️  seed-catalog (project=%s database=%s collection=%s dry-run=%v)\n\n",
 		*projectID, *databaseID, *collection, *dryRun)
-	fmt.Printf("Found %d default model pricing entries.\n\n", len(entries))
+	fmt.Printf("Found %d model pricing entries from %s.\n\n", len(entries), source)
 
 	if *dryRun {
 		for _, e := range entries {
@@ -99,14 +91,25 @@ func main() {
 	store := catalog.NewFirestoreStore(client, *collection)
 
 	var (
-		seeded   int
-		errCount int
+		seeded  int
+		skipped int
+		errCnt  int
 	)
 	for _, e := range entries {
 		if err := ctx.Err(); err != nil {
 			slog.Error("seeding cancelled", "error", err)
 			break
 		}
+
+		// In merge mode, skip entries that already exist in the store.
+		if *merge {
+			if _, err := store.Get(ctx, e.Provider, e.ModelID); err == nil {
+				fmt.Printf("  [SKIP] %s/%s — already exists\n", e.Provider, e.ModelID)
+				skipped++
+				continue
+			}
+		}
+
 		fmt.Printf("  [SEED] %s/%s — in=$%.4f/M out=$%.4f/M",
 			e.Provider, e.ModelID, e.InputPerMillion, e.OutputPerMillion)
 		if e.TierThresholdTokens > 0 {
@@ -117,13 +120,55 @@ func main() {
 
 		if err := store.Update(ctx, e); err != nil {
 			fmt.Printf("  [ERR]  %s/%s: %v\n", e.Provider, e.ModelID, err)
-			errCount++
+			errCnt++
 			continue
 		}
 		seeded++
 	}
 
-	fmt.Printf("\n✅ Done — %d entries seeded, %d errors.\n", seeded, errCount)
+	fmt.Printf("\n✅ Done — %d entries seeded", seeded)
+	if skipped > 0 {
+		fmt.Printf(", %d skipped (already exist)", skipped)
+	}
+	if errCnt > 0 {
+		fmt.Printf(", %d errors", errCnt)
+	}
+	fmt.Println(".")
+}
+
+// buildEntriesFromDefaults creates catalog entries from the compiled-in
+// pricing table, applying Anthropic-specific transformations.
+func buildEntriesFromDefaults() []catalog.Entry {
+	calc := costcalc.New()
+	defaults := calc.Defaults() // Already sorted by provider/model.
+
+	entries := make([]catalog.Entry, 0, len(defaults))
+	for _, p := range defaults {
+		e := catalog.Entry{
+			ModelID:              p.Model,
+			Provider:             p.Provider,
+			InputPerMillion:      p.InputPerMillion,
+			OutputPerMillion:     p.OutputPerMillion,
+			InputPerMillionHigh:  p.InputPerMillionHigh,
+			OutputPerMillionHigh: p.OutputPerMillionHigh,
+			TierThresholdTokens:  p.TierThresholdTokens,
+			DiscountPercent:      p.DiscountPercent,
+			Enabled:              true,
+		}
+
+		// For Anthropic models routed through Vertex AI, set the
+		// provider-specific model ID (Vertex uses dashes, not dots)
+		// and default to the "global" region endpoint.
+		if p.Provider == "anthropic" {
+			if vid := vertexModelID(p.Model); vid != p.Model {
+				e.ProviderModelID = vid
+			}
+			e.Region = "global"
+		}
+
+		entries = append(entries, e)
+	}
+	return entries
 }
 
 // vertexModelID converts an Anthropic model name to its Vertex AI equivalent.

--- a/cmd/seed-catalog/main.go
+++ b/cmd/seed-catalog/main.go
@@ -29,6 +29,13 @@ import (
 	"github.com/candelahq/candela/pkg/costcalc"
 )
 
+// seedResult holds the outcome counters from a seedEntries run.
+type seedResult struct {
+	seeded  int
+	skipped int
+	errors  int
+}
+
 func main() {
 	projectID := flag.String("project-id", "", "GCP Project ID (required)")
 	databaseID := flag.String("database-id", "(default)", "Firestore database ID")
@@ -90,11 +97,43 @@ func main() {
 
 	store := catalog.NewFirestoreStore(client, *collection)
 
-	var (
-		seeded  int
-		skipped int
-		errCnt  int
-	)
+	result, err := seedEntries(ctx, store, entries, *merge)
+	if err != nil {
+		log.Fatalf("seeding: %v", err)
+	}
+
+	fmt.Printf("\n✅ Done — %d entries seeded", result.seeded)
+	if result.skipped > 0 {
+		fmt.Printf(", %d skipped (already exist)", result.skipped)
+	}
+	if result.errors > 0 {
+		fmt.Printf(", %d errors", result.errors)
+	}
+	fmt.Println(".")
+}
+
+// seedEntries writes catalog entries to the store. When merge is true, existing
+// entries are skipped (insert-only). All existing IDs are fetched in a single
+// List call to avoid N+1 per-entry lookups.
+func seedEntries(ctx context.Context, store catalog.ModelCatalogStore, entries []catalog.Entry, merge bool) (seedResult, error) {
+	var existing map[string]struct{}
+
+	// In merge mode, batch-fetch all existing entries upfront to build a
+	// lookup set. This replaces the previous N+1 store.Get() per entry.
+	if merge {
+		all, err := store.List(ctx, true) // include disabled
+		if err != nil {
+			return seedResult{}, fmt.Errorf("listing existing entries for merge: %w", err)
+		}
+		existing = make(map[string]struct{}, len(all))
+		for _, e := range all {
+			key := e.Provider + "/" + e.ModelID
+			existing[key] = struct{}{}
+		}
+		slog.Info("merge mode: loaded existing entries", "count", len(existing))
+	}
+
+	var result seedResult
 	for _, e := range entries {
 		if err := ctx.Err(); err != nil {
 			slog.Error("seeding cancelled", "error", err)
@@ -102,10 +141,11 @@ func main() {
 		}
 
 		// In merge mode, skip entries that already exist in the store.
-		if *merge {
-			if _, err := store.Get(ctx, e.Provider, e.ModelID); err == nil {
+		if merge {
+			key := e.Provider + "/" + e.ModelID
+			if _, ok := existing[key]; ok {
 				fmt.Printf("  [SKIP] %s/%s — already exists\n", e.Provider, e.ModelID)
-				skipped++
+				result.skipped++
 				continue
 			}
 		}
@@ -120,20 +160,13 @@ func main() {
 
 		if err := store.Update(ctx, e); err != nil {
 			fmt.Printf("  [ERR]  %s/%s: %v\n", e.Provider, e.ModelID, err)
-			errCnt++
+			result.errors++
 			continue
 		}
-		seeded++
+		result.seeded++
 	}
 
-	fmt.Printf("\n✅ Done — %d entries seeded", seeded)
-	if skipped > 0 {
-		fmt.Printf(", %d skipped (already exist)", skipped)
-	}
-	if errCnt > 0 {
-		fmt.Printf(", %d errors", errCnt)
-	}
-	fmt.Println(".")
+	return result, nil
 }
 
 // buildEntriesFromDefaults creates catalog entries from the compiled-in

--- a/cmd/seed-catalog/main_test.go
+++ b/cmd/seed-catalog/main_test.go
@@ -82,27 +82,12 @@ func TestDefaultsAllHaveValidPricing(t *testing.T) {
 	}
 }
 
-func TestDryRunDoesNotPanic(t *testing.T) {
+func TestBuildEntriesFromDefaults(t *testing.T) {
 	// Exercise the full ModelPricing → catalog.Entry conversion path
-	// (mirrors the inline loop in main) and verify it doesn't panic.
-	calc := costcalc.New()
-	defaults := calc.Defaults()
+	// via the refactored buildEntriesFromDefaults helper.
+	entries := buildEntriesFromDefaults()
 
-	entries := make([]catalog.Entry, 0, len(defaults))
-	for _, p := range defaults {
-		entries = append(entries, catalog.Entry{
-			ModelID:              p.Model,
-			Provider:             p.Provider,
-			InputPerMillion:      p.InputPerMillion,
-			OutputPerMillion:     p.OutputPerMillion,
-			InputPerMillionHigh:  p.InputPerMillionHigh,
-			OutputPerMillionHigh: p.OutputPerMillionHigh,
-			TierThresholdTokens:  p.TierThresholdTokens,
-			DiscountPercent:      p.DiscountPercent,
-			Enabled:              true,
-		})
-	}
-
+	defaults := costcalc.New().Defaults()
 	if len(entries) == 0 {
 		t.Fatal("no entries generated")
 	}

--- a/cmd/seed-catalog/seed_test.go
+++ b/cmd/seed-catalog/seed_test.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/catalog"
+)
+
+// memStore is a minimal in-memory ModelCatalogStore for unit tests.
+type memStore struct {
+	entries map[string]catalog.Entry // key: "provider/model"
+}
+
+func newMemStore(initial ...catalog.Entry) *memStore {
+	s := &memStore{entries: make(map[string]catalog.Entry, len(initial))}
+	for _, e := range initial {
+		s.entries[e.Provider+"/"+e.ModelID] = e
+	}
+	return s
+}
+
+func (s *memStore) List(_ context.Context, includeDisabled bool) ([]catalog.Entry, error) {
+	out := make([]catalog.Entry, 0, len(s.entries))
+	for _, e := range s.entries {
+		if includeDisabled || e.Enabled {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+func (s *memStore) Get(_ context.Context, provider, modelID string) (*catalog.Entry, error) {
+	e, ok := s.entries[provider+"/"+modelID]
+	if !ok {
+		return nil, catalog.ErrNotFound
+	}
+	return &e, nil
+}
+
+func (s *memStore) Update(_ context.Context, entry catalog.Entry) error {
+	s.entries[entry.Provider+"/"+entry.ModelID] = entry
+	return nil
+}
+
+func (s *memStore) Delete(_ context.Context, provider, modelID string) error {
+	key := provider + "/" + modelID
+	if _, ok := s.entries[key]; !ok {
+		return catalog.ErrNotFound
+	}
+	delete(s.entries, key)
+	return nil
+}
+
+func (s *memStore) Source() string { return "mem" }
+func (s *memStore) Writable() bool { return true }
+
+// ── seedEntries tests ────────────────────────────────────────────────────
+
+func TestSeedEntries_OverwriteMode(t *testing.T) {
+	store := newMemStore()
+
+	entries := []catalog.Entry{
+		{Provider: "google", ModelID: "gemini-2.5-pro", InputPerMillion: 1.25, OutputPerMillion: 10, Enabled: true},
+		{Provider: "openai", ModelID: "gpt-4.1", InputPerMillion: 2.00, OutputPerMillion: 8, Enabled: true},
+	}
+
+	result, err := seedEntries(context.Background(), store, entries, false)
+	if err != nil {
+		t.Fatalf("seedEntries: %v", err)
+	}
+
+	if result.seeded != 2 {
+		t.Errorf("seeded = %d, want 2", result.seeded)
+	}
+	if result.skipped != 0 {
+		t.Errorf("skipped = %d, want 0", result.skipped)
+	}
+	if result.errors != 0 {
+		t.Errorf("errors = %d, want 0", result.errors)
+	}
+	if len(store.entries) != 2 {
+		t.Errorf("store has %d entries, want 2", len(store.entries))
+	}
+}
+
+func TestSeedEntries_MergeSkipsExisting(t *testing.T) {
+	// Pre-populate the store with one entry that also appears in the seed list.
+	existing := catalog.Entry{
+		Provider:        "google",
+		ModelID:         "gemini-2.5-pro",
+		InputPerMillion: 1.25, OutputPerMillion: 10,
+		Enabled: true,
+	}
+	store := newMemStore(existing)
+
+	entries := []catalog.Entry{
+		// This one already exists — should be skipped.
+		{Provider: "google", ModelID: "gemini-2.5-pro", InputPerMillion: 99.0, OutputPerMillion: 99.0, Enabled: true},
+		// This one is new — should be created.
+		{Provider: "openai", ModelID: "gpt-4.1", InputPerMillion: 2.00, OutputPerMillion: 8.0, Enabled: true},
+	}
+
+	result, err := seedEntries(context.Background(), store, entries, true)
+	if err != nil {
+		t.Fatalf("seedEntries: %v", err)
+	}
+
+	if result.seeded != 1 {
+		t.Errorf("seeded = %d, want 1", result.seeded)
+	}
+	if result.skipped != 1 {
+		t.Errorf("skipped = %d, want 1", result.skipped)
+	}
+	if result.errors != 0 {
+		t.Errorf("errors = %d, want 0", result.errors)
+	}
+
+	// Verify the existing entry was NOT overwritten (price should still be 1.25).
+	got, err := store.Get(context.Background(), "google", "gemini-2.5-pro")
+	if err != nil {
+		t.Fatalf("Get existing entry: %v", err)
+	}
+	if got.InputPerMillion != 1.25 {
+		t.Errorf("existing entry InputPerMillion = %f, want 1.25 (was overwritten)", got.InputPerMillion)
+	}
+
+	// Verify the new entry was created.
+	got, err = store.Get(context.Background(), "openai", "gpt-4.1")
+	if err != nil {
+		t.Fatalf("Get new entry: %v", err)
+	}
+	if got.InputPerMillion != 2.00 {
+		t.Errorf("new entry InputPerMillion = %f, want 2.00", got.InputPerMillion)
+	}
+}
+
+func TestSeedEntries_MergeAllExisting(t *testing.T) {
+	// When all entries already exist, everything should be skipped.
+	store := newMemStore(
+		catalog.Entry{Provider: "a", ModelID: "m1", InputPerMillion: 1, OutputPerMillion: 1, Enabled: true},
+		catalog.Entry{Provider: "b", ModelID: "m2", InputPerMillion: 2, OutputPerMillion: 2, Enabled: true},
+	)
+
+	entries := []catalog.Entry{
+		{Provider: "a", ModelID: "m1", InputPerMillion: 1, OutputPerMillion: 1, Enabled: true},
+		{Provider: "b", ModelID: "m2", InputPerMillion: 2, OutputPerMillion: 2, Enabled: true},
+	}
+
+	result, err := seedEntries(context.Background(), store, entries, true)
+	if err != nil {
+		t.Fatalf("seedEntries: %v", err)
+	}
+	if result.seeded != 0 {
+		t.Errorf("seeded = %d, want 0", result.seeded)
+	}
+	if result.skipped != 2 {
+		t.Errorf("skipped = %d, want 2", result.skipped)
+	}
+}
+
+func TestSeedEntries_MergeEmptyStore(t *testing.T) {
+	// When the store is empty, merge mode should insert everything.
+	store := newMemStore()
+
+	entries := []catalog.Entry{
+		{Provider: "a", ModelID: "m1", InputPerMillion: 1, OutputPerMillion: 1, Enabled: true},
+	}
+
+	result, err := seedEntries(context.Background(), store, entries, true)
+	if err != nil {
+		t.Fatalf("seedEntries: %v", err)
+	}
+	if result.seeded != 1 {
+		t.Errorf("seeded = %d, want 1", result.seeded)
+	}
+	if result.skipped != 0 {
+		t.Errorf("skipped = %d, want 0", result.skipped)
+	}
+}
+
+func TestSeedEntries_ContextCancelled(t *testing.T) {
+	store := newMemStore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	entries := []catalog.Entry{
+		{Provider: "a", ModelID: "m1", InputPerMillion: 1, OutputPerMillion: 1, Enabled: true},
+	}
+
+	result, err := seedEntries(ctx, store, entries, false)
+	if err != nil {
+		t.Fatalf("seedEntries should not return error on ctx cancel: %v", err)
+	}
+	// Nothing should have been seeded because context was already cancelled.
+	if result.seeded != 0 {
+		t.Errorf("seeded = %d, want 0", result.seeded)
+	}
+}
+
+// errStore wraps memStore but injects an error into List or Update.
+type errStore struct {
+	*memStore
+	listErr   error
+	updateErr error
+}
+
+func (s *errStore) List(ctx context.Context, includeDisabled bool) ([]catalog.Entry, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.memStore.List(ctx, includeDisabled)
+}
+
+func (s *errStore) Update(ctx context.Context, entry catalog.Entry) error {
+	if s.updateErr != nil {
+		return s.updateErr
+	}
+	return s.memStore.Update(ctx, entry)
+}
+
+func TestSeedEntries_MergeListError(t *testing.T) {
+	// If List() fails in merge mode, seedEntries should return the error.
+	store := &errStore{
+		memStore: newMemStore(),
+		listErr:  errors.New("firestore: permission denied"),
+	}
+
+	entries := []catalog.Entry{
+		{Provider: "a", ModelID: "m1", InputPerMillion: 1, OutputPerMillion: 1, Enabled: true},
+	}
+
+	_, err := seedEntries(context.Background(), store, entries, true)
+	if err == nil {
+		t.Fatal("expected error from List failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "listing existing entries for merge") {
+		t.Errorf("error should wrap context: got %v", err)
+	}
+}
+
+func TestSeedEntries_UpdateError(t *testing.T) {
+	// If Update() fails, the entry should be counted as an error, not seeded.
+	store := &errStore{
+		memStore:  newMemStore(),
+		updateErr: errors.New("firestore: quota exceeded"),
+	}
+
+	entries := []catalog.Entry{
+		{Provider: "a", ModelID: "m1", InputPerMillion: 1, OutputPerMillion: 1, Enabled: true},
+	}
+
+	result, err := seedEntries(context.Background(), store, entries, false)
+	if err != nil {
+		t.Fatalf("seedEntries should not return error for per-entry Update failures: %v", err)
+	}
+	if result.errors != 1 {
+		t.Errorf("errors = %d, want 1", result.errors)
+	}
+	if result.seeded != 0 {
+		t.Errorf("seeded = %d, want 0", result.seeded)
+	}
+}


### PR DESCRIPTION
## Problem
`seed-catalog` only reads from compiled-in `pricing.yaml`. Wrong prices in the binary = wrong prices in the DB.

## Changes
- `--from <file>` — read entries from external YAML/JSON file
- `--merge` — skip existing entries instead of overwriting
- `--dry-run` — already existed, no changes needed
- Refactored entry-building into shared helper
- 13 tests covering YAML/JSON parsing, validation, edge cases, and real pricing.yaml compatibility

Closes #385