### PR TITLE
fix: prevent CTRL_BREAK_EVENT leak in Windows CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,8 @@ jobs:
           skip-cache: true
 
       - name: Test Windows-relevant packages
-        run: go test ./cmd/candela/... ./pkg/runtime/... -count=1
+        shell: pwsh
+        run: go test -v ./cmd/candela/... ./pkg/runtime/... -count=1
 
       - name: Build candela.exe (windows/amd64)
         shell: pwsh

--- a/cmd/candela/main_test.go
+++ b/cmd/candela/main_test.go
@@ -377,6 +377,7 @@ func TestStopProcess_VerifiesExitBeforeReturn(t *testing.T) {
 func helperProcessCommand(mode string) *exec.Cmd {
 	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", mode)
 	cmd.Env = append(os.Environ(), "CANDELA_HELPER_PROCESS=1")
+	configureBackgroundCommand(cmd) // CREATE_NEW_PROCESS_GROUP on Windows — prevents CTRL_BREAK_EVENT from leaking to the parent shell
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

Fixes a flaky Windows CI failure where the `windows-candela` job fails with zero test output and PowerShell entering debug mode.

## Root Cause

`TestStopProcess_LiveProcess` and `TestStopProcess_VerifiesExitBeforeReturn` spawn child processes via `helperProcessCommand()` **without** calling `configureBackgroundCommand()`. On Windows, this means the child is NOT in a separate process group (`CREATE_NEW_PROCESS_GROUP` flag is missing).

When `terminateProcess()` calls `GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)`, the event leaks to the **entire console session** — including the parent PowerShell process running `go test`. PowerShell 5.1 (the default shell on `windows-latest`) enters debug mode on receipt of this signal:

```
Entering debug mode. Use h or ? for help.
[DBG]: PS D:\a\candela\candela>>
##[error]Process completed with exit code 1.
```

The flakiness arises because the race between signal delivery and process exit determines whether the parent catches the leaked event.

## Changes

1. **Root cause fix**: Add `configureBackgroundCommand(cmd)` to `helperProcessCommand()` so the child gets `CREATE_NEW_PROCESS_GROUP`, isolating the `CTRL_BREAK_EVENT` to the child's process group only
2. **Belt-and-suspenders**: Add `shell: pwsh` to the CI test step — PowerShell Core 7 handles console events more gracefully than PowerShell 5.1
3. **Diagnostics**: Add `-v` flag to `go test` for better output on future failures

## Testing

- [x] Go tests pass (`go test ./cmd/candela/... ./pkg/runtime/... -count=1`)
- [x] All pre-commit hooks pass (go-vet, golangci-lint, go-test, gofmt, check-yaml)
- [x] Manual verification — the fix directly addresses the documented `GenerateConsoleCtrlEvent` process group isolation requirement (see [MSDN docs](https://learn.microsoft.com/en-us/windows/console/generateconsolectrlevent))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows CLI smoke test handling so helper processes stay isolated, reducing the chance of signal-related test interruptions.
* **Tests**
  * Updated the Windows native CLI smoke test to run with verbose output for easier troubleshooting in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->