### PR TITLE
fix(lm): add LM Studio compat fields and /api/v0/models for JetBrains AI Chat

### DIFF
--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -155,6 +155,8 @@ func (h *lmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.URL.Path == "/v1/models" && r.Method == http.MethodGet:
 		h.serveModels(w, r)
+	case r.URL.Path == "/api/v0/models" && r.Method == http.MethodGet:
+		h.serveModels(w, r)
 	case r.URL.Path == "/v1/chat/completions" && r.Method == http.MethodPost:
 		h.serveChat(w, r)
 	default:
@@ -169,10 +171,18 @@ func (h *lmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // openaiModel represents a model in the OpenAI /v1/models response.
+// Includes LM Studio extension fields required by JetBrains AI Chat.
 type openaiModel struct {
-	ID      string `json:"id"`
-	Object  string `json:"object"`
-	OwnedBy string `json:"owned_by"`
+	ID                string `json:"id"`
+	Object            string `json:"object"`
+	Created           int64  `json:"created"`
+	OwnedBy           string `json:"owned_by"`
+	Type              string `json:"type"`               // "llm"
+	Publisher         string `json:"publisher"`          // provider name
+	Arch              string `json:"arch"`               // "auto" — required by JetBrains
+	CompatibilityType string `json:"compatibility_type"` // "gguf"
+	State             string `json:"state"`              // "loaded"
+	MaxContextLength  int    `json:"max_context_length"` // 128000
 }
 
 // openaiModelList is the OpenAI /v1/models response format.
@@ -196,9 +206,16 @@ func (h *lmHandler) serveModels(w http.ResponseWriter, r *http.Request) {
 			newSet := make(map[string]bool, len(models))
 			for _, m := range models {
 				merged = append(merged, openaiModel{
-					ID:      m.ID,
-					Object:  "model",
-					OwnedBy: backendName,
+					ID:                m.ID,
+					Object:            "model",
+					Created:           1700000000, // fixed epoch for stable responses
+					OwnedBy:           backendName,
+					Type:              "llm",
+					Publisher:         backendName,
+					Arch:              "auto",
+					CompatibilityType: "gguf",
+					State:             "loaded",
+					MaxContextLength:  128000,
 				})
 				newSet[m.ID] = true
 			}
@@ -215,9 +232,16 @@ func (h *lmHandler) serveModels(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			merged = append(merged, openaiModel{
-				ID:      modelID,
-				Object:  "model",
-				OwnedBy: providerName,
+				ID:                modelID,
+				Object:            "model",
+				Created:           1700000000, // fixed epoch for stable responses
+				OwnedBy:           providerName,
+				Type:              "llm",
+				Publisher:         providerName,
+				Arch:              "auto",
+				CompatibilityType: "gguf",
+				State:             "loaded",
+				MaxContextLength:  128000,
 			})
 		}
 	}
@@ -256,6 +280,7 @@ func (h *lmHandler) fetchRemoteModels(r *http.Request) []openaiModel {
 
 	rec := &responseRecorder{headers: make(http.Header)}
 	req := r.Clone(ctx)
+	req.URL.Path = "/v1/models" // normalize — remote only serves /v1/models
 	h.remoteProxy.ServeHTTP(rec, req)
 
 	if rec.statusCode != http.StatusOK {

--- a/cmd/candela/lm_handler_test.go
+++ b/cmd/candela/lm_handler_test.go
@@ -297,14 +297,11 @@ func TestLMHandler_Chat_UnknownModelDefaultsToRemote(t *testing.T) {
 	}
 }
 
-func TestLMHandler_Passthrough(t *testing.T) {
-	remoteSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]string{"path": r.URL.Path})
-	}))
-	defer remoteSrv.Close()
-
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
+func TestLMHandler_APIV0Models(t *testing.T) {
+	// /api/v0/models should return a model list (same as /v1/models), not passthrough.
+	// Use solo mode with a cloud model to ensure there's at least one model in the response.
+	cloudModels := map[string]string{"test-model": "test-provider"}
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, nil, true)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -315,8 +312,104 @@ func TestLMHandler_Passthrough(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(body), "/api/v0/models") {
-		t.Errorf("passthrough failed, got: %s", body)
+	if !strings.Contains(string(body), `"object":"list"`) {
+		t.Errorf("/api/v0/models should return model list, got: %s", body)
+	}
+	if !strings.Contains(string(body), `"arch"`) {
+		t.Errorf("/api/v0/models response missing arch field, got: %s", body)
+	}
+}
+
+func TestLMHandler_ModelFields(t *testing.T) {
+	// Verify that LM Studio compat fields (arch, type, state, etc.) are present
+	// on both local and cloud models in the /v1/models response.
+	localModels := []runtime.Model{{ID: "llama3.2:3b"}}
+
+	// Set up a solo-mode handler with a cloud model so we test both paths.
+	remoteSrv := mockRemoteServer(t, nil)
+	localSrv := mockLocalServer(t)
+
+	mock := &lmMockRuntime{models: localModels}
+	mgr := runtime.NewManager(mock, runtime.ManagerConfig{HealthCheck: 10 * 1e9})
+	if err := mgr.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
+
+	cloudModels := map[string]string{"gpt-4o": "openai"}
+	h := newLMHandler(mgr, proxyTo(remoteSrv.URL), proxyTo(localSrv.URL), nil, nil, cloudModels, nil, true)
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Parse into generic structure to check field presence.
+	var raw struct {
+		Data []map[string]interface{} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(raw.Data) < 2 {
+		t.Fatalf("got %d models, want at least 2 (local + cloud)", len(raw.Data))
+	}
+
+	for i, m := range raw.Data {
+		id, _ := m["id"].(string)
+
+		// arch must be "auto"
+		arch, ok := m["arch"]
+		if !ok {
+			t.Errorf("model[%d] %q: missing arch field", i, id)
+		} else if arch != "auto" {
+			t.Errorf("model[%d] %q: arch = %q, want \"auto\"", i, id, arch)
+		}
+
+		// type must be "llm"
+		typ, ok := m["type"]
+		if !ok {
+			t.Errorf("model[%d] %q: missing type field", i, id)
+		} else if typ != "llm" {
+			t.Errorf("model[%d] %q: type = %q, want \"llm\"", i, id, typ)
+		}
+
+		// state must be "loaded"
+		state, ok := m["state"]
+		if !ok {
+			t.Errorf("model[%d] %q: missing state field", i, id)
+		} else if state != "loaded" {
+			t.Errorf("model[%d] %q: state = %q, want \"loaded\"", i, id, state)
+		}
+
+		// max_context_length must be > 0
+		mcl, ok := m["max_context_length"]
+		if !ok {
+			t.Errorf("model[%d] %q: missing max_context_length field", i, id)
+		} else if mclVal, isNum := mcl.(float64); !isNum || mclVal <= 0 {
+			t.Errorf("model[%d] %q: max_context_length = %v, want > 0", i, id, mcl)
+		}
+
+		// publisher must be non-empty
+		pub, ok := m["publisher"]
+		if !ok {
+			t.Errorf("model[%d] %q: missing publisher field", i, id)
+		} else if pub == "" {
+			t.Errorf("model[%d] %q: publisher is empty", i, id)
+		}
+
+		// compatibility_type must be present
+		if _, ok := m["compatibility_type"]; !ok {
+			t.Errorf("model[%d] %q: missing compatibility_type field", i, id)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes JetBrains AI Chat integration with the Candela local CLI (port 1234).

### Problem
JetBrains AI Assistant requires the `arch` field in `/v1/models` responses to display models. The local CLI's `lm_handler` returned a minimal struct (`id`, `object`, `owned_by`) while the server (`proxy.go`) included all LM Studio extension fields. Additionally, `/api/v0/models` (used by JetBrains' Test Connection button) was not registered on the LM compat listener.

### Changes
- **H1:** Enriched `openaiModel` struct in `lm_handler.go` with `arch`, `type`, `publisher`, `compatibility_type`, `state`, `max_context_length` — matching the server's `buildModelsResponse()`
- **H2:** Registered `/api/v0/models` route on the LM compat listener, serving the same response as `/v1/models`
- Added `TestLMHandler_ModelFields` and updated `TestLMHandler_APIV0Models`

### Testing
- `go test ./cmd/candela/...` — all pass
- All pre-commit hooks pass (gofmt, golangci-lint, go-test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `GET /api/v0/models` alongside the existing models endpoint.
  * Model listings now return expanded compatibility metadata to better match OpenAI-style responses.
* **Bug Fixes**
  * Ensured solo-mode model listings include consistent metadata for both local and cloud-backed models.
* **Tests**
  * Updated and added endpoint coverage to verify `api/v0` and `v1` model response shape and required compatibility fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->