### PR TITLE
fix(translate): include tool_use blocks in non-streaming Anthropic response translation

### DIFF
--- a/pkg/proxy/translate.go
+++ b/pkg/proxy/translate.go
@@ -359,6 +359,15 @@ func (t *AnthropicFormatTranslator) TranslateResponse(body []byte, model string)
 
 	info := ParseModelName(model)
 
+	msg := openAIMessage{
+		Role:    "assistant",
+		Content: extractAnthropicText(anthResp.Content),
+	}
+
+	if toolCalls := extractAnthropicToolCalls(anthResp.Content); len(toolCalls) > 0 {
+		msg.ToolCalls = toolCalls
+	}
+
 	oaiResp := openAIResponse{
 		ID:      anthResp.ID,
 		Object:  "chat.completion",
@@ -366,11 +375,8 @@ func (t *AnthropicFormatTranslator) TranslateResponse(body []byte, model string)
 		Model:   info.Display,
 		Choices: []openAIChoice{
 			{
-				Index: 0,
-				Message: openAIMessage{
-					Role:    "assistant",
-					Content: extractAnthropicText(anthResp.Content),
-				},
+				Index:        0,
+				Message:      msg,
 				FinishReason: mapStopReason(anthResp.StopReason),
 			},
 		},
@@ -737,8 +743,9 @@ type openAIChoice struct {
 }
 
 type openAIMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role      string           `json:"role"`
+	Content   string           `json:"content"`
+	ToolCalls []openAIToolCall `json:"tool_calls,omitempty"`
 }
 
 type openAIUsage struct {
@@ -802,8 +809,11 @@ type anthropicResponse struct {
 }
 
 type anthropicContent struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type  string          `json:"type"`
+	Text  string          `json:"text,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
 }
 
 type anthropicUsage struct {
@@ -821,6 +831,31 @@ func extractAnthropicText(content []anthropicContent) string {
 		}
 	}
 	return strings.Join(parts, "")
+}
+
+// extractAnthropicToolCalls converts Anthropic tool_use content blocks into
+// OpenAI-format tool calls. The Anthropic "input" (a JSON object) is marshaled
+// to a string for the OpenAI "arguments" field.
+func extractAnthropicToolCalls(content []anthropicContent) []openAIToolCall {
+	var calls []openAIToolCall
+	for _, c := range content {
+		if c.Type != "tool_use" {
+			continue
+		}
+		args := "{}"
+		if len(c.Input) > 0 {
+			args = string(c.Input)
+		}
+		calls = append(calls, openAIToolCall{
+			ID:   c.ID,
+			Type: "function",
+			Function: openAIToolCallFn{
+				Name:      c.Name,
+				Arguments: args,
+			},
+		})
+	}
+	return calls
 }
 
 func mapStopReason(reason string) string {

--- a/pkg/proxy/translate_test.go
+++ b/pkg/proxy/translate_test.go
@@ -512,6 +512,158 @@ func TestTranslateResponse_MaxTokensStop(t *testing.T) {
 	}
 }
 
+func TestTranslateResponse_ToolUse(t *testing.T) {
+	translator := &AnthropicFormatTranslator{}
+
+	anthResp := `{
+		"id": "msg_123",
+		"type": "message",
+		"role": "assistant",
+		"content": [
+			{"type": "text", "text": "I'll look that up."},
+			{"type": "tool_use", "id": "toolu_abc", "name": "get_weather", "input": {"location": "San Francisco"}}
+		],
+		"model": "claude-sonnet-4-20250514",
+		"stop_reason": "tool_use",
+		"usage": {"input_tokens": 100, "output_tokens": 50}
+	}`
+
+	translated, err := translator.TranslateResponse([]byte(anthResp), "claude-sonnet-4-20250514")
+	if err != nil {
+		t.Fatalf("TranslateResponse failed: %v", err)
+	}
+
+	var result openAIResponse
+	if err := json.Unmarshal(translated, &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if len(result.Choices) != 1 {
+		t.Fatalf("choices len = %d, want 1", len(result.Choices))
+	}
+	choice := result.Choices[0]
+
+	// Text content should still be extracted.
+	if choice.Message.Content != "I'll look that up." {
+		t.Errorf("content = %q, want %q", choice.Message.Content, "I'll look that up.")
+	}
+
+	// Tool calls should be populated.
+	if len(choice.Message.ToolCalls) != 1 {
+		t.Fatalf("tool_calls len = %d, want 1", len(choice.Message.ToolCalls))
+	}
+	tc := choice.Message.ToolCalls[0]
+
+	if tc.ID != "toolu_abc" {
+		t.Errorf("tool_call id = %q, want %q", tc.ID, "toolu_abc")
+	}
+	if tc.Type != "function" {
+		t.Errorf("tool_call type = %q, want %q", tc.Type, "function")
+	}
+	if tc.Function.Name != "get_weather" {
+		t.Errorf("tool_call function.name = %q, want %q", tc.Function.Name, "get_weather")
+	}
+
+	// Arguments must be a valid JSON string containing the input.
+	var args map[string]interface{}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		t.Fatalf("tool_call function.arguments is not valid JSON: %v", err)
+	}
+	if loc, ok := args["location"].(string); !ok || loc != "San Francisco" {
+		t.Errorf("tool_call arguments location = %v, want %q", args["location"], "San Francisco")
+	}
+
+	// Anthropic "tool_use" stop_reason maps to OpenAI "tool_calls" finish_reason.
+	if choice.FinishReason != "tool_calls" {
+		t.Errorf("finish_reason = %q, want %q", choice.FinishReason, "tool_calls")
+	}
+
+	if result.Usage.PromptTokens != 100 {
+		t.Errorf("prompt_tokens = %d, want 100", result.Usage.PromptTokens)
+	}
+	if result.Usage.CompletionTokens != 50 {
+		t.Errorf("completion_tokens = %d, want 50", result.Usage.CompletionTokens)
+	}
+}
+
+func TestTranslateResponse_ToolUseOnly(t *testing.T) {
+	translator := &AnthropicFormatTranslator{}
+
+	// Response with only tool_use blocks, no text content.
+	anthResp := `{
+		"id": "msg_456",
+		"type": "message",
+		"role": "assistant",
+		"content": [
+			{"type": "tool_use", "id": "toolu_001", "name": "search", "input": {"query": "weather"}},
+			{"type": "tool_use", "id": "toolu_002", "name": "calendar", "input": {"date": "2025-01-01"}}
+		],
+		"stop_reason": "tool_use",
+		"usage": {"input_tokens": 20, "output_tokens": 30}
+	}`
+
+	translated, err := translator.TranslateResponse([]byte(anthResp), "claude-sonnet-4-20250514")
+	if err != nil {
+		t.Fatalf("TranslateResponse failed: %v", err)
+	}
+
+	var result openAIResponse
+	if err := json.Unmarshal(translated, &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if len(result.Choices) != 1 {
+		t.Fatalf("choices len = %d, want 1", len(result.Choices))
+	}
+	choice := result.Choices[0]
+
+	// No text content — should be empty string.
+	if choice.Message.Content != "" {
+		t.Errorf("content = %q, want empty string", choice.Message.Content)
+	}
+
+	// Should have 2 tool calls.
+	if len(choice.Message.ToolCalls) != 2 {
+		t.Fatalf("tool_calls len = %d, want 2", len(choice.Message.ToolCalls))
+	}
+
+	// Verify first tool call.
+	tc0 := choice.Message.ToolCalls[0]
+	if tc0.ID != "toolu_001" {
+		t.Errorf("tool_calls[0].id = %q, want %q", tc0.ID, "toolu_001")
+	}
+	if tc0.Function.Name != "search" {
+		t.Errorf("tool_calls[0].function.name = %q, want %q", tc0.Function.Name, "search")
+	}
+	var args0 map[string]interface{}
+	if err := json.Unmarshal([]byte(tc0.Function.Arguments), &args0); err != nil {
+		t.Fatalf("tool_calls[0].function.arguments is not valid JSON: %v", err)
+	}
+	if q, ok := args0["query"].(string); !ok || q != "weather" {
+		t.Errorf("tool_calls[0] arguments query = %v, want %q", args0["query"], "weather")
+	}
+
+	// Verify second tool call.
+	tc1 := choice.Message.ToolCalls[1]
+	if tc1.ID != "toolu_002" {
+		t.Errorf("tool_calls[1].id = %q, want %q", tc1.ID, "toolu_002")
+	}
+	if tc1.Function.Name != "calendar" {
+		t.Errorf("tool_calls[1].function.name = %q, want %q", tc1.Function.Name, "calendar")
+	}
+	var args1 map[string]interface{}
+	if err := json.Unmarshal([]byte(tc1.Function.Arguments), &args1); err != nil {
+		t.Fatalf("tool_calls[1].function.arguments is not valid JSON: %v", err)
+	}
+	if d, ok := args1["date"].(string); !ok || d != "2025-01-01" {
+		t.Errorf("tool_calls[1] arguments date = %v, want %q", args1["date"], "2025-01-01")
+	}
+
+	if choice.FinishReason != "tool_calls" {
+		t.Errorf("finish_reason = %q, want %q", choice.FinishReason, "tool_calls")
+	}
+}
+
 // ====================================================================
 // Stream Chunk Translation: Anthropic SSE → OpenAI SSE
 // ====================================================================


### PR DESCRIPTION
## Summary

Fixes a critical bug where non-streaming Anthropic responses with `tool_use` content blocks were silently dropped during OpenAI format translation.

### Problem
`TranslateResponse()` called `extractAnthropicText()` which only kept `type=="text"` content blocks. Anthropic `tool_use` blocks were silently discarded — the translated OpenAI response had no `tool_calls` field. This broke function-calling for any agent framework using the OpenAI→Anthropic translation in non-streaming mode.

Note: streaming responses already handled tool_use correctly via `content_block_start`/`content_block_delta`.

### Changes
- Added `extractAnthropicToolCalls()` to parse `tool_use` content blocks into OpenAI `tool_calls` format
- Updated `TranslateResponse()` to populate `message.tool_calls` when tool_use blocks are present
- Added `ID`, `Name`, `Input` fields to `anthropicContent` struct
- Added `ToolCalls` field to `openAIMessage` struct
- Maps Anthropic `stop_reason: "tool_use"` → OpenAI `finish_reason: "tool_calls"`

### Testing
- Added `TestTranslateResponse_ToolUse` — mixed text + tool_use response
- Added `TestTranslateResponse_ToolUseOnly` — tool_use-only response (no text)
- All existing translate tests continue to pass
- All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAI chat completion responses now include translated tool-call data when Anthropic responses contain tool-use blocks.
  * Tool-call arguments are preserved as valid JSON, with matching tool call IDs and function names.

* **Bug Fixes**
  * Fixed mixed responses so assistant text content and extracted tool calls are both returned correctly.
  * Updated finish-status mapping for tool-use responses and ensured token usage fields remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->