### PR TITLE
fix(proxy): add panic recovery to async goroutines and remove crypto/rand panic

### DIFF
--- a/cmd/candela/span_capture.go
+++ b/cmd/candela/span_capture.go
@@ -5,9 +5,11 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"runtime/debug"
 	"time"
 
 	"github.com/candelahq/candela/pkg/attribution"
@@ -104,7 +106,17 @@ func (s *spanCapture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	duration := time.Since(start)
 
 	// Build the span asynchronously to not block the response.
-	go s.buildSpan(chatReq.Model, chatReq.Stream, inputContent, rec.body.Bytes(), rec.statusCode, start, duration, sessionID, tenantID, jobID)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("recovered panic in async goroutine",
+					"panic", r,
+					"stack", string(debug.Stack()),
+				)
+			}
+		}()
+		s.buildSpan(chatReq.Model, chatReq.Stream, inputContent, rec.body.Bytes(), rec.statusCode, start, duration, sessionID, tenantID, jobID)
+	}()
 }
 
 func (s *spanCapture) buildSpan(model string, stream *bool, inputContent string, respBody []byte, statusCode int, start time.Time, duration time.Duration, sessionID, tenantID, jobID string) {
@@ -254,8 +266,11 @@ func (r *responseCapture) Flush() {
 func generateID(size int) string {
 	b := make([]byte, size)
 	if _, err := rand.Read(b); err != nil {
-		// crypto/rand should never fail on supported platforms.
-		panic("crypto/rand failed: " + err.Error())
+		// Fallback: time-based ID is not cryptographically random but
+		// keeps the server alive instead of panicking.
+		slog.Warn("crypto/rand failed, using time-based fallback", "error", err)
+		now := time.Now().UnixNano()
+		return fmt.Sprintf("%0*x", size*2, now)[:size*2]
 	}
 	return hex.EncodeToString(b)
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1502,11 +1502,11 @@ func (p *Proxy) handleStandardResponse(
 		spanCtx, spanCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
 		select {
 		case p.spanSem <- struct{}{}:
-			go func() {
+			safeGo(func() {
 				defer func() { <-p.spanSem }()
 				defer spanCancel()
 				p.createSpan(spanCtx, provider, reqBody, respBody, startTime, endTime, resp.StatusCode, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, traceCtx, proxySpanID, extendedTTL)
-			}()
+			})
 		default:
 			spanCancel()
 			p.droppedSpans.Add(1)
@@ -1662,11 +1662,11 @@ func (p *Proxy) handleStreamingResponse(
 		spanCtx, spanCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
 		select {
 		case p.spanSem <- struct{}{}:
-			go func() {
+			safeGo(func() {
 				defer func() { <-p.spanSem }()
 				defer spanCancel()
 				p.createStreamingSpan(spanCtx, provider, reqBody, parseData, startTime, endTime, ttfb, ttft, requestID, sessionID, effectiveUserID, tenantID, jobID, streamStatus, traceCtx, proxySpanID, extendedTTL)
-			}()
+			})
 		default:
 			spanCancel()
 			p.droppedSpans.Add(1)
@@ -1798,14 +1798,14 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 	// Best-effort: update the user's last-active timestamp (proxy usage).
 	select {
 	case p.asyncSem <- struct{}{}:
-		go func() {
+		safeGo(func() {
 			defer func() { <-p.asyncSem }()
 			bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			if err := p.users.TouchLastActive(bgCtx, userID); err != nil {
 				slog.Warn("touch_last_active failed", "user_id", userID, "error", err)
 			}
-		}()
+		})
 	default:
 		p.droppedAsync.Add(1)
 		slog.Debug("async op dropped: too many pending", "op", "touch_last_active", "user_id", userID)
@@ -1815,7 +1815,7 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 	if p.budgetCk != nil {
 		select {
 		case p.asyncSem <- struct{}{}:
-			go func() {
+			safeGo(func() {
 				defer func() { <-p.asyncSem }()
 				bgCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
@@ -1832,7 +1832,7 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 							LimitUSD: budget.LimitUSD,
 						})
 				}
-			}()
+			})
 		default:
 			p.droppedAsync.Add(1)
 			slog.Debug("async op dropped: too many pending", "op", "budget_notify", "user_id", userID)

--- a/pkg/proxy/safego.go
+++ b/pkg/proxy/safego.go
@@ -1,0 +1,23 @@
+package proxy
+
+import (
+	"log/slog"
+	"runtime/debug"
+)
+
+// safeGo runs fn in a new goroutine with panic recovery.
+// If fn panics, the panic is logged with a full stack trace
+// instead of crashing the process.
+func safeGo(fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("recovered panic in async goroutine",
+					"panic", r,
+					"stack", string(debug.Stack()),
+				)
+			}
+		}()
+		fn()
+	}()
+}

--- a/pkg/proxy/safego_test.go
+++ b/pkg/proxy/safego_test.go
@@ -1,0 +1,32 @@
+package proxy
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestSafeGo_NormalExecution(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var ran bool
+	safeGo(func() {
+		defer wg.Done()
+		ran = true
+	})
+	wg.Wait()
+	if !ran {
+		t.Fatal("safeGo did not execute the function")
+	}
+}
+
+func TestSafeGo_RecoversPanic(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	// This must not crash the test process.
+	safeGo(func() {
+		defer wg.Done()
+		panic("test panic")
+	})
+	wg.Wait()
+	// If we reach here, the panic was recovered.
+}


### PR DESCRIPTION
## Summary

Adds panic recovery to all async goroutines launched from HTTP handlers, preventing process crashes from unexpected panics in background tasks.

### Problem
The codebase launches several `go func()` goroutines from HTTP handlers for span creation, budget notification, and touch-active updates. While `net/http.Server` recovers panics in handlers, goroutines launched from handlers are unprotected. A nil pointer or similar panic in any of these would crash the entire process.

Additionally, `span_capture.go:generateID()` explicitly called `panic()` on `crypto/rand` failure, while `pkg/proxy/ids.go` gracefully fell back to time-based IDs.

### Changes
- Added `safeGo()` helper in `pkg/proxy/safego.go` — wraps goroutine launches with `defer recover()`, logging panics with full stack traces
- Replaced 4 unprotected `go func()` calls in `proxy.go` with `safeGo()`
- Added inline panic recovery to `span_capture.go:buildSpan` goroutine
- Replaced `panic()` in `span_capture.go:generateID()` with time-based fallback matching `ids.go` pattern

### Testing
- Added `TestSafeGo_NormalExecution` and `TestSafeGo_RecoversPanic`
- All existing tests pass
- All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability for background processing by preventing unexpected crashes from panics.
  * Made request and response observability more resilient when handled asynchronously.
  * Added a safer fallback for ID generation so requests can continue even if secure randomness is unavailable.

* **Tests**
  * Added coverage for normal and panic scenarios to verify asynchronous work stays reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->