### PR TITLE
fix(translate): use consistent stream ID across all chunks in TranslateStreamChunk

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -57,7 +57,11 @@ type FormatTranslator interface {
 	TranslateResponse(body []byte, model string) ([]byte, error)
 
 	// TranslateStreamChunk converts a single upstream SSE data payload to client format.
-	TranslateStreamChunk(chunk []byte, model string) ([]byte, error)
+	// streamID is a pointer to a string that persists across calls for a single stream.
+	// On the first call it should point to an empty string; the function will populate
+	// it (from the Anthropic message_start ID or a generated fallback) and reuse it
+	// on subsequent calls so every chunk in the stream shares the same ID.
+	TranslateStreamChunk(chunk []byte, model string, streamID *string) ([]byte, error)
 }
 
 // PathRewriter rewrites the upstream URL path for provider-specific routing
@@ -1549,6 +1553,7 @@ func (p *Proxy) handleStreamingResponse(
 
 	// Determine model name for stream chunk translation.
 	var streamModel string
+	var streamID string // consistent ID across all chunks in this stream
 	if provider.FormatTranslator != nil {
 		streamModel, _ = extractRequestInfo(provider.Name, reqBody)
 	}
@@ -1593,7 +1598,7 @@ func (p *Proxy) handleStreamingResponse(
 
 			// Translate chunk if provider has a FormatTranslator.
 			if provider.FormatTranslator != nil {
-				translated, transErr := provider.FormatTranslator.TranslateStreamChunk(chunk, streamModel)
+				translated, transErr := provider.FormatTranslator.TranslateStreamChunk(chunk, streamModel, &streamID)
 				if transErr != nil {
 					slog.Debug("stream chunk translation failed", "error", transErr)
 					// Forward raw chunk on error.

--- a/pkg/proxy/translate.go
+++ b/pkg/proxy/translate.go
@@ -392,13 +392,16 @@ func (t *AnthropicFormatTranslator) TranslateResponse(body []byte, model string)
 
 // --- Streaming Translation: Anthropic SSE → OpenAI SSE ---
 
-func (t *AnthropicFormatTranslator) TranslateStreamChunk(data []byte, model string) ([]byte, error) {
+func (t *AnthropicFormatTranslator) TranslateStreamChunk(data []byte, model string, streamID *string) ([]byte, error) {
 	info := ParseModelName(model)
 	var result strings.Builder
 
-	// We need a consistent ID across all chunks in the stream.
-	// Extract it from message_start if present, otherwise generate one.
-	streamID := "chatcmpl-" + generateSpanID()
+	// Populate the stream ID on first call if not yet set.
+	// The caller passes a pointer to a string that persists across calls for
+	// the entire stream, so every chunk shares the same ID.
+	if *streamID == "" {
+		*streamID = "chatcmpl-" + generateSpanID()
+	}
 
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
@@ -427,12 +430,12 @@ func (t *AnthropicFormatTranslator) TranslateStreamChunk(data []byte, model stri
 		chunkType, _ := chunk["type"].(string)
 		switch chunkType {
 		case "message_start":
-			// Extract message ID for use in all subsequent chunks.
+			// Prefer the Anthropic message ID for traceability.
 			if msgID := getStringField(chunk, "message", "id"); msgID != "" {
-				streamID = msgID
+				*streamID = msgID
 			}
 			oaiChunk := openAIStreamChunk{
-				ID:      streamID,
+				ID:      *streamID,
 				Object:  "chat.completion.chunk",
 				Created: time.Now().Unix(),
 				Model:   info.Display,
@@ -451,7 +454,7 @@ func (t *AnthropicFormatTranslator) TranslateStreamChunk(data []byte, model stri
 				text, _ := delta["text"].(string)
 				if text != "" {
 					oaiChunk := openAIStreamChunk{
-						ID:      streamID,
+						ID:      *streamID,
 						Object:  "chat.completion.chunk",
 						Created: time.Now().Unix(),
 						Model:   info.Display,
@@ -467,7 +470,7 @@ func (t *AnthropicFormatTranslator) TranslateStreamChunk(data []byte, model stri
 				partialJSON, _ := delta["partial_json"].(string)
 				if partialJSON != "" {
 					oaiChunk := map[string]interface{}{
-						"id":      streamID,
+						"id":      *streamID,
 						"object":  "chat.completion.chunk",
 						"created": time.Now().Unix(),
 						"model":   info.Display,
@@ -499,7 +502,7 @@ func (t *AnthropicFormatTranslator) TranslateStreamChunk(data []byte, model stri
 				toolID, _ := cb["id"].(string)
 				toolName, _ := cb["name"].(string)
 				oaiChunk := map[string]interface{}{
-					"id":      streamID,
+					"id":      *streamID,
 					"object":  "chat.completion.chunk",
 					"created": time.Now().Unix(),
 					"model":   info.Display,
@@ -532,7 +535,7 @@ func (t *AnthropicFormatTranslator) TranslateStreamChunk(data []byte, model stri
 			sr, _ := stopDelta["stop_reason"].(string)
 
 			oaiChunk := openAIStreamChunk{
-				ID:      streamID,
+				ID:      *streamID,
 				Object:  "chat.completion.chunk",
 				Created: time.Now().Unix(),
 				Model:   info.Display,

--- a/pkg/proxy/translate.go
+++ b/pkg/proxy/translate.go
@@ -396,6 +396,12 @@ func (t *AnthropicFormatTranslator) TranslateStreamChunk(data []byte, model stri
 	info := ParseModelName(model)
 	var result strings.Builder
 
+	// Guard against nil streamID to prevent a nil-pointer dereference.
+	if streamID == nil {
+		fallback := ""
+		streamID = &fallback
+	}
+
 	// Populate the stream ID on first call if not yet set.
 	// The caller passes a pointer to a string that persists across calls for
 	// the entire stream, so every chunk shares the same ID.

--- a/pkg/proxy/translate_security_test.go
+++ b/pkg/proxy/translate_security_test.go
@@ -50,7 +50,8 @@ func TestTranslateStreamChunk_MalformedSSE(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := translator.TranslateStreamChunk([]byte(tc.data), "claude-sonnet-4-20250514")
+			var streamID string
+			result, err := translator.TranslateStreamChunk([]byte(tc.data), "claude-sonnet-4-20250514", &streamID)
 			if err != nil {
 				t.Fatalf("unexpected error for %q: %v", tc.name, err)
 			}

--- a/pkg/proxy/translate_test.go
+++ b/pkg/proxy/translate_test.go
@@ -670,10 +670,11 @@ func TestTranslateResponse_ToolUseOnly(t *testing.T) {
 
 func TestTranslateStreamChunk_ContentDelta(t *testing.T) {
 	translator := &AnthropicFormatTranslator{}
+	var streamID string
 
 	chunk := `data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}`
 
-	translated, err := translator.TranslateStreamChunk([]byte(chunk), "claude-sonnet-4-20250514")
+	translated, err := translator.TranslateStreamChunk([]byte(chunk), "claude-sonnet-4-20250514", &streamID)
 	if err != nil {
 		t.Fatalf("TranslateStreamChunk failed: %v", err)
 	}
@@ -689,16 +690,135 @@ func TestTranslateStreamChunk_ContentDelta(t *testing.T) {
 
 func TestTranslateStreamChunk_MessageStop(t *testing.T) {
 	translator := &AnthropicFormatTranslator{}
+	var streamID string
 
 	chunk := `data: {"type":"message_stop"}`
 
-	translated, err := translator.TranslateStreamChunk([]byte(chunk), "claude-sonnet-4-20250514")
+	translated, err := translator.TranslateStreamChunk([]byte(chunk), "claude-sonnet-4-20250514", &streamID)
 	if err != nil {
 		t.Fatalf("TranslateStreamChunk failed: %v", err)
 	}
 
 	if !strings.Contains(string(translated), "data: [DONE]") {
 		t.Errorf("expected [DONE], got: %s", translated)
+	}
+}
+
+func TestTranslateStreamChunk_ConsistentID(t *testing.T) {
+	translator := &AnthropicFormatTranslator{}
+
+	// Simulate a multi-chunk Anthropic stream split across TCP reads.
+	chunks := []string{
+		// First TCP read: message_start with Anthropic message ID.
+		`event: message_start
+data: {"type":"message_start","message":{"id":"msg_abc123","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}`,
+		// Second TCP read: content delta.
+		`event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`,
+		// Third TCP read: another content delta.
+		`event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}`,
+		// Fourth TCP read: message_delta with usage and stop.
+		`event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`,
+	}
+
+	var streamID string
+	var allIDs []string
+
+	for _, c := range chunks {
+		translated, err := translator.TranslateStreamChunk([]byte(c), "claude-sonnet-4-20250514", &streamID)
+		if err != nil {
+			t.Fatalf("TranslateStreamChunk failed: %v", err)
+		}
+
+		// Extract all "id" fields from the translated SSE data lines.
+		for _, line := range strings.Split(string(translated), "\n") {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			payload := strings.TrimPrefix(line, "data: ")
+			if payload == "[DONE]" {
+				continue
+			}
+			var obj map[string]interface{}
+			if err := json.Unmarshal([]byte(payload), &obj); err != nil {
+				t.Fatalf("failed to parse translated chunk: %v", err)
+			}
+			if id, ok := obj["id"].(string); ok {
+				allIDs = append(allIDs, id)
+			}
+		}
+	}
+
+	if len(allIDs) == 0 {
+		t.Fatal("expected at least one chunk with an ID")
+	}
+
+	// All IDs should be the Anthropic message ID from message_start.
+	expectedID := "msg_abc123"
+	for i, id := range allIDs {
+		if id != expectedID {
+			t.Errorf("chunk %d: got id %q, want %q", i, id, expectedID)
+		}
+	}
+
+	// The streamID pointer should also reflect the Anthropic message ID.
+	if streamID != expectedID {
+		t.Errorf("streamID pointer: got %q, want %q", streamID, expectedID)
+	}
+}
+
+func TestTranslateStreamChunk_ConsistentID_NoMessageStart(t *testing.T) {
+	translator := &AnthropicFormatTranslator{}
+
+	// Simulate a stream where message_start has no ID — should fall back to
+	// a generated ID and keep it consistent across calls.
+	chunks := []string{
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}`,
+	}
+
+	var streamID string
+	var allIDs []string
+
+	for _, c := range chunks {
+		translated, err := translator.TranslateStreamChunk([]byte(c), "claude-sonnet-4-20250514", &streamID)
+		if err != nil {
+			t.Fatalf("TranslateStreamChunk failed: %v", err)
+		}
+		for _, line := range strings.Split(string(translated), "\n") {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			payload := strings.TrimPrefix(line, "data: ")
+			if payload == "[DONE]" {
+				continue
+			}
+			var obj map[string]interface{}
+			if err := json.Unmarshal([]byte(payload), &obj); err != nil {
+				t.Fatalf("failed to parse translated chunk: %v", err)
+			}
+			if id, ok := obj["id"].(string); ok {
+				allIDs = append(allIDs, id)
+			}
+		}
+	}
+
+	if len(allIDs) < 2 {
+		t.Fatalf("expected at least 2 IDs, got %d", len(allIDs))
+	}
+
+	// All IDs must be identical (generated fallback).
+	for i := 1; i < len(allIDs); i++ {
+		if allIDs[i] != allIDs[0] {
+			t.Errorf("chunk %d id %q != chunk 0 id %q", i, allIDs[i], allIDs[0])
+		}
+	}
+
+	// Should have the chatcmpl- prefix.
+	if !strings.HasPrefix(allIDs[0], "chatcmpl-") {
+		t.Errorf("expected chatcmpl- prefix, got %q", allIDs[0])
 	}
 }
 


### PR DESCRIPTION
## Summary

Ensures all SSE chunks in a translated Anthropic→OpenAI stream share the same `id` field, as required by the OpenAI SDK.

### Problem
`TranslateStreamChunk()` generated a new `streamID` on every call. Since the function is called per TCP read, multi-batch streams produced different IDs across chunks. OpenAI SDK clients correlating by ID could behave incorrectly.

### Changes
- Changed `FormatTranslator` interface: `TranslateStreamChunk` now accepts `streamID *string`
- Caller in `proxy.go` declares `var streamID string` once before the streaming loop, passes pointer to every call
- First call generates or extracts ID from `message_start`; subsequent calls reuse it

### Testing
- `TestTranslateStreamChunk_ConsistentID` — 4-chunk stream, verifies all chunks share the Anthropic message ID
- `TestTranslateStreamChunk_ConsistentID_NoMessageStart` — verifies generated `chatcmpl-*` ID is consistent
- All existing stream tests updated, all pass
- All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming responses now keep a consistent event/message ID across all chunks in the same stream.
  * When the upstream provides an ID, it’s reused across streamed events; otherwise a stable fallback ID is used (with the expected `chatcmpl-` prefix).
* **Bug Fixes**
  * Fixed fluctuating chunk identifiers during streamed translation, improving reliability for clients that depend on stable IDs.
* **Tests**
  * Added/updated coverage to verify ID consistency across multi-chunk streams, including streams that don’t start with `message_start`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->