### PR TITLE
fix(proxy): defer pendingSpend release to prevent reservation leak on early returns

### DIFF
--- a/pkg/proxy/pendingspend_leak_test.go
+++ b/pkg/proxy/pendingspend_leak_test.go
@@ -1,0 +1,267 @@
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/auth"
+	"github.com/candelahq/candela/pkg/costcalc"
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// TestPendingSpend_ReleasedOnCostCapEarlyReturn verifies that the pending-spend
+// reservation is released when the request is rejected by the per-request cost
+// cap check (early return AFTER Reserve).
+func TestPendingSpend_ReleasedOnCostCapEarlyReturn(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream should NOT be called when cost cap rejects request")
+		w.WriteHeader(500)
+	}))
+	defer upstream.Close()
+
+	submitter := &mockSubmitter{}
+	calc := costcalc.New()
+
+	p, _ := New(Config{
+		Providers:      []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
+		ProjectID:      "test",
+		MaxRequestCost: 0.0001, // Extremely low cap to force rejection
+	}, submitter, calc)
+
+	userID := "leak-test-user@example.com"
+	p.SetUserStore(&budgetUserStore{
+		checkResult: &storage.BudgetCheckResult{
+			Allowed:      true,
+			RemainingUSD: 100.0, // Budget passes, but cost cap will reject
+		},
+	})
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.NewContext(r.Context(), &auth.User{ID: userID, Email: userID})
+		mux.ServeHTTP(w, r.WithContext(ctx))
+	}))
+	defer srv.Close()
+
+	// Pre-check: no pending spend.
+	if got := p.pendingSpend.Get(userID); got != 0 {
+		t.Fatalf("pre-request pending spend = %f, want 0", got)
+	}
+
+	// Send a request with a large body so estimated cost exceeds the tiny cap.
+	bigBody := fmt.Sprintf(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"%s"}]}`,
+		strings.Repeat("x", 50000))
+	req, _ := http.NewRequest("POST",
+		srv.URL+"/proxy/anthropic/v1/messages",
+		strings.NewReader(bigBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tok")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body) // drain
+
+	// Should be rejected by cost cap.
+	if resp.StatusCode != http.StatusPaymentRequired {
+		t.Fatalf("status = %d, want 402 (cost cap)", resp.StatusCode)
+	}
+
+	// CRITICAL: pending spend must be zero — the deferred Release should have cleaned it up.
+	if got := p.pendingSpend.Get(userID); got != 0 {
+		t.Errorf("pending spend after cost-cap rejection = %f, want 0 (reservation leaked!)", got)
+	}
+}
+
+// TestPendingSpend_ReleasedOnDailyLimitEarlyReturn verifies that the pending-spend
+// reservation is released when the request is rejected by the daily spend limit.
+func TestPendingSpend_ReleasedOnDailyLimitEarlyReturn(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream should NOT be called when daily limit rejects request")
+		w.WriteHeader(500)
+	}))
+	defer upstream.Close()
+
+	submitter := &mockSubmitter{}
+	calc := costcalc.New()
+
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+		DailyLimits: []SpendLimitConfig{
+			{Model: "claude-sonnet-4", MaxDailyUSD: 0.0001}, // Tiny limit
+		},
+	}, submitter, calc)
+
+	userID := "daily-limit-leak@example.com"
+	p.SetUserStore(&budgetUserStore{
+		checkResult: &storage.BudgetCheckResult{
+			Allowed:      true,
+			RemainingUSD: 100.0,
+		},
+	})
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.NewContext(r.Context(), &auth.User{ID: userID, Email: userID})
+		mux.ServeHTTP(w, r.WithContext(ctx))
+	}))
+	defer srv.Close()
+
+	// Pre-spend to exhaust the daily limit.
+	limitUser := userID
+	p.spendTracker.Record(limitUser, "claude-sonnet-4-20250514", 1.0, p.config.DailyLimits)
+
+	// Pre-check: no pending spend.
+	if got := p.pendingSpend.Get(userID); got != 0 {
+		t.Fatalf("pre-request pending spend = %f, want 0", got)
+	}
+
+	req, _ := http.NewRequest("POST",
+		srv.URL+"/proxy/anthropic/v1/messages",
+		strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tok")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body) // drain
+
+	if resp.StatusCode != http.StatusPaymentRequired {
+		t.Fatalf("status = %d, want 402 (daily limit)", resp.StatusCode)
+	}
+
+	// CRITICAL: pending spend must be zero.
+	if got := p.pendingSpend.Get(userID); got != 0 {
+		t.Errorf("pending spend after daily-limit rejection = %f, want 0 (reservation leaked!)", got)
+	}
+}
+
+// TestPendingSpend_ReleasedOnUpstreamFailure verifies that the pending-spend
+// reservation is released when the upstream request fails (connection refused).
+// This is an early return AFTER the reservation at L1324.
+func TestPendingSpend_ReleasedOnUpstreamFailure(t *testing.T) {
+	submitter := &mockSubmitter{}
+	calc := costcalc.New()
+
+	// Point at a closed server so the upstream request fails immediately.
+	closedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	closedServer.Close() // close it so connections are refused
+
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "anthropic", UpstreamURL: closedServer.URL}},
+		ProjectID: "test",
+	}, submitter, calc)
+
+	userID := "upstream-fail-leak@example.com"
+	p.SetUserStore(&budgetUserStore{
+		checkResult: &storage.BudgetCheckResult{
+			Allowed:      true,
+			RemainingUSD: 100.0,
+		},
+	})
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.NewContext(r.Context(), &auth.User{ID: userID, Email: userID})
+		mux.ServeHTTP(w, r.WithContext(ctx))
+	}))
+	defer srv.Close()
+
+	// Pre-check: no pending spend.
+	if got := p.pendingSpend.Get(userID); got != 0 {
+		t.Fatalf("pre-request pending spend = %f, want 0", got)
+	}
+
+	body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`
+	req, _ := http.NewRequest("POST",
+		srv.URL+"/proxy/anthropic/v1/messages",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tok")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	// Upstream failure returns 502.
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502 (upstream failure)", resp.StatusCode)
+	}
+
+	// CRITICAL: pending spend must be zero.
+	if got := p.pendingSpend.Get(userID); got != 0 {
+		t.Errorf("pending spend after upstream failure = %f, want 0 (reservation leaked!)", got)
+	}
+}
+
+// TestPendingSpend_ReleasedOnSuccessfulRequest verifies that the defer does not
+// double-release on the happy path (handler releases, then defer sees 0).
+func TestPendingSpend_ReleasedOnSuccessfulRequest(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer upstream.Close()
+
+	submitter := &mockSubmitter{}
+	calc := costcalc.New()
+
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, submitter, calc)
+
+	userID := "happy-path@example.com"
+	p.SetUserStore(&budgetUserStore{
+		checkResult: &storage.BudgetCheckResult{
+			Allowed:      true,
+			RemainingUSD: 100.0,
+		},
+	})
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.NewContext(r.Context(), &auth.User{ID: userID, Email: userID})
+		mux.ServeHTTP(w, r.WithContext(ctx))
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST",
+		srv.URL+"/proxy/anthropic/v1/messages",
+		strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tok")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// After successful request, pending spend must be zero (no double-release, no leak).
+	if got := p.pendingSpend.Get(userID); got != 0 {
+		t.Errorf("pending spend after successful request = %f, want 0", got)
+	}
+}

--- a/pkg/proxy/pendingspend_leak_test.go
+++ b/pkg/proxy/pendingspend_leak_test.go
@@ -7,11 +7,27 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/candelahq/candela/pkg/auth"
 	"github.com/candelahq/candela/pkg/costcalc"
 	"github.com/candelahq/candela/pkg/storage"
 )
+
+// assertEventually polls check every 10ms until it returns true or timeout
+// elapses. This avoids races where the HTTP response arrives before the
+// server's deferred Release() has completed.
+func assertEventually(t *testing.T, check func() bool, timeout time.Duration, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if check() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}
 
 // TestPendingSpend_ReleasedOnCostCapEarlyReturn verifies that the pending-spend
 // reservation is released when the request is rejected by the per-request cost
@@ -75,9 +91,9 @@ func TestPendingSpend_ReleasedOnCostCapEarlyReturn(t *testing.T) {
 	}
 
 	// CRITICAL: pending spend must be zero — the deferred Release should have cleaned it up.
-	if got := p.pendingSpend.Get(userID); got != 0 {
-		t.Errorf("pending spend after cost-cap rejection = %f, want 0 (reservation leaked!)", got)
-	}
+	assertEventually(t, func() bool {
+		return p.pendingSpend.Get(userID) == 0
+	}, 2*time.Second, fmt.Sprintf("pending spend after cost-cap rejection = %f, want 0 (reservation leaked!)", p.pendingSpend.Get(userID)))
 }
 
 // TestPendingSpend_ReleasedOnDailyLimitEarlyReturn verifies that the pending-spend
@@ -143,9 +159,9 @@ func TestPendingSpend_ReleasedOnDailyLimitEarlyReturn(t *testing.T) {
 	}
 
 	// CRITICAL: pending spend must be zero.
-	if got := p.pendingSpend.Get(userID); got != 0 {
-		t.Errorf("pending spend after daily-limit rejection = %f, want 0 (reservation leaked!)", got)
-	}
+	assertEventually(t, func() bool {
+		return p.pendingSpend.Get(userID) == 0
+	}, 2*time.Second, fmt.Sprintf("pending spend after daily-limit rejection = %f, want 0 (reservation leaked!)", p.pendingSpend.Get(userID)))
 }
 
 // TestPendingSpend_ReleasedOnUpstreamFailure verifies that the pending-spend
@@ -205,9 +221,9 @@ func TestPendingSpend_ReleasedOnUpstreamFailure(t *testing.T) {
 	}
 
 	// CRITICAL: pending spend must be zero.
-	if got := p.pendingSpend.Get(userID); got != 0 {
-		t.Errorf("pending spend after upstream failure = %f, want 0 (reservation leaked!)", got)
-	}
+	assertEventually(t, func() bool {
+		return p.pendingSpend.Get(userID) == 0
+	}, 2*time.Second, fmt.Sprintf("pending spend after upstream failure = %f, want 0 (reservation leaked!)", p.pendingSpend.Get(userID)))
 }
 
 // TestPendingSpend_ReleasedOnSuccessfulRequest verifies that the defer does not
@@ -261,7 +277,12 @@ func TestPendingSpend_ReleasedOnSuccessfulRequest(t *testing.T) {
 	}
 
 	// After successful request, pending spend must be zero (no double-release, no leak).
-	if got := p.pendingSpend.Get(userID); got != 0 {
-		t.Errorf("pending spend after successful request = %f, want 0", got)
+	assertEventually(t, func() bool {
+		return p.pendingSpend.Get(userID) == 0
+	}, 2*time.Second, fmt.Sprintf("pending spend after successful request = %f, want 0", p.pendingSpend.Get(userID)))
+
+	// Verify no double-release drove the value negative.
+	if got := p.pendingSpend.Get(userID); got < 0 {
+		t.Errorf("pending spend after successful request = %f, want >= 0 (double-release detected!)", got)
 	}
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1016,6 +1016,11 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		// small reservation prevents unlimited concurrent overdraft.
 		budgetReserved = budgetCheckFloor
 		p.pendingSpend.Reserve(effectiveUserID, budgetReserved)
+		defer func() {
+			if budgetReserved > 0 {
+				p.pendingSpend.Release(effectiveUserID, budgetReserved)
+			}
+		}()
 	}
 
 	// ── Per-request cost cap (#277) ──
@@ -1362,9 +1367,9 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if isStreaming && resp.StatusCode == http.StatusOK {
-		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, budgetReserved)
+		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, &budgetReserved)
 	} else {
-		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, budgetReserved)
+		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, &budgetReserved)
 	}
 }
 
@@ -1400,7 +1405,7 @@ func (p *Proxy) handleStandardResponse(
 	traceCtx *traceContext,
 	proxySpanID string,
 	extendedTTL bool, // true = Anthropic 1h TTL (2.0× cache creation rate)
-	budgetReserved float64, // pending-spend reservation to release after DeductSpend
+	budgetReserved *float64, // pending-spend reservation to release after DeductSpend
 ) {
 	// Read the full response (reject if over 10MB to prevent OOM under concurrent load).
 	// CRIT-15: Previously 50MB — with 100 concurrent requests that's 5GB of heap.
@@ -1472,10 +1477,12 @@ func (p *Proxy) handleStandardResponse(
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
 		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens)
 		deductCancel()
-		// Release the pending-spend reservation now that DeductSpend has
-		// recorded the actual cost in Firestore.
-		if budgetReserved > 0 {
-			p.pendingSpend.Release(effectiveUserID, budgetReserved)
+		// Clear the pending-spend reservation now that DeductSpend has
+		// recorded the actual cost in Firestore. The deferred Release in
+		// ServeHTTP will see 0 and become a no-op.
+		if budgetReserved != nil && *budgetReserved > 0 {
+			p.pendingSpend.Release(effectiveUserID, *budgetReserved)
+			*budgetReserved = 0
 		}
 	} else if p.spendTracker != nil {
 		// Solo mode: no UserStore but spend tracker is active.
@@ -1531,7 +1538,7 @@ func (p *Proxy) handleStreamingResponse(
 	traceCtx *traceContext,
 	proxySpanID string,
 	extendedTTL bool, // true = Anthropic 1h TTL (2.0× cache creation rate)
-	budgetReserved float64, // pending-spend reservation to release after DeductSpend
+	budgetReserved *float64, // pending-spend reservation to release after DeductSpend
 ) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -1636,8 +1643,9 @@ func (p *Proxy) handleStreamingResponse(
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
 		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens)
 		deductCancel()
-		if budgetReserved > 0 {
-			p.pendingSpend.Release(effectiveUserID, budgetReserved)
+		if budgetReserved != nil && *budgetReserved > 0 {
+			p.pendingSpend.Release(effectiveUserID, *budgetReserved)
+			*budgetReserved = 0
 		}
 	} else if p.spendTracker != nil {
 		// Solo mode: record per-model spend for daily limits.


### PR DESCRIPTION
## Summary

Fixes a budget reservation leak where `pendingSpend.Reserve()` was never released on early return paths, causing progressive user lockout under load.

### Problem
In `ServeHTTP`, budget reservations were made at L1017 but only released in the happy path (`handleStandardResponse`/`handleStreamingResponse`). Multiple early return paths (cost cap, daily limit, upstream failure, request signing failure, etc.) leaked the reservation, progressively reducing the user's apparent budget.

### Changes
- Added `defer` after `Reserve()` to guarantee release on ALL exit paths
- Changed `handleStandardResponse`/`handleStreamingResponse` to accept `*float64` and zero `budgetReserved` after successful deduction, making the defer a no-op on the happy path

### Testing
- `TestPendingSpend_ReleasedOnCostCapEarlyReturn`
- `TestPendingSpend_ReleasedOnDailyLimitEarlyReturn`
- `TestPendingSpend_ReleasedOnUpstreamFailure`
- `TestPendingSpend_ReleasedOnSuccessfulRequest` (no double-release)
- Full test suite passes, all pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved budget “pending spend” reservation cleanup across early rejections, upstream failures, and successful requests.
  * Prevented double-release behavior by ensuring the reservation is cleared exactly once.
* **Tests**
  * Added HTTP-level coverage to confirm pending spend returns to exactly zero after request handling, including checks for non-negative behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->