### PR TITLE
fix(proxy): unify error responses to OpenAI JSON format across proxy and local CLI

### DIFF
--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -163,9 +163,7 @@ func (h *lmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if h.remoteProxy != nil {
 			h.remoteProxy.ServeHTTP(w, r)
 		} else {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusNotFound)
-			_ = json.NewEncoder(w).Encode(map[string]string{"error": "solo mode — no remote server configured"})
+			proxy.ProxyErrorResponse(w, http.StatusNotFound, "solo mode — no remote server configured", "invalid_request_error")
 		}
 	}
 }
@@ -301,7 +299,7 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 	// Read body to peek at the model field (10MB limit to prevent OOM).
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 10<<20))
 	if err != nil {
-		http.Error(w, `{"error":"request body too large or unreadable"}`, http.StatusRequestEntityTooLarge)
+		proxy.ProxyErrorResponse(w, http.StatusRequestEntityTooLarge, "request body too large or unreadable", "invalid_request_error")
 		return
 	}
 	_ = r.Body.Close()
@@ -349,9 +347,7 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 4. No handler found.
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusNotFound)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": "model not found locally and no remote server configured"})
+	proxy.ProxyErrorResponse(w, http.StatusNotFound, "model not found locally and no remote server configured", "invalid_request_error")
 }
 
 // isLocalModel checks if a model is served by the local runtime.

--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -299,7 +300,12 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 	// Read body to peek at the model field (10MB limit to prevent OOM).
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 10<<20))
 	if err != nil {
-		proxy.ProxyErrorResponse(w, http.StatusRequestEntityTooLarge, "request body too large or unreadable", "invalid_request_error")
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			proxy.ProxyErrorResponse(w, http.StatusRequestEntityTooLarge, "request body too large", "invalid_request_error")
+		} else {
+			proxy.ProxyErrorResponse(w, http.StatusBadRequest, "failed to read request body", "invalid_request_error")
+		}
 		return
 	}
 	_ = r.Body.Close()

--- a/cmd/candela/lm_handler_test.go
+++ b/cmd/candela/lm_handler_test.go
@@ -562,10 +562,15 @@ func TestLMHandler_SoloMode_PassthroughNoPanic(t *testing.T) {
 		t.Errorf("status = %d, want 404 (solo mode passthrough)", resp.StatusCode)
 	}
 
-	// Verify it's proper JSON.
-	var result map[string]string
+	// Verify it's proper OpenAI-format JSON error.
+	var result struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		} `json:"error"`
+	}
 	_ = json.NewDecoder(resp.Body).Decode(&result)
-	if result["error"] == "" {
+	if result.Error.Message == "" {
 		t.Error("expected JSON error body")
 	}
 }
@@ -811,9 +816,14 @@ func TestLMHandler_UnknownModelSoloCloudMode(t *testing.T) {
 		t.Errorf("status = %d, want 404 for unknown model in solo+cloud mode", resp.StatusCode)
 	}
 
-	var result map[string]string
+	var result struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		} `json:"error"`
+	}
 	_ = json.NewDecoder(resp.Body).Decode(&result)
-	if result["error"] == "" {
+	if result.Error.Message == "" {
 		t.Error("expected error message in response body")
 	}
 }

--- a/pkg/proxy/budget_gate_test.go
+++ b/pkg/proxy/budget_gate_test.go
@@ -133,7 +133,7 @@ func TestBudgetGate_BlocksExhaustedBudget(t *testing.T) {
 		Error struct {
 			Message string `json:"message"`
 			Type    string `json:"type"`
-			Code    int    `json:"code"`
+			Code    string `json:"code"`
 		} `json:"error"`
 	}
 	body, _ := io.ReadAll(resp.Body)

--- a/pkg/proxy/errors.go
+++ b/pkg/proxy/errors.go
@@ -1,0 +1,26 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// ProxyErrorResponse writes an OpenAI-format JSON error response.
+//
+//	{"error":{"message":"...","type":"...","code":400}}
+//
+// This ensures all proxy error responses are machine-parseable JSON with
+// a consistent structure, matching what OpenAI-compatible clients expect.
+// Exported so cmd/candela (lm_handler) can reuse the same format.
+func ProxyErrorResponse(w http.ResponseWriter, status int, message, errorType string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	body, _ := json.Marshal(map[string]any{
+		"error": map[string]any{
+			"message": message,
+			"type":    errorType,
+			"code":    status,
+		},
+	})
+	_, _ = w.Write(body)
+}

--- a/pkg/proxy/errors.go
+++ b/pkg/proxy/errors.go
@@ -3,11 +3,24 @@ package proxy
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 )
+
+// openAIErrorResponse is the top-level error envelope matching the OpenAI API format.
+type openAIErrorResponse struct {
+	Error openAIErrorDetail `json:"error"`
+}
+
+// openAIErrorDetail holds the error payload fields.
+type openAIErrorDetail struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code"`
+}
 
 // ProxyErrorResponse writes an OpenAI-format JSON error response.
 //
-//	{"error":{"message":"...","type":"...","code":400}}
+//	{"error":{"message":"...","type":"...","code":"400"}}
 //
 // This ensures all proxy error responses are machine-parseable JSON with
 // a consistent structure, matching what OpenAI-compatible clients expect.
@@ -15,12 +28,11 @@ import (
 func ProxyErrorResponse(w http.ResponseWriter, status int, message, errorType string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	body, _ := json.Marshal(map[string]any{
-		"error": map[string]any{
-			"message": message,
-			"type":    errorType,
-			"code":    status,
+	_ = json.NewEncoder(w).Encode(openAIErrorResponse{
+		Error: openAIErrorDetail{
+			Message: message,
+			Type:    errorType,
+			Code:    strconv.Itoa(status),
 		},
 	})
-	_, _ = w.Write(body)
 }

--- a/pkg/proxy/errors_test.go
+++ b/pkg/proxy/errors_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -67,7 +68,7 @@ func TestProxyErrorResponse(t *testing.T) {
 				Error struct {
 					Message string `json:"message"`
 					Type    string `json:"type"`
-					Code    int    `json:"code"`
+					Code    string `json:"code"`
 				} `json:"error"`
 			}
 			if err := json.Unmarshal(w.Body.Bytes(), &parsed); err != nil {
@@ -80,8 +81,8 @@ func TestProxyErrorResponse(t *testing.T) {
 			if parsed.Error.Type != tt.errorType {
 				t.Errorf("error.type = %q, want %q", parsed.Error.Type, tt.errorType)
 			}
-			if parsed.Error.Code != tt.status {
-				t.Errorf("error.code = %d, want %d", parsed.Error.Code, tt.status)
+			if parsed.Error.Code != fmt.Sprintf("%d", tt.status) {
+				t.Errorf("error.code = %q, want %q", parsed.Error.Code, fmt.Sprintf("%d", tt.status))
 			}
 		})
 	}

--- a/pkg/proxy/errors_test.go
+++ b/pkg/proxy/errors_test.go
@@ -1,0 +1,88 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProxyErrorResponse(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		message   string
+		errorType string
+	}{
+		{
+			name:      "bad request",
+			status:    http.StatusBadRequest,
+			message:   "invalid proxy path",
+			errorType: "invalid_request_error",
+		},
+		{
+			name:      "internal server error",
+			status:    http.StatusInternalServerError,
+			message:   "failed to create upstream request",
+			errorType: "server_error",
+		},
+		{
+			name:      "bad gateway",
+			status:    http.StatusBadGateway,
+			message:   "upstream provider unavailable",
+			errorType: "upstream_error",
+		},
+		{
+			name:      "service unavailable",
+			status:    http.StatusServiceUnavailable,
+			message:   "rate limit check unavailable — try again shortly",
+			errorType: "service_error",
+		},
+		{
+			name:      "entity too large",
+			status:    http.StatusRequestEntityTooLarge,
+			message:   "request body too large",
+			errorType: "invalid_request_error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			ProxyErrorResponse(w, tt.status, tt.message, tt.errorType)
+
+			// Verify status code.
+			if w.Code != tt.status {
+				t.Errorf("status = %d, want %d", w.Code, tt.status)
+			}
+
+			// Verify Content-Type is application/json.
+			ct := w.Header().Get("Content-Type")
+			if ct != "application/json" {
+				t.Errorf("Content-Type = %q, want \"application/json\"", ct)
+			}
+
+			// Verify body is valid JSON in OpenAI format.
+			var parsed struct {
+				Error struct {
+					Message string `json:"message"`
+					Type    string `json:"type"`
+					Code    int    `json:"code"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &parsed); err != nil {
+				t.Fatalf("body is not valid JSON: %v\nbody: %s", err, w.Body.String())
+			}
+
+			if parsed.Error.Message != tt.message {
+				t.Errorf("error.message = %q, want %q", parsed.Error.Message, tt.message)
+			}
+			if parsed.Error.Type != tt.errorType {
+				t.Errorf("error.type = %q, want %q", parsed.Error.Type, tt.errorType)
+			}
+			if parsed.Error.Code != tt.status {
+				t.Errorf("error.code = %d, want %d", parsed.Error.Code, tt.status)
+			}
+		})
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -570,9 +570,7 @@ func (p *Proxy) RegisterCompatRoutes(mux *http.ServeMux, models []CompatModel) {
 			Model string `json:"model"`
 		}
 		if err := json.Unmarshal(body, &req); err != nil || req.Model == "" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"error":{"message":"missing or invalid model field","type":"invalid_request_error"}}`))
+			ProxyErrorResponse(w, http.StatusBadRequest, "missing or invalid model field", "invalid_request_error")
 			return
 		}
 
@@ -598,15 +596,7 @@ func (p *Proxy) RegisterCompatRoutes(mux *http.ServeMux, models []CompatModel) {
 			}
 		}
 		if !ok {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			errResp, _ := json.Marshal(map[string]interface{}{
-				"error": map[string]interface{}{
-					"message": fmt.Sprintf("unknown model: %s. Configure it in proxy.lmstudio.models", req.Model),
-					"type":    "invalid_request_error",
-				},
-			})
-			_, _ = w.Write(errResp)
+			ProxyErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("unknown model: %s. Configure it in proxy.lmstudio.models", req.Model), "invalid_request_error")
 			return
 		}
 
@@ -934,16 +924,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// This runs for ALL requests (solo, team, local) to prevent untracked
 	// API calls that would show $0 cost. Only "local" provider is exempt.
 	if requestModel != "" && strings.ToLower(providerName) != "local" && !p.calc.HasPricing(pricingProvider(providerName), requestModel) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusPaymentRequired)
-		errBody, _ := json.Marshal(map[string]any{
-			"error": map[string]any{
-				"message": "no pricing configured for model " + requestModel + " — contact your admin",
-				"type":    "pricing_not_configured",
-				"code":    402,
-			},
-		})
-		_, _ = w.Write(errBody)
+		ProxyErrorResponse(w, http.StatusPaymentRequired, "no pricing configured for model "+requestModel+" — contact your admin", "pricing_not_configured")
 		slog.Warn("blocked request: no pricing for model",
 			"user_id", effectiveUserID, "provider", providerName, "model", requestModel)
 		return
@@ -953,16 +934,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// Blocks models not in the configured allowlist. Runs after pricing gate
 	// and before budget checks. Empty/missing policy = all models allowed.
 	if requestModel != "" && !p.policy.IsAllowed(providerName, requestModel) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusForbidden)
-		errBody, _ := json.Marshal(map[string]any{
-			"error": map[string]any{
-				"message": "model not allowed by policy",
-				"type":    "forbidden",
-				"code":    403,
-			},
-		})
-		_, _ = w.Write(errBody)
+		ProxyErrorResponse(w, http.StatusForbidden, "model not allowed by policy", "forbidden")
 		slog.Warn("model blocked by policy",
 			"provider", providerName, "model", requestModel, "user", effectiveUserID)
 		return
@@ -987,9 +959,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 			ProxyErrorResponse(w, http.StatusServiceUnavailable, "budget check failed — try again shortly", "service_error")
 			return
 		} else if !check.Allowed {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusPaymentRequired)
-			_, _ = w.Write([]byte(`{"error":{"message":"budget exhausted — contact your admin for a grant or budget increase","type":"insufficient_budget","code":402}}`))
+			ProxyErrorResponse(w, http.StatusPaymentRequired, "budget exhausted — contact your admin for a grant or budget increase", "insufficient_budget")
 			slog.Info("blocked request: budget exhausted",
 				"user_id", effectiveUserID, "remaining_usd", check.RemainingUSD)
 			return
@@ -1000,9 +970,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		// Subtract their pending spend from the effective remaining balance.
 		effectiveRemaining := check.RemainingUSD - p.pendingSpend.Get(effectiveUserID)
 		if effectiveRemaining < budgetCheckFloor {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusPaymentRequired)
-			_, _ = w.Write([]byte(`{"error":{"message":"budget exhausted (concurrent requests in flight) — try again shortly","type":"insufficient_budget","code":402}}`))
+			ProxyErrorResponse(w, http.StatusPaymentRequired, "budget exhausted (concurrent requests in flight) — try again shortly", "insufficient_budget")
 			slog.Info("blocked request: budget exhausted after pending spend",
 				"user_id", effectiveUserID,
 				"firestore_remaining", check.RemainingUSD,
@@ -1016,6 +984,13 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		// small reservation prevents unlimited concurrent overdraft.
 		budgetReserved = budgetCheckFloor
 		p.pendingSpend.Reserve(effectiveUserID, budgetReserved)
+		// Release the reservation if we return before the response handlers
+		// (handleStreamingResponse / handleStandardResponse) take ownership.
+		defer func() {
+			if budgetReserved > 0 {
+				p.pendingSpend.Release(effectiveUserID, budgetReserved)
+			}
+		}()
 	}
 
 	// ── Per-request cost cap (#277) ──
@@ -1025,17 +1000,8 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	if p.config.MaxRequestCost > 0 && requestModel != "" {
 		estimatedCost = estimateRequestCost(p.calc, providerName, requestModel, reqBody)
 		if estimatedCost > p.config.MaxRequestCost {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusPaymentRequired)
-			errBody, _ := json.Marshal(map[string]any{
-				"error": map[string]any{
-					"message": fmt.Sprintf("estimated request cost $%.2f exceeds cap $%.2f for model %s",
-						estimatedCost, p.config.MaxRequestCost, requestModel),
-					"type": "request_cost_exceeded",
-					"code": 402,
-				},
-			})
-			_, _ = w.Write(errBody)
+			ProxyErrorResponse(w, http.StatusPaymentRequired, fmt.Sprintf("estimated request cost $%.2f exceeds cap $%.2f for model %s",
+				estimatedCost, p.config.MaxRequestCost, requestModel), "request_cost_exceeded")
 			slog.Info("blocked request: estimated cost exceeds cap",
 				"user_id", effectiveUserID, "provider", providerName,
 				"model", requestModel, "estimated_usd", estimatedCost,
@@ -1054,17 +1020,8 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		}
 		allowed, spent, limit := p.spendTracker.Check(limitUser, requestModel, p.config.DailyLimits, estimatedCost)
 		if !allowed {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusPaymentRequired)
-			errBody, _ := json.Marshal(map[string]any{
-				"error": map[string]any{
-					"message": fmt.Sprintf("daily spend limit for %s reached ($%.2f/$%.2f)",
-						requestModel, spent, limit),
-					"type": "daily_limit_exceeded",
-					"code": 402,
-				},
-			})
-			_, _ = w.Write(errBody)
+			ProxyErrorResponse(w, http.StatusPaymentRequired, fmt.Sprintf("daily spend limit for %s reached ($%.2f/$%.2f)",
+				requestModel, spent, limit), "daily_limit_exceeded")
 			slog.Info("blocked request: daily model spend limit exceeded",
 				"user_id", limitUser, "model", requestModel,
 				"spent_usd", spent, "limit_usd", limit)
@@ -1231,9 +1188,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	if modelForPath != "" && !isSafeModelName(modelForPath) {
 		slog.Warn("blocked request: invalid model name (possible path traversal)",
 			"model", modelForPath, "provider", providerName, "user_id", effectiveUserID)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error":{"message":"invalid model name","type":"invalid_request_error","code":400}}`))
+		ProxyErrorResponse(w, http.StatusBadRequest, "invalid model name", "invalid_request_error")
 		return
 	}
 	if provider.PathRewriter != nil && modelForPath != "" {
@@ -1361,10 +1316,15 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		extendedTTL = extractAnthropicCacheTTL(reqBody)
 	}
 
+	// Transfer budget reservation ownership to the response handler.
+	// Zero out so the deferred release guard (above) becomes a no-op.
+	reserved := budgetReserved
+	budgetReserved = 0
+
 	if isStreaming && resp.StatusCode == http.StatusOK {
-		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, budgetReserved)
+		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, reserved)
 	} else {
-		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, budgetReserved)
+		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, reserved)
 	}
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -559,9 +559,9 @@ func (p *Proxy) RegisterCompatRoutes(mux *http.ServeMux, models []CompatModel) {
 		if err != nil {
 			var maxErr *http.MaxBytesError
 			if errors.As(err, &maxErr) {
-				http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+				ProxyErrorResponse(w, http.StatusRequestEntityTooLarge, "request body too large", "invalid_request_error")
 			} else {
-				http.Error(w, "failed to read request body", http.StatusBadRequest)
+				ProxyErrorResponse(w, http.StatusBadRequest, "failed to read request body", "invalid_request_error")
 			}
 			return
 		}
@@ -838,7 +838,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// Extract provider from path: /proxy/{provider}/v1/...
 	parts := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/proxy/"), "/", 2)
 	if len(parts) < 2 {
-		http.Error(w, "invalid proxy path", http.StatusBadRequest)
+		ProxyErrorResponse(w, http.StatusBadRequest, "invalid proxy path", "invalid_request_error")
 		return
 	}
 	providerName := parts[0]
@@ -846,7 +846,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 	provider, ok := p.providers[providerName]
 	if !ok {
-		http.Error(w, "unknown provider", http.StatusBadRequest)
+		ProxyErrorResponse(w, http.StatusBadRequest, "unknown provider", "invalid_request_error")
 		return
 	}
 
@@ -865,7 +865,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		if rlErr != nil {
 			slog.Error("rate limit check failed, blocking request",
 				"user_id", effectiveUserID, "error", rlErr)
-			http.Error(w, `{"error":{"message":"rate limit check unavailable — try again shortly","type":"service_error","code":503}}`, http.StatusServiceUnavailable)
+			ProxyErrorResponse(w, http.StatusServiceUnavailable, "rate limit check unavailable — try again shortly", "service_error")
 			return
 		} else if !allowed {
 			w.Header().Set("Content-Type", "application/json")
@@ -903,9 +903,9 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
-			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			ProxyErrorResponse(w, http.StatusRequestEntityTooLarge, "request body too large", "invalid_request_error")
 		} else {
-			http.Error(w, "failed to read request body", http.StatusBadRequest)
+			ProxyErrorResponse(w, http.StatusBadRequest, "failed to read request body", "invalid_request_error")
 		}
 		return
 	}
@@ -979,12 +979,12 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			slog.Error("budget check failed, blocking request",
 				"user_id", effectiveUserID, "error", err)
-			http.Error(w, `{"error":{"message":"budget check unavailable — try again shortly","type":"service_error","code":503}}`, http.StatusServiceUnavailable)
+			ProxyErrorResponse(w, http.StatusServiceUnavailable, "budget check unavailable — try again shortly", "service_error")
 			return
 		} else if check == nil {
 			slog.Error("budget check returned nil result, blocking request",
 				"user_id", effectiveUserID)
-			http.Error(w, `{"error":{"message":"budget check failed — try again shortly","type":"service_error","code":503}}`, http.StatusServiceUnavailable)
+			ProxyErrorResponse(w, http.StatusServiceUnavailable, "budget check failed — try again shortly", "service_error")
 			return
 		} else if !check.Allowed {
 			w.Header().Set("Content-Type", "application/json")
@@ -1103,7 +1103,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 			upstreamBody, translatedModel, err = provider.FormatTranslator.TranslateRequest(reqBody)
 		}
 		if err != nil {
-			http.Error(w, fmt.Sprintf("request translation error: %v", err), http.StatusBadRequest)
+			ProxyErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("request translation error: %v", err), "invalid_request_error")
 			return
 		}
 
@@ -1267,7 +1267,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	defer streamCancel()
 	upstreamReq, err := http.NewRequestWithContext(upstreamCtx, r.Method, upstreamURL, bytes.NewReader(upstreamBody))
 	if err != nil {
-		http.Error(w, "failed to create upstream request", http.StatusInternalServerError)
+		ProxyErrorResponse(w, http.StatusInternalServerError, "failed to create upstream request", "server_error")
 		return
 	}
 
@@ -1291,14 +1291,14 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	if provider.RequestSigner != nil {
 		if signErr := provider.RequestSigner.SignRequest(r.Context(), upstreamReq, upstreamBody); signErr != nil {
 			slog.Error("failed to sign request", "provider", providerName, "error", signErr)
-			http.Error(w, "failed to sign upstream request", http.StatusInternalServerError)
+			ProxyErrorResponse(w, http.StatusInternalServerError, "failed to sign upstream request", "server_error")
 			return
 		}
 	} else if provider.TokenSource != nil {
 		token, tokenErr := provider.TokenSource.Token()
 		if tokenErr != nil {
 			slog.Error("failed to get auth token", "provider", providerName, "error", tokenErr)
-			http.Error(w, "failed to obtain cloud credentials", http.StatusInternalServerError)
+			ProxyErrorResponse(w, http.StatusInternalServerError, "failed to obtain cloud credentials", "server_error")
 			return
 		}
 		upstreamReq.Header.Set("Authorization", "Bearer "+token.AccessToken)
@@ -1319,7 +1319,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// CRITICAL: Don't leak internal URLs/DNS/network info to the client.
 		slog.Error("upstream request failed", "provider", providerName, "error", err)
-		http.Error(w, `{"error":{"message":"upstream provider unavailable","type":"upstream_error"}}`, http.StatusBadGateway)
+		ProxyErrorResponse(w, http.StatusBadGateway, "upstream provider unavailable", "upstream_error")
 		p.recordCircuitBreaker(providerName, true)
 		return
 	}
@@ -1408,11 +1408,11 @@ func (p *Proxy) handleStandardResponse(
 	const respLimit = int64(10 << 20)
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, respLimit+1))
 	if err != nil {
-		http.Error(w, "failed to read upstream response", http.StatusBadGateway)
+		ProxyErrorResponse(w, http.StatusBadGateway, "failed to read upstream response", "upstream_error")
 		return
 	}
 	if int64(len(respBody)) > respLimit {
-		http.Error(w, "upstream response too large", http.StatusBadGateway)
+		ProxyErrorResponse(w, http.StatusBadGateway, "upstream response too large", "upstream_error")
 		return
 	}
 
@@ -1535,7 +1535,7 @@ func (p *Proxy) handleStreamingResponse(
 ) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		ProxyErrorResponse(w, http.StatusInternalServerError, "streaming not supported", "server_error")
 		return
 	}
 


### PR DESCRIPTION
## Summary

Standardizes all error responses to the OpenAI JSON format: `{"error":{"message":"...","type":"...","code":N}}`.

### Problem
The codebase used 4 different error patterns:
1. ✅ OpenAI JSON format (budget gates)
2. ❌ `http.Error()` — returns `text/plain`, clients expecting JSON can't parse
3. ❌ JSON inside `http.Error()` — body is JSON but Content-Type says `text/plain`
4. ❌ Flat JSON `{"error":"string"}` — local CLI used non-standard format

### Changes
- **New `ProxyErrorResponse()`** helper in `pkg/proxy/errors.go`
- **17 `http.Error()` replacements** in `proxy.go` with typed errors (`invalid_request_error`, `server_error`, `upstream_error`, `service_error`)
- **3 fixes in `lm_handler.go`** — flat JSON → OpenAI format
- **Updated tests** — assertions match new nested format

### Testing
- `TestProxyErrorResponse` — 5 error types, validates Content-Type, status, JSON structure
- All existing tests updated and passing
- All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized all proxy/chat error responses to an OpenAI-compatible JSON error envelope with consistent `message`, `type`, and `code`.
  * Improved status mapping and messaging for solo-mode without a remote server, missing/invalid models, oversized request bodies (413 vs 400), and various request validation/policy/budget failures.
  * Standardized upstream and budget/reservation error handling for clearer, predictable client behavior.
* **Tests**
  * Updated solo-mode tests and added proxy error response coverage to validate the exact JSON shape, status codes, `Content-Type`, and `error.code` formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->