### PR TITLE
fix: improve SSE proxy for JetBrains and strict OpenAI clients

### DIFF
--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -24,14 +24,15 @@ import (
 // It intercepts /v1/models (merging local + remote + cloud models) and
 // /v1/chat/completions (routing to local runtime, cloud proxy, or remote server).
 type lmHandler struct {
-	mgr          *runtime.Manager       // local runtime manager (may be nil)
-	remoteProxy  *httputil.ReverseProxy // proxy to remote Candela server
-	localProxy   *httputil.ReverseProxy // proxy to local runtime (e.g. Ollama)
-	localHandler http.Handler           // localProxy wrapped with optional span capture
-	cloudProxy   *proxy.Proxy           // direct cloud proxy (solo + cloud mode)
-	cloudModels  map[string]string      // model ID → provider name
-	calc         *costcalc.Calculator   // pricing calculator (for filtering unpriced models)
-	soloMode     bool                   // true = solo mode (use embedded cloud models), false = team mode
+	mgr              *runtime.Manager       // local runtime manager (may be nil)
+	remoteProxy      *httputil.ReverseProxy // proxy to remote Candela server
+	localProxy       *httputil.ReverseProxy // proxy to local runtime (e.g. Ollama)
+	localHandler     http.Handler           // localProxy wrapped with optional span capture
+	cloudProxy       *proxy.Proxy           // direct cloud proxy (solo + cloud mode)
+	cloudModels      map[string]string      // model ID → provider name
+	calc             *costcalc.Calculator   // pricing calculator (for filtering unpriced models)
+	soloMode         bool                   // true = solo mode (use embedded cloud models), false = team mode
+	defaultMaxTokens int                    // injected when client omits max_tokens (default: 8192)
 
 	// Model caches stored as atomic.Value holding map[string]bool.
 	// Updated atomically by swapping the entire map — no in-place mutation.
@@ -49,23 +50,27 @@ type lmHandler struct {
 
 // newLMHandler creates a smart LM compat handler that merges local + remote + cloud
 // models and routes chat completions to the correct backend.
-func newLMHandler(mgr *runtime.Manager, remoteProxy, localProxy *httputil.ReverseProxy, localHandler http.Handler, cloudProxy *proxy.Proxy, cloudModels map[string]string, calc *costcalc.Calculator, soloMode bool) *lmHandler {
+func newLMHandler(mgr *runtime.Manager, remoteProxy, localProxy *httputil.ReverseProxy, localHandler http.Handler, cloudProxy *proxy.Proxy, cloudModels map[string]string, calc *costcalc.Calculator, soloMode bool, defaultMaxTokens int) *lmHandler {
 	if localHandler == nil && localProxy != nil {
 		localHandler = localProxy
 	}
 	if cloudModels == nil {
 		cloudModels = make(map[string]string)
 	}
+	if defaultMaxTokens <= 0 {
+		defaultMaxTokens = 8192
+	}
 	h := &lmHandler{
-		mgr:          mgr,
-		remoteProxy:  remoteProxy,
-		localProxy:   localProxy,
-		localHandler: localHandler,
-		cloudProxy:   cloudProxy,
-		cloudModels:  cloudModels,
-		calc:         calc,
-		soloMode:     soloMode,
-		stopCh:       make(chan struct{}),
+		mgr:              mgr,
+		remoteProxy:      remoteProxy,
+		localProxy:       localProxy,
+		localHandler:     localHandler,
+		cloudProxy:       cloudProxy,
+		cloudModels:      cloudModels,
+		calc:             calc,
+		soloMode:         soloMode,
+		defaultMaxTokens: defaultMaxTokens,
+		stopCh:           make(chan struct{}),
 	}
 
 	// Initialize empty maps in atomic values.
@@ -158,6 +163,8 @@ func (h *lmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case r.URL.Path == "/api/v0/models" && r.Method == http.MethodGet:
 		h.serveModels(w, r)
 	case r.URL.Path == "/v1/chat/completions" && r.Method == http.MethodPost:
+		h.serveChat(w, r)
+	case r.URL.Path == "/api/v0/chat/completions" && r.Method == http.MethodPost:
 		h.serveChat(w, r)
 	default:
 		if h.remoteProxy != nil {
@@ -307,9 +314,23 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 	_ = r.Body.Close()
 
 	var req struct {
-		Model string `json:"model"`
+		Model     string `json:"model"`
+		MaxTokens *int   `json:"max_tokens,omitempty"`
 	}
 	_ = json.Unmarshal(body, &req)
+
+	// Inject max_tokens if absent or non-positive — some clients (JetBrains)
+	// don't send it, but providers like Anthropic require it.
+	if req.MaxTokens == nil || *req.MaxTokens <= 0 {
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(body, &raw); err == nil {
+			defaultMax := h.defaultMaxTokens
+			if b, err := json.Marshal(defaultMax); err == nil {
+				raw["max_tokens"] = b
+				body, _ = json.Marshal(raw)
+			}
+		}
+	}
 
 	// Resolve model aliases (e.g. "claude-sonnet-4" → "claude-sonnet-4-20250514").
 	resolved := h.resolveModel(req.Model)
@@ -344,6 +365,7 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 
 	// 3. Remote server → team mode proxy.
 	if h.remoteProxy != nil {
+		r.URL.Path = "/v1/chat/completions" // normalize — remote only serves /v1/
 		h.remoteProxy.ServeHTTP(w, r)
 		return
 	}

--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -316,6 +316,7 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Model     string `json:"model"`
 		MaxTokens *int   `json:"max_tokens,omitempty"`
+		Stream    bool   `json:"stream"`
 	}
 	_ = json.Unmarshal(body, &req)
 
@@ -351,6 +352,14 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// For streaming requests, wrap the ResponseWriter with an SSE normalizer
+	// that filters out malformed chunks (empty choices, missing delta.content)
+	// which crash JetBrains' LM Studio SSE parser.
+	writer := w
+	if req.Stream {
+		writer = newSSENormalizer(w)
+	}
+
 	// 2. Cloud model → direct cloud proxy (solo mode only).
 	// In team mode, all cloud traffic must go through the remote server
 	// so the server catalog remains the single source of truth.
@@ -358,7 +367,7 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 		if providerName, ok := h.cloudModels[req.Model]; ok && h.cloudProxy != nil {
 			slog.Debug("lm handler: routing to cloud provider", "model", req.Model, "provider", providerName)
 			r.URL.Path = fmt.Sprintf("/proxy/%s/v1/chat/completions", providerName)
-			h.cloudProxy.ServeHTTP(w, r)
+			h.cloudProxy.ServeHTTP(writer, r)
 			return
 		}
 	}
@@ -366,7 +375,7 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 	// 3. Remote server → team mode proxy.
 	if h.remoteProxy != nil {
 		r.URL.Path = "/v1/chat/completions" // normalize — remote only serves /v1/
-		h.remoteProxy.ServeHTTP(w, r)
+		h.remoteProxy.ServeHTTP(writer, r)
 		return
 	}
 
@@ -537,3 +546,173 @@ func (r *responseRecorder) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 func (r *responseRecorder) WriteHeader(code int) { r.statusCode = code }
+
+// sseNormalizer wraps an http.ResponseWriter to intercept SSE events and
+// normalize them for JetBrains compatibility. It filters out chunks with
+// empty choices arrays (Qwen) and ensures delta.content is always present
+// (Claude sends chunks with only delta.role).
+type sseNormalizer struct {
+	w      http.ResponseWriter
+	buf    []byte // accumulates partial writes until we have a complete SSE event
+	header http.Header
+}
+
+func newSSENormalizer(w http.ResponseWriter) *sseNormalizer {
+	return &sseNormalizer{w: w, header: w.Header()}
+}
+
+func (n *sseNormalizer) Header() http.Header { return n.header }
+
+func (n *sseNormalizer) WriteHeader(code int) {
+	// Normalize Content-Type: JetBrains' ktor SSE parser requires exactly
+	// "text/event-stream" and rejects "text/event-stream; charset=utf-8"
+	// (which Claude/Anthropic sends via Vertex AI).
+	ct := n.header.Get("Content-Type")
+	if strings.HasPrefix(ct, "text/event-stream") {
+		if ct != "text/event-stream" {
+			n.header.Set("Content-Type", "text/event-stream")
+		}
+		// Remove Content-Length: the upstream may include it, but SSE
+		// responses must use chunked transfer encoding. If Content-Length
+		// is present, ktor tries fixed-length body reading instead of
+		// streaming, causing "fixed content-length: N, bytes received: 0".
+		n.header.Del("Content-Length")
+	}
+	n.w.WriteHeader(code)
+}
+
+func (n *sseNormalizer) Flush() {
+	if f, ok := n.w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (n *sseNormalizer) Write(b []byte) (int, error) {
+	originalLen := len(b)
+	n.buf = append(n.buf, b...)
+
+	// Process complete SSE events (delimited by \n\n).
+	// Batch all events from this Write call into a single output write
+	// to minimize the number of HTTP/1.1 chunked frames.
+	var out bytes.Buffer
+	for {
+		idx := bytes.Index(n.buf, []byte("\n\n"))
+		if idx == -1 {
+			break
+		}
+		event := n.buf[:idx+2] // include the \n\n
+		n.buf = n.buf[idx+2:]
+
+		normalized := n.normalizeEvent(event)
+		if normalized != nil {
+			out.Write(normalized)
+		}
+	}
+	if out.Len() > 0 {
+		if _, err := n.w.Write(out.Bytes()); err != nil {
+			return originalLen, err
+		}
+		n.Flush()
+	}
+	return originalLen, nil
+}
+
+// normalizeEvent processes a single SSE event. Returns nil to suppress the event.
+func (n *sseNormalizer) normalizeEvent(event []byte) []byte {
+	line := bytes.TrimSpace(event)
+
+	// Pass through non-data lines (comments, empty lines, "data: [DONE]").
+	if !bytes.HasPrefix(line, []byte("data: ")) {
+		return event
+	}
+	payload := bytes.TrimPrefix(line, []byte("data: "))
+
+	// Pass through [DONE] sentinel.
+	if bytes.Equal(payload, []byte("[DONE]")) {
+		return event
+	}
+
+	// Parse the JSON chunk.
+	var chunk map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &chunk); err != nil {
+		return event // pass through unparseable events
+	}
+
+	// Parse choices array.
+	choicesRaw, ok := chunk["choices"]
+	if !ok {
+		return event
+	}
+
+	var choices []map[string]json.RawMessage
+	if err := json.Unmarshal(choicesRaw, &choices); err != nil {
+		return event
+	}
+
+	// Drop events with empty choices array (Qwen final usage-only chunk).
+	if len(choices) == 0 {
+		return nil
+	}
+
+	modified := false
+
+	for i := range choices {
+		deltaRaw, hasDelta := choices[i]["delta"]
+		if !hasDelta {
+			continue
+		}
+
+		var delta map[string]json.RawMessage
+		if err := json.Unmarshal(deltaRaw, &delta); err != nil {
+			continue
+		}
+
+		// Ensure delta.content is always a string (Claude sends role-only
+		// first chunk; Qwen sends content:null on its finish chunk).
+		contentRaw, hasContent := delta["content"]
+		if !hasContent || bytes.Equal(contentRaw, []byte("null")) {
+			delta["content"] = json.RawMessage(`""`)
+			modified = true
+		}
+
+		// Remove non-standard fields that may confuse strict parsers.
+		for _, field := range []string{"reasoning_content", "tool_calls", "matched_stop"} {
+			if _, has := delta[field]; has {
+				delete(delta, field)
+				modified = true
+			}
+		}
+
+		// Remove non-standard choice-level fields.
+		for _, field := range []string{"matched_stop"} {
+			if _, has := choices[i][field]; has {
+				delete(choices[i], field)
+				modified = true
+			}
+		}
+
+		if modified {
+			if b, err := json.Marshal(delta); err == nil {
+				choices[i]["delta"] = b
+			}
+		}
+	}
+
+	if !modified {
+		return event
+	}
+
+	// Re-serialize.
+	if b, err := json.Marshal(choices); err == nil {
+		chunk["choices"] = b
+	}
+	if b, err := json.Marshal(chunk); err == nil {
+		var out bytes.Buffer
+		out.WriteString("data: ")
+		out.Write(b)
+		out.WriteString("\n\n")
+		return out.Bytes()
+	}
+
+	return event // fallback: pass through
+}

--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -320,11 +320,15 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = json.Unmarshal(body, &req)
 
+	// Normalize path early so all backends (local, cloud, remote) receive
+	// the standard /v1/ path regardless of what the client sent.
+	r.URL.Path = "/v1/chat/completions"
+
 	// Inject max_tokens if absent or non-positive — some clients (JetBrains)
 	// don't send it, but providers like Anthropic require it.
 	if req.MaxTokens == nil || *req.MaxTokens <= 0 {
 		var raw map[string]json.RawMessage
-		if err := json.Unmarshal(body, &raw); err == nil {
+		if err := json.Unmarshal(body, &raw); err == nil && raw != nil {
 			defaultMax := h.defaultMaxTokens
 			if b, err := json.Marshal(defaultMax); err == nil {
 				raw["max_tokens"] = b
@@ -374,7 +378,7 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 
 	// 3. Remote server → team mode proxy.
 	if h.remoteProxy != nil {
-		r.URL.Path = "/v1/chat/completions" // normalize — remote only serves /v1/
+		// Path already normalized at top of serveChat.
 		h.remoteProxy.ServeHTTP(writer, r)
 		return
 	}

--- a/cmd/candela/lm_handler_test.go
+++ b/cmd/candela/lm_handler_test.go
@@ -98,7 +98,7 @@ func setupLMHandler(t *testing.T, localModels []runtime.Model, remoteModels []op
 	}
 	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
 
-	h := newLMHandler(mgr, proxyTo(remoteSrv.URL), proxyTo(localSrv.URL), nil, nil, nil, nil, false)
+	h := newLMHandler(mgr, proxyTo(remoteSrv.URL), proxyTo(localSrv.URL), nil, nil, nil, nil, false, 0)
 
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
@@ -160,7 +160,7 @@ func TestLMHandler_Models_NoRuntime(t *testing.T) {
 
 	remoteSrv := mockRemoteServer(t, remoteModels)
 
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false, 0)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -197,7 +197,7 @@ func TestLMHandler_Models_RemoteDown(t *testing.T) {
 	_ = mgr.Start(context.Background())
 	defer func() { _ = mgr.Stop(context.Background()) }()
 
-	h := newLMHandler(mgr, proxyTo(failSrv.URL), proxyTo(localSrv.URL), nil, nil, nil, nil, false)
+	h := newLMHandler(mgr, proxyTo(failSrv.URL), proxyTo(localSrv.URL), nil, nil, nil, nil, false, 0)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -301,7 +301,7 @@ func TestLMHandler_APIV0Models(t *testing.T) {
 	// /api/v0/models should return a model list (same as /v1/models), not passthrough.
 	// Use solo mode with a cloud model to ensure there's at least one model in the response.
 	cloudModels := map[string]string{"test-model": "test-provider"}
-	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, nil, true)
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, nil, true, 0)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -337,7 +337,7 @@ func TestLMHandler_ModelFields(t *testing.T) {
 	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
 
 	cloudModels := map[string]string{"gpt-4o": "openai"}
-	h := newLMHandler(mgr, proxyTo(remoteSrv.URL), proxyTo(localSrv.URL), nil, nil, cloudModels, nil, true)
+	h := newLMHandler(mgr, proxyTo(remoteSrv.URL), proxyTo(localSrv.URL), nil, nil, cloudModels, nil, true, 0)
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
 
@@ -475,7 +475,7 @@ func setupSoloLMHandler(t *testing.T, localModels []runtime.Model) *httptest.Ser
 	t.Cleanup(func() { _ = mgr.Stop(context.Background()) })
 
 	// Solo mode: nil remote proxy.
-	h := newLMHandler(mgr, nil, proxyTo(localSrv.URL), nil, nil, nil, nil, true)
+	h := newLMHandler(mgr, nil, proxyTo(localSrv.URL), nil, nil, nil, nil, true, 0)
 
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
@@ -577,7 +577,7 @@ func TestLMHandler_CloudModelsIncluded(t *testing.T) {
 		"claude-sonnet-4-20250514": "anthropic",
 	}
 
-	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New(), true)
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New(), true, 0)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -642,7 +642,7 @@ func TestLMHandler_CloudChatRouting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := newLMHandler(nil, nil, nil, nil, cp, cloudModels, calc, true)
+	h := newLMHandler(nil, nil, nil, nil, cp, cloudModels, calc, true, 0)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -687,7 +687,7 @@ func TestLMHandler_LocalPreference(t *testing.T) {
 	defer func() { _ = mgr.Stop(context.Background()) }()
 
 	localProxy := proxyTo(localSrv.URL)
-	h := newLMHandler(mgr, nil, localProxy, localProxy, nil, cloudModels, costcalc.New(), true)
+	h := newLMHandler(mgr, nil, localProxy, localProxy, nil, cloudModels, costcalc.New(), true, 0)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -730,7 +730,7 @@ func TestLMHandler_CloudAndLocalModelsMerged(t *testing.T) {
 	defer func() { _ = mgr.Stop(context.Background()) }()
 
 	localProxy := proxyTo(localSrv.URL)
-	h := newLMHandler(mgr, nil, localProxy, nil, nil, cloudModels, costcalc.New(), true)
+	h := newLMHandler(mgr, nil, localProxy, nil, nil, cloudModels, costcalc.New(), true, 0)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -764,7 +764,7 @@ func TestLMHandler_CloudModelWhenProxyNil(t *testing.T) {
 	// models should still appear in /v1/models but chat should 404.
 	cloudModels := map[string]string{"gemini-2.5-pro": "gemini-oai"}
 
-	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New(), true) // no cloudProxy
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New(), true, 0) // no cloudProxy
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -796,7 +796,7 @@ func TestLMHandler_UnknownModelSoloCloudMode(t *testing.T) {
 	// cloudModels should return 404 (not panic or route incorrectly).
 	cloudModels := map[string]string{"gemini-2.5-pro": "gemini-oai"}
 
-	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New(), true)
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New(), true, 0)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -874,7 +874,7 @@ func TestLMHandler_ModelAlias_PrefixResolvesRemote(t *testing.T) {
 	}
 
 	remoteSrv := mockRemoteServer(t, remoteModels)
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false, 0)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -925,7 +925,7 @@ func TestLMHandler_ModelAlias_BodyRewritten(t *testing.T) {
 	}))
 	defer remoteSrv.Close()
 
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false, 0)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -949,7 +949,7 @@ func TestLMHandler_ModelAlias_AmbiguousPrefixNoResolve(t *testing.T) {
 	}
 
 	remoteSrv := mockRemoteServer(t, remoteModels)
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false, 0)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -975,7 +975,7 @@ func TestLMHandler_ModelAlias_ExactMatchSkipsResolution(t *testing.T) {
 	}
 
 	remoteSrv := mockRemoteServer(t, remoteModels)
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false, 0)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -1023,7 +1023,7 @@ func TestLMHandler_ModelAlias_CloudModel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := newLMHandler(nil, nil, nil, nil, cp, cloudModels, calc, true)
+	h := newLMHandler(nil, nil, nil, nil, cp, cloudModels, calc, true, 0)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
@@ -1110,7 +1110,7 @@ func TestTeamMode_ExcludesCloudModels(t *testing.T) {
 	}
 
 	// Team mode: soloMode=false
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, cloudModels, costcalc.New(), false)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, cloudModels, costcalc.New(), false, 0)
 	t.Cleanup(h.Close)
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
@@ -1152,7 +1152,7 @@ func TestSoloMode_IncludesCloudModels(t *testing.T) {
 	}
 
 	// Solo mode: soloMode=true, no remote
-	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New(), true)
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, costcalc.New(), true, 0)
 	t.Cleanup(h.Close)
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
@@ -1187,7 +1187,7 @@ func TestLMHandler_Close(t *testing.T) {
 	t.Cleanup(remoteSrv.Close)
 
 	// Team mode starts a background goroutine.
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false, 0)
 	// Close should not block or panic.
 	h.Close()
 	// Calling Close again should be safe.
@@ -1196,7 +1196,7 @@ func TestLMHandler_Close(t *testing.T) {
 
 // TestAtomicModelCache verifies that the atomic model caches work correctly.
 func TestAtomicModelCache(t *testing.T) {
-	h := newLMHandler(nil, nil, nil, nil, nil, nil, nil, true)
+	h := newLMHandler(nil, nil, nil, nil, nil, nil, nil, true, 0)
 	t.Cleanup(h.Close)
 
 	// Initially empty.
@@ -1259,7 +1259,7 @@ func TestTeamMode_ChatRejectsCloudRouting(t *testing.T) {
 	cloudModels := map[string]string{"claude-sonnet-4": "anthropic"}
 
 	// Team mode: soloMode=false — cloud routing should be bypassed.
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, cloudModels, nil, false)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, cloudModels, nil, false, 0)
 	t.Cleanup(h.Close)
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
@@ -1299,7 +1299,7 @@ func TestRemoteEmptyResponse_ClearsCache(t *testing.T) {
 	}))
 	t.Cleanup(remoteSrv.Close)
 
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false, 0)
 	t.Cleanup(h.Close)
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
@@ -1337,7 +1337,7 @@ func TestRemoteDown_PreservesStaleCache(t *testing.T) {
 	}))
 	t.Cleanup(remoteSrv.Close)
 
-	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false)
+	h := newLMHandler(nil, proxyTo(remoteSrv.URL), nil, nil, nil, nil, nil, false, 0)
 	t.Cleanup(h.Close)
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -798,6 +798,13 @@ func runForeground() {
 				if _, ok := req.Header["User-Agent"]; !ok {
 					req.Header.Set("User-Agent", "candela/1.0")
 				}
+
+				// Strip hop-by-hop headers that break HTTP/2 upstream.
+				// Clients (JetBrains/ktor) may send Upgrade: h2c which causes
+				// "http2: invalid Upgrade request header" on the remote connection.
+				req.Header.Del("Upgrade")
+				req.Header.Del("Connection")
+				req.Header.Del("HTTP2-Settings")
 			},
 			ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 				slog.Error("proxy error", "path", r.URL.Path, "error", err)
@@ -805,6 +812,10 @@ func runForeground() {
 				w.WriteHeader(http.StatusBadGateway)
 				_ = json.NewEncoder(w).Encode(map[string]string{"error": "remote server unavailable"})
 			},
+			// Flush immediately so SSE chunks stream to the client without
+			// buffering. Without this, responses are fully buffered and slow
+			// models (Claude, Qwen) cause client-side timeouts.
+			FlushInterval: -1, // -1 = flush every chunk immediately
 		}
 
 		// Initialize local traces store for offline sync.

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -80,11 +80,12 @@ type Config struct {
 	RuntimeManage  runtime.ManagerConfig `yaml:"runtime_manage"`  // Auto-start, auto-pull, models
 
 	// Direct cloud providers (solo mode — call Gemini/Claude without a server).
-	Providers      []LocalProvider          `yaml:"providers"`
-	VertexAI       VertexAIConfig           `yaml:"vertex_ai"`
-	AWS            AWSConfig                `yaml:"aws"`
-	MaxRequestCost float64                  `yaml:"max_request_cost_usd"` // Per-request cost cap (0 = disabled)
-	DailyLimits    []proxy.SpendLimitConfig `yaml:"daily_limits"`         // Per-model daily spend limits
+	Providers        []LocalProvider          `yaml:"providers"`
+	VertexAI         VertexAIConfig           `yaml:"vertex_ai"`
+	AWS              AWSConfig                `yaml:"aws"`
+	MaxRequestCost   float64                  `yaml:"max_request_cost_usd"` // Per-request cost cap (0 = disabled)
+	DailyLimits      []proxy.SpendLimitConfig `yaml:"daily_limits"`         // Per-model daily spend limits
+	DefaultMaxTokens int                      `yaml:"default_max_tokens"`   // Injected when client omits max_tokens (default: 8192)
 }
 
 // LocalProvider configures a direct cloud provider for solo mode.
@@ -1036,7 +1037,7 @@ func runForeground() {
 		cloudCalc = costcalc.New()
 	}
 
-	lmH := newLMHandler(mgr, remoteProxy, runtimeLocalProxy, localHandler, cloudProxy, cloudModels, cloudCalc, soloMode)
+	lmH := newLMHandler(mgr, remoteProxy, runtimeLocalProxy, localHandler, cloudProxy, cloudModels, cloudCalc, soloMode, cfg.DefaultMaxTokens)
 	lmAddr := fmt.Sprintf("127.0.0.1:%d", lmPort)
 
 	// ── Graceful shutdown ──

--- a/cmd/candela/sse_normalizer_test.go
+++ b/cmd/candela/sse_normalizer_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSSENormalizerNormalizeEvent(t *testing.T) {
+	n := newSSENormalizer(httptest.NewRecorder())
+
+	tests := []struct {
+		name     string
+		input    string
+		wantNil  bool   // expect event to be suppressed
+		wantJSON string // substring to look for in output (empty = pass-through)
+	}{
+		{
+			name:    "pass through DONE sentinel",
+			input:   "data: [DONE]\n\n",
+			wantNil: false,
+		},
+		{
+			name:    "pass through comment",
+			input:   ": keepalive\n\n",
+			wantNil: false,
+		},
+		{
+			name:    "drop empty choices array (Qwen usage chunk)",
+			input:   `data: {"choices":[],"created":123,"id":"x","model":"qwen","object":"chat.completion.chunk","usage":{}}` + "\n\n",
+			wantNil: true,
+		},
+		{
+			name:     "add content to role-only delta (Claude first chunk)",
+			input:    `data: {"choices":[{"delta":{"role":"assistant"},"index":0}],"created":123,"id":"x","model":"claude","object":"chat.completion.chunk"}` + "\n\n",
+			wantNil:  false,
+			wantJSON: `"content":""`,
+		},
+		{
+			name:     "normalize null content to empty string (Qwen finish)",
+			input:    `data: {"choices":[{"delta":{"content":null,"role":null},"finish_reason":"stop","index":0}],"created":123,"id":"x","model":"qwen","object":"chat.completion.chunk"}` + "\n\n",
+			wantNil:  false,
+			wantJSON: `"content":""`,
+		},
+		{
+			name:     "strip reasoning_content from delta",
+			input:    `data: {"choices":[{"delta":{"content":"hi","reasoning_content":"thinking..."},"index":0}],"created":123,"id":"x","model":"qwen","object":"chat.completion.chunk"}` + "\n\n",
+			wantNil:  false,
+			wantJSON: `"content":"hi"`,
+		},
+		{
+			name:    "pass through normal event unmodified",
+			input:   `data: {"choices":[{"delta":{"content":"hello"},"index":0}],"created":123,"id":"x","model":"gemini","object":"chat.completion.chunk"}` + "\n\n",
+			wantNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := n.normalizeEvent([]byte(tt.input))
+
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil (suppressed), got: %s", string(result))
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("expected event, got nil")
+			}
+
+			if tt.wantJSON != "" && !bytes.Contains(result, []byte(tt.wantJSON)) {
+				t.Errorf("expected result to contain %q, got: %s", tt.wantJSON, string(result))
+			}
+		})
+	}
+}
+
+func TestSSENormalizerStripReasoningContent(t *testing.T) {
+	n := newSSENormalizer(httptest.NewRecorder())
+
+	input := `data: {"choices":[{"delta":{"content":"hi","reasoning_content":"deep thought","tool_calls":[]},"index":0}],"created":123,"id":"x","model":"qwen","object":"chat.completion.chunk"}` + "\n\n"
+	result := n.normalizeEvent([]byte(input))
+
+	if result == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if bytes.Contains(result, []byte("reasoning_content")) {
+		t.Error("reasoning_content should have been stripped")
+	}
+	if bytes.Contains(result, []byte("tool_calls")) {
+		t.Error("tool_calls should have been stripped")
+	}
+}
+
+func TestSSENormalizerWriteHeader(t *testing.T) {
+	t.Run("normalizes content-type charset", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSENormalizer(rec)
+		n.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		n.WriteHeader(http.StatusOK)
+
+		if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
+			t.Errorf("Content-Type = %q, want %q", got, "text/event-stream")
+		}
+	})
+
+	t.Run("strips content-length from SSE", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSENormalizer(rec)
+		n.Header().Set("Content-Type", "text/event-stream")
+		n.Header().Set("Content-Length", "48606")
+		n.WriteHeader(http.StatusOK)
+
+		if got := rec.Header().Get("Content-Length"); got != "" {
+			t.Errorf("Content-Length should be stripped, got %q", got)
+		}
+	})
+
+	t.Run("preserves content-length for non-SSE", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSENormalizer(rec)
+		n.Header().Set("Content-Type", "application/json")
+		n.Header().Set("Content-Length", "42")
+		n.WriteHeader(http.StatusOK)
+
+		if got := rec.Header().Get("Content-Length"); got != "42" {
+			t.Errorf("Content-Length should be preserved for non-SSE, got %q", got)
+		}
+	})
+}
+
+func TestSSENormalizerWrite(t *testing.T) {
+	t.Run("buffers partial events", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSENormalizer(rec)
+
+		// Write partial event (no \n\n yet)
+		_, _ = n.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"},\"index\":0}"))
+		if rec.Body.Len() > 0 {
+			t.Error("should not write until event is complete")
+		}
+
+		// Complete the event
+		_, _ = n.Write([]byte("}],\"created\":1,\"id\":\"x\",\"model\":\"m\",\"object\":\"chat.completion.chunk\"}\n\n"))
+		if rec.Body.Len() == 0 {
+			t.Error("should write after event is complete")
+		}
+	})
+
+	t.Run("batches multiple events from single write", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSENormalizer(rec)
+
+		event1 := `data: {"choices":[{"delta":{"content":"a"},"index":0}],"created":1,"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+		event2 := `data: {"choices":[{"delta":{"content":"b"},"index":0}],"created":1,"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+
+		_, _ = n.Write([]byte(event1 + event2))
+
+		body := rec.Body.String()
+		if !bytes.Contains([]byte(body), []byte(`"content":"a"`)) {
+			t.Error("missing first event")
+		}
+		if !bytes.Contains([]byte(body), []byte(`"content":"b"`)) {
+			t.Error("missing second event")
+		}
+	})
+
+	t.Run("suppresses empty choices in batch", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSENormalizer(rec)
+
+		good := `data: {"choices":[{"delta":{"content":"hi"},"index":0}],"created":1,"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+		empty := `data: {"choices":[],"created":1,"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+		done := "data: [DONE]\n\n"
+
+		_, _ = n.Write([]byte(good + empty + done))
+
+		body := rec.Body.String()
+		if !bytes.Contains([]byte(body), []byte(`"content":"hi"`)) {
+			t.Error("good event should be present")
+		}
+		if bytes.Contains([]byte(body), []byte(`"choices":[]`)) {
+			t.Error("empty choices should be suppressed")
+		}
+		if !bytes.Contains([]byte(body), []byte("[DONE]")) {
+			t.Error("DONE sentinel should be present")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes SSE streaming compatibility for JetBrains and other strict OpenAI-compatible clients.

### Problem
JetBrains AI Chat (LM Studio compat) was failing with `unexpected EOF` and `fixed content-length: N, bytes received: 0` errors when using non-Gemini models (Claude, Qwen, Mistral). Root causes:

1. **Hop-by-hop headers** — JetBrains ktor sends `Upgrade: h2c` which breaks HTTP/2 upstream
2. **Buffered proxy** — SSE responses fully buffered, causing client timeouts
3. **Content-Length on SSE** — Upstream includes `Content-Length` with SSE, causing fixed-length body reading
4. **Content-Type charset** — Claude sends `text/event-stream; charset=utf-8` which strict parsers reject
5. **Malformed SSE chunks** — Empty `choices: []` (Qwen), missing `delta.content` (Claude), `content: null` (Qwen)

### Changes

**`cmd/candela/main.go`**
- Strip hop-by-hop headers (`Upgrade`, `Connection`, `HTTP2-Settings`) in remote proxy Director
- Set `FlushInterval: -1` on remoteProxy for immediate SSE chunk flushing

**`cmd/candela/lm_handler.go`**
- Add `sseNormalizer` ResponseWriter wrapper for streaming requests:
  - Normalizes `Content-Type` to exact `text/event-stream`
  - Strips `Content-Length` from SSE responses (forces chunked encoding)
  - Filters empty `choices` arrays (Qwen usage-only chunks)
  - Ensures `delta.content` is always a string
  - Strips non-standard fields (`reasoning_content`, `tool_calls`, `matched_stop`)
  - Batches events to reduce HTTP/1.1 chunk count

**`cmd/candela/sse_normalizer_test.go`** (new)
- 13 unit tests covering event normalization, header fixes, buffering, and batching

### Testing
- All 13 SSE normalizer tests pass
- Full test suite passes (45+ packages)
- golangci-lint: 0 issues
- Verified with JetBrains IDEA 2026.1.3 using AI Assistant OpenAI-compatible provider
- Gemini, Claude, Qwen, DeepSeek, and Mistral models tested via curl

### Note
JetBrains LM Studio compat mode (`LMStudioClientAPI.kt`) has a known ktor bug with multi-chunk SSE — use **AI Assistant → OpenAI-compatible provider** instead for full model support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable default `max_tokens` (`default_max_tokens`) for chat completions when `max_tokens` is missing or non-positive.
  * Added support for an additional compatible chat-completions API path: `POST /api/v0/chat/completions`.
* **Bug Fixes**
  * Improved request routing and forwarding for chat completions across local, remote, and team-based flows.
  * Enhanced streaming/SSE compatibility by normalizing SSE payloads (including safe handling of empty/missing content).
* **Chores**
  * Reduced streaming buffering delays and removed upgrade-related hop-by-hop headers during reverse proxying.
* **Tests**
  * Added unit tests for SSE normalization and max-token defaulting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->