### PR TITLE
fix: LM Studio compatibility — strip empty tools, normalize final chunks, clean headers

### DIFF
--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -330,12 +330,41 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 
 	// Inject max_tokens if absent or non-positive — some clients (JetBrains)
 	// don't send it, but providers like Anthropic require it.
-	if req.MaxTokens == nil || *req.MaxTokens <= 0 {
+	// Also strip empty tools array (JetBrains sends "tools":[] which causes
+	// 422 on strict backends like Mistral) and stream_options (not all
+	// upstreams support it).
+	{
 		var raw map[string]json.RawMessage
 		if err := json.Unmarshal(body, &raw); err == nil && raw != nil {
-			defaultMax := h.defaultMaxTokens
-			if b, err := json.Marshal(defaultMax); err == nil {
-				raw["max_tokens"] = b
+			needRewrite := false
+
+			// Inject max_tokens if absent or non-positive.
+			if req.MaxTokens == nil || *req.MaxTokens <= 0 {
+				defaultMax := h.defaultMaxTokens
+				if b, err := json.Marshal(defaultMax); err == nil {
+					raw["max_tokens"] = b
+					needRewrite = true
+				}
+			}
+
+			// Strip empty "tools":[] — JetBrains sends it in every request,
+			// but Mistral/vLLM reject it with HTTP 422.
+			if toolsRaw, ok := raw["tools"]; ok {
+				var tools []json.RawMessage
+				if json.Unmarshal(toolsRaw, &tools) == nil && len(tools) == 0 {
+					delete(raw, "tools")
+					delete(raw, "tool_choice")
+					needRewrite = true
+				}
+			}
+
+			// Strip stream_options — not all upstreams support it.
+			if _, ok := raw["stream_options"]; ok {
+				delete(raw, "stream_options")
+				needRewrite = true
+			}
+
+			if needRewrite {
 				body, _ = json.Marshal(raw)
 			}
 		}
@@ -583,7 +612,18 @@ func (n *sseNormalizer) WriteHeader(code int) {
 		// is present, ktor tries fixed-length body reading instead of
 		// streaming, causing "fixed content-length: N, bytes received: 0".
 		n.header.Del("Content-Length")
+
+		// Strip upstream provider headers that LM Studio wouldn't send.
+		// Scoped to SSE responses only — non-SSE error responses keep their headers.
+		for _, h := range []string{
+			"Server", "Alt-Svc", "Via",
+			"X-Frame-Options", "X-Xss-Protection", "X-Accel-Buffering",
+			"X-Vertex-Ai-Received-Request-Id", "Request-Id",
+		} {
+			n.header.Del(h)
+		}
 	}
+
 	n.w.WriteHeader(code)
 }
 
@@ -671,6 +711,28 @@ func (n *sseNormalizer) normalizeEvent(event []byte) []byte {
 		var delta map[string]json.RawMessage
 		if err := json.Unmarshal(deltaRaw, &delta); err != nil {
 			continue
+		}
+
+		// LM Studio spec: final chunk should have empty delta {} with
+		// finish_reason "stop". Normalize providers that include content
+		// in the final chunk.
+		if frRaw, hasFR := choices[i]["finish_reason"]; hasFR {
+			var fr string
+			if json.Unmarshal(frRaw, &fr) == nil && fr == "stop" {
+				// Clear the delta to match LM Studio's format.
+				for k := range delta {
+					delete(delta, k)
+				}
+				modified = true
+				if b, err := json.Marshal(delta); err == nil {
+					choices[i]["delta"] = b
+				}
+				// Remove non-standard choice-level fields before continuing.
+				for _, field := range []string{"matched_stop"} {
+					delete(choices[i], field)
+				}
+				continue
+			}
 		}
 
 		// Ensure delta.content is always a string (Claude sends role-only

--- a/cmd/candela/sse_normalizer_test.go
+++ b/cmd/candela/sse_normalizer_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -38,10 +39,10 @@ func TestSSENormalizerNormalizeEvent(t *testing.T) {
 			wantJSON: `"content":""`,
 		},
 		{
-			name:     "normalize null content to empty string (Qwen finish)",
+			name:     "clear delta on finish_reason stop (Qwen finish)",
 			input:    `data: {"choices":[{"delta":{"content":null,"role":null},"finish_reason":"stop","index":0}],"created":123,"id":"x","model":"qwen","object":"chat.completion.chunk"}` + "\n\n",
 			wantNil:  false,
-			wantJSON: `"content":""`,
+			wantJSON: `"delta":{}`,
 		},
 		{
 			name:     "strip reasoning_content from delta",
@@ -189,4 +190,129 @@ func TestSSENormalizerWrite(t *testing.T) {
 			t.Error("DONE sentinel should be present")
 		}
 	})
+}
+
+func TestSSENormalizerFinalChunk(t *testing.T) {
+	n := newSSENormalizer(httptest.NewRecorder())
+
+	t.Run("clears delta on finish_reason stop", func(t *testing.T) {
+		// Claude sends {"delta":{"content":""},"finish_reason":"stop"} but
+		// LM Studio spec says final chunk should be {"delta":{},"finish_reason":"stop"}.
+		input := `data: {"choices":[{"delta":{"content":"","role":"assistant"},"finish_reason":"stop","index":0}],"created":123,"id":"x","model":"claude","object":"chat.completion.chunk"}` + "\n\n"
+		result := n.normalizeEvent([]byte(input))
+
+		if result == nil {
+			t.Fatal("expected event, got nil")
+		}
+		// Delta should be empty object.
+		if bytes.Contains(result, []byte(`"content"`)) {
+			t.Errorf("delta should be empty on stop, got: %s", string(result))
+		}
+		if bytes.Contains(result, []byte(`"role"`)) {
+			t.Errorf("delta should not contain role on stop, got: %s", string(result))
+		}
+		if !bytes.Contains(result, []byte(`"finish_reason":"stop"`)) {
+			t.Errorf("finish_reason should still be present, got: %s", string(result))
+		}
+	})
+
+	t.Run("preserves delta when finish_reason is null", func(t *testing.T) {
+		input := `data: {"choices":[{"delta":{"content":"hello"},"finish_reason":null,"index":0}],"created":123,"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+		result := n.normalizeEvent([]byte(input))
+
+		if result == nil {
+			t.Fatal("expected event, got nil")
+		}
+		if !bytes.Contains(result, []byte(`"content":"hello"`)) {
+			t.Errorf("content should be preserved when streaming, got: %s", string(result))
+		}
+	})
+}
+
+func TestSSENormalizerStripUpstreamHeaders(t *testing.T) {
+	t.Run("strips upstream headers for SSE responses", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSENormalizer(rec)
+
+		n.Header().Set("Content-Type", "text/event-stream")
+		n.Header().Set("Server", "Google Frontend")
+		n.Header().Set("Alt-Svc", `h3=":443"`)
+		n.Header().Set("Via", "1.1 google")
+		n.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		n.Header().Set("X-Vertex-Ai-Received-Request-Id", "abc-123")
+		n.WriteHeader(http.StatusOK)
+
+		for _, h := range []string{"Server", "Alt-Svc", "Via", "X-Frame-Options", "X-Vertex-Ai-Received-Request-Id"} {
+			if got := rec.Header().Get(h); got != "" {
+				t.Errorf("header %q should be stripped for SSE, got %q", h, got)
+			}
+		}
+		if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
+			t.Errorf("Content-Type should be preserved, got %q", got)
+		}
+	})
+
+	t.Run("preserves headers for non-SSE responses", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSENormalizer(rec)
+
+		n.Header().Set("Content-Type", "application/json")
+		n.Header().Set("Server", "Google Frontend")
+		n.Header().Set("Request-Id", "req-456")
+		n.WriteHeader(http.StatusBadRequest)
+
+		if got := rec.Header().Get("Server"); got != "Google Frontend" {
+			t.Errorf("Server header should be preserved for non-SSE, got %q", got)
+		}
+		if got := rec.Header().Get("Request-Id"); got != "req-456" {
+			t.Errorf("Request-Id should be preserved for non-SSE, got %q", got)
+		}
+	})
+}
+
+func TestServeChatStripEmptyTools(t *testing.T) {
+	// Simulate what JetBrains sends: {"model":"m","messages":[...],"tools":[],"tool_choice":"auto"}
+	body := []byte(`{"model":"test","messages":[{"role":"user","content":"hi"}],"tools":[],"tool_choice":"auto","stream":true}`)
+
+	var raw map[string]json.RawMessage
+	_ = json.Unmarshal(body, &raw)
+
+	// Verify tools is present before stripping.
+	if _, ok := raw["tools"]; !ok {
+		t.Fatal("test setup: tools should be present")
+	}
+
+	// Apply the same stripping logic as serveChat.
+	if toolsRaw, ok := raw["tools"]; ok {
+		var tools []json.RawMessage
+		if json.Unmarshal(toolsRaw, &tools) == nil && len(tools) == 0 {
+			delete(raw, "tools")
+			delete(raw, "tool_choice")
+		}
+	}
+
+	if _, ok := raw["tools"]; ok {
+		t.Error("empty tools[] should be stripped")
+	}
+	if _, ok := raw["tool_choice"]; ok {
+		t.Error("tool_choice should be stripped when tools is empty")
+	}
+}
+
+func TestServeChatStripStreamOptions(t *testing.T) {
+	body := []byte(`{"model":"test","messages":[{"role":"user","content":"hi"}],"stream":true,"stream_options":{"include_usage":true}}`)
+
+	var raw map[string]json.RawMessage
+	_ = json.Unmarshal(body, &raw)
+
+	if _, ok := raw["stream_options"]; !ok {
+		t.Fatal("test setup: stream_options should be present")
+	}
+
+	// Apply the same stripping logic as serveChat.
+	delete(raw, "stream_options")
+
+	if _, ok := raw["stream_options"]; ok {
+		t.Error("stream_options should be stripped")
+	}
 }


### PR DESCRIPTION
## Summary

Aligns Candela SSE proxy with the [LM Studio API spec](https://lmstudio.ai/docs/developer/rest) for full JetBrains AI Assistant compatibility across all model providers.

### Problem
JetBrains AI Chat sends request fields that strict backends reject, and upstream providers return SSE chunks that deviate from the LM Studio format JetBrains expects:

1. **`"tools": []`** — JetBrains always includes an empty tools array. Mistral/vLLM reject with HTTP 422.
2. **`"stream_options"`** — Not all upstreams support this field.
3. **Final chunk format** — Providers send `{"delta":{"content":""},"finish_reason":"stop"}` but LM Studio spec requires `{"delta":{},"finish_reason":"stop"}`.
4. **Upstream headers** — Google Frontend headers (`Server`, `Alt-Svc`, `Via`, `X-Frame-Options`) leak through the proxy.

### Changes

**Request normalization** (`serveChat`):
- Strip empty `tools:[]` and `tool_choice` from request body
- Strip `stream_options` from request body
- Consolidated with existing `max_tokens` injection into single JSON parse/rewrite pass

**Response normalization** (`sseNormalizer`):
- Clear delta to `{}` on final chunk with `finish_reason: "stop"` per LM Studio spec
- Strip upstream provider headers (`Server`, `Alt-Svc`, `Via`, `X-Frame-Options`, `X-Vertex-Ai-Received-Request-Id`, `Request-Id`)

### Testing
- 20 unit tests pass (7 new tests for LM Studio compat)
- Full test suite passes (45+ packages)
- golangci-lint: 0 issues

### Spec Reference
Based on thorough analysis of:
- [LM Studio REST API](https://lmstudio.ai/docs/developer/rest)
- JetBrains AI Assistant ktor client behavior (LMStudioClientAPI.kt)
- YouTrack issues LLM-25363, LLM-27045, LLM-28719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat request-body normalization by removing unsupported empty fields, stripping incompatible streaming options, and ensuring token limits are set when missing or invalid.
  * Cleaned up SSE response headers to remove provider/internal headers while preserving the event-stream content type.
  * Updated final-chunk SSE handling so completed responses produce a fully cleared delta payload.
* **Tests**
  * Added/updated unit tests to cover request cleanup (empty tools, stream options), SSE header stripping, and final-stream delta behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->