### PR TITLE
feat: LM Studio endpoints and test hardening

### DIFF
--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -159,14 +159,30 @@ func (h *lmHandler) loadRemoteModels() map[string]bool {
 
 func (h *lmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
+	// ── Model discovery ──
 	case r.URL.Path == "/v1/models" && r.Method == http.MethodGet:
 		h.serveModels(w, r)
 	case r.URL.Path == "/api/v0/models" && r.Method == http.MethodGet:
 		h.serveModels(w, r)
+
+	// ── Chat completions ──
 	case r.URL.Path == "/v1/chat/completions" && r.Method == http.MethodPost:
 		h.serveChat(w, r)
 	case r.URL.Path == "/api/v0/chat/completions" && r.Method == http.MethodPost:
 		h.serveChat(w, r)
+	case r.URL.Path == "/chat/completions" && r.Method == http.MethodPost:
+		h.serveChat(w, r)
+
+	// ── LM Studio / OpenAI compat stubs ──
+	case r.URL.Path == "/v1/completions" && r.Method == http.MethodPost:
+		h.serveCompletionsStub(w, r)
+	case r.URL.Path == "/v1/embeddings" && r.Method == http.MethodPost:
+		h.serveEmbeddingsStub(w, r)
+
+	// ── LM Studio diagnostics ──
+	case r.URL.Path == "/lmstudio/diagnostics" && r.Method == http.MethodGet:
+		h.serveDiagnostics(w, r)
+
 	default:
 		if h.remoteProxy != nil {
 			h.remoteProxy.ServeHTTP(w, r)
@@ -783,4 +799,57 @@ func (n *sseNormalizer) normalizeEvent(event []byte) []byte {
 	}
 
 	return event // fallback: pass through
+}
+
+// ── LM Studio compat endpoint stubs ──
+
+// serveCompletionsStub returns 501 for the legacy /v1/completions endpoint.
+// Candela is a chat-completions proxy and does not support the legacy
+// completions API. This prevents confusing 404s.
+func (h *lmHandler) serveCompletionsStub(w http.ResponseWriter, _ *http.Request) {
+	proxy.ProxyErrorResponse(w, http.StatusNotImplemented,
+		"legacy /v1/completions is not supported — use /v1/chat/completions",
+		"invalid_request_error")
+}
+
+// serveEmbeddingsStub returns 501 for the /v1/embeddings endpoint.
+// Candela does not currently support embedding generation. This prevents
+// confusing 404s when clients probe for capabilities.
+func (h *lmHandler) serveEmbeddingsStub(w http.ResponseWriter, _ *http.Request) {
+	proxy.ProxyErrorResponse(w, http.StatusNotImplemented,
+		"/v1/embeddings is not currently supported",
+		"invalid_request_error")
+}
+
+// serveDiagnostics returns a lightweight JSON health check compatible with
+// LM Studio's /lmstudio/diagnostics endpoint. JetBrains and other clients
+// may use this to verify the server is alive before sending requests.
+func (h *lmHandler) serveDiagnostics(w http.ResponseWriter, _ *http.Request) {
+	localCount := 0
+	if m := h.loadLocalModels(); m != nil {
+		localCount = len(m)
+	}
+	remoteCount := 0
+	if m := h.loadRemoteModels(); m != nil {
+		remoteCount = len(m)
+	}
+	cloudCount := len(h.cloudModels)
+
+	runtimeBackend := "none"
+	if h.mgr != nil {
+		runtimeBackend = h.mgr.Runtime().Name()
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status":  "ok",
+		"version": "candela",
+		"models": map[string]int{
+			"local":  localCount,
+			"remote": remoteCount,
+			"cloud":  cloudCount,
+			"total":  localCount + remoteCount + cloudCount,
+		},
+		"runtime": runtimeBackend,
+	})
 }

--- a/cmd/candela/sse_normalizer_test.go
+++ b/cmd/candela/sse_normalizer_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -314,5 +315,224 @@ func TestServeChatStripStreamOptions(t *testing.T) {
 
 	if _, ok := raw["stream_options"]; ok {
 		t.Error("stream_options should be stripped")
+	}
+}
+
+// ── Test Hardening: Edge Cases ──
+
+func TestSSENormalizerFinishReasonLength(t *testing.T) {
+	// finish_reason "length" means the model hit max_tokens — delta should NOT be cleared.
+	n := newSSENormalizer(httptest.NewRecorder())
+
+	input := `data: {"choices":[{"delta":{"content":"truncat"},"finish_reason":"length","index":0}],"created":123,"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+	result := n.normalizeEvent([]byte(input))
+
+	if result == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if !bytes.Contains(result, []byte(`"content":"truncat"`)) {
+		t.Errorf("content should be preserved for finish_reason=length, got: %s", string(result))
+	}
+}
+
+func TestServeChatPreserveNonEmptyTools(t *testing.T) {
+	// When tools array is non-empty, it must NOT be stripped.
+	body := []byte(`{"model":"test","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"get_weather"}}],"tool_choice":"auto","stream":true}`)
+
+	var raw map[string]json.RawMessage
+	_ = json.Unmarshal(body, &raw)
+
+	// Apply the same stripping logic as serveChat.
+	if toolsRaw, ok := raw["tools"]; ok {
+		var tools []json.RawMessage
+		if json.Unmarshal(toolsRaw, &tools) == nil && len(tools) == 0 {
+			delete(raw, "tools")
+			delete(raw, "tool_choice")
+		}
+	}
+
+	if _, ok := raw["tools"]; !ok {
+		t.Error("non-empty tools should be preserved")
+	}
+	if _, ok := raw["tool_choice"]; !ok {
+		t.Error("tool_choice should be preserved when tools is non-empty")
+	}
+}
+
+func TestSSENormalizerFinalChunkMatchedStop(t *testing.T) {
+	// Verify matched_stop is stripped from final chunk (Gemini review fix).
+	n := newSSENormalizer(httptest.NewRecorder())
+
+	input := `data: {"choices":[{"delta":{"content":"done"},"finish_reason":"stop","matched_stop":"<|endoftext|>","index":0}],"created":123,"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+	result := n.normalizeEvent([]byte(input))
+
+	if result == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if bytes.Contains(result, []byte("matched_stop")) {
+		t.Errorf("matched_stop should be stripped from final chunk, got: %s", string(result))
+	}
+	if !bytes.Contains(result, []byte(`"delta":{}`)) {
+		t.Errorf("delta should be empty on stop, got: %s", string(result))
+	}
+}
+
+// ── LM Studio Endpoint Tests ──
+
+func TestLMHandlerRouting(t *testing.T) {
+	h := newLMHandler(nil, nil, nil, nil, nil, nil, nil, true, 8192)
+
+	tests := []struct {
+		method string
+		path   string
+		want   int // expected status code
+	}{
+		// Model discovery
+		{"GET", "/v1/models", http.StatusOK},
+		// Chat completions aliases — can't easily test POST without body, but
+		// we can verify routing doesn't 404.
+		// Stubs should return 501
+		{"POST", "/v1/completions", http.StatusNotImplemented},
+		{"POST", "/v1/embeddings", http.StatusNotImplemented},
+		// Diagnostics
+		{"GET", "/lmstudio/diagnostics", http.StatusOK},
+		// Unknown paths in solo mode (no remote) → 404
+		{"GET", "/v1/unknown", http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.want {
+				t.Errorf("got status %d, want %d. Body: %s", rec.Code, tt.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestLMHandlerCompletionsStub(t *testing.T) {
+	h := newLMHandler(nil, nil, nil, nil, nil, nil, nil, true, 8192)
+
+	req := httptest.NewRequest("POST", "/v1/completions", strings.NewReader(`{"model":"test","prompt":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "/v1/chat/completions") {
+		t.Errorf("error should mention chat/completions endpoint, got: %s", body)
+	}
+}
+
+func TestLMHandlerEmbeddingsStub(t *testing.T) {
+	h := newLMHandler(nil, nil, nil, nil, nil, nil, nil, true, 8192)
+
+	req := httptest.NewRequest("POST", "/v1/embeddings", strings.NewReader(`{"model":"test","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d", rec.Code)
+	}
+}
+
+func TestLMHandlerDiagnostics(t *testing.T) {
+	cloudModels := map[string]string{
+		"gpt-4":         "openai",
+		"claude-sonnet": "anthropic",
+	}
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, nil, true, 8192)
+
+	req := httptest.NewRequest("GET", "/lmstudio/diagnostics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if resp["status"] != "ok" {
+		t.Errorf("expected status ok, got %v", resp["status"])
+	}
+	if resp["version"] != "candela" {
+		t.Errorf("expected version candela, got %v", resp["version"])
+	}
+	if resp["runtime"] != "none" {
+		t.Errorf("expected runtime none (no manager), got %v", resp["runtime"])
+	}
+
+	models, ok := resp["models"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected models map, got %T", resp["models"])
+	}
+	if total, ok := models["total"].(float64); !ok || int(total) != 2 {
+		t.Errorf("expected 2 total models (cloud), got %v", models["total"])
+	}
+}
+
+func TestLMHandlerChatCompletionsPathAlias(t *testing.T) {
+	// /chat/completions (without /v1 prefix) should also be routed to serveChat.
+	h := newLMHandler(nil, nil, nil, nil, nil, nil, nil, true, 8192)
+
+	body := `{"model":"nonexistent","messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest("POST", "/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	// It should be routed to serveChat (not the default handler). serveChat
+	// returns "model not found locally" for unknown models, whereas the
+	// default fallback returns "solo mode — no remote server configured".
+	respBody := rec.Body.String()
+	if strings.Contains(respBody, "solo mode") {
+		t.Errorf("/chat/completions should route to serveChat, not default handler: %s", respBody)
+	}
+	if !strings.Contains(respBody, "model not found") {
+		t.Errorf("expected model-not-found error from serveChat, got: %s", respBody)
+	}
+}
+
+func TestSSENormalizerMultipleChunksEndToEnd(t *testing.T) {
+	// Simulate a complete LM Studio-compatible stream: first chunk (role),
+	// content chunks, final chunk (stop), and [DONE].
+	rec := httptest.NewRecorder()
+	n := newSSENormalizer(rec)
+
+	first := `data: {"choices":[{"delta":{"role":"assistant"},"finish_reason":null,"index":0}],"created":123,"id":"chatcmpl-abc","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+	content := `data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null,"index":0}],"created":123,"id":"chatcmpl-abc","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+	final := `data: {"choices":[{"delta":{"content":""},"finish_reason":"stop","index":0}],"created":123,"id":"chatcmpl-abc","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+	done := "data: [DONE]\n\n"
+
+	_, _ = n.Write([]byte(first + content + final + done))
+
+	body := rec.Body.String()
+
+	// First chunk should have content:"" added (role-only delta).
+	if !strings.Contains(body, `"role":"assistant"`) {
+		t.Error("first chunk should contain role")
+	}
+	// Content chunk should pass through.
+	if !strings.Contains(body, `"content":"Hello"`) {
+		t.Error("content chunk should pass through")
+	}
+	// Final chunk should have empty delta.
+	if !strings.Contains(body, `"delta":{}`) {
+		t.Errorf("final chunk should have empty delta, got: %s", body)
+	}
+	// DONE sentinel must be present.
+	if !strings.Contains(body, "[DONE]") {
+		t.Error("DONE sentinel should be present")
 	}
 }


### PR DESCRIPTION
## Summary

Adds LM Studio-specific endpoints and comprehensive test hardening.

### New Endpoints

| Endpoint | Method | Response | Purpose |
|----------|--------|----------|---------|
| `/v1/completions` | POST | 501 + redirect | Legacy completions stub |
| `/v1/embeddings` | POST | 501 | Embedding stub |
| `/lmstudio/diagnostics` | GET | 200 + JSON | Health check with model counts |
| `/chat/completions` | POST | serveChat | Path alias (no /v1 prefix) |

### Test Hardening (9 new tests)
- finish_reason=length preserves delta
- Non-empty tools NOT stripped
- matched_stop cleaned from final chunk
- Table-driven endpoint routing
- Completions/embeddings 501 stubs
- Diagnostics response validation
- /chat/completions path alias routing
- Full end-to-end stream simulation

All 45+ packages pass, 0 lint issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional AI-compatible endpoints, including model listing, chat completions, and a diagnostics view.
  * Enabled a direct chat-completions path for broader compatibility.
* **Bug Fixes**
  * Improved streaming response handling so partial content and final stop states are preserved correctly.
  * Kept tool-related fields intact in chat responses when tools are provided.
* **Tests**
  * Expanded coverage for endpoint routing, diagnostics, legacy endpoint behavior, and end-to-end streaming normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->