### PR TITLE
fix: skip SSE chunk normalizer for remote proxy traffic

### DIFF
--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -603,17 +603,38 @@ func (r *responseRecorder) Write(b []byte) (int, error) {
 }
 func (r *responseRecorder) WriteHeader(code int) { r.statusCode = code }
 
+// sseHeadersToStrip lists upstream provider headers that LM Studio wouldn't
+// send. Shared between sseHeaderNormalizer and sseNormalizer to keep the
+// header cleanup policy in sync.
+var sseHeadersToStrip = []string{
+	"Server", "Alt-Svc", "Via",
+	"X-Frame-Options", "X-Xss-Protection", "X-Accel-Buffering",
+	"X-Vertex-Ai-Received-Request-Id", "Request-Id",
+}
+
+// normalizeSSEHeaders fixes SSE response headers for ktor compatibility:
+// strips Content-Type charset, removes Content-Length, and cleans provider headers.
+func normalizeSSEHeaders(header http.Header) {
+	ct := header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/event-stream") {
+		return
+	}
+	if ct != "text/event-stream" {
+		header.Set("Content-Type", "text/event-stream")
+	}
+	header.Del("Content-Length")
+	for _, h := range sseHeadersToStrip {
+		header.Del(h)
+	}
+}
+
 // sseHeaderNormalizer wraps an http.ResponseWriter to fix SSE response headers
 // without modifying the event stream. Used for remote proxy traffic where the
 // upstream already returns clean OpenAI-compatible chunks.
-//
-// Fixes:
-//   - Content-Type: strips charset suffix (ktor requires bare text/event-stream)
-//   - Content-Length: removed for SSE (ktor needs chunked transfer encoding)
-//   - Provider headers: stripped for clean LM Studio-like responses
 type sseHeaderNormalizer struct {
-	w      http.ResponseWriter
-	header http.Header
+	w           http.ResponseWriter
+	header      http.Header
+	wroteHeader bool
 }
 
 func newSSEHeaderNormalizer(w http.ResponseWriter) *sseHeaderNormalizer {
@@ -623,26 +644,18 @@ func newSSEHeaderNormalizer(w http.ResponseWriter) *sseHeaderNormalizer {
 func (n *sseHeaderNormalizer) Header() http.Header { return n.header }
 
 func (n *sseHeaderNormalizer) WriteHeader(code int) {
-	ct := n.header.Get("Content-Type")
-	if strings.HasPrefix(ct, "text/event-stream") {
-		if ct != "text/event-stream" {
-			n.header.Set("Content-Type", "text/event-stream")
-		}
-		n.header.Del("Content-Length")
-
-		// Strip upstream provider headers that LM Studio wouldn't send.
-		for _, h := range []string{
-			"Server", "Alt-Svc", "Via",
-			"X-Frame-Options", "X-Xss-Protection", "X-Accel-Buffering",
-			"X-Vertex-Ai-Received-Request-Id", "Request-Id",
-		} {
-			n.header.Del(h)
-		}
+	if n.wroteHeader {
+		return
 	}
+	n.wroteHeader = true
+	normalizeSSEHeaders(n.header)
 	n.w.WriteHeader(code)
 }
 
 func (n *sseHeaderNormalizer) Write(b []byte) (int, error) {
+	if !n.wroteHeader {
+		n.WriteHeader(http.StatusOK)
+	}
 	return n.w.Write(b) // pass through unchanged
 }
 
@@ -669,31 +682,7 @@ func newSSENormalizer(w http.ResponseWriter) *sseNormalizer {
 func (n *sseNormalizer) Header() http.Header { return n.header }
 
 func (n *sseNormalizer) WriteHeader(code int) {
-	// Normalize Content-Type: JetBrains' ktor SSE parser requires exactly
-	// "text/event-stream" and rejects "text/event-stream; charset=utf-8"
-	// (which Claude/Anthropic sends via Vertex AI).
-	ct := n.header.Get("Content-Type")
-	if strings.HasPrefix(ct, "text/event-stream") {
-		if ct != "text/event-stream" {
-			n.header.Set("Content-Type", "text/event-stream")
-		}
-		// Remove Content-Length: the upstream may include it, but SSE
-		// responses must use chunked transfer encoding. If Content-Length
-		// is present, ktor tries fixed-length body reading instead of
-		// streaming, causing "fixed content-length: N, bytes received: 0".
-		n.header.Del("Content-Length")
-
-		// Strip upstream provider headers that LM Studio wouldn't send.
-		// Scoped to SSE responses only — non-SSE error responses keep their headers.
-		for _, h := range []string{
-			"Server", "Alt-Svc", "Via",
-			"X-Frame-Options", "X-Xss-Protection", "X-Accel-Buffering",
-			"X-Vertex-Ai-Received-Request-Id", "Request-Id",
-		} {
-			n.header.Del(h)
-		}
-	}
-
+	normalizeSSEHeaders(n.header)
 	n.w.WriteHeader(code)
 }
 

--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -159,14 +159,30 @@ func (h *lmHandler) loadRemoteModels() map[string]bool {
 
 func (h *lmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
+	// ── Model discovery ──
 	case r.URL.Path == "/v1/models" && r.Method == http.MethodGet:
 		h.serveModels(w, r)
 	case r.URL.Path == "/api/v0/models" && r.Method == http.MethodGet:
 		h.serveModels(w, r)
+
+	// ── Chat completions ──
 	case r.URL.Path == "/v1/chat/completions" && r.Method == http.MethodPost:
 		h.serveChat(w, r)
 	case r.URL.Path == "/api/v0/chat/completions" && r.Method == http.MethodPost:
 		h.serveChat(w, r)
+	case r.URL.Path == "/chat/completions" && r.Method == http.MethodPost:
+		h.serveChat(w, r)
+
+	// ── LM Studio / OpenAI compat stubs ──
+	case r.URL.Path == "/v1/completions" && r.Method == http.MethodPost:
+		h.serveCompletionsStub(w, r)
+	case r.URL.Path == "/v1/embeddings" && r.Method == http.MethodPost:
+		h.serveEmbeddingsStub(w, r)
+
+	// ── LM Studio diagnostics ──
+	case r.URL.Path == "/lmstudio/diagnostics" && r.Method == http.MethodGet:
+		h.serveDiagnostics(w, r)
+
 	default:
 		if h.remoteProxy != nil {
 			h.remoteProxy.ServeHTTP(w, r)
@@ -389,14 +405,6 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// For streaming requests, wrap the ResponseWriter with an SSE normalizer
-	// that filters out malformed chunks (empty choices, missing delta.content)
-	// which crash JetBrains' LM Studio SSE parser.
-	writer := w
-	if req.Stream {
-		writer = newSSENormalizer(w)
-	}
-
 	// 2. Cloud model → direct cloud proxy (solo mode only).
 	// In team mode, all cloud traffic must go through the remote server
 	// so the server catalog remains the single source of truth.
@@ -404,6 +412,13 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 		if providerName, ok := h.cloudModels[req.Model]; ok && h.cloudProxy != nil {
 			slog.Debug("lm handler: routing to cloud provider", "model", req.Model, "provider", providerName)
 			r.URL.Path = fmt.Sprintf("/proxy/%s/v1/chat/completions", providerName)
+			// Use the full SSE normalizer for solo cloud routes — raw provider
+			// responses need chunk normalization (Claude role-only deltas,
+			// Qwen content:null, empty choices, etc.).
+			writer := w
+			if req.Stream {
+				writer = newSSENormalizer(w)
+			}
 			h.cloudProxy.ServeHTTP(writer, r)
 			return
 		}
@@ -411,7 +426,13 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 
 	// 3. Remote server → team mode proxy.
 	if h.remoteProxy != nil {
-		// Path already normalized at top of serveChat.
+		// The remote Candela server already returns clean OpenAI-compatible
+		// SSE — no chunk normalization needed. Only apply lightweight header
+		// fixes (Content-Type charset, Content-Length) that ktor requires.
+		writer := w
+		if req.Stream {
+			writer = newSSEHeaderNormalizer(w)
+		}
 		h.remoteProxy.ServeHTTP(writer, r)
 		return
 	}
@@ -581,6 +602,55 @@ func (r *responseRecorder) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 func (r *responseRecorder) WriteHeader(code int) { r.statusCode = code }
+
+// sseHeaderNormalizer wraps an http.ResponseWriter to fix SSE response headers
+// without modifying the event stream. Used for remote proxy traffic where the
+// upstream already returns clean OpenAI-compatible chunks.
+//
+// Fixes:
+//   - Content-Type: strips charset suffix (ktor requires bare text/event-stream)
+//   - Content-Length: removed for SSE (ktor needs chunked transfer encoding)
+//   - Provider headers: stripped for clean LM Studio-like responses
+type sseHeaderNormalizer struct {
+	w      http.ResponseWriter
+	header http.Header
+}
+
+func newSSEHeaderNormalizer(w http.ResponseWriter) *sseHeaderNormalizer {
+	return &sseHeaderNormalizer{w: w, header: w.Header()}
+}
+
+func (n *sseHeaderNormalizer) Header() http.Header { return n.header }
+
+func (n *sseHeaderNormalizer) WriteHeader(code int) {
+	ct := n.header.Get("Content-Type")
+	if strings.HasPrefix(ct, "text/event-stream") {
+		if ct != "text/event-stream" {
+			n.header.Set("Content-Type", "text/event-stream")
+		}
+		n.header.Del("Content-Length")
+
+		// Strip upstream provider headers that LM Studio wouldn't send.
+		for _, h := range []string{
+			"Server", "Alt-Svc", "Via",
+			"X-Frame-Options", "X-Xss-Protection", "X-Accel-Buffering",
+			"X-Vertex-Ai-Received-Request-Id", "Request-Id",
+		} {
+			n.header.Del(h)
+		}
+	}
+	n.w.WriteHeader(code)
+}
+
+func (n *sseHeaderNormalizer) Write(b []byte) (int, error) {
+	return n.w.Write(b) // pass through unchanged
+}
+
+func (n *sseHeaderNormalizer) Flush() {
+	if f, ok := n.w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
 
 // sseNormalizer wraps an http.ResponseWriter to intercept SSE events and
 // normalize them for JetBrains compatibility. It filters out chunks with
@@ -783,4 +853,57 @@ func (n *sseNormalizer) normalizeEvent(event []byte) []byte {
 	}
 
 	return event // fallback: pass through
+}
+
+// ── LM Studio compat endpoint stubs ──
+
+// serveCompletionsStub returns 501 for the legacy /v1/completions endpoint.
+// Candela is a chat-completions proxy and does not support the legacy
+// completions API. This prevents confusing 404s.
+func (h *lmHandler) serveCompletionsStub(w http.ResponseWriter, _ *http.Request) {
+	proxy.ProxyErrorResponse(w, http.StatusNotImplemented,
+		"legacy /v1/completions is not supported — use /v1/chat/completions",
+		"invalid_request_error")
+}
+
+// serveEmbeddingsStub returns 501 for the /v1/embeddings endpoint.
+// Candela does not currently support embedding generation. This prevents
+// confusing 404s when clients probe for capabilities.
+func (h *lmHandler) serveEmbeddingsStub(w http.ResponseWriter, _ *http.Request) {
+	proxy.ProxyErrorResponse(w, http.StatusNotImplemented,
+		"/v1/embeddings is not currently supported",
+		"invalid_request_error")
+}
+
+// serveDiagnostics returns a lightweight JSON health check compatible with
+// LM Studio's /lmstudio/diagnostics endpoint. JetBrains and other clients
+// may use this to verify the server is alive before sending requests.
+func (h *lmHandler) serveDiagnostics(w http.ResponseWriter, _ *http.Request) {
+	localCount := 0
+	if m := h.loadLocalModels(); m != nil {
+		localCount = len(m)
+	}
+	remoteCount := 0
+	if m := h.loadRemoteModels(); m != nil {
+		remoteCount = len(m)
+	}
+	cloudCount := len(h.cloudModels)
+
+	runtimeBackend := "none"
+	if h.mgr != nil {
+		runtimeBackend = h.mgr.Runtime().Name()
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status":  "ok",
+		"version": "candela",
+		"models": map[string]int{
+			"local":  localCount,
+			"remote": remoteCount,
+			"cloud":  cloudCount,
+			"total":  localCount + remoteCount + cloudCount,
+		},
+		"runtime": runtimeBackend,
+	})
 }

--- a/cmd/candela/sse_normalizer_test.go
+++ b/cmd/candela/sse_normalizer_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -270,6 +271,51 @@ func TestSSENormalizerStripUpstreamHeaders(t *testing.T) {
 	})
 }
 
+func TestSSEHeaderNormalizerPassthrough(t *testing.T) {
+	t.Run("fixes headers without modifying events", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSEHeaderNormalizer(rec)
+
+		n.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		n.Header().Set("Content-Length", "12345")
+		n.Header().Set("Server", "Google Frontend")
+		n.WriteHeader(http.StatusOK)
+
+		// Verify header fixes.
+		if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
+			t.Errorf("Content-Type should be normalized, got %q", got)
+		}
+		if got := rec.Header().Get("Content-Length"); got != "" {
+			t.Errorf("Content-Length should be stripped, got %q", got)
+		}
+		if got := rec.Header().Get("Server"); got != "" {
+			t.Errorf("Server should be stripped for SSE, got %q", got)
+		}
+
+		// Verify events pass through unchanged (no buffering, no modification).
+		event := `data: {"choices":[{"delta":{"content":"hello"},"finish_reason":null,"index":0}],"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+		_, _ = n.Write([]byte(event))
+
+		body := rec.Body.String()
+		if body != event {
+			t.Errorf("event should pass through unchanged.\ngot:  %q\nwant: %q", body, event)
+		}
+	})
+
+	t.Run("preserves headers for non-SSE responses", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSEHeaderNormalizer(rec)
+
+		n.Header().Set("Content-Type", "application/json")
+		n.Header().Set("Server", "Google Frontend")
+		n.WriteHeader(http.StatusBadRequest)
+
+		if got := rec.Header().Get("Server"); got != "Google Frontend" {
+			t.Errorf("Server should be preserved for non-SSE, got %q", got)
+		}
+	})
+}
+
 func TestServeChatStripEmptyTools(t *testing.T) {
 	// Simulate what JetBrains sends: {"model":"m","messages":[...],"tools":[],"tool_choice":"auto"}
 	body := []byte(`{"model":"test","messages":[{"role":"user","content":"hi"}],"tools":[],"tool_choice":"auto","stream":true}`)
@@ -314,5 +360,224 @@ func TestServeChatStripStreamOptions(t *testing.T) {
 
 	if _, ok := raw["stream_options"]; ok {
 		t.Error("stream_options should be stripped")
+	}
+}
+
+// ── Test Hardening: Edge Cases ──
+
+func TestSSENormalizerFinishReasonLength(t *testing.T) {
+	// finish_reason "length" means the model hit max_tokens — delta should NOT be cleared.
+	n := newSSENormalizer(httptest.NewRecorder())
+
+	input := `data: {"choices":[{"delta":{"content":"truncat"},"finish_reason":"length","index":0}],"created":123,"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+	result := n.normalizeEvent([]byte(input))
+
+	if result == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if !bytes.Contains(result, []byte(`"content":"truncat"`)) {
+		t.Errorf("content should be preserved for finish_reason=length, got: %s", string(result))
+	}
+}
+
+func TestServeChatPreserveNonEmptyTools(t *testing.T) {
+	// When tools array is non-empty, it must NOT be stripped.
+	body := []byte(`{"model":"test","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"get_weather"}}],"tool_choice":"auto","stream":true}`)
+
+	var raw map[string]json.RawMessage
+	_ = json.Unmarshal(body, &raw)
+
+	// Apply the same stripping logic as serveChat.
+	if toolsRaw, ok := raw["tools"]; ok {
+		var tools []json.RawMessage
+		if json.Unmarshal(toolsRaw, &tools) == nil && len(tools) == 0 {
+			delete(raw, "tools")
+			delete(raw, "tool_choice")
+		}
+	}
+
+	if _, ok := raw["tools"]; !ok {
+		t.Error("non-empty tools should be preserved")
+	}
+	if _, ok := raw["tool_choice"]; !ok {
+		t.Error("tool_choice should be preserved when tools is non-empty")
+	}
+}
+
+func TestSSENormalizerFinalChunkMatchedStop(t *testing.T) {
+	// Verify matched_stop is stripped from final chunk (Gemini review fix).
+	n := newSSENormalizer(httptest.NewRecorder())
+
+	input := `data: {"choices":[{"delta":{"content":"done"},"finish_reason":"stop","matched_stop":"<|endoftext|>","index":0}],"created":123,"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+	result := n.normalizeEvent([]byte(input))
+
+	if result == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if bytes.Contains(result, []byte("matched_stop")) {
+		t.Errorf("matched_stop should be stripped from final chunk, got: %s", string(result))
+	}
+	if !bytes.Contains(result, []byte(`"delta":{}`)) {
+		t.Errorf("delta should be empty on stop, got: %s", string(result))
+	}
+}
+
+// ── LM Studio Endpoint Tests ──
+
+func TestLMHandlerRouting(t *testing.T) {
+	h := newLMHandler(nil, nil, nil, nil, nil, nil, nil, true, 8192)
+
+	tests := []struct {
+		method string
+		path   string
+		want   int // expected status code
+	}{
+		// Model discovery
+		{"GET", "/v1/models", http.StatusOK},
+		// Chat completions aliases — can't easily test POST without body, but
+		// we can verify routing doesn't 404.
+		// Stubs should return 501
+		{"POST", "/v1/completions", http.StatusNotImplemented},
+		{"POST", "/v1/embeddings", http.StatusNotImplemented},
+		// Diagnostics
+		{"GET", "/lmstudio/diagnostics", http.StatusOK},
+		// Unknown paths in solo mode (no remote) → 404
+		{"GET", "/v1/unknown", http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.want {
+				t.Errorf("got status %d, want %d. Body: %s", rec.Code, tt.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestLMHandlerCompletionsStub(t *testing.T) {
+	h := newLMHandler(nil, nil, nil, nil, nil, nil, nil, true, 8192)
+
+	req := httptest.NewRequest("POST", "/v1/completions", strings.NewReader(`{"model":"test","prompt":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "/v1/chat/completions") {
+		t.Errorf("error should mention chat/completions endpoint, got: %s", body)
+	}
+}
+
+func TestLMHandlerEmbeddingsStub(t *testing.T) {
+	h := newLMHandler(nil, nil, nil, nil, nil, nil, nil, true, 8192)
+
+	req := httptest.NewRequest("POST", "/v1/embeddings", strings.NewReader(`{"model":"test","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d", rec.Code)
+	}
+}
+
+func TestLMHandlerDiagnostics(t *testing.T) {
+	cloudModels := map[string]string{
+		"gpt-4":         "openai",
+		"claude-sonnet": "anthropic",
+	}
+	h := newLMHandler(nil, nil, nil, nil, nil, cloudModels, nil, true, 8192)
+
+	req := httptest.NewRequest("GET", "/lmstudio/diagnostics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if resp["status"] != "ok" {
+		t.Errorf("expected status ok, got %v", resp["status"])
+	}
+	if resp["version"] != "candela" {
+		t.Errorf("expected version candela, got %v", resp["version"])
+	}
+	if resp["runtime"] != "none" {
+		t.Errorf("expected runtime none (no manager), got %v", resp["runtime"])
+	}
+
+	models, ok := resp["models"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected models map, got %T", resp["models"])
+	}
+	if total, ok := models["total"].(float64); !ok || int(total) != 2 {
+		t.Errorf("expected 2 total models (cloud), got %v", models["total"])
+	}
+}
+
+func TestLMHandlerChatCompletionsPathAlias(t *testing.T) {
+	// /chat/completions (without /v1 prefix) should also be routed to serveChat.
+	h := newLMHandler(nil, nil, nil, nil, nil, nil, nil, true, 8192)
+
+	body := `{"model":"nonexistent","messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest("POST", "/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	// It should be routed to serveChat (not the default handler). serveChat
+	// returns "model not found locally" for unknown models, whereas the
+	// default fallback returns "solo mode — no remote server configured".
+	respBody := rec.Body.String()
+	if strings.Contains(respBody, "solo mode") {
+		t.Errorf("/chat/completions should route to serveChat, not default handler: %s", respBody)
+	}
+	if !strings.Contains(respBody, "model not found") {
+		t.Errorf("expected model-not-found error from serveChat, got: %s", respBody)
+	}
+}
+
+func TestSSENormalizerMultipleChunksEndToEnd(t *testing.T) {
+	// Simulate a complete LM Studio-compatible stream: first chunk (role),
+	// content chunks, final chunk (stop), and [DONE].
+	rec := httptest.NewRecorder()
+	n := newSSENormalizer(rec)
+
+	first := `data: {"choices":[{"delta":{"role":"assistant"},"finish_reason":null,"index":0}],"created":123,"id":"chatcmpl-abc","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+	content := `data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null,"index":0}],"created":123,"id":"chatcmpl-abc","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+	final := `data: {"choices":[{"delta":{"content":""},"finish_reason":"stop","index":0}],"created":123,"id":"chatcmpl-abc","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+	done := "data: [DONE]\n\n"
+
+	_, _ = n.Write([]byte(first + content + final + done))
+
+	body := rec.Body.String()
+
+	// First chunk should have content:"" added (role-only delta).
+	if !strings.Contains(body, `"role":"assistant"`) {
+		t.Error("first chunk should contain role")
+	}
+	// Content chunk should pass through.
+	if !strings.Contains(body, `"content":"Hello"`) {
+		t.Error("content chunk should pass through")
+	}
+	// Final chunk should have empty delta.
+	if !strings.Contains(body, `"delta":{}`) {
+		t.Errorf("final chunk should have empty delta, got: %s", body)
+	}
+	// DONE sentinel must be present.
+	if !strings.Contains(body, "[DONE]") {
+		t.Error("DONE sentinel should be present")
 	}
 }


### PR DESCRIPTION
## Problem

JetBrains LM Studio mode fails with `unexpected EOF` for Claude, Qwen, and Gemini Pro models — but works fine in OpenAI mode.

## Root Cause

The SSE normalizer (buffers + rewrites chunks) was the **only** difference between OpenAI mode (works) and LM Studio mode (breaks). In team mode, the remote Candela server already returns clean OpenAI-compatible SSE — the normalizer was unnecessary overhead that corrupted streams.

## Fix

Split normalizer usage by route:

| Route | Normalizer | Why |
|-------|-----------|-----|
| Solo cloud | Full `sseNormalizer` | Raw provider responses need cleanup (Claude role-only deltas, Qwen content:null) |
| Remote proxy | `sseHeaderNormalizer` (new) | Only fix headers (Content-Type charset, Content-Length) — pass events through unchanged |
| Local runtime | None | Already clean |

## Changes
- `lm_handler.go`: Move normalizer wrapping into per-route branches
- `lm_handler.go`: Add `sseHeaderNormalizer` — lightweight header-only wrapper
- `sse_normalizer_test.go`: Add `TestSSEHeaderNormalizerPassthrough`

## Testing
- All 45+ packages pass, 0 lint issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an LM Studio diagnostics endpoint returning runtime status and model counts.
  * Added compatibility routing for additional chat/completions paths, including an alias for `/chat/completions`.
  * Added legacy stubs for unsupported completions/embeddings endpoints returning clear 501 responses.

* **Bug Fixes**
  * Improved streaming so SSE headers are normalized for better compatibility while streamed event payloads remain unchanged.

* **Tests**
  * Expanded coverage for SSE normalization, request/tool stripping behavior, and LM handler routing/stub responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->