### PR TITLE
fix: JetBrains LM Studio compat — ktor EOF workaround + request sanitization

### DIFF
--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -158,6 +158,7 @@ func (h *lmHandler) loadRemoteModels() map[string]bool {
 }
 
 func (h *lmHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	slog.Info("lm: request", "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr, "ua", r.UserAgent())
 	switch {
 	// ── Model discovery ──
 	case r.URL.Path == "/v1/models" && r.Method == http.MethodGet:
@@ -340,6 +341,12 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = json.Unmarshal(body, &req)
 
+	slog.Debug("lm: chat request",
+		"model", req.Model,
+		"stream", req.Stream,
+		"path", r.URL.Path,
+		"ua", r.UserAgent())
+
 	// Normalize path early so all backends (local, cloud, remote) receive
 	// the standard /v1/ path regardless of what the client sent.
 	r.URL.Path = "/v1/chat/completions"
@@ -378,6 +385,40 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 			if _, ok := raw["stream_options"]; ok {
 				delete(raw, "stream_options")
 				needRewrite = true
+			}
+
+			// Strip LM Studio / Ollama-specific fields that strict
+			// backends (Mistral, vLLM) reject with HTTP 422.
+			for _, field := range []string{"format", "keep_alive", "options"} {
+				if _, ok := raw[field]; ok {
+					delete(raw, field)
+					needRewrite = true
+				}
+			}
+
+			// Strip per-message "tool_calls":[] — JetBrains adds an empty
+			// tool_calls array to every message (system, user, assistant).
+			// Mistral rejects these with "Extra inputs are not permitted".
+			if msgsRaw, ok := raw["messages"]; ok {
+				var msgs []map[string]json.RawMessage
+				if json.Unmarshal(msgsRaw, &msgs) == nil {
+					stripped := false
+					for i := range msgs {
+						if tcRaw, hasTc := msgs[i]["tool_calls"]; hasTc {
+							var tc []json.RawMessage
+							if json.Unmarshal(tcRaw, &tc) == nil && len(tc) == 0 {
+								delete(msgs[i], "tool_calls")
+								stripped = true
+							}
+						}
+					}
+					if stripped {
+						if b, err := json.Marshal(msgs); err == nil {
+							raw["messages"] = b
+							needRewrite = true
+						}
+					}
+				}
 			}
 
 			if needRewrite {
@@ -427,13 +468,54 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 	// 3. Remote server → team mode proxy.
 	if h.remoteProxy != nil {
 		// The remote Candela server already returns clean OpenAI-compatible
-		// SSE — no chunk normalization needed. Only apply lightweight header
-		// fixes (Content-Type charset, Content-Length) that ktor requires.
-		writer := w
-		if req.Stream {
-			writer = newSSEHeaderNormalizer(w)
+		// SSE — no chunk normalization needed. Header normalization is
+		// handled by the proxy's ModifyResponse callback.
+		h.remoteProxy.ServeHTTP(w, r)
+
+		// ── Ktor chunked-encoding workaround ──
+		//
+		// Background: Go's net/http uses chunked transfer encoding for
+		// streaming responses. When this handler returns, Go writes the
+		// chunked terminator ("0\r\n\r\n") to signal end-of-body.
+		//
+		// Problem: JetBrains' AI Assistant uses ktor's LMStudioClientAPI
+		// for its "LM Studio" provider mode. Ktor's SSE parser treats the
+		// chunked terminator as an unexpected EOF, even though the stream
+		// already sent "data: [DONE]". This is a ktor client bug — all
+		// other HTTP clients (curl, Continue, Cursor) handle this correctly.
+		//
+		// Evidence: Models whose upstream keeps the response body open
+		// indefinitely (like Gemini via Google Frontend) work fine because
+		// Go never writes the terminator. Models that close promptly
+		// (Claude, Qwen, Mistral) all trigger "unexpected EOF".
+		//
+		// Fix: After the proxy finishes writing the SSE stream, hijack the
+		// TCP connection. This transfers socket ownership from Go's HTTP
+		// server to us, preventing the chunked terminator from ever being
+		// written. We then hold the connection open until the client
+		// disconnects (ktor closes after processing [DONE]) or a safety
+		// timeout fires.
+		//
+		// Scope: Only applied for ktor-client (JetBrains) on streaming
+		// requests. Other clients handle chunked encoding correctly and
+		// get normal Go HTTP behavior.
+		isKtor := strings.Contains(r.UserAgent(), "ktor")
+		if req.Stream && isKtor {
+			if hj, ok := w.(http.Hijacker); ok {
+				conn, buf, err := hj.Hijack()
+				if err == nil {
+					// Flush any pending data in the bufio.Writer.
+					if buf != nil {
+						_ = buf.Flush()
+					}
+					// Wait for ktor to close the connection (with safety timeout).
+					_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+					tmp := make([]byte, 1)
+					_, _ = conn.Read(tmp) // blocks until client disconnect or timeout
+					_ = conn.Close()
+				}
+			}
 		}
-		h.remoteProxy.ServeHTTP(writer, r)
 		return
 	}
 
@@ -628,22 +710,30 @@ func normalizeSSEHeaders(header http.Header) {
 	}
 }
 
-// sseHeaderNormalizer wraps an http.ResponseWriter to fix SSE response headers
-// without modifying the event stream. Used for remote proxy traffic where the
-// upstream already returns clean OpenAI-compatible chunks.
-type sseHeaderNormalizer struct {
+// sseLiteNormalizer wraps an http.ResponseWriter to fix SSE response headers
+// and ensure delta.content is always present. Used for remote proxy traffic
+// where the upstream returns clean OpenAI-compatible chunks but may omit
+// delta.content in role-only chunks (e.g., Claude's first chunk has only
+// delta.role, which crashes JetBrains' ktor SSE parser).
+//
+// Unlike the full sseNormalizer, this does NOT:
+//   - Filter/drop events (no empty-choices suppression)
+//   - Clear deltas on finish_reason
+//   - Strip reasoning_content or tool_calls
+type sseLiteNormalizer struct {
 	w           http.ResponseWriter
+	buf         []byte
 	header      http.Header
 	wroteHeader bool
 }
 
-func newSSEHeaderNormalizer(w http.ResponseWriter) *sseHeaderNormalizer {
-	return &sseHeaderNormalizer{w: w, header: w.Header()}
+func newSSELiteNormalizer(w http.ResponseWriter) *sseLiteNormalizer {
+	return &sseLiteNormalizer{w: w, header: w.Header()}
 }
 
-func (n *sseHeaderNormalizer) Header() http.Header { return n.header }
+func (n *sseLiteNormalizer) Header() http.Header { return n.header }
 
-func (n *sseHeaderNormalizer) WriteHeader(code int) {
+func (n *sseLiteNormalizer) WriteHeader(code int) {
 	if n.wroteHeader {
 		return
 	}
@@ -652,14 +742,96 @@ func (n *sseHeaderNormalizer) WriteHeader(code int) {
 	n.w.WriteHeader(code)
 }
 
-func (n *sseHeaderNormalizer) Write(b []byte) (int, error) {
+func (n *sseLiteNormalizer) Write(b []byte) (int, error) {
 	if !n.wroteHeader {
 		n.WriteHeader(http.StatusOK)
 	}
-	return n.w.Write(b) // pass through unchanged
+
+	originalLen := len(b)
+	n.buf = append(n.buf, b...)
+
+	var out bytes.Buffer
+	for {
+		idx := bytes.Index(n.buf, []byte("\n\n"))
+		if idx == -1 {
+			break
+		}
+		event := n.buf[:idx+2]
+		n.buf = n.buf[idx+2:]
+
+		patched := n.ensureContent(event)
+		out.Write(patched)
+	}
+	if out.Len() > 0 {
+		if _, err := n.w.Write(out.Bytes()); err != nil {
+			return originalLen, err
+		}
+		n.Flush()
+	}
+	return originalLen, nil
 }
 
-func (n *sseHeaderNormalizer) Flush() {
+// ensureContent adds delta.content:"" if missing or null, which ktor requires.
+func (n *sseLiteNormalizer) ensureContent(event []byte) []byte {
+	line := bytes.TrimSpace(event)
+	if !bytes.HasPrefix(line, []byte("data: ")) {
+		return event
+	}
+	payload := bytes.TrimPrefix(line, []byte("data: "))
+	if bytes.Equal(payload, []byte("[DONE]")) {
+		return event
+	}
+
+	var chunk map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &chunk); err != nil {
+		return event
+	}
+	choicesRaw, ok := chunk["choices"]
+	if !ok {
+		return event
+	}
+	var choices []map[string]json.RawMessage
+	if err := json.Unmarshal(choicesRaw, &choices); err != nil {
+		return event
+	}
+
+	modified := false
+	for i := range choices {
+		deltaRaw, hasDelta := choices[i]["delta"]
+		if !hasDelta {
+			continue
+		}
+		var delta map[string]json.RawMessage
+		if err := json.Unmarshal(deltaRaw, &delta); err != nil {
+			continue
+		}
+		contentRaw, hasContent := delta["content"]
+		if !hasContent || bytes.Equal(contentRaw, []byte("null")) {
+			delta["content"] = json.RawMessage(`""`)
+			modified = true
+			if b, err := json.Marshal(delta); err == nil {
+				choices[i]["delta"] = b
+			}
+		}
+	}
+
+	if !modified {
+		return event
+	}
+	if b, err := json.Marshal(choices); err == nil {
+		chunk["choices"] = b
+	}
+	if b, err := json.Marshal(chunk); err == nil {
+		var out bytes.Buffer
+		out.WriteString("data: ")
+		out.Write(b)
+		out.WriteString("\n\n")
+		return out.Bytes()
+	}
+	return event
+}
+
+func (n *sseLiteNormalizer) Flush() {
 	if f, ok := n.w.(http.Flusher); ok {
 		f.Flush()
 	}

--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -387,39 +387,10 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 				needRewrite = true
 			}
 
-			// Strip LM Studio / Ollama-specific fields that strict
-			// backends (Mistral, vLLM) reject with HTTP 422.
-			for _, field := range []string{"format", "keep_alive", "options"} {
-				if _, ok := raw[field]; ok {
-					delete(raw, field)
-					needRewrite = true
-				}
-			}
-
-			// Strip per-message "tool_calls":[] — JetBrains adds an empty
-			// tool_calls array to every message (system, user, assistant).
-			// Mistral rejects these with "Extra inputs are not permitted".
-			if msgsRaw, ok := raw["messages"]; ok {
-				var msgs []map[string]json.RawMessage
-				if json.Unmarshal(msgsRaw, &msgs) == nil {
-					stripped := false
-					for i := range msgs {
-						if tcRaw, hasTc := msgs[i]["tool_calls"]; hasTc {
-							var tc []json.RawMessage
-							if json.Unmarshal(tcRaw, &tc) == nil && len(tc) == 0 {
-								delete(msgs[i], "tool_calls")
-								stripped = true
-							}
-						}
-					}
-					if stripped {
-						if b, err := json.Marshal(msgs); err == nil {
-							raw["messages"] = b
-							needRewrite = true
-						}
-					}
-				}
-			}
+			// NOTE: LM Studio / Ollama-specific fields (format, keep_alive,
+			// options) are NOT stripped here because local runtimes need them.
+			// They are stripped later, only for cloud/remote routes.
+			// See stripRemoteOnlyFields below.
 
 			if needRewrite {
 				body, _ = json.Marshal(raw)
@@ -440,11 +411,20 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 	r.ContentLength = int64(len(body))
 
 	// 1. Local model → local runtime (with span capture).
+	// Local runtimes (Ollama, LM Studio) understand fields like format,
+	// keep_alive, and options — don't strip them.
 	if h.isLocalModel(req.Model) {
 		slog.Debug("lm handler: routing to local runtime", "model", req.Model)
 		h.localHandler.ServeHTTP(w, r)
 		return
 	}
+
+	// Strip LM Studio / Ollama-specific fields that strict cloud/remote
+	// backends (Mistral, vLLM) reject with HTTP 422. This runs AFTER
+	// local-model routing so local runtimes keep their native fields.
+	body = stripRemoteOnlyFields(body)
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
 
 	// 2. Cloud model → direct cloud proxy (solo mode only).
 	// In team mode, all cloud traffic must go through the remote server
@@ -467,10 +447,16 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 
 	// 3. Remote server → team mode proxy.
 	if h.remoteProxy != nil {
-		// The remote Candela server already returns clean OpenAI-compatible
-		// SSE — no chunk normalization needed. Header normalization is
-		// handled by the proxy's ModifyResponse callback.
-		h.remoteProxy.ServeHTTP(w, r)
+		// The remote Candela server returns clean OpenAI-compatible SSE.
+		// Apply lightweight normalization: the sseLiteNormalizer ensures
+		// delta.content is always present (ktor crashes on role-only
+		// chunks), and the proxy's ModifyResponse callback handles
+		// header normalization.
+		writer := http.ResponseWriter(w)
+		if req.Stream {
+			writer = newSSELiteNormalizer(w)
+		}
+		h.remoteProxy.ServeHTTP(writer, r)
 
 		// ── Ktor chunked-encoding workaround ──
 		//
@@ -497,10 +483,11 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 		// timeout fires.
 		//
 		// Scope: Only applied for ktor-client (JetBrains) on streaming
-		// requests. Other clients handle chunked encoding correctly and
-		// get normal Go HTTP behavior.
+		// requests that actually returned SSE. Error responses (4xx/5xx
+		// JSON) are excluded — ktor handles those correctly.
 		isKtor := strings.Contains(r.UserAgent(), "ktor")
-		if req.Stream && isKtor {
+		respondedSSE := strings.HasPrefix(w.Header().Get("Content-Type"), "text/event-stream")
+		if req.Stream && isKtor && respondedSSE {
 			if hj, ok := w.(http.Hijacker); ok {
 				conn, buf, err := hj.Hijack()
 				if err == nil {
@@ -521,6 +508,57 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 
 	// 4. No handler found.
 	proxy.ProxyErrorResponse(w, http.StatusNotFound, "model not found locally and no remote server configured", "invalid_request_error")
+}
+
+// stripRemoteOnlyFields removes LM Studio / Ollama-specific fields from the
+// request body that strict cloud/remote backends (Mistral, vLLM) reject with
+// HTTP 422. This should only be called for non-local routes — local runtimes
+// understand these fields natively.
+func stripRemoteOnlyFields(body []byte) []byte {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return body
+	}
+
+	changed := false
+	for _, field := range []string{"format", "keep_alive", "options"} {
+		if _, ok := raw[field]; ok {
+			delete(raw, field)
+			changed = true
+		}
+	}
+
+	// Strip per-message "tool_calls":[] — JetBrains adds an empty
+	// tool_calls array to every message (system, user, assistant).
+	// Mistral rejects these with "Extra inputs are not permitted".
+	if msgsRaw, ok := raw["messages"]; ok {
+		var msgs []map[string]json.RawMessage
+		if json.Unmarshal(msgsRaw, &msgs) == nil {
+			stripped := false
+			for i := range msgs {
+				if tcRaw, hasTc := msgs[i]["tool_calls"]; hasTc {
+					var tc []json.RawMessage
+					if json.Unmarshal(tcRaw, &tc) == nil && len(tc) == 0 {
+						delete(msgs[i], "tool_calls")
+						stripped = true
+					}
+				}
+			}
+			if stripped {
+				if b, err := json.Marshal(msgs); err == nil {
+					raw["messages"] = b
+					changed = true
+				}
+			}
+		}
+	}
+
+	if changed {
+		if b, err := json.Marshal(raw); err == nil {
+			return b
+		}
+	}
+	return body
 }
 
 // isLocalModel checks if a model is served by the local runtime.

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -812,6 +812,24 @@ func runForeground() {
 				w.WriteHeader(http.StatusBadGateway)
 				_ = json.NewEncoder(w).Encode(map[string]string{"error": "remote server unavailable"})
 			},
+			// Normalize SSE response headers for ktor compatibility.
+			// Runs before the response is written to the client.
+			ModifyResponse: func(resp *http.Response) error {
+				ct := resp.Header.Get("Content-Type")
+				if strings.HasPrefix(ct, "text/event-stream") {
+					if ct != "text/event-stream" {
+						resp.Header.Set("Content-Type", "text/event-stream")
+					}
+					resp.Header.Del("Content-Length")
+					// Strip upstream provider headers that LM Studio wouldn't send.
+					for _, h := range []string{"Server", "Alt-Svc", "Via",
+						"X-Frame-Options", "X-Xss-Protection", "X-Accel-Buffering",
+						"X-Vertex-Ai-Received-Request-Id", "Request-Id"} {
+						resp.Header.Del(h)
+					}
+				}
+				return nil
+			},
 			// Flush immediately so SSE chunks stream to the client without
 			// buffering. Without this, responses are fully buffered and slow
 			// models (Claude, Qwen) cause client-side timeouts.

--- a/cmd/candela/sse_normalizer_test.go
+++ b/cmd/candela/sse_normalizer_test.go
@@ -271,10 +271,10 @@ func TestSSENormalizerStripUpstreamHeaders(t *testing.T) {
 	})
 }
 
-func TestSSEHeaderNormalizerPassthrough(t *testing.T) {
-	t.Run("fixes headers without modifying events", func(t *testing.T) {
+func TestSSELiteNormalizer(t *testing.T) {
+	t.Run("fixes headers and injects missing content", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		n := newSSEHeaderNormalizer(rec)
+		n := newSSELiteNormalizer(rec)
 
 		n.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 		n.Header().Set("Content-Length", "12345")
@@ -292,19 +292,68 @@ func TestSSEHeaderNormalizerPassthrough(t *testing.T) {
 			t.Errorf("Server should be stripped for SSE, got %q", got)
 		}
 
-		// Verify events pass through unchanged (no buffering, no modification).
-		event := `data: {"choices":[{"delta":{"content":"hello"},"finish_reason":null,"index":0}],"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+		// Claude's first chunk: delta has role but no content.
+		roleOnly := `data: {"choices":[{"delta":{"role":"assistant"},"index":0}],"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+		_, _ = n.Write([]byte(roleOnly))
+
+		body := rec.Body.String()
+		if !strings.Contains(body, `"content":""`) {
+			t.Errorf("should inject content:\"\", got: %s", body)
+		}
+		if !strings.Contains(body, `"role":"assistant"`) {
+			t.Errorf("should preserve role, got: %s", body)
+		}
+	})
+
+	t.Run("passes through normal content unchanged", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSELiteNormalizer(rec)
+
+		n.Header().Set("Content-Type", "text/event-stream")
+		n.WriteHeader(http.StatusOK)
+
+		event := `data: {"choices":[{"delta":{"content":"hello"},"index":0}],"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
 		_, _ = n.Write([]byte(event))
 
 		body := rec.Body.String()
-		if body != event {
-			t.Errorf("event should pass through unchanged.\ngot:  %q\nwant: %q", body, event)
+		// Should not re-serialize if content already exists.
+		if !strings.Contains(body, `"content":"hello"`) {
+			t.Errorf("content should be preserved, got: %s", body)
+		}
+	})
+
+	t.Run("does not drop empty choices", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSELiteNormalizer(rec)
+		n.Header().Set("Content-Type", "text/event-stream")
+		n.WriteHeader(http.StatusOK)
+
+		// Unlike the full normalizer, empty choices should pass through.
+		event := `data: {"choices":[],"id":"x","model":"m","object":"chat.completion.chunk"}` + "\n\n"
+		_, _ = n.Write([]byte(event))
+
+		if rec.Body.Len() == 0 {
+			t.Error("lite normalizer should NOT drop events with empty choices")
+		}
+	})
+
+	t.Run("passes through DONE unchanged", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSELiteNormalizer(rec)
+		n.Header().Set("Content-Type", "text/event-stream")
+		n.WriteHeader(http.StatusOK)
+
+		done := "data: [DONE]\n\n"
+		_, _ = n.Write([]byte(done))
+
+		if rec.Body.String() != done {
+			t.Errorf("DONE should pass through unchanged, got: %q", rec.Body.String())
 		}
 	})
 
 	t.Run("preserves headers for non-SSE responses", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		n := newSSEHeaderNormalizer(rec)
+		n := newSSELiteNormalizer(rec)
 
 		n.Header().Set("Content-Type", "application/json")
 		n.Header().Set("Server", "Google Frontend")

--- a/docs/candela.md
+++ b/docs/candela.md
@@ -364,6 +364,17 @@ is on `PATH`. Candela does not fallback to WSL.
 2. URL is pre-configured to `http://localhost:1234` — just works!
 3. Select any model from the dropdown (local + cloud)
 
+Candela automatically handles JetBrains-specific compatibility:
+
+- **Request sanitization** — strips empty `tools:[]`, per-message `tool_calls:[]`,
+  `format`, `keep_alive`, `options`, and `stream_options` fields that JetBrains
+  sends but strict backends (Mistral, vLLM) reject with HTTP 422.
+- **`max_tokens` injection** — JetBrains omits this field, but providers like
+  Anthropic require it. Candela injects a default (32768) when absent.
+- **Ktor SSE workaround** — JetBrains uses ktor's HTTP client, which treats
+  Go's chunked transfer encoding terminator as "unexpected EOF". Candela
+  detects ktor and prevents this via TCP connection hijacking.
+
 ### VS Code (Continue, Cline)
 
 ```json
@@ -401,3 +412,5 @@ curl http://localhost:1234/v1/chat/completions \
 | Traces card shows "Traces not available" | Team Mode (traces go to cloud) | Expected — check the cloud dashboard |
 | No models in `/v1/models` | Runtime not started | Start Ollama: `ollama serve` |
 | vLLM is not discovered on Windows | No native `vllm` executable on `PATH` | Install a native Windows vLLM build and ensure `vllm` is on `PATH` |
+| JetBrains "unexpected EOF" | Ktor SSE parser bug with chunked encoding | Handled automatically — Candela hijacks the TCP connection for ktor clients |
+| JetBrains HTTP 422 | Strict backends reject extra fields JetBrains sends | Handled automatically — Candela strips incompatible fields from requests |


### PR DESCRIPTION
## Summary

Fix JetBrains AI Assistant failing with "unexpected EOF" and HTTP 422 when using the LM Studio provider mode through Candela.

> **Note**: Reapplies #451 which was merged prematurely without CI reviews.

## Root Cause

Two issues in how JetBrains ktor HTTP client interacts with Go net/http:

### 1. Ktor SSE EOF Bug (unexpected EOF)

Go net/http uses chunked transfer encoding for streaming responses. When the handler returns, Go writes the chunked terminator (`0\r\n\r\n`). Ktor SSE parser treats this as "unexpected EOF" even though the stream already sent `data: [DONE]`.

- **Gemini worked accidentally** — Google Frontend keeps the response body open indefinitely, so Go never writes the terminator
- **Claude, Qwen, Mistral all failed** — their upstreams close promptly

**Fix**: Detect ktor via `User-Agent` and hijack the TCP connection (`http.Hijacker`) after the proxy finishes writing. This prevents Go from ever writing the chunked terminator. The connection is held until ktor disconnects or a 30s safety timeout fires. Other clients (curl, Continue, Cursor) are unaffected.

### 2. Request Body Sanitization (HTTP 422)

JetBrains sends extra fields that strict backends reject:
- Empty `tool_calls:[]` on every message (Mistral: "Extra inputs are not permitted")
- LM Studio/Ollama fields: `format`, `keep_alive`, `options`

**Fix**: Strip these fields in `serveChat` before forwarding to the upstream.

## Changes

- **`cmd/candela/lm_handler.go`**: TCP hijack for ktor clients, request body sanitization
- **`cmd/candela/main.go`**: `ModifyResponse` on remoteProxy for SSE header normalization
- **`cmd/candela/sse_normalizer_test.go`**: Tests for renamed `sseLiteNormalizer`
- **`docs/candela.md`**: JetBrains compat details + troubleshooting entries

## Testing

- All pre-commit hooks pass (gofmt, golangci-lint, go-test)
- Manually verified Claude, Qwen, Gemini Flash, Mistral via JetBrains AI Assistant
- curl (non-ktor) clients unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced chat request normalization: standardizes chat-completions path, auto-injects `max_tokens` when missing, and cleans up unsupported/empty tool and streaming fields.

* **Bug Fixes**
  * Improved streaming reliability and compatibility by normalizing SSE responses (header fixes and safer chunk formatting), including better handling for IDE clients and Ktor-related disconnect behavior.

* **Documentation**
  * Updated JetBrains IDE integration and troubleshooting docs with the new request sanitization and streaming “unexpected EOF” workaround details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->