### PR TITLE
fix: correct hijack Content-Type guard + add ktor compat tests

### DIFF
--- a/cmd/candela/lm_compat_test.go
+++ b/cmd/candela/lm_compat_test.go
@@ -1,0 +1,401 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ─── Test 1: stripRemoteOnlyFields ──────────────────────────────────────────
+//
+// Verifies the JSON-level stripping of LM Studio / Ollama-specific fields
+// that strict cloud backends (Mistral, vLLM) reject with HTTP 422.
+
+func TestStripRemoteOnlyFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		check func(t *testing.T, result []byte)
+	}{
+		{
+			name:  "strips format, keep_alive, and options fields",
+			input: `{"model":"llama3","messages":[{"role":"user","content":"hi"}],"format":"json","keep_alive":"5m","options":{"temperature":0.7}}`,
+			check: func(t *testing.T, result []byte) {
+				var raw map[string]json.RawMessage
+				if err := json.Unmarshal(result, &raw); err != nil {
+					t.Fatalf("result is not valid JSON: %v", err)
+				}
+				for _, field := range []string{"format", "keep_alive", "options"} {
+					if _, ok := raw[field]; ok {
+						t.Errorf("field %q should have been stripped", field)
+					}
+				}
+			},
+		},
+		{
+			name:  "preserves model, messages, stream, and max_tokens",
+			input: `{"model":"llama3","messages":[{"role":"user","content":"hi"}],"stream":true,"max_tokens":1024,"format":"json"}`,
+			check: func(t *testing.T, result []byte) {
+				var raw map[string]json.RawMessage
+				if err := json.Unmarshal(result, &raw); err != nil {
+					t.Fatalf("result is not valid JSON: %v", err)
+				}
+				for _, field := range []string{"model", "messages", "stream", "max_tokens"} {
+					if _, ok := raw[field]; !ok {
+						t.Errorf("field %q should have been preserved", field)
+					}
+				}
+				// format should still be stripped
+				if _, ok := raw["format"]; ok {
+					t.Error("format should have been stripped")
+				}
+			},
+		},
+		{
+			name:  "strips empty per-message tool_calls but keeps non-empty",
+			input: `{"model":"m","messages":[{"role":"system","content":"you are helpful","tool_calls":[]},{"role":"assistant","content":"ok","tool_calls":[{"id":"call_1","function":{"name":"get_weather"}}]}]}`,
+			check: func(t *testing.T, result []byte) {
+				var raw map[string]json.RawMessage
+				if err := json.Unmarshal(result, &raw); err != nil {
+					t.Fatalf("result is not valid JSON: %v", err)
+				}
+				var msgs []map[string]json.RawMessage
+				if err := json.Unmarshal(raw["messages"], &msgs); err != nil {
+					t.Fatalf("failed to parse messages: %v", err)
+				}
+				// System message: empty tool_calls should be stripped.
+				if _, ok := msgs[0]["tool_calls"]; ok {
+					t.Error("empty tool_calls on system message should have been stripped")
+				}
+				// Assistant message: non-empty tool_calls should be preserved.
+				if _, ok := msgs[1]["tool_calls"]; !ok {
+					t.Error("non-empty tool_calls on assistant message should have been preserved")
+				}
+			},
+		},
+		{
+			name:  "no-op on clean input returns identical JSON",
+			input: `{"model":"gpt-4","messages":[{"role":"user","content":"hello"}],"stream":true}`,
+			check: func(t *testing.T, result []byte) {
+				// Re-parse both to compare semantically (key order may differ).
+				var orig, got map[string]json.RawMessage
+				if err := json.Unmarshal([]byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hello"}],"stream":true}`), &orig); err != nil {
+					t.Fatal(err)
+				}
+				if err := json.Unmarshal(result, &got); err != nil {
+					t.Fatal(err)
+				}
+				origBytes, _ := json.Marshal(orig)
+				gotBytes, _ := json.Marshal(got)
+				if !bytes.Equal(origBytes, gotBytes) {
+					t.Errorf("clean input should be semantically identical\n  orig: %s\n  got:  %s", origBytes, gotBytes)
+				}
+			},
+		},
+		{
+			name:  "no-op on invalid JSON returns input unchanged",
+			input: `{not valid json!!!`,
+			check: func(t *testing.T, result []byte) {
+				if string(result) != `{not valid json!!!` {
+					t.Errorf("invalid JSON should be returned unchanged, got: %s", string(result))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stripRemoteOnlyFields([]byte(tt.input))
+			tt.check(t, result)
+		})
+	}
+}
+
+// ─── Test 2: Ktor SSE Hijack ────────────────────────────────────────────────
+//
+// Verifies the TCP hijack behavior that prevents Go's chunked transfer
+// terminator ("0\r\n\r\n") from reaching ktor clients. The test handler
+// mimics the remote proxy SSE path: it writes SSE headers, streams data
+// chunks, then conditionally hijacks the connection for ktor User-Agents.
+//
+// We use raw TCP (net.Dial) for the ktor test to read raw bytes on the wire
+// and verify no chunked terminator is present after [DONE].
+
+func TestKtorSSEHijack(t *testing.T) {
+	// SSE events to send.
+	sseEvents := []string{
+		`data: {"choices":[{"delta":{"role":"assistant"},"index":0}],"id":"x","model":"m","object":"chat.completion.chunk"}`,
+		`data: {"choices":[{"delta":{"content":"Hello"},"index":0}],"id":"x","model":"m","object":"chat.completion.chunk"}`,
+		`data: {"choices":[{"delta":{},"finish_reason":"stop","index":0}],"id":"x","model":"m","object":"chat.completion.chunk"}`,
+		`data: [DONE]`,
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming not supported", http.StatusInternalServerError)
+			return
+		}
+
+		for _, event := range sseEvents {
+			_, _ = fmt.Fprintf(w, "%s\n\n", event)
+			flusher.Flush()
+		}
+
+		// Ktor workaround: hijack to prevent chunked terminator.
+		isKtor := strings.Contains(r.UserAgent(), "ktor")
+		if isKtor {
+			if hj, ok := w.(http.Hijacker); ok {
+				conn, buf, err := hj.Hijack()
+				if err == nil {
+					if buf != nil {
+						_ = buf.Flush()
+					}
+					// Short timeout for test — don't wait 30s.
+					_ = conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+					tmp := make([]byte, 1)
+					_, _ = conn.Read(tmp)
+					_ = conn.Close()
+				}
+			}
+		}
+		// For non-ktor: handler returns normally, Go writes chunked terminator.
+	})
+
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	t.Run("ktor client sees no chunked terminator after DONE", func(t *testing.T) {
+		// Use raw TCP to see every byte on the wire.
+		addr := ts.Listener.Addr().String()
+		conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+		if err != nil {
+			t.Fatalf("failed to connect: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		// Send a raw HTTP/1.1 request with ktor user agent.
+		reqLine := fmt.Sprintf("GET / HTTP/1.1\r\nHost: %s\r\nUser-Agent: ktor-client/2.3.7\r\nAccept: text/event-stream\r\n\r\n", addr)
+		if _, err := conn.Write([]byte(reqLine)); err != nil {
+			t.Fatalf("failed to write request: %v", err)
+		}
+
+		// Read entire response with a deadline.
+		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		raw, err := io.ReadAll(conn)
+		if err != nil {
+			t.Fatalf("failed to read response: %v", err)
+		}
+
+		body := string(raw)
+
+		// Verify all SSE events arrived.
+		if !strings.Contains(body, "data: [DONE]") {
+			t.Errorf("expected data: [DONE] in response, got:\n%s", body)
+		}
+		for _, event := range sseEvents[:3] {
+			if !strings.Contains(body, event) {
+				t.Errorf("missing SSE event: %s", event)
+			}
+		}
+
+		// The critical assertion: after [DONE], there should be no
+		// chunked terminator. Find the last occurrence of [DONE] and
+		// check what follows.
+		doneIdx := strings.LastIndex(body, "data: [DONE]")
+		if doneIdx == -1 {
+			t.Fatal("data: [DONE] not found")
+		}
+
+		// After "data: [DONE]\n\n", everything remaining should be
+		// whitespace or nothing — NOT a chunked terminator "0\r\n\r\n".
+		afterDone := body[doneIdx+len("data: [DONE]"):]
+		trimmed := strings.TrimRight(afterDone, "\r\n ")
+		if strings.Contains(trimmed, "0\r\n") {
+			t.Errorf("chunked terminator found after [DONE] — ktor will see unexpected EOF.\nAfter [DONE]: %q", afterDone)
+		}
+		// Also check there's no "0" chunk marker at all.
+		if strings.TrimSpace(trimmed) == "0" {
+			t.Errorf("chunked terminator '0' found after [DONE].\nAfter [DONE]: %q", afterDone)
+		}
+	})
+
+	t.Run("normal client completes normally", func(t *testing.T) {
+		client := ts.Client()
+		req, err := http.NewRequest("GET", ts.URL+"/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("User-Agent", "curl/8.0")
+		req.Header.Set("Accept", "text/event-stream")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+
+		// Read all events via standard SSE line scanning.
+		var events []string
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "data: ") {
+				events = append(events, line)
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			t.Fatalf("scanner error: %v", err)
+		}
+
+		// Should have all 4 data lines.
+		if len(events) != 4 {
+			t.Errorf("expected 4 SSE data events, got %d: %v", len(events), events)
+		}
+
+		// Verify [DONE] is the last event.
+		if len(events) > 0 && events[len(events)-1] != "data: [DONE]" {
+			t.Errorf("last event should be data: [DONE], got %q", events[len(events)-1])
+		}
+	})
+}
+
+// ─── Test 3: sseLiteNormalizer delta.content injection ──────────────────────
+//
+// Verifies that the lite normalizer injects delta.content:"" when missing
+// (ktor crashes on role-only chunks). This is the key JetBrains compat fix
+// for remote proxy traffic.
+
+func TestSSELiteNormalizerDeltaContent(t *testing.T) {
+	t.Run("injects content into role-only delta", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSELiteNormalizer(rec)
+
+		n.Header().Set("Content-Type", "text/event-stream")
+		n.WriteHeader(http.StatusOK)
+
+		// Claude's first chunk: delta has role but no content.
+		roleOnly := `data: {"choices":[{"delta":{"role":"assistant"}}]}` + "\n\n"
+		_, err := n.Write([]byte(roleOnly))
+		if err != nil {
+			t.Fatalf("Write failed: %v", err)
+		}
+
+		body := rec.Body.String()
+
+		// Must contain injected content:"".
+		if !strings.Contains(body, `"content":""`) {
+			t.Errorf("expected delta.content:\"\" to be injected, got: %s", body)
+		}
+		// Must preserve role.
+		if !strings.Contains(body, `"role":"assistant"`) {
+			t.Errorf("expected role to be preserved, got: %s", body)
+		}
+
+		// Verify the output is valid SSE (starts with "data: " and ends with "\n\n").
+		if !strings.HasPrefix(body, "data: ") {
+			t.Errorf("output should start with 'data: ', got: %q", body)
+		}
+		if !strings.HasSuffix(body, "\n\n") {
+			t.Errorf("output should end with '\\n\\n', got: %q", body)
+		}
+
+		// Verify the JSON payload is valid.
+		payload := strings.TrimPrefix(strings.TrimSuffix(body, "\n\n"), "data: ")
+		var parsed map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
+			t.Errorf("output JSON is invalid: %v\npayload: %s", err, payload)
+		}
+	})
+
+	t.Run("data: [DONE] passes through unchanged", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSELiteNormalizer(rec)
+		n.Header().Set("Content-Type", "text/event-stream")
+		n.WriteHeader(http.StatusOK)
+
+		done := "data: [DONE]\n\n"
+		_, err := n.Write([]byte(done))
+		if err != nil {
+			t.Fatalf("Write failed: %v", err)
+		}
+
+		if rec.Body.String() != done {
+			t.Errorf("DONE should pass through unchanged, got: %q", rec.Body.String())
+		}
+	})
+
+	// Regression: FlushRemaining must drain non-SSE data (e.g., JSON error
+	// bodies that don't contain \n\n event boundaries).
+	t.Run("FlushRemaining drains non-SSE data", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSELiteNormalizer(rec)
+		n.WriteHeader(http.StatusBadRequest)
+
+		// A JSON error body has no \n\n, so Write() buffers it forever.
+		errBody := `{"error":{"type":"invalid_request_error","message":"unknown model"}}`
+		_, err := n.Write([]byte(errBody))
+		if err != nil {
+			t.Fatalf("Write failed: %v", err)
+		}
+
+		// Before FlushRemaining, nothing should be written.
+		if rec.Body.Len() != 0 {
+			t.Errorf("expected empty body before FlushRemaining, got: %q", rec.Body.String())
+		}
+
+		n.FlushRemaining()
+
+		// After FlushRemaining, the full error body should appear.
+		if rec.Body.String() != errBody {
+			t.Errorf("expected error body after FlushRemaining, got: %q", rec.Body.String())
+		}
+	})
+
+	// Regression: the hijack guard must check writer.Header() (the
+	// normalizer) to determine if the upstream returned SSE. This test
+	// verifies that Content-Type set on the normalizer is visible via
+	// writer.Header().Get("Content-Type") — which is what serveChat checks.
+	t.Run("writer.Header reflects Content-Type for hijack guard", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		n := newSSELiteNormalizer(rec)
+
+		// Simulate what httputil.ReverseProxy does: set Content-Type
+		// on the writer's Header() map before calling WriteHeader.
+		n.Header().Set("Content-Type", "text/event-stream")
+
+		// The hijack guard calls: writer.Header().Get("Content-Type")
+		// This must return the value, not empty string.
+		ct := n.Header().Get("Content-Type")
+		if ct != "text/event-stream" {
+			t.Errorf("writer.Header() should return Content-Type for hijack guard, got: %q", ct)
+		}
+
+		// For a JSON error, Content-Type should be application/json
+		rec2 := httptest.NewRecorder()
+		n2 := newSSELiteNormalizer(rec2)
+		n2.Header().Set("Content-Type", "application/json")
+
+		ct2 := n2.Header().Get("Content-Type")
+		if strings.HasPrefix(ct2, "text/event-stream") {
+			t.Error("JSON error response should NOT trigger SSE hijack guard")
+		}
+	})
+}

--- a/cmd/candela/lm_handler.go
+++ b/cmd/candela/lm_handler.go
@@ -452,11 +452,20 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 		// delta.content is always present (ktor crashes on role-only
 		// chunks), and the proxy's ModifyResponse callback handles
 		// header normalization.
+		var liteNorm *sseLiteNormalizer
 		writer := http.ResponseWriter(w)
 		if req.Stream {
-			writer = newSSELiteNormalizer(w)
+			liteNorm = newSSELiteNormalizer(w)
+			writer = liteNorm
 		}
 		h.remoteProxy.ServeHTTP(writer, r)
+
+		// Flush any data remaining in the normalizer's buffer. This handles
+		// non-SSE responses (e.g., JSON errors) that don't contain \n\n
+		// event boundaries and would otherwise stay buffered forever.
+		if liteNorm != nil {
+			liteNorm.FlushRemaining()
+		}
 
 		// ── Ktor chunked-encoding workaround ──
 		//
@@ -484,9 +493,14 @@ func (h *lmHandler) serveChat(w http.ResponseWriter, r *http.Request) {
 		//
 		// Scope: Only applied for ktor-client (JetBrains) on streaming
 		// requests that actually returned SSE. Error responses (4xx/5xx
-		// JSON) are excluded — ktor handles those correctly.
+		// JSON) are excluded — ktor handles those fine and hijacking
+		// would hang the connection for 30s.
+		//
+		// NOTE: We check writer.Header() (the sseLiteNormalizer's header
+		// map) rather than w.Header(), because the proxy writes upstream
+		// headers to the writer, not the underlying ResponseWriter.
 		isKtor := strings.Contains(r.UserAgent(), "ktor")
-		respondedSSE := strings.HasPrefix(w.Header().Get("Content-Type"), "text/event-stream")
+		respondedSSE := strings.HasPrefix(writer.Header().Get("Content-Type"), "text/event-stream")
 		if req.Stream && isKtor && respondedSSE {
 			if hj, ok := w.(http.Hijacker); ok {
 				conn, buf, err := hj.Hijack()
@@ -872,6 +886,17 @@ func (n *sseLiteNormalizer) ensureContent(event []byte) []byte {
 func (n *sseLiteNormalizer) Flush() {
 	if f, ok := n.w.(http.Flusher); ok {
 		f.Flush()
+	}
+}
+
+// FlushRemaining writes any data left in the buffer that doesn't end with
+// \n\n. This handles non-SSE responses (e.g., JSON error bodies) that pass
+// through the normalizer without matching the event boundary pattern.
+func (n *sseLiteNormalizer) FlushRemaining() {
+	if len(n.buf) > 0 {
+		_, _ = n.w.Write(n.buf)
+		n.buf = n.buf[:0]
+		n.Flush()
 	}
 }
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +264,79 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio-test",
+ "uuid",
+]
+
+[[package]]
+name = "candela-harness"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "candela-core",
+ "candela-harness-chat",
+ "candela-harness-mcp",
+ "candela-harness-rpc",
+ "candela-harness-storage",
+ "clap",
+ "dirs",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "candela-harness-chat"
+version = "0.1.0"
+dependencies = [
+ "candela-core",
+ "candela-harness-storage",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "candela-harness-mcp"
+version = "0.1.0"
+dependencies = [
+ "candela-core",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "candela-harness-rpc"
+version = "0.1.0"
+dependencies = [
+ "candela-core",
+ "candela-harness-storage",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "candela-harness-storage"
+version = "0.1.0"
+dependencies = [
+ "candela-core",
+ "chrono",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio-test",
+ "tracing",
 ]
 
 [[package]]
@@ -366,6 +489,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +536,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compression-codecs"
@@ -446,6 +615,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +673,18 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "find-msvc-tools"
@@ -639,6 +841,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -917,6 +1128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1187,26 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947e6816f7825b2b45027c2c32e7085da9934defa535de4a6a46b10a4d5257fa"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "litemap"
@@ -1121,6 +1358,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1413,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1369,6 +1624,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1713,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22715a5d6deef63c637207afbe68d0c72c3f8d0022d7cf9714c442d6157606b"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -1659,6 +1939,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2046,6 +2332,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,6 +2353,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "want"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1722,6 +1722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22715a5d6deef63c637207afbe68d0c72c3f8d0022d7cf9714c442d6157606b"
 dependencies = [
  "bitflags",
+ "chrono",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,8 +6,13 @@ members = [
     "crates/candela-processor",
     "crates/candela-storage",
     "crates/candela-transparent",
+    "crates/candela-harness-storage",
+    "crates/candela-harness-chat",
+    "crates/candela-harness-mcp",
+    "crates/candela-harness-rpc",
     "bins/candela-proxy",
     "bins/candela-sidecar",
+    "bins/candela-harness",
 ]
 
 [workspace.package]
@@ -67,12 +72,21 @@ url = "2"
 # Testing
 tokio-test = "0.4"
 
+# Harness deps
+rusqlite = { version = "0.35", features = ["bundled"] }
+clap = { version = "4", features = ["derive"] }
+dirs = "6"
+
 # Workspace crates
 candela-core = { path = "crates/candela-core" }
 candela-proxy = { path = "crates/candela-proxy" }
 candela-processor = { path = "crates/candela-processor" }
 candela-storage = { path = "crates/candela-storage" }
 candela-transparent = { path = "crates/candela-transparent" }
+candela-harness-storage = { path = "crates/candela-harness-storage" }
+candela-harness-chat = { path = "crates/candela-harness-chat" }
+candela-harness-mcp = { path = "crates/candela-harness-mcp" }
+candela-harness-rpc = { path = "crates/candela-harness-rpc" }
 
 [profile.release]
 lto = true

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -73,7 +73,7 @@ url = "2"
 tokio-test = "0.4"
 
 # Harness deps
-rusqlite = { version = "0.35", features = ["bundled"] }
+rusqlite = { version = "0.35", features = ["bundled", "chrono"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
 

--- a/rust/bins/candela-harness/Cargo.toml
+++ b/rust/bins/candela-harness/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "candela-harness"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "candela-harness"
+path = "src/main.rs"
+
+[dependencies]
+candela-core = { workspace = true }
+candela-harness-storage = { workspace = true }
+candela-harness-chat = { workspace = true }
+candela-harness-mcp = { workspace = true }
+candela-harness-rpc = { workspace = true }
+tokio = { workspace = true }
+clap = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+dirs = { workspace = true }

--- a/rust/bins/candela-harness/src/main.rs
+++ b/rust/bins/candela-harness/src/main.rs
@@ -1,0 +1,126 @@
+//! candela-harness — IDE sidecar for AI-assisted development.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use candela_core::harness::{HarnessConfig, TransportMode};
+use candela_harness_rpc::{RpcHandler, protocol::JsonRpcRequest};
+use candela_harness_storage::Database;
+use clap::Parser;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser)]
+#[command(
+    name = "candela-harness",
+    version,
+    about = "IDE sidecar for AI-assisted development"
+)]
+struct Cli {
+    /// Transport mode: stdio (default) or http
+    #[arg(long, default_value = "stdio")]
+    transport: String,
+
+    /// HTTP port for daemon mode
+    #[arg(long, default_value_t = 8200)]
+    port: u16,
+
+    /// Session storage directory
+    #[arg(long)]
+    save_dir: Option<PathBuf>,
+
+    /// Resume a conversation by ID
+    #[arg(long)]
+    conversation_id: Option<String>,
+
+    /// Default model
+    #[arg(long, default_value = "gemini-2.0-flash")]
+    model: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("harness=info".parse()?))
+        .with_writer(std::io::stderr)
+        .init();
+
+    let cli = Cli::parse();
+
+    let config = HarnessConfig {
+        save_dir: cli.save_dir.unwrap_or_else(|| {
+            dirs::home_dir()
+                .unwrap_or_default()
+                .join(".candela")
+                .join("sessions")
+        }),
+        model: cli.model,
+        transport: match cli.transport.as_str() {
+            "http" => TransportMode::Http,
+            _ => TransportMode::Stdio,
+        },
+        http_port: cli.port,
+        ..Default::default()
+    };
+
+    // Ensure save directory exists
+    std::fs::create_dir_all(&config.save_dir)?;
+
+    // Open database
+    let db_path = config.save_dir.join("harness.db");
+    let db = Database::open(&db_path)?;
+    let db = Arc::new(std::sync::Mutex::new(db));
+
+    let handler = RpcHandler::new(db);
+
+    info!(
+        transport = ?config.transport,
+        model = %config.model,
+        save_dir = %config.save_dir.display(),
+        "candela-harness started"
+    );
+
+    match config.transport {
+        TransportMode::Stdio => serve_stdio(handler).await?,
+        TransportMode::Http => {
+            info!(port = config.http_port, "HTTP mode not yet implemented");
+            // TODO: Axum HTTP server
+        }
+    }
+
+    Ok(())
+}
+
+/// Read JSON-RPC from stdin, write responses to stdout.
+async fn serve_stdio(handler: RpcHandler) -> anyhow::Result<()> {
+    use tokio::io::{AsyncBufReadExt, BufReader};
+
+    let stdin = tokio::io::stdin();
+    let reader = BufReader::new(stdin);
+    let mut lines = reader.lines();
+
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let request: JsonRpcRequest = match serde_json::from_str(&line) {
+            Ok(req) => req,
+            Err(_) => {
+                let resp = candela_harness_rpc::protocol::JsonRpcResponse::error(
+                    None,
+                    candela_harness_rpc::protocol::PARSE_ERROR,
+                    "Parse error".to_string(),
+                );
+                println!("{}", serde_json::to_string(&resp)?);
+                continue;
+            }
+        };
+
+        let response = handler.handle(request).await;
+        println!("{}", serde_json::to_string(&response)?);
+    }
+
+    Ok(())
+}

--- a/rust/bins/candela-harness/src/main.rs
+++ b/rust/bins/candela-harness/src/main.rs
@@ -29,10 +29,6 @@ struct Cli {
     #[arg(long)]
     save_dir: Option<PathBuf>,
 
-    /// Resume a conversation by ID
-    #[arg(long)]
-    conversation_id: Option<String>,
-
     /// Default model
     #[arg(long, default_value = "gemini-2.0-flash")]
     model: String,
@@ -48,6 +44,12 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
 
+    let transport = match cli.transport.as_str() {
+        "stdio" => TransportMode::Stdio,
+        "http" => TransportMode::Http,
+        other => anyhow::bail!("unsupported transport: {other:?} (expected \"stdio\" or \"http\")"),
+    };
+
     let config = HarnessConfig {
         save_dir: cli.save_dir.unwrap_or_else(|| {
             dirs::home_dir()
@@ -56,10 +58,7 @@ async fn main() -> anyhow::Result<()> {
                 .join("sessions")
         }),
         model: cli.model,
-        transport: match cli.transport.as_str() {
-            "http" => TransportMode::Http,
-            _ => TransportMode::Stdio,
-        },
+        transport,
         http_port: cli.port,
         ..Default::default()
     };
@@ -72,7 +71,7 @@ async fn main() -> anyhow::Result<()> {
     let db = Database::open(&db_path)?;
     let db = Arc::new(std::sync::Mutex::new(db));
 
-    let handler = RpcHandler::new(db);
+    let handler = RpcHandler::new(db, config.model.clone());
 
     info!(
         transport = ?config.transport,
@@ -84,8 +83,8 @@ async fn main() -> anyhow::Result<()> {
     match config.transport {
         TransportMode::Stdio => serve_stdio(handler).await?,
         TransportMode::Http => {
-            info!(port = config.http_port, "HTTP mode not yet implemented");
             // TODO: Axum HTTP server
+            anyhow::bail!("HTTP transport is not yet implemented");
         }
     }
 
@@ -118,8 +117,9 @@ async fn serve_stdio(handler: RpcHandler) -> anyhow::Result<()> {
             }
         };
 
-        let response = handler.handle(request).await;
-        println!("{}", serde_json::to_string(&response)?);
+        if let Some(response) = handler.handle(request).await {
+            println!("{}", serde_json::to_string(&response)?);
+        }
     }
 
     Ok(())

--- a/rust/bins/candela-harness/src/main.rs
+++ b/rust/bins/candela-harness/src/main.rs
@@ -1,5 +1,6 @@
 //! candela-harness — IDE sidecar for AI-assisted development.
 
+use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -113,12 +114,14 @@ async fn serve_stdio(handler: RpcHandler) -> anyhow::Result<()> {
                     "Parse error".to_string(),
                 );
                 println!("{}", serde_json::to_string(&resp)?);
+                std::io::stdout().flush()?;
                 continue;
             }
         };
 
         if let Some(response) = handler.handle(request).await {
             println!("{}", serde_json::to_string(&response)?);
+            std::io::stdout().flush()?;
         }
     }
 

--- a/rust/crates/candela-core/Cargo.toml
+++ b/rust/crates/candela-core/Cargo.toml
@@ -13,6 +13,7 @@ prost-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tokio-test = { workspace = true }

--- a/rust/crates/candela-core/src/harness.rs
+++ b/rust/crates/candela-core/src/harness.rs
@@ -19,6 +19,8 @@ pub struct HarnessConfig {
     /// Default model identifier.
     pub model: String,
     /// Budget limit in USD. 0 = unlimited.
+    // TODO: Consider using integer micro-units (i64 microdollars) instead of f64
+    // to avoid floating-point rounding in budget calculations.
     pub budget_limit_usd: f64,
     /// Device ID for cross-device sync.
     pub device_id: String,

--- a/rust/crates/candela-core/src/harness.rs
+++ b/rust/crates/candela-core/src/harness.rs
@@ -1,0 +1,241 @@
+//! Domain types, configuration, and errors for the candela-harness IDE sidecar.
+//!
+//! These types were originally in the standalone `harness-core` crate and have
+//! been merged into `candela-core` so that every harness crate depends on a
+//! single shared type library.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// ── Configuration ──
+
+/// Top-level harness configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HarnessConfig {
+    /// Directory for session storage.
+    pub save_dir: std::path::PathBuf,
+    /// Candela proxy URL for model routing.
+    pub proxy_url: Option<String>,
+    /// Default model identifier.
+    pub model: String,
+    /// Budget limit in USD. 0 = unlimited.
+    pub budget_limit_usd: f64,
+    /// Device ID for cross-device sync.
+    pub device_id: String,
+    /// Enable subagent delegation.
+    pub enable_subagents: bool,
+    /// Transport mode.
+    pub transport: TransportMode,
+    /// HTTP port (for daemon mode).
+    pub http_port: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TransportMode {
+    #[default]
+    Stdio,
+    Http,
+}
+
+impl Default for HarnessConfig {
+    fn default() -> Self {
+        Self {
+            save_dir: std::path::PathBuf::from(".candela/sessions"),
+            proxy_url: None,
+            model: "gemini-2.0-flash".to_string(),
+            budget_limit_usd: 5.0,
+            device_id: String::new(),
+            enable_subagents: true,
+            transport: TransportMode::Stdio,
+            http_port: 8200,
+        }
+    }
+}
+
+// ── Errors ──
+
+/// Harness-specific error type.
+#[derive(Debug, thiserror::Error)]
+pub enum HarnessError {
+    #[error("storage error: {0}")]
+    Storage(String),
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("session not found: {0}")]
+    SessionNotFound(String),
+
+    #[error("budget exceeded: used ${used:.4} of ${limit:.4} limit")]
+    BudgetExceeded { used: f64, limit: f64 },
+
+    #[error("transport error: {0}")]
+    Transport(String),
+
+    #[error("{0}")]
+    Other(#[from] anyhow::Error),
+}
+
+// ── Domain Types ──
+
+/// A chat session (conversation).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+    pub id: String,
+    pub title: String,
+    pub model: String,
+    pub message_count: i32,
+    pub total_tokens: i64,
+    pub total_cost_usd: f64,
+    pub device_id: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+impl Session {
+    pub fn new(model: &str, device_id: &str) -> Self {
+        let now = Utc::now();
+        let id = uuid::Uuid::new_v4().to_string();
+        Self {
+            id,
+            title: "New Chat".to_string(),
+            model: model.to_string(),
+            message_count: 0,
+            total_tokens: 0,
+            total_cost_usd: 0.0,
+            device_id: device_id.to_string(),
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+        }
+    }
+}
+
+/// A single chat message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub id: i64,
+    pub session_id: String,
+    pub role: MessageRole,
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_count: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Message roles.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageRole {
+    User,
+    Assistant,
+    System,
+    Tool,
+}
+
+/// Streaming chat events sent as JSON-RPC notifications.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ChatEvent {
+    /// Text delta from the model.
+    Chunk { stream_id: String, delta: String },
+    /// Model wants to call a tool.
+    ToolCall {
+        stream_id: String,
+        call_id: String,
+        tool: String,
+        args: serde_json::Value,
+        requires_approval: bool,
+    },
+    /// Status update (e.g., "Analyzing codebase...").
+    Status {
+        stream_id: String,
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        agent: Option<String>,
+    },
+    /// Stream completed.
+    Done {
+        stream_id: String,
+        usage: UsageSummary,
+    },
+    /// Stream error.
+    Error { stream_id: String, message: String },
+}
+
+/// Token/cost usage summary.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UsageSummary {
+    pub prompt_tokens: i64,
+    pub completion_tokens: i64,
+    pub total_tokens: i64,
+    pub total_cost_usd: f64,
+}
+
+/// Search result from FTS5 index.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchResult {
+    pub session_id: String,
+    pub session_title: String,
+    pub message_preview: String,
+    pub role: MessageRole,
+    pub score: f64,
+    pub created_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_new_has_valid_defaults() {
+        let session = Session::new("gemini-2.0-flash", "device-1");
+        assert_eq!(session.title, "New Chat");
+        assert_eq!(session.model, "gemini-2.0-flash");
+        assert_eq!(session.message_count, 0);
+        assert!(session.deleted_at.is_none());
+        assert!(!session.id.is_empty());
+    }
+
+    #[test]
+    fn session_json_round_trip() {
+        let session = Session::new("test-model", "dev-1");
+        let json = serde_json::to_string(&session).unwrap();
+        let restored: Session = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.id, session.id);
+        assert_eq!(restored.model, "test-model");
+    }
+
+    #[test]
+    fn chat_event_serde_round_trip() {
+        let event = ChatEvent::Done {
+            stream_id: "s1".into(),
+            usage: UsageSummary::default(),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let restored: ChatEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(restored, ChatEvent::Done { .. }));
+    }
+
+    #[test]
+    fn message_role_serde() {
+        let json = serde_json::to_string(&MessageRole::Assistant).unwrap();
+        assert_eq!(json, "\"assistant\"");
+        let restored: MessageRole = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, MessageRole::Assistant);
+    }
+
+    #[test]
+    fn harness_config_default() {
+        let config = HarnessConfig::default();
+        assert_eq!(config.model, "gemini-2.0-flash");
+        assert_eq!(config.http_port, 8200);
+    }
+}

--- a/rust/crates/candela-core/src/lib.rs
+++ b/rust/crates/candela-core/src/lib.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+pub mod harness;
 pub mod proto;
 
 // ── Error Types ──

--- a/rust/crates/candela-harness-chat/Cargo.toml
+++ b/rust/crates/candela-harness-chat/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "candela-harness-chat"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+candela-core = { workspace = true }
+candela-harness-storage = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }

--- a/rust/crates/candela-harness-chat/src/lib.rs
+++ b/rust/crates/candela-harness-chat/src/lib.rs
@@ -1,0 +1,12 @@
+//! Chat runtime — manages the conversation loop, model calls, and streaming.
+//!
+//! This crate will handle:
+//! - Assembling context (system prompt + history + pinned context)
+//! - Calling LLM providers via Candela proxy
+//! - Streaming responses back to the IDE
+//! - Tool call execution and approval flow
+//! - Budget enforcement
+
+pub mod runtime;
+
+pub use runtime::ChatRuntime;

--- a/rust/crates/candela-harness-chat/src/runtime.rs
+++ b/rust/crates/candela-harness-chat/src/runtime.rs
@@ -1,0 +1,49 @@
+//! Chat runtime stub.
+
+use candela_core::harness::{ChatEvent, HarnessConfig, UsageSummary};
+use candela_harness_storage::Database;
+use tracing::info;
+
+/// The chat runtime manages active conversations.
+pub struct ChatRuntime {
+    _config: HarnessConfig,
+    _db: Database,
+}
+
+impl ChatRuntime {
+    /// Create a new chat runtime.
+    pub fn new(config: HarnessConfig, db: Database) -> Self {
+        Self {
+            _config: config,
+            _db: db,
+        }
+    }
+
+    /// Send a message and stream the response.
+    ///
+    /// Returns the stream ID. Events will be sent via the notification callback.
+    pub async fn send_message(
+        &self,
+        session_id: &str,
+        content: &str,
+        on_event: impl Fn(ChatEvent) + Send + 'static,
+    ) -> Result<String, candela_core::harness::HarnessError> {
+        info!(session_id, content_len = content.len(), "chat.send");
+
+        let stream_id = uuid::Uuid::new_v4().to_string();
+
+        // TODO: Implement actual LLM call via Candela proxy
+        // For now, echo back a stub response
+        on_event(ChatEvent::Chunk {
+            stream_id: stream_id.clone(),
+            delta: format!("Echo: {content}"),
+        });
+
+        on_event(ChatEvent::Done {
+            stream_id: stream_id.clone(),
+            usage: UsageSummary::default(),
+        });
+
+        Ok(stream_id)
+    }
+}

--- a/rust/crates/candela-harness-mcp/Cargo.toml
+++ b/rust/crates/candela-harness-mcp/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "candela-harness-mcp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+candela-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }

--- a/rust/crates/candela-harness-mcp/src/lib.rs
+++ b/rust/crates/candela-harness-mcp/src/lib.rs
@@ -1,0 +1,12 @@
+//! MCP (Model Context Protocol) server and client management.
+//!
+//! This crate will handle:
+//! - Spawning and managing MCP server processes
+//! - Connecting to remote MCP servers (SSE)
+//! - Routing tool calls to the correct MCP server
+//! - Exposing harness capabilities as an MCP server
+
+/// Placeholder — MCP integration coming in Phase 3.
+pub fn init() {
+    tracing::info!("harness-mcp initialized (stub)");
+}

--- a/rust/crates/candela-harness-rpc/Cargo.toml
+++ b/rust/crates/candela-harness-rpc/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "candela-harness-rpc"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+candela-core = { workspace = true }
+candela-harness-storage = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }

--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -1,6 +1,6 @@
 //! JSON-RPC request handler — dispatches method calls.
 
-use candela_core::harness::Session;
+use candela_core::harness::{HarnessError, Session};
 use candela_harness_storage::Database;
 use tracing::info;
 
@@ -9,18 +9,25 @@ use crate::protocol::*;
 /// Handles JSON-RPC requests from IDE plugins.
 pub struct RpcHandler {
     db: std::sync::Arc<std::sync::Mutex<Database>>,
+    default_model: String,
 }
 
 impl RpcHandler {
-    pub fn new(db: std::sync::Arc<std::sync::Mutex<Database>>) -> Self {
-        Self { db }
+    pub fn new(db: std::sync::Arc<std::sync::Mutex<Database>>, default_model: String) -> Self {
+        Self { db, default_model }
     }
 
     /// Dispatch a JSON-RPC request to the appropriate handler.
-    pub async fn handle(&self, req: JsonRpcRequest) -> JsonRpcResponse {
+    ///
+    /// Returns `None` for JSON-RPC notifications (requests with no `id`),
+    /// since the spec says notifications MUST NOT receive a response.
+    pub async fn handle(&self, req: JsonRpcRequest) -> Option<JsonRpcResponse> {
         info!(method = %req.method, "rpc request");
 
-        match req.method.as_str() {
+        // JSON-RPC notifications have no id — never send a response.
+        req.id.as_ref()?;
+
+        let response = match req.method.as_str() {
             "initialize" => self.handle_initialize(req.id).await,
             "session.list" => self.handle_session_list(req.id, req.params).await,
             "session.create" => self.handle_session_create(req.id, req.params).await,
@@ -31,7 +38,8 @@ impl RpcHandler {
                 METHOD_NOT_FOUND,
                 format!("Unknown method: {}", req.method),
             ),
-        }
+        };
+        Some(response)
     }
 
     async fn handle_initialize(&self, id: Option<serde_json::Value>) -> JsonRpcResponse {
@@ -54,8 +62,16 @@ impl RpcHandler {
         id: Option<serde_json::Value>,
         params: serde_json::Value,
     ) -> JsonRpcResponse {
-        let limit = params.get("limit").and_then(|v| v.as_i64()).unwrap_or(50);
-        let offset = params.get("offset").and_then(|v| v.as_i64()).unwrap_or(0);
+        let limit = params
+            .get("limit")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(50)
+            .max(0);
+        let offset = params
+            .get("offset")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0)
+            .max(0);
 
         match self.db.lock().unwrap().list_sessions(limit, offset) {
             Ok(sessions) => JsonRpcResponse::success(
@@ -77,7 +93,7 @@ impl RpcHandler {
         let model = params
             .get("model")
             .and_then(|v| v.as_str())
-            .unwrap_or("gemini-2.0-flash");
+            .unwrap_or(&self.default_model);
         let device_id = params
             .get("device_id")
             .and_then(|v| v.as_str())
@@ -108,6 +124,9 @@ impl RpcHandler {
 
         match self.db.lock().unwrap().delete_session(session_id) {
             Ok(()) => JsonRpcResponse::success(id, serde_json::json!({ "status": "deleted" })),
+            Err(HarnessError::SessionNotFound(sid)) => {
+                JsonRpcResponse::error(id, INVALID_PARAMS, format!("session not found: {sid}"))
+            }
             Err(e) => JsonRpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
         }
     }
@@ -135,7 +154,10 @@ mod tests {
 
     fn test_handler() -> RpcHandler {
         let db = Database::open_in_memory().unwrap();
-        RpcHandler::new(Arc::new(std::sync::Mutex::new(db)))
+        RpcHandler::new(
+            Arc::new(std::sync::Mutex::new(db)),
+            "test-model".to_string(),
+        )
     }
 
     #[tokio::test]
@@ -147,11 +169,24 @@ mod tests {
             method: "initialize".to_string(),
             params: serde_json::Value::Null,
         };
-        let resp = handler.handle(req).await;
+        let resp = handler.handle(req).await.expect("should return response");
         assert!(resp.result.is_some());
         assert!(resp.error.is_none());
         let result = resp.result.unwrap();
         assert_eq!(result["name"], "candela-harness");
+    }
+
+    #[tokio::test]
+    async fn test_notification_returns_none() {
+        let handler = test_handler();
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            method: "initialize".to_string(),
+            params: serde_json::Value::Null,
+        };
+        let resp = handler.handle(req).await;
+        assert!(resp.is_none(), "notifications must not produce a response");
     }
 
     #[tokio::test]
@@ -165,7 +200,7 @@ mod tests {
             method: "session.create".to_string(),
             params: serde_json::json!({ "model": "test-model" }),
         };
-        let resp = handler.handle(req).await;
+        let resp = handler.handle(req).await.unwrap();
         let session_id = resp.result.unwrap()["id"].as_str().unwrap().to_string();
 
         // List
@@ -175,7 +210,7 @@ mod tests {
             method: "session.list".to_string(),
             params: serde_json::json!({}),
         };
-        let resp = handler.handle(req).await;
+        let resp = handler.handle(req).await.unwrap();
         let sessions = resp.result.unwrap();
         assert_eq!(sessions["sessions"].as_array().unwrap().len(), 1);
 
@@ -186,8 +221,22 @@ mod tests {
             method: "session.delete".to_string(),
             params: serde_json::json!({ "session_id": session_id }),
         };
-        let resp = handler.handle(req).await;
+        let resp = handler.handle(req).await.unwrap();
         assert!(resp.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_session_delete_not_found() {
+        let handler = test_handler();
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: "session.delete".to_string(),
+            params: serde_json::json!({ "session_id": "nonexistent" }),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        assert!(resp.error.is_some());
+        assert_eq!(resp.error.unwrap().code, INVALID_PARAMS);
     }
 
     #[tokio::test]
@@ -199,8 +248,36 @@ mod tests {
             method: "nonexistent".to_string(),
             params: serde_json::Value::Null,
         };
-        let resp = handler.handle(req).await;
+        let resp = handler.handle(req).await.unwrap();
         assert!(resp.error.is_some());
         assert_eq!(resp.error.unwrap().code, METHOD_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_session_create_uses_default_model() {
+        let handler = test_handler();
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: "session.create".to_string(),
+            params: serde_json::json!({}),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        let model = resp.result.unwrap()["model"].as_str().unwrap().to_string();
+        assert_eq!(model, "test-model");
+    }
+
+    #[tokio::test]
+    async fn test_negative_limit_clamped() {
+        let handler = test_handler();
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: "session.list".to_string(),
+            params: serde_json::json!({ "limit": -5, "offset": -10 }),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        // Should not error — clamped to 0
+        assert!(resp.error.is_none());
     }
 }

--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -1,0 +1,206 @@
+//! JSON-RPC request handler — dispatches method calls.
+
+use candela_core::harness::Session;
+use candela_harness_storage::Database;
+use tracing::info;
+
+use crate::protocol::*;
+
+/// Handles JSON-RPC requests from IDE plugins.
+pub struct RpcHandler {
+    db: std::sync::Arc<std::sync::Mutex<Database>>,
+}
+
+impl RpcHandler {
+    pub fn new(db: std::sync::Arc<std::sync::Mutex<Database>>) -> Self {
+        Self { db }
+    }
+
+    /// Dispatch a JSON-RPC request to the appropriate handler.
+    pub async fn handle(&self, req: JsonRpcRequest) -> JsonRpcResponse {
+        info!(method = %req.method, "rpc request");
+
+        match req.method.as_str() {
+            "initialize" => self.handle_initialize(req.id).await,
+            "session.list" => self.handle_session_list(req.id, req.params).await,
+            "session.create" => self.handle_session_create(req.id, req.params).await,
+            "session.delete" => self.handle_session_delete(req.id, req.params).await,
+            "chat.send" => self.handle_chat_send(req.id, req.params).await,
+            _ => JsonRpcResponse::error(
+                req.id,
+                METHOD_NOT_FOUND,
+                format!("Unknown method: {}", req.method),
+            ),
+        }
+    }
+
+    async fn handle_initialize(&self, id: Option<serde_json::Value>) -> JsonRpcResponse {
+        JsonRpcResponse::success(
+            id,
+            serde_json::json!({
+                "name": "candela-harness",
+                "version": env!("CARGO_PKG_VERSION"),
+                "capabilities": {
+                    "streaming": true,
+                    "sessions": true,
+                    "search": true,
+                }
+            }),
+        )
+    }
+
+    async fn handle_session_list(
+        &self,
+        id: Option<serde_json::Value>,
+        params: serde_json::Value,
+    ) -> JsonRpcResponse {
+        let limit = params.get("limit").and_then(|v| v.as_i64()).unwrap_or(50);
+        let offset = params.get("offset").and_then(|v| v.as_i64()).unwrap_or(0);
+
+        match self.db.lock().unwrap().list_sessions(limit, offset) {
+            Ok(sessions) => JsonRpcResponse::success(
+                id,
+                serde_json::json!({
+                    "sessions": sessions,
+                    "total": sessions.len(),
+                }),
+            ),
+            Err(e) => JsonRpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        }
+    }
+
+    async fn handle_session_create(
+        &self,
+        id: Option<serde_json::Value>,
+        params: serde_json::Value,
+    ) -> JsonRpcResponse {
+        let model = params
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or("gemini-2.0-flash");
+        let device_id = params
+            .get("device_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        let session = Session::new(model, device_id);
+        match self.db.lock().unwrap().create_session(&session) {
+            Ok(()) => JsonRpcResponse::success(id, serde_json::json!(session)),
+            Err(e) => JsonRpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        }
+    }
+
+    async fn handle_session_delete(
+        &self,
+        id: Option<serde_json::Value>,
+        params: serde_json::Value,
+    ) -> JsonRpcResponse {
+        let session_id = match params.get("session_id").and_then(|v| v.as_str()) {
+            Some(sid) => sid,
+            None => {
+                return JsonRpcResponse::error(
+                    id,
+                    INVALID_PARAMS,
+                    "session_id required".to_string(),
+                );
+            }
+        };
+
+        match self.db.lock().unwrap().delete_session(session_id) {
+            Ok(()) => JsonRpcResponse::success(id, serde_json::json!({ "status": "deleted" })),
+            Err(e) => JsonRpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        }
+    }
+
+    async fn handle_chat_send(
+        &self,
+        id: Option<serde_json::Value>,
+        _params: serde_json::Value,
+    ) -> JsonRpcResponse {
+        // TODO: Wire up ChatRuntime
+        JsonRpcResponse::success(
+            id,
+            serde_json::json!({
+                "status": "accepted",
+                "stream_id": uuid::Uuid::new_v4().to_string(),
+            }),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn test_handler() -> RpcHandler {
+        let db = Database::open_in_memory().unwrap();
+        RpcHandler::new(Arc::new(std::sync::Mutex::new(db)))
+    }
+
+    #[tokio::test]
+    async fn test_initialize() {
+        let handler = test_handler();
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: "initialize".to_string(),
+            params: serde_json::Value::Null,
+        };
+        let resp = handler.handle(req).await;
+        assert!(resp.result.is_some());
+        assert!(resp.error.is_none());
+        let result = resp.result.unwrap();
+        assert_eq!(result["name"], "candela-harness");
+    }
+
+    #[tokio::test]
+    async fn test_session_lifecycle() {
+        let handler = test_handler();
+
+        // Create
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: "session.create".to_string(),
+            params: serde_json::json!({ "model": "test-model" }),
+        };
+        let resp = handler.handle(req).await;
+        let session_id = resp.result.unwrap()["id"].as_str().unwrap().to_string();
+
+        // List
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(2)),
+            method: "session.list".to_string(),
+            params: serde_json::json!({}),
+        };
+        let resp = handler.handle(req).await;
+        let sessions = resp.result.unwrap();
+        assert_eq!(sessions["sessions"].as_array().unwrap().len(), 1);
+
+        // Delete
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(3)),
+            method: "session.delete".to_string(),
+            params: serde_json::json!({ "session_id": session_id }),
+        };
+        let resp = handler.handle(req).await;
+        assert!(resp.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_unknown_method() {
+        let handler = test_handler();
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: "nonexistent".to_string(),
+            params: serde_json::Value::Null,
+        };
+        let resp = handler.handle(req).await;
+        assert!(resp.error.is_some());
+        assert_eq!(resp.error.unwrap().code, METHOD_NOT_FOUND);
+    }
+}

--- a/rust/crates/candela-harness-rpc/src/lib.rs
+++ b/rust/crates/candela-harness-rpc/src/lib.rs
@@ -1,0 +1,6 @@
+//! JSON-RPC 2.0 transport for IDE communication.
+
+pub mod handler;
+pub mod protocol;
+
+pub use handler::RpcHandler;

--- a/rust/crates/candela-harness-rpc/src/protocol.rs
+++ b/rust/crates/candela-harness-rpc/src/protocol.rs
@@ -16,7 +16,6 @@ pub struct JsonRpcRequest {
 #[derive(Debug, Clone, Serialize)]
 pub struct JsonRpcResponse {
     pub jsonrpc: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<serde_json::Value>,

--- a/rust/crates/candela-harness-rpc/src/protocol.rs
+++ b/rust/crates/candela-harness-rpc/src/protocol.rs
@@ -1,0 +1,77 @@
+//! JSON-RPC 2.0 protocol types.
+
+use serde::{Deserialize, Serialize};
+
+/// A JSON-RPC 2.0 request.
+#[derive(Debug, Clone, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    pub id: Option<serde_json::Value>,
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+/// A JSON-RPC 2.0 response.
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+impl JsonRpcResponse {
+    pub fn success(id: Option<serde_json::Value>, result: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn error(id: Option<serde_json::Value>, code: i32, message: String) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: Some(JsonRpcError { code, message }),
+        }
+    }
+}
+
+/// A JSON-RPC 2.0 notification (no id, no response expected).
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonRpcNotification {
+    pub jsonrpc: String,
+    pub method: String,
+    pub params: serde_json::Value,
+}
+
+impl JsonRpcNotification {
+    pub fn new(method: &str, params: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            method: method.to_string(),
+            params,
+        }
+    }
+}
+
+/// JSON-RPC error object.
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+// Standard JSON-RPC error codes
+pub const PARSE_ERROR: i32 = -32700;
+pub const INVALID_REQUEST: i32 = -32600;
+pub const METHOD_NOT_FOUND: i32 = -32601;
+pub const INVALID_PARAMS: i32 = -32602;
+pub const INTERNAL_ERROR: i32 = -32603;

--- a/rust/crates/candela-harness-storage/Cargo.toml
+++ b/rust/crates/candela-harness-storage/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "candela-harness-storage"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+candela-core = { workspace = true }
+rusqlite = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio-test = { workspace = true }

--- a/rust/crates/candela-harness-storage/src/db.rs
+++ b/rust/crates/candela-harness-storage/src/db.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 
 use candela_core::harness::{HarnessError, Message, MessageRole, Session};
+use chrono::{DateTime, Utc};
 use rusqlite::{Connection, params};
 use tracing::info;
 
@@ -15,6 +16,8 @@ impl Database {
     /// Open or create the database at the given path.
     pub fn open(path: &Path) -> Result<Self, HarnessError> {
         let conn = Connection::open(path).map_err(|e| HarnessError::Storage(e.to_string()))?;
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
         let db = Self { conn };
         db.init_schema()?;
         info!(path = %path.display(), "database opened");
@@ -25,6 +28,8 @@ impl Database {
     pub fn open_in_memory() -> Result<Self, HarnessError> {
         let conn =
             Connection::open_in_memory().map_err(|e| HarnessError::Storage(e.to_string()))?;
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
         let db = Self { conn };
         db.init_schema()?;
         Ok(db)
@@ -114,11 +119,9 @@ impl Database {
                     total_tokens: row.get(4)?,
                     total_cost_usd: row.get(5)?,
                     device_id: row.get(6)?,
-                    created_at: row.get::<_, String>(7)?.parse().unwrap_or_default(),
-                    updated_at: row.get::<_, String>(8)?.parse().unwrap_or_default(),
-                    deleted_at: row
-                        .get::<_, Option<String>>(9)?
-                        .and_then(|s| s.parse().ok()),
+                    created_at: row.get::<_, DateTime<Utc>>(7)?,
+                    updated_at: row.get::<_, DateTime<Utc>>(8)?,
+                    deleted_at: row.get::<_, Option<DateTime<Utc>>>(9)?,
                 })
             })
             .map_err(|e| HarnessError::Storage(e.to_string()))?
@@ -147,30 +150,38 @@ impl Database {
     // -- Messages --
 
     /// Insert a message and increment session counters.
-    pub fn insert_message(&self, msg: &Message) -> Result<i64, HarnessError> {
-        self.conn
-            .execute(
-                "INSERT INTO messages (session_id, role, content, model, token_count, cost_usd, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                params![
-                    msg.session_id,
-                    serde_json::to_string(&msg.role)
-                        .unwrap_or_default()
-                        .trim_matches('"'),
-                    msg.content,
-                    msg.model,
-                    msg.token_count,
-                    msg.cost_usd,
-                    msg.created_at.to_rfc3339(),
-                ],
-            )
+    ///
+    /// Uses a transaction to ensure atomicity between the message insert and
+    /// session counter update. Verifies the target session exists and is not
+    /// soft-deleted.
+    pub fn insert_message(&mut self, msg: &Message) -> Result<i64, HarnessError> {
+        let tx = self
+            .conn
+            .transaction()
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
-        let id = self.conn.last_insert_rowid();
 
-        // Update session counters
-        self.conn
+        tx.execute(
+            "INSERT INTO messages (session_id, role, content, model, token_count, cost_usd, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                msg.session_id,
+                serde_json::to_string(&msg.role)
+                    .unwrap_or_default()
+                    .trim_matches('"'),
+                msg.content,
+                msg.model,
+                msg.token_count,
+                msg.cost_usd,
+                msg.created_at.to_rfc3339(),
+            ],
+        )
+        .map_err(|e| HarnessError::Storage(e.to_string()))?;
+        let id = tx.last_insert_rowid();
+
+        // Update session counters — only for non-deleted sessions.
+        let rows_updated = tx
             .execute(
-                "UPDATE sessions SET message_count = message_count + 1, updated_at = ?1, total_tokens = total_tokens + ?2, total_cost_usd = total_cost_usd + ?3 WHERE id = ?4",
+                "UPDATE sessions SET message_count = message_count + 1, updated_at = ?1, total_tokens = total_tokens + ?2, total_cost_usd = total_cost_usd + ?3 WHERE id = ?4 AND deleted_at IS NULL",
                 params![
                     chrono::Utc::now().to_rfc3339(),
                     msg.token_count.unwrap_or(0),
@@ -178,6 +189,13 @@ impl Database {
                     msg.session_id,
                 ],
             )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
+        if rows_updated != 1 {
+            return Err(HarnessError::SessionNotFound(msg.session_id.clone()));
+        }
+
+        tx.commit()
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
 
         Ok(id)
@@ -214,7 +232,7 @@ impl Database {
                     model: row.get(4)?,
                     token_count: row.get(5)?,
                     cost_usd: row.get(6)?,
-                    created_at: row.get::<_, String>(7)?.parse().unwrap_or_default(),
+                    created_at: row.get::<_, DateTime<Utc>>(7)?,
                 })
             })
             .map_err(|e| HarnessError::Storage(e.to_string()))?
@@ -256,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_insert_and_get_messages() {
-        let db = Database::open_in_memory().unwrap();
+        let mut db = Database::open_in_memory().unwrap();
         let session = Session::new("test-model", "device-1");
         db.create_session(&session).unwrap();
 

--- a/rust/crates/candela-harness-storage/src/db.rs
+++ b/rust/crates/candela-harness-storage/src/db.rs
@@ -1,0 +1,279 @@
+//! Session and message persistence.
+
+use std::path::Path;
+
+use candela_core::harness::{HarnessError, Message, MessageRole, Session};
+use rusqlite::{Connection, params};
+use tracing::info;
+
+/// SQLite database for session and message storage.
+pub struct Database {
+    conn: Connection,
+}
+
+impl Database {
+    /// Open or create the database at the given path.
+    pub fn open(path: &Path) -> Result<Self, HarnessError> {
+        let conn = Connection::open(path).map_err(|e| HarnessError::Storage(e.to_string()))?;
+        let db = Self { conn };
+        db.init_schema()?;
+        info!(path = %path.display(), "database opened");
+        Ok(db)
+    }
+
+    /// Open an in-memory database (for testing).
+    pub fn open_in_memory() -> Result<Self, HarnessError> {
+        let conn =
+            Connection::open_in_memory().map_err(|e| HarnessError::Storage(e.to_string()))?;
+        let db = Self { conn };
+        db.init_schema()?;
+        Ok(db)
+    }
+
+    fn init_schema(&self) -> Result<(), HarnessError> {
+        self.conn
+            .execute_batch(
+                "
+            CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL DEFAULT 'New Chat',
+                model TEXT NOT NULL DEFAULT '',
+                message_count INTEGER NOT NULL DEFAULT 0,
+                total_tokens INTEGER NOT NULL DEFAULT 0,
+                total_cost_usd REAL NOT NULL DEFAULT 0.0,
+                device_id TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                deleted_at TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL,
+                model TEXT,
+                token_count INTEGER,
+                cost_usd REAL,
+                created_at TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_messages_session
+                ON messages(session_id, created_at);
+        ",
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    // -- Sessions --
+
+    /// Insert a new session.
+    pub fn create_session(&self, session: &Session) -> Result<(), HarnessError> {
+        self.conn
+            .execute(
+                "INSERT INTO sessions (id, title, model, message_count, total_tokens, total_cost_usd, device_id, created_at, updated_at, deleted_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                params![
+                    session.id,
+                    session.title,
+                    session.model,
+                    session.message_count,
+                    session.total_tokens,
+                    session.total_cost_usd,
+                    session.device_id,
+                    session.created_at.to_rfc3339(),
+                    session.updated_at.to_rfc3339(),
+                    session.deleted_at.map(|dt| dt.to_rfc3339()),
+                ],
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// List all non-deleted sessions, most recent first.
+    pub fn list_sessions(&self, limit: i64, offset: i64) -> Result<Vec<Session>, HarnessError> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, title, model, message_count, total_tokens, total_cost_usd, device_id, created_at, updated_at, deleted_at
+             FROM sessions
+             WHERE deleted_at IS NULL
+             ORDER BY updated_at DESC
+             LIMIT ?1 OFFSET ?2",
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
+        let sessions = stmt
+            .query_map(params![limit, offset], |row| {
+                Ok(Session {
+                    id: row.get(0)?,
+                    title: row.get(1)?,
+                    model: row.get(2)?,
+                    message_count: row.get(3)?,
+                    total_tokens: row.get(4)?,
+                    total_cost_usd: row.get(5)?,
+                    device_id: row.get(6)?,
+                    created_at: row.get::<_, String>(7)?.parse().unwrap_or_default(),
+                    updated_at: row.get::<_, String>(8)?.parse().unwrap_or_default(),
+                    deleted_at: row
+                        .get::<_, Option<String>>(9)?
+                        .and_then(|s| s.parse().ok()),
+                })
+            })
+            .map_err(|e| HarnessError::Storage(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
+        Ok(sessions)
+    }
+
+    /// Soft-delete a session.
+    pub fn delete_session(&self, id: &str) -> Result<(), HarnessError> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let rows = self
+            .conn
+            .execute(
+                "UPDATE sessions SET deleted_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
+                params![now, id],
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+        if rows == 0 {
+            return Err(HarnessError::SessionNotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
+    // -- Messages --
+
+    /// Insert a message and increment session counters.
+    pub fn insert_message(&self, msg: &Message) -> Result<i64, HarnessError> {
+        self.conn
+            .execute(
+                "INSERT INTO messages (session_id, role, content, model, token_count, cost_usd, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    msg.session_id,
+                    serde_json::to_string(&msg.role)
+                        .unwrap_or_default()
+                        .trim_matches('"'),
+                    msg.content,
+                    msg.model,
+                    msg.token_count,
+                    msg.cost_usd,
+                    msg.created_at.to_rfc3339(),
+                ],
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+        let id = self.conn.last_insert_rowid();
+
+        // Update session counters
+        self.conn
+            .execute(
+                "UPDATE sessions SET message_count = message_count + 1, updated_at = ?1, total_tokens = total_tokens + ?2, total_cost_usd = total_cost_usd + ?3 WHERE id = ?4",
+                params![
+                    chrono::Utc::now().to_rfc3339(),
+                    msg.token_count.unwrap_or(0),
+                    msg.cost_usd.unwrap_or(0.0),
+                    msg.session_id,
+                ],
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
+        Ok(id)
+    }
+
+    /// Get messages for a session.
+    pub fn get_messages(&self, session_id: &str, limit: i64) -> Result<Vec<Message>, HarnessError> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, session_id, role, content, model, token_count, cost_usd, created_at
+             FROM messages
+             WHERE session_id = ?1
+             ORDER BY created_at ASC
+             LIMIT ?2",
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
+        let messages = stmt
+            .query_map(params![session_id, limit], |row| {
+                let role_str: String = row.get(2)?;
+                let role = match role_str.as_str() {
+                    "user" => MessageRole::User,
+                    "assistant" => MessageRole::Assistant,
+                    "system" => MessageRole::System,
+                    "tool" => MessageRole::Tool,
+                    _ => MessageRole::User,
+                };
+                Ok(Message {
+                    id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    role,
+                    content: row.get(3)?,
+                    model: row.get(4)?,
+                    token_count: row.get(5)?,
+                    cost_usd: row.get(6)?,
+                    created_at: row.get::<_, String>(7)?.parse().unwrap_or_default(),
+                })
+            })
+            .map_err(|e| HarnessError::Storage(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
+        Ok(messages)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candela_core::harness::Session;
+
+    #[test]
+    fn test_create_and_list_sessions() {
+        let db = Database::open_in_memory().unwrap();
+        let session = Session::new("gemini-2.0-flash", "device-1");
+        db.create_session(&session).unwrap();
+
+        let sessions = db.list_sessions(50, 0).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id, session.id);
+        assert_eq!(sessions[0].title, "New Chat");
+    }
+
+    #[test]
+    fn test_soft_delete_session() {
+        let db = Database::open_in_memory().unwrap();
+        let session = Session::new("test-model", "device-1");
+        db.create_session(&session).unwrap();
+
+        db.delete_session(&session.id).unwrap();
+
+        let sessions = db.list_sessions(50, 0).unwrap();
+        assert_eq!(sessions.len(), 0); // soft-deleted, not visible
+    }
+
+    #[test]
+    fn test_insert_and_get_messages() {
+        let db = Database::open_in_memory().unwrap();
+        let session = Session::new("test-model", "device-1");
+        db.create_session(&session).unwrap();
+
+        let msg = Message {
+            id: 0,
+            session_id: session.id.clone(),
+            role: MessageRole::User,
+            content: "Hello!".to_string(),
+            model: None,
+            token_count: Some(5),
+            cost_usd: Some(0.001),
+            created_at: chrono::Utc::now(),
+        };
+        db.insert_message(&msg).unwrap();
+
+        let messages = db.get_messages(&session.id, 50).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].content, "Hello!");
+    }
+}

--- a/rust/crates/candela-harness-storage/src/lib.rs
+++ b/rust/crates/candela-harness-storage/src/lib.rs
@@ -1,0 +1,7 @@
+//! SQLite storage for sessions and messages with FTS5 search.
+
+pub mod db;
+pub mod search;
+
+pub use db::Database;
+pub use search::SearchIndex;

--- a/rust/crates/candela-harness-storage/src/search.rs
+++ b/rust/crates/candela-harness-storage/src/search.rs
@@ -1,0 +1,134 @@
+//! FTS5 full-text search index for messages.
+
+use candela_core::harness::{HarnessError, MessageRole, SearchResult};
+use rusqlite::{Connection, params};
+use tracing::info;
+
+/// FTS5 search index for cross-session message search.
+pub struct SearchIndex {
+    conn: Connection,
+}
+
+impl SearchIndex {
+    /// Open or create the search index at the given path.
+    pub fn open(path: &std::path::Path) -> Result<Self, HarnessError> {
+        let conn = Connection::open(path).map_err(|e| HarnessError::Storage(e.to_string()))?;
+        let idx = Self { conn };
+        idx.init_schema()?;
+        info!(path = %path.display(), "search index opened");
+        Ok(idx)
+    }
+
+    /// Open an in-memory search index (for testing).
+    pub fn open_in_memory() -> Result<Self, HarnessError> {
+        let conn =
+            Connection::open_in_memory().map_err(|e| HarnessError::Storage(e.to_string()))?;
+        let idx = Self { conn };
+        idx.init_schema()?;
+        Ok(idx)
+    }
+
+    fn init_schema(&self) -> Result<(), HarnessError> {
+        self.conn
+            .execute_batch(
+                "
+            CREATE VIRTUAL TABLE IF NOT EXISTS message_fts USING fts5(
+                content,
+                session_id UNINDEXED,
+                session_title UNINDEXED,
+                role UNINDEXED,
+                created_at UNINDEXED
+            );
+        ",
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Index a message for full-text search.
+    pub fn index_message(
+        &self,
+        content: &str,
+        session_id: &str,
+        session_title: &str,
+        role: &str,
+        created_at: &str,
+    ) -> Result<(), HarnessError> {
+        self.conn
+            .execute(
+                "INSERT INTO message_fts (content, session_id, session_title, role, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![content, session_id, session_title, role, created_at],
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Search messages across all sessions.
+    pub fn search(&self, query: &str, limit: i64) -> Result<Vec<SearchResult>, HarnessError> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT content, session_id, session_title, role, created_at, rank
+             FROM message_fts
+             WHERE message_fts MATCH ?1
+             ORDER BY rank
+             LIMIT ?2",
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
+        let results = stmt
+            .query_map(params![query, limit], |row| {
+                let role_str: String = row.get(3)?;
+                let role = match role_str.as_str() {
+                    "user" => MessageRole::User,
+                    "assistant" => MessageRole::Assistant,
+                    "system" => MessageRole::System,
+                    "tool" => MessageRole::Tool,
+                    _ => MessageRole::User,
+                };
+                Ok(SearchResult {
+                    message_preview: row.get(0)?,
+                    session_id: row.get(1)?,
+                    session_title: row.get(2)?,
+                    role,
+                    created_at: row.get::<_, String>(4)?.parse().unwrap_or_default(),
+                    score: row.get(5)?,
+                })
+            })
+            .map_err(|e| HarnessError::Storage(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_index_and_search() {
+        let idx = SearchIndex::open_in_memory().unwrap();
+        idx.index_message(
+            "How do I refactor the auth module?",
+            "session-1",
+            "Auth Refactor",
+            "user",
+            "2025-01-01T00:00:00Z",
+        )
+        .unwrap();
+        idx.index_message(
+            "Let me analyze the database schema.",
+            "session-2",
+            "DB Analysis",
+            "assistant",
+            "2025-01-02T00:00:00Z",
+        )
+        .unwrap();
+
+        let results = idx.search("refactor auth", 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].session_id, "session-1");
+    }
+}

--- a/rust/crates/candela-harness-storage/src/search.rs
+++ b/rust/crates/candela-harness-storage/src/search.rs
@@ -1,6 +1,7 @@
 //! FTS5 full-text search index for messages.
 
 use candela_core::harness::{HarnessError, MessageRole, SearchResult};
+use chrono::{DateTime, Utc};
 use rusqlite::{Connection, params};
 use tracing::info;
 
@@ -39,6 +40,11 @@ impl SearchIndex {
                 role UNINDEXED,
                 created_at UNINDEXED
             );
+
+            -- Track soft-deleted sessions so we can exclude them from search.
+            CREATE TABLE IF NOT EXISTS deleted_sessions (
+                session_id TEXT PRIMARY KEY
+            );
         ",
             )
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
@@ -63,15 +69,27 @@ impl SearchIndex {
         Ok(())
     }
 
-    /// Search messages across all sessions.
+    /// Mark a session as deleted, excluding its messages from future searches.
+    pub fn mark_session_deleted(&self, session_id: &str) -> Result<(), HarnessError> {
+        self.conn
+            .execute(
+                "INSERT OR IGNORE INTO deleted_sessions (session_id) VALUES (?1)",
+                params![session_id],
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Search messages across all non-deleted sessions.
     pub fn search(&self, query: &str, limit: i64) -> Result<Vec<SearchResult>, HarnessError> {
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT content, session_id, session_title, role, created_at, rank
-             FROM message_fts
-             WHERE message_fts MATCH ?1
-             ORDER BY rank
+                "SELECT f.content, f.session_id, f.session_title, f.role, f.created_at, f.rank
+             FROM message_fts f
+             WHERE f.message_fts MATCH ?1
+               AND f.session_id NOT IN (SELECT session_id FROM deleted_sessions)
+             ORDER BY f.rank
              LIMIT ?2",
             )
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
@@ -91,7 +109,7 @@ impl SearchIndex {
                     session_id: row.get(1)?,
                     session_title: row.get(2)?,
                     role,
-                    created_at: row.get::<_, String>(4)?.parse().unwrap_or_default(),
+                    created_at: row.get::<_, DateTime<Utc>>(4)?,
                     score: row.get(5)?,
                 })
             })
@@ -130,5 +148,29 @@ mod tests {
         let results = idx.search("refactor auth", 10).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].session_id, "session-1");
+    }
+
+    #[test]
+    fn test_deleted_sessions_excluded_from_search() {
+        let idx = SearchIndex::open_in_memory().unwrap();
+        idx.index_message(
+            "How do I refactor the auth module?",
+            "session-1",
+            "Auth Refactor",
+            "user",
+            "2025-01-01T00:00:00Z",
+        )
+        .unwrap();
+
+        // Before deletion, the message is findable.
+        let results = idx.search("refactor auth", 10).unwrap();
+        assert_eq!(results.len(), 1);
+
+        // Mark session as deleted.
+        idx.mark_session_deleted("session-1").unwrap();
+
+        // After deletion, the message is excluded.
+        let results = idx.search("refactor auth", 10).unwrap();
+        assert_eq!(results.len(), 0);
     }
 }

--- a/test/functional/compat/jetbrains_compat.hurl
+++ b/test/functional/compat/jetbrains_compat.hurl
@@ -1,0 +1,119 @@
+# JETBRAINS-COMPAT: JetBrains / ktor client compatibility tests
+#
+# These tests verify that the LM compat listener correctly handles
+# JetBrains AI Assistant's ktor-based HTTP client quirks:
+#
+# 1. Request body sanitization (strip fields that strict backends reject)
+# 2. SSE streaming response format
+# 3. User-Agent detection for ktor-specific workarounds
+#
+# Run against a live candela instance:
+#   hurl --variable CANDELA_LM_URL=http://localhost:1234 test/functional/compat/jetbrains_compat.hurl
+#
+# These tests are protocol-level and should survive a Rust rewrite.
+
+
+# ── JB-01: /v1/models with ktor User-Agent ─────────────────────────────────
+# JetBrains sends ktor-client as User-Agent. Verify model list works.
+GET {{CANDELA_LM_URL}}/v1/models
+User-Agent: ktor-client-jvm/3.1.3
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.object" == "list"
+jsonpath "$.data" isCollection
+
+
+# ── JB-02: /api/v0/models — LM Studio native API ───────────────────────────
+# IntelliJ uses this endpoint for "Test Connection".
+GET {{CANDELA_LM_URL}}/api/v0/models
+User-Agent: ktor-client-jvm/3.1.3
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.object" == "list"
+jsonpath "$.data" isCollection
+
+
+# ── JB-03: Request with extra JetBrains fields → still routed correctly ────
+# JetBrains sends format, keep_alive, options, empty tools:[], and
+# per-message tool_calls:[]. These must not cause 422 on strict backends.
+# Use a nonsense model to get a clean 400 "unknown model" — proving the
+# request body was parsed and routed, not rejected for invalid fields.
+POST {{CANDELA_LM_URL}}/v1/chat/completions
+Content-Type: application/json
+User-Agent: ktor-client-jvm/3.1.3
+```
+{
+  "model": "nonexistent-model-for-test",
+  "messages": [
+    {"role": "system", "content": "test", "tool_calls": []},
+    {"role": "user", "content": "hello", "tool_calls": []}
+  ],
+  "stream": true,
+  "format": "json",
+  "keep_alive": "5m",
+  "options": {"temperature": 0.7},
+  "tools": [],
+  "stream_options": {"include_usage": true}
+}
+```
+
+HTTP 400
+[Asserts]
+jsonpath "$.error.type" == "invalid_request_error"
+jsonpath "$.error.message" contains "unknown model"
+
+
+# ── JB-04: max_tokens injection — negative value handled ───────────────────
+# JetBrains sometimes sends max_tokens: -1. Candela must inject a sane
+# default before forwarding. Again use a nonsense model for clean routing.
+POST {{CANDELA_LM_URL}}/v1/chat/completions
+Content-Type: application/json
+User-Agent: ktor-client-jvm/3.1.3
+```
+{
+  "model": "nonexistent-model-for-test",
+  "messages": [{"role": "user", "content": "test"}],
+  "max_tokens": -1,
+  "stream": true
+}
+```
+
+HTTP 400
+[Asserts]
+jsonpath "$.error.type" == "invalid_request_error"
+jsonpath "$.error.message" contains "unknown model"
+
+
+# ── JB-05: Non-streaming request — normal JSON response ────────────────────
+# Even with ktor User-Agent, non-streaming requests should return JSON.
+POST {{CANDELA_LM_URL}}/v1/chat/completions
+Content-Type: application/json
+User-Agent: ktor-client-jvm/3.1.3
+```
+{
+  "model": "nonexistent-model-for-test",
+  "messages": [{"role": "user", "content": "test"}],
+  "stream": false
+}
+```
+
+HTTP 400
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.error.type" == "invalid_request_error"
+
+
+# ── JB-06: /v1/completions stub returns 501 ────────────────────────────────
+# JetBrains may probe legacy completions endpoint.
+POST {{CANDELA_LM_URL}}/v1/completions
+Content-Type: application/json
+User-Agent: ktor-client-jvm/3.1.3
+```
+{"model": "test", "prompt": "hello"}
+```
+
+HTTP 501


### PR DESCRIPTION
## Bug Fix

v0.9.4's respondedSSE guard checked w.Header() but sseLiteNormalizer has its own header map — so w.Header() was always empty, the hijack never fired, and ktor clients still got EOF.

### Fix
- Check writer.Header() (normalizer's map) instead of w.Header()
- Add FlushRemaining() to drain non-SSE data (JSON errors) stuck in the normalizer buffer

### Tests Added (protocol-level, survive Rust rewrite)

**Go unit tests** (lm_compat_test.go):
- TestStripRemoteOnlyFields — 5 table-driven cases
- TestKtorSSEHijack — raw TCP: no chunked terminator after [DONE]
- TestSSELiteNormalizerDeltaContent — role-only delta injection

**Hurl integration tests** (jetbrains_compat.hurl):
- 6 tests: model listing, request sanitization, max_tokens, non-streaming, endpoint stubs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new harness mode that runs over standard input with JSON-RPC, including session-based chat workflows.
  * Introduced SQLite-backed session persistence plus full-text search across saved messages.
  * Added additional client compatibility validation for JetBrains/ktor behaviors.
* **Bug Fixes**
  * Improved SSE streaming normalization and ensured buffered trailing data is flushed to prevent broken responses.
  * Updated SSE detection to use the normalized response content type for JetBrains/Ktor quirks.
* **Tests**
  * Expanded functional and unit tests covering request rewriting, SSE hijack/termination handling, and edge-case streaming payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->