### PR TITLE
fix(storage): use metadata-only query for ListUsers count fallback

### DIFF
--- a/pkg/storage/firestoredb/firestoredb.go
+++ b/pkg/storage/firestoredb/firestoredb.go
@@ -425,10 +425,34 @@ func (s *Store) ListUsers(ctx context.Context, statusFilter string, limit, offse
 		return nil, 0, fmt.Errorf("firestoredb: listing users: %w", err)
 	}
 
-	// If aggregation count returned 0 but we fetched users, use the
-	// fetched length as a fallback (handles count API mismatches).
-	if total == 0 && len(snaps) > 0 {
-		total = len(snaps)
+	// If aggregation count returned 0 but we have reason to believe
+	// users exist, count via a metadata-only iterator. Select() with no
+	// field paths avoids transferring field data; iterating (rather than
+	// GetAll) avoids loading every snapshot into memory at once.
+	// The offset > 0 guard catches past-last-page requests where snaps
+	// is empty but the collection is not.
+	if total == 0 && (len(snaps) > 0 || offset > 0 || limit == 0) {
+		iter := q.Select().Documents(ctx)
+		defer iter.Stop()
+		count := 0
+		var countErr error
+		for {
+			_, err := iter.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				countErr = err
+				break
+			}
+			count++
+		}
+		if countErr == nil {
+			total = count
+		} else {
+			slog.Warn("firestoredb: count fallback query failed", "error", countErr)
+			total = len(snaps)
+		}
 	}
 
 	users := make([]*storage.UserRecord, 0, len(snaps))


### PR DESCRIPTION
## Summary

When the Firestore aggregation count API fails (e.g. emulator, SDK mismatch), the `ListUsers` fallback used `len(snaps)` — which is capped by the page `limit`. With paginated results this reports the page size as the total (e.g. "10 users total" instead of 20), and breaks pagination since `offset + limit < total` is always false.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

### `pkg/storage/firestoredb/firestoredb.go`

The fallback when aggregation count returns 0 now runs a `Select()` query with no field paths — a metadata-only scan that fetches document references without any field data. This gives the true total count cheaply.

```diff
 if total == 0 && len(snaps) > 0 {
-    total = len(snaps)
+    countSnaps, countErr := q.Select().Documents(ctx).GetAll()
+    if countErr == nil {
+        total = len(countSnaps)
+    } else {
+        slog.Warn("firestoredb: count fallback query failed", "error", countErr)
+        total = len(snaps)
+    }
 }
```

Falls back to `len(snaps)` only as a last resort if the metadata query also fails.

## Root Cause

The aggregation count (`q.NewAggregationQuery().WithCount("total")`) silently returns 0 in some environments. The old fallback set `total = len(snaps)`, but `snaps` is already paginated via `q.Offset(offset).Limit(limit)`. When all users fit on one page the fallback happened to be correct, but with `limit < totalUsers` it reports the wrong count and suppresses the `nextPageToken`.

## Testing

- `go build ./pkg/storage/firestoredb/` — compiles clean
- `go test ./pkg/connecthandlers/ -run TestUserHandler_ListUsers` — passes
- Full pre-commit suite (go-vet, golangci-lint, go-test all packages) — passes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of user list totals when the system’s fast count reports zero while the current page still displays users.
  * The total is now recalculated using a lightweight scan of matching records to better reflect the real count.
  * If the recalculation fails, the app falls back to using the current page size to keep totals stable and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->