### PR TITLE
feat(ui): reduce admin users page size from 25 to 10

### DIFF
--- a/ui/src/app/admin/users/page.tsx
+++ b/ui/src/app/admin/users/page.tsx
@@ -8,7 +8,7 @@ import type { User, UserBudget, BudgetGrant } from "@/gen/candela/types/user_pb"
 import { UserRole, UserStatus, BudgetPeriod } from "@/gen/candela/types/user_pb";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 
-const PAGE_SIZE = 25;
+const PAGE_SIZE = 10;
 
 interface UsersState {
   users: User[];


### PR DESCRIPTION
## Summary

Reduce the admin users table page size from 25 to 10 for faster page loads and a more manageable table view.

## Type of Change

- [x] Enhancement (non-breaking change which improves existing functionality)

## Changes

### `ui/src/app/admin/users/page.tsx`
- `PAGE_SIZE` constant changed from `25` to `10`

## Context

Pagination controls and the count fallback (#456) already handle multi-page navigation correctly. Smaller pages reduce payload size and render faster, especially as the user base grows.

## Testing

- Pagination shows "Page 1 of N" with correct total count
- Next/Previous buttons navigate between pages
- No visual regressions

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the users list to show fewer results per page, improving pagination behavior and making page navigation more responsive.
  * Pagination now recalculates the total number of pages based on the new page size, affecting when navigation controls appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->