### PR TITLE
test: add ListUsers pagination and count fallback regression tests

### DIFF
--- a/pkg/connecthandlers/user_handler_test.go
+++ b/pkg/connecthandlers/user_handler_test.go
@@ -699,6 +699,99 @@ func TestUserHandler_ListUsers(t *testing.T) {
 	}
 }
 
+// TestUserHandler_ListUsers_BrokenTotalBreaksPagination is a regression test
+// for the count fallback bug fixed in PR #456. It demonstrates that when the
+// store returns total=0 (simulating Firestore aggregation failure without the
+// fallback fix), the handler produces no nextPageToken and reports 0 total —
+// breaking pagination for the client.
+func TestUserHandler_ListUsers_BrokenTotalBreaksPagination(t *testing.T) {
+	store := &brokenCountStore{
+		mockUserStore: newMockUserStore(),
+		reportTotal:   0, // simulate broken aggregation
+	}
+	handler := NewUserHandler(store, 0)
+	ctx := authedCtx("admin@example.com")
+
+	// Create 5 users.
+	for i := range 5 {
+		if _, err := handler.CreateUser(ctx, connect.NewRequest(&v1.CreateUserRequest{
+			Email: fmt.Sprintf("user%d@broken.com", i),
+		})); err != nil {
+			t.Fatalf("CreateUser[%d]: %v", i, err)
+		}
+	}
+
+	// Request page of size 2 — with total=0 from store, handler can't
+	// compute nextPageToken (offset+limit < total is 2 < 0 = false).
+	resp, err := handler.ListUsers(ctx, connect.NewRequest(&v1.ListUsersRequest{
+		Pagination: &typespb.PaginationRequest{PageSize: 2},
+	}))
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	if len(resp.Msg.Users) != 2 {
+		t.Errorf("got %d users, want 2", len(resp.Msg.Users))
+	}
+	// With broken total=0, pagination metadata is wrong:
+	if resp.Msg.Pagination.TotalCount != 0 {
+		t.Errorf("total = %d, want 0 (broken store)", resp.Msg.Pagination.TotalCount)
+	}
+	if resp.Msg.Pagination.NextPageToken != "" {
+		t.Errorf("next_page_token = %q, want empty (broken total suppresses pagination)", resp.Msg.Pagination.NextPageToken)
+	}
+}
+
+// TestUserHandler_ListUsers_CorrectTotalEnablesPagination verifies that when
+// the store returns the correct total, pagination works as expected.
+func TestUserHandler_ListUsers_CorrectTotalEnablesPagination(t *testing.T) {
+	store := &brokenCountStore{
+		mockUserStore: newMockUserStore(),
+		reportTotal:   -1, // -1 = use real total
+	}
+	handler := NewUserHandler(store, 0)
+	ctx := authedCtx("admin@example.com")
+
+	// Create 5 users.
+	for i := range 5 {
+		if _, err := handler.CreateUser(ctx, connect.NewRequest(&v1.CreateUserRequest{
+			Email: fmt.Sprintf("user%d@fixed.com", i),
+		})); err != nil {
+			t.Fatalf("CreateUser[%d]: %v", i, err)
+		}
+	}
+
+	resp, err := handler.ListUsers(ctx, connect.NewRequest(&v1.ListUsersRequest{
+		Pagination: &typespb.PaginationRequest{PageSize: 2},
+	}))
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	if resp.Msg.Pagination.TotalCount != 5 {
+		t.Errorf("total = %d, want 5", resp.Msg.Pagination.TotalCount)
+	}
+	if resp.Msg.Pagination.NextPageToken == "" {
+		t.Error("expected next_page_token when more pages exist")
+	}
+}
+
+// brokenCountStore wraps mockUserStore but overrides the total returned by
+// ListUsers to simulate Firestore aggregation failures.
+type brokenCountStore struct {
+	*mockUserStore
+	reportTotal int // total to return; -1 means use real total
+}
+
+func (s *brokenCountStore) ListUsers(ctx context.Context, statusFilter string, limit, offset int) ([]*storage.UserRecord, int, error) {
+	users, realTotal, err := s.mockUserStore.ListUsers(ctx, statusFilter, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	if s.reportTotal >= 0 {
+		return users, s.reportTotal, nil
+	}
+	return users, realTotal, nil
+}
+
 func TestUserHandler_ListUsers_LastActiveAtMapping(t *testing.T) {
 	store := newMockUserStore()
 	handler := NewUserHandler(store, 0)

--- a/pkg/storage/firestoredb/list_users_test.go
+++ b/pkg/storage/firestoredb/list_users_test.go
@@ -1,0 +1,169 @@
+package firestoredb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// TestListUsers_PaginationAndTotalCount verifies that ListUsers returns
+// the correct total count and paginated results, regardless of page size.
+// This is a regression test for the count fallback bug fixed in PR #456:
+// when Firestore's aggregation count fails, the fallback must still
+// return the true total — not len(snaps) capped by the page limit.
+func TestListUsers_PaginationAndTotalCount(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	const numUsers = 5
+
+	// Create test users.
+	userIDs := make([]string, numUsers)
+	for i := range numUsers {
+		id := fmt.Sprintf("list-test-%d-%d", time.Now().UnixNano(), i)
+		userIDs[i] = id
+		err := s.CreateUser(ctx, &storage.UserRecord{
+			ID:     id,
+			Email:  fmt.Sprintf("user%d@test.com", i),
+			Status: "active",
+			Role:   "developer",
+		})
+		if err != nil {
+			t.Fatalf("CreateUser[%d]: %v", i, err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, id := range userIDs {
+			if id != "" {
+				cleanupUser(ctx, s, id)
+			}
+		}
+	})
+
+	// ── Test 1: full page (limit >= numUsers) ──
+	users, total, err := s.ListUsers(ctx, "", numUsers+10, 0)
+	if err != nil {
+		t.Fatalf("ListUsers full page: %v", err)
+	}
+	if total < numUsers {
+		t.Errorf("total = %d, want >= %d", total, numUsers)
+	}
+	if len(users) < numUsers {
+		t.Errorf("got %d users, want >= %d", len(users), numUsers)
+	}
+
+	// ── Test 2: paginated (limit < total) ──
+	// Page 1: limit=2, offset=0
+	page1, total1, err := s.ListUsers(ctx, "", 2, 0)
+	if err != nil {
+		t.Fatalf("ListUsers page 1: %v", err)
+	}
+	if len(page1) != 2 {
+		t.Errorf("page 1: got %d users, want 2", len(page1))
+	}
+	if total1 < numUsers {
+		t.Errorf("page 1 total = %d, want >= %d (must not be capped by page limit)", total1, numUsers)
+	}
+
+	// Page 2: limit=2, offset=2
+	page2, total2, err := s.ListUsers(ctx, "", 2, 2)
+	if err != nil {
+		t.Fatalf("ListUsers page 2: %v", err)
+	}
+	if len(page2) != 2 {
+		t.Errorf("page 2: got %d users, want 2", len(page2))
+	}
+	if total2 != total1 {
+		t.Errorf("total changed between pages: page1=%d, page2=%d", total1, total2)
+	}
+
+	// Page 3 (last page): limit=2, offset=4
+	page3, total3, err := s.ListUsers(ctx, "", 2, 4)
+	if err != nil {
+		t.Fatalf("ListUsers page 3: %v", err)
+	}
+	if len(page3) < 1 {
+		t.Errorf("page 3: got %d users, want >= 1", len(page3))
+	}
+	if total3 != total1 {
+		t.Errorf("total changed between pages: page1=%d, page3=%d", total1, total3)
+	}
+
+	// ── Test 3: past-last-page (offset > total) ──
+	// Use the observed total to derive a guaranteed past-end offset,
+	// in case the emulator has pre-existing rows.
+	pastEnd, totalPast, err := s.ListUsers(ctx, "", 2, total1)
+	if err != nil {
+		t.Fatalf("ListUsers past end: %v", err)
+	}
+	if len(pastEnd) != 0 {
+		t.Errorf("past end: got %d users, want 0", len(pastEnd))
+	}
+	if totalPast < numUsers {
+		t.Errorf("past end total = %d, want >= %d (must report true count even for empty pages)", totalPast, numUsers)
+	}
+
+	// ── Test 4: status filter ──
+	filteredUsers, filteredTotal, err := s.ListUsers(ctx, "active", 100, 0)
+	if err != nil {
+		t.Fatalf("ListUsers with status filter: %v", err)
+	}
+	if filteredTotal < numUsers {
+		t.Errorf("filtered total = %d, want >= %d", filteredTotal, numUsers)
+	}
+	if len(filteredUsers) < numUsers {
+		t.Errorf("filtered users = %d, want >= %d", len(filteredUsers), numUsers)
+	}
+}
+
+// TestListUsers_TotalConsistentAcrossPages verifies that the total count
+// remains the same regardless of which page is requested. This catches
+// the pre-#456 bug where total = len(snaps) = min(limit, actual_count).
+func TestListUsers_TotalConsistentAcrossPages(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	const numUsers = 7
+	const pageSize = 3
+
+	userIDs := make([]string, numUsers)
+	for i := range numUsers {
+		id := fmt.Sprintf("consistent-%d-%d", time.Now().UnixNano(), i)
+		userIDs[i] = id
+		err := s.CreateUser(ctx, &storage.UserRecord{
+			ID:     id,
+			Email:  fmt.Sprintf("consist%d@test.com", i),
+			Status: "active",
+			Role:   "developer",
+		})
+		if err != nil {
+			t.Fatalf("CreateUser[%d]: %v", i, err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, id := range userIDs {
+			if id != "" {
+				cleanupUser(ctx, s, id)
+			}
+		}
+	})
+
+	// Fetch every page and verify total is consistent.
+	var prevTotal int
+	for offset := 0; offset < numUsers+pageSize; offset += pageSize {
+		_, total, err := s.ListUsers(ctx, "", pageSize, offset)
+		if err != nil {
+			t.Fatalf("ListUsers offset=%d: %v", offset, err)
+		}
+		if total < numUsers {
+			t.Errorf("offset=%d: total=%d, want >= %d", offset, total, numUsers)
+		}
+		if prevTotal != 0 && total != prevTotal {
+			t.Errorf("total changed: offset=%d got %d, previous was %d", offset, total, prevTotal)
+		}
+		prevTotal = total
+	}
+}


### PR DESCRIPTION
## Summary

Add regression tests for the count fallback bug fixed in #456. The existing `TestUserHandler_ListUsers` used a mock that always returns the correct total, so it never exercised the broken-aggregation path.

## Type of Change

- [x] Test coverage improvement

## Changes

### [NEW] `pkg/storage/firestoredb/list_users_test.go`
Firestore emulator tests (skipped without `FIRESTORE_EMULATOR_HOST`):
- **`TestListUsers_PaginationAndTotalCount`**: Verifies total is correct regardless of page size, including past-last-page (`offset > total`) and status-filtered requests
- **`TestListUsers_TotalConsistentAcrossPages`**: Verifies total stays the same across all pages of a paginated result set — catches the pre-#456 bug where `total = len(snaps) = min(limit, actual_count)`

### [MODIFY] `pkg/connecthandlers/user_handler_test.go`
Handler-level tests (always run, no emulator needed):
- **`TestUserHandler_ListUsers_BrokenTotalBreaksPagination`**: Uses a `brokenCountStore` mock that returns `total=0` to prove that when the store reports the wrong total, the handler produces no `nextPageToken` — demonstrating the bug
- **`TestUserHandler_ListUsers_CorrectTotalEnablesPagination`**: Verifies that with correct total, pagination tokens work properly

## Testing

```
$ go test ./pkg/connecthandlers/ -run TestUserHandler_ListUsers -v
--- PASS: TestUserHandler_ListUsers (0.00s)
--- PASS: TestUserHandler_ListUsers_BrokenTotalBreaksPagination (0.00s)
--- PASS: TestUserHandler_ListUsers_CorrectTotalEnablesPagination (0.00s)
--- PASS: TestUserHandler_ListUsers_LastActiveAtMapping (0.00s)

$ go test ./pkg/storage/firestoredb/ -run TestListUsers -v
--- SKIP: TestListUsers_PaginationAndTotalCount (emulator not running)
--- SKIP: TestListUsers_TotalConsistentAcrossPages (emulator not running)
```

Full pre-commit suite passes (go-vet, golangci-lint, go-test all packages).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user list pagination so total counts remain accurate across different limits and offsets.
  * Ensured totals and pagination metadata stay correct when filters are applied.
  * Avoided showing next-page pagination when the total count is missing or invalid.
* **Tests**
  * Added regression tests covering pagination and total-count consistency, including scenarios where the underlying total is incorrect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->