### PR TITLE
refactor(rust): use proto-generated types from candela-types

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -257,6 +257,7 @@ name = "candela-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "candela-types",
  "chrono",
  "prost",
  "prost-types",

--- a/rust/crates/candela-core/Cargo.toml
+++ b/rust/crates/candela-core/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+candela-types = { workspace = true }
 chrono = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }

--- a/rust/crates/candela-core/src/harness.rs
+++ b/rust/crates/candela-core/src/harness.rs
@@ -1,11 +1,48 @@
 //! Domain types, configuration, and errors for the candela-harness IDE sidecar.
 //!
-//! These types were originally in the standalone `harness-core` crate and have
-//! been merged into `candela-core` so that every harness crate depends on a
-//! single shared type library.
+//! Session, Message, MessageRole, SearchResult, and UsageSummary are
+//! re-exported from `candela-types` (generated from candela-protos).
+//! HarnessConfig, HarnessError, TransportMode, and ChatEvent remain
+//! harness-specific and are defined here.
 
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+// ── Re-exported proto-generated types ──
+
+pub use candela_types::chat::UsageSummary;
+pub use candela_types::session::{Message, MessageRole, SearchResult, Session};
+
+// ── Session constructor ──
+
+/// Extension methods for creating new sessions.
+pub fn new_session(model: &str, device_id: &str) -> Session {
+    let now = chrono::Utc::now();
+    let id = uuid::Uuid::new_v4().to_string();
+    Session {
+        id,
+        title: "New Chat".to_string(),
+        model: model.to_string(),
+        message_count: 0,
+        total_tokens: 0,
+        total_cost_usd: 0.0,
+        device_id: device_id.to_string(),
+        created_at: now,
+        updated_at: now,
+        deleted_at: None,
+    }
+}
+
+/// Create a new user message for a session.
+pub fn new_message(session_id: &str, role: MessageRole, content: &str) -> Message {
+    Message {
+        id: uuid::Uuid::new_v4().to_string(),
+        session_id: session_id.to_string(),
+        role,
+        content: content.to_string(),
+        created_at: chrono::Utc::now(),
+        ..Default::default()
+    }
+}
 
 // ── Configuration ──
 
@@ -79,70 +116,14 @@ pub enum HarnessError {
     Other(#[from] anyhow::Error),
 }
 
-// ── Domain Types ──
-
-/// A chat session (conversation).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Session {
-    pub id: String,
-    pub title: String,
-    pub model: String,
-    pub message_count: i32,
-    pub total_tokens: i64,
-    pub total_cost_usd: f64,
-    pub device_id: String,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub deleted_at: Option<DateTime<Utc>>,
-}
-
-impl Session {
-    pub fn new(model: &str, device_id: &str) -> Self {
-        let now = Utc::now();
-        let id = uuid::Uuid::new_v4().to_string();
-        Self {
-            id,
-            title: "New Chat".to_string(),
-            model: model.to_string(),
-            message_count: 0,
-            total_tokens: 0,
-            total_cost_usd: 0.0,
-            device_id: device_id.to_string(),
-            created_at: now,
-            updated_at: now,
-            deleted_at: None,
-        }
-    }
-}
-
-/// A single chat message.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Message {
-    pub id: i64,
-    pub session_id: String,
-    pub role: MessageRole,
-    pub content: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub token_count: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cost_usd: Option<f64>,
-    pub created_at: DateTime<Utc>,
-}
-
-/// Message roles.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum MessageRole {
-    User,
-    Assistant,
-    System,
-    Tool,
-}
+// ── Streaming Chat Events (wire format) ──
 
 /// Streaming chat events sent as JSON-RPC notifications.
+///
+/// This type defines the JSON-RPC wire format for streaming. It intentionally
+/// differs from the proto-generated `ChatEvent` (which uses struct + oneof)
+/// because the JSON-RPC protocol needs a flat tagged enum for ergonomic
+/// serialization over stdio.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ChatEvent {
@@ -172,33 +153,13 @@ pub enum ChatEvent {
     Error { stream_id: String, message: String },
 }
 
-/// Token/cost usage summary.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct UsageSummary {
-    pub prompt_tokens: i64,
-    pub completion_tokens: i64,
-    pub total_tokens: i64,
-    pub total_cost_usd: f64,
-}
-
-/// Search result from FTS5 index.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SearchResult {
-    pub session_id: String,
-    pub session_title: String,
-    pub message_preview: String,
-    pub role: MessageRole,
-    pub score: f64,
-    pub created_at: DateTime<Utc>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn session_new_has_valid_defaults() {
-        let session = Session::new("gemini-2.0-flash", "device-1");
+        let session = new_session("gemini-2.0-flash", "device-1");
         assert_eq!(session.title, "New Chat");
         assert_eq!(session.model, "gemini-2.0-flash");
         assert_eq!(session.message_count, 0);
@@ -208,7 +169,7 @@ mod tests {
 
     #[test]
     fn session_json_round_trip() {
-        let session = Session::new("test-model", "dev-1");
+        let session = new_session("test-model", "dev-1");
         let json = serde_json::to_string(&session).unwrap();
         let restored: Session = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.id, session.id);
@@ -227,11 +188,11 @@ mod tests {
     }
 
     #[test]
-    fn message_role_serde() {
-        let json = serde_json::to_string(&MessageRole::Assistant).unwrap();
-        assert_eq!(json, "\"assistant\"");
-        let restored: MessageRole = serde_json::from_str(&json).unwrap();
-        assert_eq!(restored, MessageRole::Assistant);
+    fn message_new_has_uuid() {
+        let msg = new_message("sess-1", MessageRole::User, "hello");
+        assert!(!msg.id.is_empty());
+        assert_eq!(msg.session_id, "sess-1");
+        assert_eq!(msg.content, "hello");
     }
 
     #[test]

--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -1,6 +1,6 @@
 //! JSON-RPC request handler — dispatches method calls.
 
-use candela_core::harness::{HarnessError, Session};
+use candela_core::harness::{HarnessError, new_session};
 use candela_harness_storage::Database;
 use tracing::info;
 
@@ -99,7 +99,7 @@ impl RpcHandler {
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
-        let session = Session::new(model, device_id);
+        let session = new_session(model, device_id);
         match self.db.lock().unwrap().create_session(&session) {
             Ok(()) => JsonRpcResponse::success(id, serde_json::json!(session)),
             Err(e) => JsonRpcResponse::error(id, INTERNAL_ERROR, e.to_string()),

--- a/rust/crates/candela-harness-storage/src/db.rs
+++ b/rust/crates/candela-harness-storage/src/db.rs
@@ -53,18 +53,19 @@ impl Database {
             );
 
             CREATE TABLE IF NOT EXISTS messages (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                id TEXT PRIMARY KEY,
                 session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
                 role TEXT NOT NULL,
                 content TEXT NOT NULL,
                 model TEXT,
                 token_count INTEGER,
                 cost_usd REAL,
-                created_at TEXT NOT NULL
+                created_at TEXT NOT NULL,
+                sequence INTEGER NOT NULL DEFAULT 0
             );
 
             CREATE INDEX IF NOT EXISTS idx_messages_session
-                ON messages(session_id, created_at);
+                ON messages(session_id, sequence);
         ",
             )
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
@@ -154,29 +155,28 @@ impl Database {
     /// Uses a transaction to ensure atomicity between the message insert and
     /// session counter update. Verifies the target session exists and is not
     /// soft-deleted.
-    pub fn insert_message(&mut self, msg: &Message) -> Result<i64, HarnessError> {
+    pub fn insert_message(&mut self, msg: &Message) -> Result<String, HarnessError> {
         let tx = self
             .conn
             .transaction()
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
 
         tx.execute(
-            "INSERT INTO messages (session_id, role, content, model, token_count, cost_usd, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO messages (id, session_id, role, content, model, token_count, cost_usd, created_at, sequence)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             params![
+                msg.id,
                 msg.session_id,
-                serde_json::to_string(&msg.role)
-                    .unwrap_or_default()
-                    .trim_matches('"'),
+                format!("{}", msg.role).to_lowercase(),
                 msg.content,
                 msg.model,
                 msg.token_count,
                 msg.cost_usd,
                 msg.created_at.to_rfc3339(),
+                msg.sequence,
             ],
         )
         .map_err(|e| HarnessError::Storage(e.to_string()))?;
-        let id = tx.last_insert_rowid();
 
         // Update session counters — only for non-deleted sessions.
         let rows_updated = tx
@@ -198,7 +198,7 @@ impl Database {
         tx.commit()
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
 
-        Ok(id)
+        Ok(msg.id.clone())
     }
 
     /// Get messages for a session.
@@ -206,10 +206,10 @@ impl Database {
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT id, session_id, role, content, model, token_count, cost_usd, created_at
+                "SELECT id, session_id, role, content, model, token_count, cost_usd, created_at, sequence
              FROM messages
              WHERE session_id = ?1
-             ORDER BY created_at ASC
+             ORDER BY sequence ASC
              LIMIT ?2",
             )
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
@@ -222,7 +222,7 @@ impl Database {
                     "assistant" => MessageRole::Assistant,
                     "system" => MessageRole::System,
                     "tool" => MessageRole::Tool,
-                    _ => MessageRole::User,
+                    _ => MessageRole::Unspecified,
                 };
                 Ok(Message {
                     id: row.get(0)?,
@@ -233,6 +233,7 @@ impl Database {
                     token_count: row.get(5)?,
                     cost_usd: row.get(6)?,
                     created_at: row.get::<_, DateTime<Utc>>(7)?,
+                    sequence: row.get(8)?,
                 })
             })
             .map_err(|e| HarnessError::Storage(e.to_string()))?
@@ -246,12 +247,12 @@ impl Database {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use candela_core::harness::Session;
+    use candela_core::harness::{new_message, new_session};
 
     #[test]
     fn test_create_and_list_sessions() {
         let db = Database::open_in_memory().unwrap();
-        let session = Session::new("gemini-2.0-flash", "device-1");
+        let session = new_session("gemini-2.0-flash", "device-1");
         db.create_session(&session).unwrap();
 
         let sessions = db.list_sessions(50, 0).unwrap();
@@ -263,7 +264,7 @@ mod tests {
     #[test]
     fn test_soft_delete_session() {
         let db = Database::open_in_memory().unwrap();
-        let session = Session::new("test-model", "device-1");
+        let session = new_session("test-model", "device-1");
         db.create_session(&session).unwrap();
 
         db.delete_session(&session.id).unwrap();
@@ -275,19 +276,10 @@ mod tests {
     #[test]
     fn test_insert_and_get_messages() {
         let mut db = Database::open_in_memory().unwrap();
-        let session = Session::new("test-model", "device-1");
+        let session = new_session("test-model", "device-1");
         db.create_session(&session).unwrap();
 
-        let msg = Message {
-            id: 0,
-            session_id: session.id.clone(),
-            role: MessageRole::User,
-            content: "Hello!".to_string(),
-            model: None,
-            token_count: Some(5),
-            cost_usd: Some(0.001),
-            created_at: chrono::Utc::now(),
-        };
+        let msg = new_message(&session.id, MessageRole::User, "Hello!");
         db.insert_message(&msg).unwrap();
 
         let messages = db.get_messages(&session.id, 50).unwrap();

--- a/rust/crates/candela-harness-storage/src/db.rs
+++ b/rust/crates/candela-harness-storage/src/db.rs
@@ -7,6 +7,28 @@ use chrono::{DateTime, Utc};
 use rusqlite::{Connection, params};
 use tracing::info;
 
+/// Convert a MessageRole to a lowercase string for DB storage.
+fn role_to_str(role: &MessageRole) -> &'static str {
+    match role {
+        MessageRole::User => "user",
+        MessageRole::Assistant => "assistant",
+        MessageRole::System => "system",
+        MessageRole::Tool => "tool",
+        MessageRole::Unspecified => "unspecified",
+    }
+}
+
+/// Parse a role string from the DB back to MessageRole.
+fn role_from_str(s: &str) -> MessageRole {
+    match s {
+        "user" => MessageRole::User,
+        "assistant" => MessageRole::Assistant,
+        "system" => MessageRole::System,
+        "tool" => MessageRole::Tool,
+        _ => MessageRole::Unspecified,
+    }
+}
+
 /// SQLite database for session and message storage.
 pub struct Database {
     conn: Connection,
@@ -167,7 +189,7 @@ impl Database {
             params![
                 msg.id,
                 msg.session_id,
-                format!("{}", msg.role).to_lowercase(),
+                role_to_str(&msg.role),
                 msg.content,
                 msg.model,
                 msg.token_count,
@@ -209,7 +231,7 @@ impl Database {
                 "SELECT id, session_id, role, content, model, token_count, cost_usd, created_at, sequence
              FROM messages
              WHERE session_id = ?1
-             ORDER BY sequence ASC
+             ORDER BY sequence ASC, created_at ASC
              LIMIT ?2",
             )
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
@@ -217,13 +239,7 @@ impl Database {
         let messages = stmt
             .query_map(params![session_id, limit], |row| {
                 let role_str: String = row.get(2)?;
-                let role = match role_str.as_str() {
-                    "user" => MessageRole::User,
-                    "assistant" => MessageRole::Assistant,
-                    "system" => MessageRole::System,
-                    "tool" => MessageRole::Tool,
-                    _ => MessageRole::Unspecified,
-                };
+                let role = role_from_str(&role_str);
                 Ok(Message {
                     id: row.get(0)?,
                     session_id: row.get(1)?,

--- a/rust/crates/candela-harness-storage/src/db.rs
+++ b/rust/crates/candela-harness-storage/src/db.rs
@@ -58,39 +58,53 @@ impl Database {
     }
 
     fn init_schema(&self) -> Result<(), HarnessError> {
-        self.conn
-            .execute_batch(
-                "
-            CREATE TABLE IF NOT EXISTS sessions (
-                id TEXT PRIMARY KEY,
-                title TEXT NOT NULL DEFAULT 'New Chat',
-                model TEXT NOT NULL DEFAULT '',
-                message_count INTEGER NOT NULL DEFAULT 0,
-                total_tokens INTEGER NOT NULL DEFAULT 0,
-                total_cost_usd REAL NOT NULL DEFAULT 0.0,
-                device_id TEXT NOT NULL DEFAULT '',
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL,
-                deleted_at TEXT
-            );
-
-            CREATE TABLE IF NOT EXISTS messages (
-                id TEXT PRIMARY KEY,
-                session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-                role TEXT NOT NULL,
-                content TEXT NOT NULL,
-                model TEXT,
-                token_count INTEGER,
-                cost_usd REAL,
-                created_at TEXT NOT NULL,
-                sequence INTEGER NOT NULL DEFAULT 0
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_messages_session
-                ON messages(session_id, sequence);
-        ",
-            )
+        let version: i32 = self
+            .conn
+            .pragma_query_value(None, "user_version", |row| row.get(0))
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
+        if version < 1 {
+            self.conn
+                .execute_batch(
+                    "
+                -- Drop legacy tables if they exist (pre-v1 schema).
+                DROP TABLE IF EXISTS messages;
+                DROP TABLE IF EXISTS sessions;
+
+                CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY,
+                    title TEXT NOT NULL DEFAULT 'New Chat',
+                    model TEXT NOT NULL DEFAULT '',
+                    message_count INTEGER NOT NULL DEFAULT 0,
+                    total_tokens INTEGER NOT NULL DEFAULT 0,
+                    total_cost_usd REAL NOT NULL DEFAULT 0.0,
+                    device_id TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    deleted_at TEXT
+                );
+
+                CREATE TABLE messages (
+                    id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                    role TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    model TEXT,
+                    token_count INTEGER,
+                    cost_usd REAL,
+                    created_at TEXT NOT NULL,
+                    sequence INTEGER NOT NULL DEFAULT 0
+                );
+
+                CREATE INDEX idx_messages_session
+                    ON messages(session_id, sequence);
+
+                PRAGMA user_version = 1;
+            ",
+                )
+                .map_err(|e| HarnessError::Storage(e.to_string()))?;
+        }
+
         Ok(())
     }
 
@@ -183,6 +197,15 @@ impl Database {
             .transaction()
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
 
+        // Auto-assign sequence: next value for this session.
+        let next_seq: i64 = tx
+            .query_row(
+                "SELECT COALESCE(MAX(sequence), 0) + 1 FROM messages WHERE session_id = ?1",
+                params![msg.session_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
         tx.execute(
             "INSERT INTO messages (id, session_id, role, content, model, token_count, cost_usd, created_at, sequence)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
@@ -195,7 +218,7 @@ impl Database {
                 msg.token_count,
                 msg.cost_usd,
                 msg.created_at.to_rfc3339(),
-                msg.sequence,
+                next_seq,
             ],
         )
         .map_err(|e| HarnessError::Storage(e.to_string()))?;

--- a/rust/crates/candela-harness-storage/src/search.rs
+++ b/rust/crates/candela-harness-storage/src/search.rs
@@ -30,25 +30,38 @@ impl SearchIndex {
     }
 
     fn init_schema(&self) -> Result<(), HarnessError> {
-        self.conn
-            .execute_batch(
-                "
-            CREATE VIRTUAL TABLE IF NOT EXISTS message_fts USING fts5(
-                content,
-                session_id UNINDEXED,
-                message_id UNINDEXED,
-                session_title UNINDEXED,
-                role UNINDEXED,
-                created_at UNINDEXED
-            );
-
-            -- Track soft-deleted sessions so we can exclude them from search.
-            CREATE TABLE IF NOT EXISTS deleted_sessions (
-                session_id TEXT PRIMARY KEY
-            );
-        ",
-            )
+        let version: i32 = self
+            .conn
+            .pragma_query_value(None, "user_version", |row| row.get(0))
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
+        if version < 1 {
+            // Drop and recreate to ensure message_id column exists.
+            self.conn
+                .execute_batch(
+                    "
+                DROP TABLE IF EXISTS message_fts;
+                DROP TABLE IF EXISTS deleted_sessions;
+
+                CREATE VIRTUAL TABLE message_fts USING fts5(
+                    content,
+                    session_id UNINDEXED,
+                    message_id UNINDEXED,
+                    session_title UNINDEXED,
+                    role UNINDEXED,
+                    created_at UNINDEXED
+                );
+
+                CREATE TABLE deleted_sessions (
+                    session_id TEXT PRIMARY KEY
+                );
+
+                PRAGMA user_version = 1;
+            ",
+                )
+                .map_err(|e| HarnessError::Storage(e.to_string()))?;
+        }
+
         Ok(())
     }
 
@@ -153,6 +166,7 @@ mod tests {
         let results = idx.search("refactor auth", 10).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].session_id, "session-1");
+        assert_eq!(results[0].message_id, "msg-1");
     }
 
     #[test]

--- a/rust/crates/candela-harness-storage/src/search.rs
+++ b/rust/crates/candela-harness-storage/src/search.rs
@@ -36,6 +36,7 @@ impl SearchIndex {
             CREATE VIRTUAL TABLE IF NOT EXISTS message_fts USING fts5(
                 content,
                 session_id UNINDEXED,
+                message_id UNINDEXED,
                 session_title UNINDEXED,
                 role UNINDEXED,
                 created_at UNINDEXED
@@ -56,14 +57,15 @@ impl SearchIndex {
         &self,
         content: &str,
         session_id: &str,
+        message_id: &str,
         session_title: &str,
         role: &str,
         created_at: &str,
     ) -> Result<(), HarnessError> {
         self.conn
             .execute(
-                "INSERT INTO message_fts (content, session_id, session_title, role, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
-                params![content, session_id, session_title, role, created_at],
+                "INSERT INTO message_fts (content, session_id, message_id, session_title, role, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![content, session_id, message_id, session_title, role, created_at],
             )
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
         Ok(())
@@ -85,7 +87,7 @@ impl SearchIndex {
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT f.content, f.session_id, f.session_title, f.role, f.created_at, f.rank
+                "SELECT f.content, f.session_id, f.message_id, f.session_title, f.role, f.created_at, f.rank
              FROM message_fts f
              WHERE f.message_fts MATCH ?1
                AND f.session_id NOT IN (SELECT session_id FROM deleted_sessions)
@@ -96,21 +98,22 @@ impl SearchIndex {
 
         let results = stmt
             .query_map(params![query, limit], |row| {
-                let role_str: String = row.get(3)?;
+                let role_str: String = row.get(4)?;
                 let role = match role_str.as_str() {
                     "user" => MessageRole::User,
                     "assistant" => MessageRole::Assistant,
                     "system" => MessageRole::System,
                     "tool" => MessageRole::Tool,
-                    _ => MessageRole::User,
+                    _ => MessageRole::Unspecified,
                 };
                 Ok(SearchResult {
                     message_preview: row.get(0)?,
                     session_id: row.get(1)?,
-                    session_title: row.get(2)?,
+                    message_id: row.get(2)?,
+                    session_title: row.get(3)?,
                     role,
-                    created_at: row.get::<_, DateTime<Utc>>(4)?,
-                    score: row.get(5)?,
+                    created_at: row.get::<_, DateTime<Utc>>(5)?,
+                    score: row.get(6)?,
                 })
             })
             .map_err(|e| HarnessError::Storage(e.to_string()))?
@@ -131,6 +134,7 @@ mod tests {
         idx.index_message(
             "How do I refactor the auth module?",
             "session-1",
+            "msg-1",
             "Auth Refactor",
             "user",
             "2025-01-01T00:00:00Z",
@@ -139,6 +143,7 @@ mod tests {
         idx.index_message(
             "Let me analyze the database schema.",
             "session-2",
+            "msg-2",
             "DB Analysis",
             "assistant",
             "2025-01-02T00:00:00Z",
@@ -156,6 +161,7 @@ mod tests {
         idx.index_message(
             "How do I refactor the auth module?",
             "session-1",
+            "msg-1",
             "Auth Refactor",
             "user",
             "2025-01-01T00:00:00Z",

--- a/rust/crates/candela-types/src/chat.rs
+++ b/rust/crates/candela-types/src/chat.rs
@@ -28,7 +28,7 @@ pub enum ChatEventEvent {
 /// Each event carries a stream_id that correlates it to the originating
 /// chat.send request.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
+
 pub struct ChatEvent {
     pub stream_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -39,7 +39,7 @@ pub struct ChatEvent {
 ///
 /// ChunkEvent is a text delta from the model's streaming response.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
+
 pub struct ChunkEvent {
     pub delta: String,
 }
@@ -48,7 +48,7 @@ pub struct ChunkEvent {
 ///
 /// ToolCallEvent is emitted when the model requests a tool invocation.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
+
 pub struct ToolCallEvent {
     pub call_id: String,
     pub tool: String,
@@ -60,7 +60,7 @@ pub struct ToolCallEvent {
 ///
 /// StatusEvent provides a progress update during generation.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
+
 pub struct StatusEvent {
     pub text: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -71,7 +71,7 @@ pub struct StatusEvent {
 ///
 /// DoneEvent signals successful completion of the stream.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
+
 pub struct DoneEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage: Option<Box<UsageSummary>>,
@@ -81,7 +81,7 @@ pub struct DoneEvent {
 ///
 /// ErrorEvent signals that the stream terminated with an error.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
+
 pub struct ErrorEvent {
     pub message: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -92,7 +92,7 @@ pub struct ErrorEvent {
 ///
 /// UsageSummary reports token consumption and cost for a single completion.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
+
 pub struct UsageSummary {
     pub prompt_tokens: i64,
     pub completion_tokens: i64,

--- a/rust/crates/candela-types/src/model_catalog.rs
+++ b/rust/crates/candela-types/src/model_catalog.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 /// ModelCatalogEntry represents a single model in the catalog with its
 /// pricing, metadata, and visibility state.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
+
 pub struct ModelCatalogEntry {
     pub model_id: String,
     pub provider: String,

--- a/rust/crates/candela-types/src/session.rs
+++ b/rust/crates/candela-types/src/session.rs
@@ -50,7 +50,7 @@ impl std::fmt::Display for MessageRole {
 ///
 /// Storage: SQLite (local harness), Firestore (cloud sync)
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
+
 pub struct Session {
     pub id: String,
     pub title: String,
@@ -69,7 +69,7 @@ pub struct Session {
 ///
 /// Message is a single turn in a chat session.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
+
 pub struct Message {
     pub id: String,
     pub session_id: String,
@@ -89,7 +89,7 @@ pub struct Message {
 ///
 /// SearchResult is a ranked match from full-text search across sessions.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
+
 pub struct SearchResult {
     pub session_id: String,
     pub message_id: String,


### PR DESCRIPTION
## Summary

Replaces hand-written Session/Message/SearchResult/UsageSummary types in `candela-core::harness` with re-exports from `candela-types` (proto2type-generated from `candela-protos`).

## Key Changes

### Type system
- `Session`, `Message`, `MessageRole`, `SearchResult`, `UsageSummary` → re-exported from `candela_types`
- `ChatEvent` stays hand-written (JSON-RPC wire format uses flat tagged enum, proto uses struct+oneof)
- `HarnessConfig`, `HarnessError`, `TransportMode` unchanged

### Schema migration
- `messages.id`: `INTEGER AUTOINCREMENT` → `TEXT PRIMARY KEY` (UUID v4)
- `messages.sequence`: new column for display ordering
- `messages` index: `(session_id, created_at)` → `(session_id, sequence)`

### API changes
- `Session::new()` → `new_session()` free function
- `insert_message()` returns `String` (UUID) instead of `i64`
- New `new_message()` factory with UUID generation
- `SearchResult` gains `message_id` field for IDE scroll-to-match

### Generated types vendor
- Removed `#[non_exhaustive]` from vendored types (we own the crate)

## Tests
All 37 harness tests pass + full workspace (196 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session and message records now use stable, explicit message IDs to improve linking and traceability.
  * Search results now include message-level identifiers so you can jump directly to the matching message.

* **Bug Fixes**
  * Messages within a session are now ordered reliably using a stable per-session sequence.
  * Unknown or unexpected message roles are handled more gracefully (treated as “Unspecified”).
  * Database/search indexing has been migrated to support the new message ID and stable ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->