### PR TITLE
test(rust): comprehensive harness storage + core tests

### DIFF
--- a/rust/crates/candela-core/src/harness.rs
+++ b/rust/crates/candela-core/src/harness.rs
@@ -201,4 +201,61 @@ mod tests {
         assert_eq!(config.model, "gemini-2.0-flash");
         assert_eq!(config.http_port, 8200);
     }
+
+    #[test]
+    fn test_chat_event_all_variants_serde() {
+        let events = vec![
+            ChatEvent::Chunk {
+                stream_id: "s1".into(),
+                delta: "Hello".into(),
+            },
+            ChatEvent::ToolCall {
+                stream_id: "s1".into(),
+                call_id: "c1".into(),
+                tool: "read_file".into(),
+                args: serde_json::json!({"path": "/tmp/test"}),
+                requires_approval: true,
+            },
+            ChatEvent::Status {
+                stream_id: "s1".into(),
+                text: "Analyzing...".into(),
+                agent: Some("sub-1".into()),
+            },
+            ChatEvent::Error {
+                stream_id: "s1".into(),
+                message: "rate limit".into(),
+            },
+        ];
+
+        for event in &events {
+            let json = serde_json::to_string(event).unwrap();
+            let restored: ChatEvent = serde_json::from_str(&json).unwrap();
+            // Verify the variant tag survived the round-trip.
+            let tag = |e: &ChatEvent| match e {
+                ChatEvent::Chunk { .. } => "chunk",
+                ChatEvent::ToolCall { .. } => "tool_call",
+                ChatEvent::Status { .. } => "status",
+                ChatEvent::Done { .. } => "done",
+                ChatEvent::Error { .. } => "error",
+            };
+            assert_eq!(
+                tag(event),
+                tag(&restored),
+                "variant mismatch for json: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_new_message_sets_defaults() {
+        let msg = new_message("sess-1", MessageRole::Assistant, "hi");
+        // model should be None (from Default).
+        assert_eq!(msg.model, None);
+        // token_count should be None.
+        assert_eq!(msg.token_count, None);
+        // sequence defaults to 0 (DB auto-assigns on insert).
+        assert_eq!(msg.sequence, 0);
+        // cost_usd should be None.
+        assert_eq!(msg.cost_usd, None);
+    }
 }

--- a/rust/crates/candela-core/src/harness.rs
+++ b/rust/crates/candela-core/src/harness.rs
@@ -225,6 +225,10 @@ mod tests {
                 stream_id: "s1".into(),
                 message: "rate limit".into(),
             },
+            ChatEvent::Done {
+                stream_id: "s1".into(),
+                usage: UsageSummary::default(),
+            },
         ];
 
         for event in &events {

--- a/rust/crates/candela-harness-storage/src/db.rs
+++ b/rust/crates/candela-harness-storage/src/db.rs
@@ -325,4 +325,116 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].content, "Hello!");
     }
+
+    #[test]
+    fn test_message_sequence_auto_assign() {
+        let mut db = Database::open_in_memory().unwrap();
+        let session = new_session("test-model", "device-1");
+        db.create_session(&session).unwrap();
+
+        let m1 = new_message(&session.id, MessageRole::User, "first");
+        let m2 = new_message(&session.id, MessageRole::Assistant, "second");
+        let m3 = new_message(&session.id, MessageRole::User, "third");
+        db.insert_message(&m1).unwrap();
+        db.insert_message(&m2).unwrap();
+        db.insert_message(&m3).unwrap();
+
+        let messages = db.get_messages(&session.id, 50).unwrap();
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].sequence, 1);
+        assert_eq!(messages[1].sequence, 2);
+        assert_eq!(messages[2].sequence, 3);
+    }
+
+    #[test]
+    fn test_message_role_round_trip() {
+        let mut db = Database::open_in_memory().unwrap();
+        let session = new_session("test-model", "device-1");
+        db.create_session(&session).unwrap();
+
+        let roles = [
+            MessageRole::User,
+            MessageRole::Assistant,
+            MessageRole::System,
+            MessageRole::Tool,
+            MessageRole::Unspecified,
+        ];
+
+        for role in &roles {
+            let msg = new_message(&session.id, *role, "content");
+            db.insert_message(&msg).unwrap();
+        }
+
+        let messages = db.get_messages(&session.id, 50).unwrap();
+        assert_eq!(messages.len(), roles.len());
+        for (msg, expected_role) in messages.iter().zip(roles.iter()) {
+            assert_eq!(
+                msg.role, *expected_role,
+                "role mismatch for {:?}",
+                expected_role
+            );
+        }
+    }
+
+    #[test]
+    fn test_insert_message_returns_uuid() {
+        let mut db = Database::open_in_memory().unwrap();
+        let session = new_session("test-model", "device-1");
+        db.create_session(&session).unwrap();
+
+        let msg = new_message(&session.id, MessageRole::User, "hello");
+        let returned_id = db.insert_message(&msg).unwrap();
+
+        assert!(!returned_id.is_empty());
+        assert_eq!(returned_id, msg.id);
+    }
+
+    #[test]
+    fn test_session_not_found_on_insert() {
+        let mut db = Database::open_in_memory().unwrap();
+
+        let msg = new_message("non-existent-session", MessageRole::User, "hello");
+        let result = db.insert_message(&msg);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        // The FK constraint on session_id fires before the manual row-count check,
+        // so we get a Storage error containing "FOREIGN KEY".
+        assert!(
+            matches!(err, HarnessError::Storage(ref s) if s.contains("FOREIGN KEY"))
+                || matches!(err, HarnessError::SessionNotFound(_)),
+            "expected FK or SessionNotFound error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_multiple_sessions_independent_sequence() {
+        let mut db = Database::open_in_memory().unwrap();
+
+        let s1 = new_session("model-a", "device-1");
+        let s2 = new_session("model-b", "device-1");
+        db.create_session(&s1).unwrap();
+        db.create_session(&s2).unwrap();
+
+        // Insert 2 messages in session 1, then 1 in session 2.
+        db.insert_message(&new_message(&s1.id, MessageRole::User, "s1-m1"))
+            .unwrap();
+        db.insert_message(&new_message(&s1.id, MessageRole::Assistant, "s1-m2"))
+            .unwrap();
+        db.insert_message(&new_message(&s2.id, MessageRole::User, "s2-m1"))
+            .unwrap();
+
+        let msgs_s1 = db.get_messages(&s1.id, 50).unwrap();
+        let msgs_s2 = db.get_messages(&s2.id, 50).unwrap();
+
+        assert_eq!(msgs_s1.len(), 2);
+        assert_eq!(msgs_s1[0].sequence, 1);
+        assert_eq!(msgs_s1[1].sequence, 2);
+
+        assert_eq!(msgs_s2.len(), 1);
+        assert_eq!(
+            msgs_s2[0].sequence, 1,
+            "session 2 sequence should start at 1 independently"
+        );
+    }
 }

--- a/rust/crates/candela-harness-storage/src/search.rs
+++ b/rust/crates/candela-harness-storage/src/search.rs
@@ -229,10 +229,9 @@ mod tests {
 
         let results = idx.search("Rust", 10).unwrap();
         assert_eq!(results.len(), 1);
-        // FTS5 rank is negative (lower = better match); verify it's non-zero.
         assert!(
-            results[0].score != 0.0,
-            "expected non-zero score from FTS5 rank, got {}",
+            results[0].score < 0.0,
+            "expected negative score from FTS5 rank, got {}",
             results[0].score
         );
     }

--- a/rust/crates/candela-harness-storage/src/search.rs
+++ b/rust/crates/candela-harness-storage/src/search.rs
@@ -193,4 +193,47 @@ mod tests {
         let results = idx.search("refactor auth", 10).unwrap();
         assert_eq!(results.len(), 0);
     }
+
+    #[test]
+    fn test_search_returns_message_id() {
+        let idx = SearchIndex::open_in_memory().unwrap();
+        idx.index_message(
+            "The quick brown fox jumps over the lazy dog",
+            "session-42",
+            "msg-abc-123",
+            "Fox Session",
+            "user",
+            "2025-06-15T12:00:00Z",
+        )
+        .unwrap();
+
+        let results = idx.search("quick brown fox", 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].message_id, "msg-abc-123");
+        assert_eq!(results[0].session_id, "session-42");
+        assert_eq!(results[0].session_title, "Fox Session");
+    }
+
+    #[test]
+    fn test_search_score_is_negative_rank() {
+        let idx = SearchIndex::open_in_memory().unwrap();
+        idx.index_message(
+            "Rust language is fast and safe",
+            "s1",
+            "m1",
+            "Rust Chat",
+            "assistant",
+            "2025-03-01T00:00:00Z",
+        )
+        .unwrap();
+
+        let results = idx.search("Rust", 10).unwrap();
+        assert_eq!(results.len(), 1);
+        // FTS5 rank is negative (lower = better match); verify it's non-zero.
+        assert!(
+            results[0].score != 0.0,
+            "expected non-zero score from FTS5 rank, got {}",
+            results[0].score
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds 9 new tests for the harness crates that were missing coverage (committed after #459 was squash-merged).

### Storage tests (`candela-harness-storage`)
- `test_message_sequence_auto_assign` — 3 messages get sequence 1, 2, 3
- `test_message_role_round_trip` — all 5 MessageRole variants survive insert → get
- `test_insert_message_returns_uuid` — returned ID matches msg.id
- `test_session_not_found_on_insert` — FK violation on non-existent session
- `test_multiple_sessions_independent_sequence` — each session gets its own numbering
- `test_search_returns_message_id` — message_id in FTS results
- `test_search_score_is_negative_rank` — FTS5 rank score is non-zero

### Core tests (`candela-core`)
- `test_chat_event_all_variants_serde` — Chunk, ToolCall, Status, Error round-trip
- `test_new_message_sets_defaults` — model=None, token_count=None, sequence=0

Total: 27 core + 12 storage = **39 harness tests** (up from 30).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage for JSON-RPC serialization/deserialization of all `ChatEvent` variants.
  * Added checks that new assistant messages get the expected default fields.
  * Added database tests for message auto-assigned, monotonically increasing sequences (including independence across sessions), correct role round-tripping, and that insert returns the inserted message ID.
  * Added coverage for inserting into a missing session returning an error.
  * Added search tests validating returned message/session details and confirming score ranking semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->