### PR TITLE
feat(rust): implement chat runtime with SSE streaming

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -290,12 +290,17 @@ dependencies = [
 name = "candela-harness-chat"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "candela-core",
  "candela-harness-storage",
+ "futures-core",
+ "pin-project-lite",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "uuid",
 ]
@@ -317,6 +322,7 @@ name = "candela-harness-rpc"
 version = "0.1.0"
 dependencies = [
  "candela-core",
+ "candela-harness-chat",
  "candela-harness-storage",
  "serde",
  "serde_json",
@@ -756,6 +762,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,7 +797,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1683,6 +1710,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1702,12 +1730,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -2480,6 +2510,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,7 +52,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 
 # HTTP client (OTLP export, upstream proxying)
-reqwest = { version = "0.12", default-features = false, features = ["gzip", "json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["gzip", "json", "rustls-tls", "stream"] }
+futures-core = "0.3"
+tokio-stream = "0.1"
+pin-project-lite = "0.2"
 
 # TLS (MITM transparent proxy)
 rustls = "0.23"
@@ -75,7 +78,7 @@ tokio-test = "0.4"
 
 # Harness deps
 rusqlite = { version = "0.35", features = ["bundled", "chrono"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 dirs = "6"
 
 # Workspace crates

--- a/rust/bins/candela-harness/src/main.rs
+++ b/rust/bins/candela-harness/src/main.rs
@@ -5,9 +5,14 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use candela_core::harness::{HarnessConfig, TransportMode};
-use candela_harness_rpc::{RpcHandler, protocol::JsonRpcRequest};
-use candela_harness_storage::Database;
+use candela_harness_chat::ChatRuntime;
+use candela_harness_rpc::{
+    RpcHandler,
+    protocol::{JsonRpcNotification, JsonRpcRequest},
+};
+use candela_harness_storage::{Database, SearchIndex};
 use clap::Parser;
+use tokio::sync::mpsc;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
@@ -33,6 +38,10 @@ struct Cli {
     /// Default model
     #[arg(long, default_value = "gemini-2.0-flash")]
     model: String,
+
+    /// LLM API base URL (e.g. http://localhost:8080/proxy/openai or https://api.openai.com)
+    #[arg(long, env = "CANDELA_PROXY_URL")]
+    proxy_url: Option<String>,
 }
 
 #[tokio::main]
@@ -61,6 +70,7 @@ async fn main() -> anyhow::Result<()> {
         model: cli.model,
         transport,
         http_port: cli.port,
+        proxy_url: cli.proxy_url,
         ..Default::default()
     };
 
@@ -72,17 +82,30 @@ async fn main() -> anyhow::Result<()> {
     let db = Database::open(&db_path)?;
     let db = Arc::new(std::sync::Mutex::new(db));
 
-    let handler = RpcHandler::new(db, config.model.clone());
+    // Open search index
+    let search_path = config.save_dir.join("search.db");
+    let search = SearchIndex::open(&search_path)?;
+    let search = Arc::new(std::sync::Mutex::new(search));
+
+    // Create notification channel for streaming events
+    let (notify_tx, notify_rx) = mpsc::unbounded_channel::<JsonRpcNotification>();
+
+    // Create chat runtime
+    let chat = Arc::new(ChatRuntime::new(config.clone(), db.clone(), search));
+
+    // Create RPC handler
+    let handler = RpcHandler::new(db, chat, notify_tx, config.model.clone());
 
     info!(
         transport = ?config.transport,
         model = %config.model,
         save_dir = %config.save_dir.display(),
+        proxy_url = ?config.proxy_url,
         "candela-harness started"
     );
 
     match config.transport {
-        TransportMode::Stdio => serve_stdio(handler).await?,
+        TransportMode::Stdio => serve_stdio(handler, notify_rx).await?,
         TransportMode::Http => {
             // TODO: Axum HTTP server
             anyhow::bail!("HTTP transport is not yet implemented");
@@ -92,13 +115,28 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Read JSON-RPC from stdin, write responses to stdout.
-async fn serve_stdio(handler: RpcHandler) -> anyhow::Result<()> {
+/// Read JSON-RPC from stdin, write responses + notifications to stdout.
+async fn serve_stdio(
+    handler: RpcHandler,
+    mut notify_rx: mpsc::UnboundedReceiver<JsonRpcNotification>,
+) -> anyhow::Result<()> {
     use tokio::io::{AsyncBufReadExt, BufReader};
 
     let stdin = tokio::io::stdin();
     let reader = BufReader::new(stdin);
     let mut lines = reader.lines();
+
+    // Spawn a task to write notifications to stdout.
+    // This runs independently of the request/response loop so streaming
+    // events can be emitted while the main loop waits for the next request.
+    let stdout_notify = tokio::spawn(async move {
+        while let Some(notif) = notify_rx.recv().await {
+            if let Ok(json) = serde_json::to_string(&notif) {
+                let _ = writeln!(std::io::stdout(), "{json}");
+                let _ = std::io::stdout().flush();
+            }
+        }
+    });
 
     while let Some(line) = lines.next_line().await? {
         if line.trim().is_empty() {
@@ -124,6 +162,9 @@ async fn serve_stdio(handler: RpcHandler) -> anyhow::Result<()> {
             std::io::stdout().flush()?;
         }
     }
+
+    // Clean up notification task
+    stdout_notify.abort();
 
     Ok(())
 }

--- a/rust/crates/candela-harness-chat/Cargo.toml
+++ b/rust/crates/candela-harness-chat/Cargo.toml
@@ -7,6 +7,11 @@ license.workspace = true
 [dependencies]
 candela-core = { workspace = true }
 candela-harness-storage = { workspace = true }
+reqwest = { workspace = true }
+bytes = { workspace = true }
+futures-core = { workspace = true }
+tokio-stream = { workspace = true }
+pin-project-lite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/rust/crates/candela-harness-chat/src/client.rs
+++ b/rust/crates/candela-harness-chat/src/client.rs
@@ -1,0 +1,458 @@
+//! LLM model client — streams chat completions via SSE.
+
+use candela_core::harness::Message;
+use candela_core::harness::{ChatEvent, HarnessError, UsageSummary};
+use futures_core::Stream;
+use pin_project_lite::pin_project;
+use reqwest::Client;
+use serde::Deserialize;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tracing::{debug, warn};
+
+/// Client for streaming chat completions from an OpenAI-compatible API.
+pub struct ModelClient {
+    http: Client,
+    base_url: String,
+}
+
+impl ModelClient {
+    /// Create a new model client.
+    ///
+    /// `base_url` should be the base URL for the API, e.g.:
+    /// - Direct: `https://generativelanguage.googleapis.com/v1beta/openai`
+    /// - Via proxy: `http://localhost:8080/proxy/openai`
+    pub fn new(base_url: &str) -> Self {
+        Self {
+            http: Client::new(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+        }
+    }
+
+    /// Stream a chat completion. Returns an async stream of ChatEvents.
+    pub async fn stream_chat(
+        &self,
+        messages: &[Message],
+        model: &str,
+        stream_id: &str,
+    ) -> Result<impl Stream<Item = Result<ChatEvent, HarnessError>>, HarnessError> {
+        let url = format!("{}/v1/chat/completions", self.base_url);
+
+        // Build OpenAI-compatible message array
+        let api_messages: Vec<serde_json::Value> = messages
+            .iter()
+            .map(|m| {
+                serde_json::json!({
+                    "role": role_to_api(&m.role),
+                    "content": &m.content,
+                })
+            })
+            .collect();
+
+        let body = serde_json::json!({
+            "model": model,
+            "messages": api_messages,
+            "stream": true,
+        });
+
+        debug!(url = %url, model = %model, msg_count = messages.len(), "streaming chat");
+
+        // Resolve API key from env
+        let api_key = resolve_api_key().ok_or_else(|| {
+            HarnessError::Transport(
+                "No API key found. Set GEMINI_API_KEY, OPENAI_API_KEY, or CANDELA_API_KEY"
+                    .to_string(),
+            )
+        })?;
+
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| HarnessError::Transport(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body_text = resp
+                .text()
+                .await
+                .unwrap_or_else(|_| "failed to read body".to_string());
+            return Err(HarnessError::Transport(format!(
+                "API returned {status}: {body_text}"
+            )));
+        }
+
+        let byte_stream = resp.bytes_stream();
+        Ok(SseStream::new(byte_stream, stream_id.to_string()))
+    }
+}
+
+/// Resolve an API key from environment variables.
+fn resolve_api_key() -> Option<String> {
+    std::env::var("CANDELA_API_KEY")
+        .or_else(|_| std::env::var("GEMINI_API_KEY"))
+        .or_else(|_| std::env::var("OPENAI_API_KEY"))
+        .ok()
+}
+
+/// Map our MessageRole to the OpenAI API role string.
+fn role_to_api(role: &candela_core::harness::MessageRole) -> &'static str {
+    use candela_core::harness::MessageRole;
+    match role {
+        MessageRole::User => "user",
+        MessageRole::Assistant => "assistant",
+        MessageRole::System => "system",
+        MessageRole::Tool => "tool",
+        MessageRole::Unspecified => "user",
+    }
+}
+
+// --- SSE stream parsing ---
+
+/// Partial OpenAI chat completion chunk.
+#[derive(Debug, Deserialize)]
+struct ChatCompletionChunk {
+    choices: Vec<ChunkChoice>,
+    usage: Option<ChunkUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChunkChoice {
+    delta: ChunkDelta,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChunkDelta {
+    content: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChunkUsage {
+    prompt_tokens: Option<i64>,
+    completion_tokens: Option<i64>,
+    total_tokens: Option<i64>,
+}
+
+pin_project! {
+    /// Transforms a raw byte stream into ChatEvent items by parsing SSE `data:` lines.
+    struct SseStream<S> {
+        #[pin]
+        inner: S,
+        stream_id: String,
+        buffer: String,
+    }
+}
+
+impl<S> SseStream<S> {
+    fn new(inner: S, stream_id: String) -> Self {
+        Self {
+            inner,
+            stream_id,
+            buffer: String::new(),
+        }
+    }
+}
+
+impl<S, E> Stream for SseStream<S>
+where
+    S: Stream<Item = Result<bytes::Bytes, E>>,
+    E: std::fmt::Display,
+{
+    type Item = Result<ChatEvent, HarnessError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        loop {
+            // Try to extract a complete line from the buffer.
+            if let Some(pos) = this.buffer.find('\n') {
+                let line = this.buffer.drain(..=pos).collect::<String>();
+                let line = line.trim();
+
+                if line.is_empty() {
+                    continue;
+                }
+
+                // SSE: data: [DONE]
+                if line == "data: [DONE]" {
+                    return Poll::Ready(Some(Ok(ChatEvent::Done {
+                        stream_id: this.stream_id.clone(),
+                        usage: UsageSummary::default(),
+                    })));
+                }
+
+                // SSE: data: {...}
+                if let Some(json_str) = line.strip_prefix("data: ") {
+                    match serde_json::from_str::<ChatCompletionChunk>(json_str) {
+                        Ok(chunk) => {
+                            // Extract content delta
+                            if let Some(choice) = chunk.choices.first()
+                                && let Some(content) = &choice.delta.content
+                                && !content.is_empty()
+                            {
+                                return Poll::Ready(Some(Ok(ChatEvent::Chunk {
+                                    stream_id: this.stream_id.clone(),
+                                    delta: content.clone(),
+                                })));
+                            }
+
+                            // Check for usage in final chunk
+                            if let Some(usage) = chunk.usage {
+                                return Poll::Ready(Some(Ok(ChatEvent::Done {
+                                    stream_id: this.stream_id.clone(),
+                                    usage: UsageSummary {
+                                        prompt_tokens: usage.prompt_tokens.unwrap_or(0),
+                                        completion_tokens: usage.completion_tokens.unwrap_or(0),
+                                        total_tokens: usage.total_tokens.unwrap_or(0),
+                                        total_cost_usd: 0.0,
+                                        model: String::new(),
+                                    },
+                                })));
+                            }
+
+                            // Empty delta (e.g. role-only chunk) — skip
+                            continue;
+                        }
+                        Err(e) => {
+                            warn!(json = %json_str, error = %e, "failed to parse SSE chunk");
+                            continue;
+                        }
+                    }
+                }
+
+                // Non-data SSE lines (event:, id:, retry:) — skip
+                continue;
+            }
+
+            // No complete line in buffer — poll for more bytes.
+            match this.inner.as_mut().poll_next(cx) {
+                Poll::Ready(Some(Ok(bytes))) => {
+                    this.buffer.push_str(&String::from_utf8_lossy(&bytes));
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    return Poll::Ready(Some(Err(HarnessError::Transport(format!(
+                        "stream error: {}",
+                        e
+                    )))));
+                }
+                Poll::Ready(None) => {
+                    // Stream ended. If there's remaining data in the buffer, try to process it.
+                    if !this.buffer.is_empty() {
+                        let remaining = std::mem::take(this.buffer);
+                        let remaining = remaining.trim();
+                        if remaining == "data: [DONE]" {
+                            return Poll::Ready(Some(Ok(ChatEvent::Done {
+                                stream_id: this.stream_id.clone(),
+                                usage: UsageSummary::default(),
+                            })));
+                        }
+                    }
+                    return Poll::Ready(None);
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_stream::StreamExt;
+
+    #[test]
+    fn test_role_to_api() {
+        use candela_core::harness::MessageRole;
+        assert_eq!(role_to_api(&MessageRole::User), "user");
+        assert_eq!(role_to_api(&MessageRole::Assistant), "assistant");
+        assert_eq!(role_to_api(&MessageRole::System), "system");
+        assert_eq!(role_to_api(&MessageRole::Tool), "tool");
+        assert_eq!(role_to_api(&MessageRole::Unspecified), "user");
+    }
+
+    #[test]
+    fn test_resolve_api_key_missing() {
+        // This test just verifies the function doesn't panic.
+        // It may or may not return Some depending on env.
+        let _ = resolve_api_key();
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_parses_chunks() {
+        use tokio_stream::iter;
+
+        let sse_data = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n\
+                        data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n\
+                        data: [DONE]\n\n";
+
+        let chunks = vec![Ok::<_, std::io::Error>(bytes::Bytes::from(sse_data))];
+        let byte_stream = iter(chunks);
+        let mut stream = SseStream::new(byte_stream, "test-stream".to_string());
+
+        let mut events = Vec::new();
+        while let Some(item) = stream.next().await {
+            events.push(item.unwrap());
+        }
+
+        assert_eq!(events.len(), 3); // Hello, " world", Done
+        match &events[0] {
+            ChatEvent::Chunk { delta, .. } => assert_eq!(delta, "Hello"),
+            other => panic!("expected Chunk, got {other:?}"),
+        }
+        match &events[1] {
+            ChatEvent::Chunk { delta, .. } => assert_eq!(delta, " world"),
+            other => panic!("expected Chunk, got {other:?}"),
+        }
+        assert!(matches!(&events[2], ChatEvent::Done { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_handles_split_bytes() {
+        use tokio_stream::iter;
+
+        // SSE data split across two byte chunks
+        let chunks = vec![
+            Ok::<_, std::io::Error>(bytes::Bytes::from("data: {\"choices\":[{\"del")),
+            Ok(bytes::Bytes::from(
+                "ta\":{\"content\":\"Hi\"}}]}\n\ndata: [DONE]\n\n",
+            )),
+        ];
+        let byte_stream = iter(chunks);
+        let mut stream = SseStream::new(byte_stream, "s1".to_string());
+
+        let mut events = Vec::new();
+        while let Some(item) = stream.next().await {
+            events.push(item.unwrap());
+        }
+
+        assert_eq!(events.len(), 2);
+        match &events[0] {
+            ChatEvent::Chunk { delta, .. } => assert_eq!(delta, "Hi"),
+            other => panic!("expected Chunk, got {other:?}"),
+        }
+        assert!(matches!(&events[1], ChatEvent::Done { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_skips_empty_delta() {
+        use tokio_stream::iter;
+
+        // Role-only chunk (no content field) should be skipped
+        let sse_data = "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n\
+                        data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n\
+                        data: [DONE]\n\n";
+
+        let chunks = vec![Ok::<_, std::io::Error>(bytes::Bytes::from(sse_data))];
+        let mut stream = SseStream::new(tokio_stream::iter(chunks), "s1".to_string());
+
+        let mut events = Vec::new();
+        while let Some(item) = stream.next().await {
+            events.push(item.unwrap());
+        }
+
+        // Role-only chunk should be skipped, leaving Chunk("Hi") + Done
+        assert_eq!(events.len(), 2);
+        match &events[0] {
+            ChatEvent::Chunk { delta, .. } => assert_eq!(delta, "Hi"),
+            other => panic!("expected Chunk, got {other:?}"),
+        }
+        assert!(matches!(&events[1], ChatEvent::Done { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_extracts_usage() {
+        use tokio_stream::iter;
+
+        let sse_data = "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n\
+                        data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n\
+                        data: [DONE]\n\n";
+
+        let chunks = vec![Ok::<_, std::io::Error>(bytes::Bytes::from(sse_data))];
+        let mut stream = SseStream::new(iter(chunks), "s1".to_string());
+
+        let mut events = Vec::new();
+        while let Some(item) = stream.next().await {
+            events.push(item.unwrap());
+        }
+
+        assert_eq!(events.len(), 3); // Chunk, Done(usage), Done([DONE])
+        match &events[1] {
+            ChatEvent::Done { usage, .. } => {
+                assert_eq!(usage.prompt_tokens, 10);
+                assert_eq!(usage.completion_tokens, 5);
+                assert_eq!(usage.total_tokens, 15);
+            }
+            other => panic!("expected Done with usage, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_skips_malformed_json() {
+        use tokio_stream::iter;
+
+        // Malformed JSON line should be skipped, not cause an error
+        let sse_data = "data: {not valid json}\n\n\
+                        data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n\
+                        data: [DONE]\n\n";
+
+        let chunks = vec![Ok::<_, std::io::Error>(bytes::Bytes::from(sse_data))];
+        let mut stream = SseStream::new(iter(chunks), "s1".to_string());
+
+        let mut events = Vec::new();
+        while let Some(item) = stream.next().await {
+            events.push(item.unwrap());
+        }
+
+        // Malformed line skipped, then Chunk + Done
+        assert_eq!(events.len(), 2);
+        match &events[0] {
+            ChatEvent::Chunk { delta, .. } => assert_eq!(delta, "ok"),
+            other => panic!("expected Chunk, got {other:?}"),
+        }
+        assert!(matches!(&events[1], ChatEvent::Done { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_propagates_stream_error() {
+        use tokio_stream::iter;
+
+        let chunks: Vec<Result<bytes::Bytes, std::io::Error>> = vec![
+            Ok(bytes::Bytes::from(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
+            )),
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "pipe broke",
+            )),
+        ];
+        let mut stream = SseStream::new(iter(chunks), "s1".to_string());
+
+        // First event should be a Chunk
+        let first = stream.next().await.unwrap();
+        assert!(first.is_ok());
+
+        // Second event should be a Transport error
+        let second = stream.next().await.unwrap();
+        assert!(second.is_err());
+        let err = second.unwrap_err();
+        assert!(
+            matches!(&err, HarnessError::Transport(msg) if msg.contains("pipe broke")),
+            "expected Transport error containing 'pipe broke', got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sse_stream_empty_stream() {
+        use tokio_stream::iter;
+
+        // Completely empty stream — should yield nothing
+        let chunks: Vec<Result<bytes::Bytes, std::io::Error>> = vec![];
+        let mut stream = SseStream::new(iter(chunks), "s1".to_string());
+
+        let event = stream.next().await;
+        assert!(event.is_none(), "empty stream should yield None");
+    }
+}

--- a/rust/crates/candela-harness-chat/src/lib.rs
+++ b/rust/crates/candela-harness-chat/src/lib.rs
@@ -1,12 +1,14 @@
 //! Chat runtime — manages the conversation loop, model calls, and streaming.
 //!
-//! This crate will handle:
+//! This crate handles:
 //! - Assembling context (system prompt + history + pinned context)
-//! - Calling LLM providers via Candela proxy
+//! - Calling LLM providers via Candela proxy or direct API
 //! - Streaming responses back to the IDE
 //! - Tool call execution and approval flow
 //! - Budget enforcement
 
+pub mod client;
 pub mod runtime;
 
+pub use client::ModelClient;
 pub use runtime::ChatRuntime;

--- a/rust/crates/candela-harness-chat/src/runtime.rs
+++ b/rust/crates/candela-harness-chat/src/runtime.rs
@@ -1,49 +1,138 @@
-//! Chat runtime stub.
+//! Chat runtime — manages the conversation loop, model calls, and streaming.
 
-use candela_core::harness::{ChatEvent, HarnessConfig, UsageSummary};
-use candela_harness_storage::Database;
-use tracing::info;
+use candela_core::harness::{
+    ChatEvent, HarnessConfig, HarnessError, MessageRole, UsageSummary, new_message,
+};
+use candela_harness_storage::{Database, SearchIndex};
+use std::sync::{Arc, Mutex};
+use tokio_stream::StreamExt;
+use tracing::{error, info};
+
+use crate::client::ModelClient;
 
 /// The chat runtime manages active conversations.
 pub struct ChatRuntime {
-    _config: HarnessConfig,
-    _db: Database,
+    config: HarnessConfig,
+    db: Arc<Mutex<Database>>,
+    search: Arc<Mutex<SearchIndex>>,
+    client: ModelClient,
 }
 
 impl ChatRuntime {
     /// Create a new chat runtime.
-    pub fn new(config: HarnessConfig, db: Database) -> Self {
+    pub fn new(
+        config: HarnessConfig,
+        db: Arc<Mutex<Database>>,
+        search: Arc<Mutex<SearchIndex>>,
+    ) -> Self {
+        let base_url = config.proxy_url.clone().unwrap_or_else(|| {
+            "https://generativelanguage.googleapis.com/v1beta/openai".to_string()
+        });
+
+        let client = ModelClient::new(&base_url);
+
         Self {
-            _config: config,
-            _db: db,
+            config,
+            db,
+            search,
+            client,
         }
     }
 
     /// Send a message and stream the response.
     ///
-    /// Returns the stream ID. Events will be sent via the notification callback.
+    /// Returns the stream ID. Events will be sent via the `on_event` callback
+    /// as they arrive from the model.
     pub async fn send_message(
         &self,
         session_id: &str,
         content: &str,
         on_event: impl Fn(ChatEvent) + Send + 'static,
-    ) -> Result<String, candela_core::harness::HarnessError> {
-        info!(session_id, content_len = content.len(), "chat.send");
-
+    ) -> Result<String, HarnessError> {
         let stream_id = uuid::Uuid::new_v4().to_string();
+        info!(
+            session_id,
+            stream_id,
+            content_len = content.len(),
+            "chat.send"
+        );
 
-        // TODO: Implement actual LLM call via Candela proxy
-        // For now, echo back a stub response
-        on_event(ChatEvent::Chunk {
+        // 1. Emit status
+        on_event(ChatEvent::Status {
             stream_id: stream_id.clone(),
-            delta: format!("Echo: {content}"),
+            text: "Thinking...".to_string(),
+            agent: None,
         });
 
+        // 2. Store user message
+        let user_msg = new_message(session_id, MessageRole::User, content);
+        self.db.lock().unwrap().insert_message(&user_msg)?;
+
+        // 3. Load conversation history
+        let history = self.db.lock().unwrap().get_messages(session_id, 100)?;
+
+        // 4. Stream from model
+        let model = &self.config.model;
+        let mut full_response = String::new();
+        let mut usage = UsageSummary::default();
+
+        let stream = self.client.stream_chat(&history, model, &stream_id).await?;
+        tokio::pin!(stream);
+
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(ChatEvent::Chunk { delta, .. }) => {
+                    full_response.push_str(&delta);
+                    on_event(ChatEvent::Chunk {
+                        stream_id: stream_id.clone(),
+                        delta,
+                    });
+                }
+                Ok(ChatEvent::Done { usage: u, .. }) => {
+                    usage = u;
+                    usage.model = model.to_string();
+                }
+                Ok(other) => on_event(other),
+                Err(e) => {
+                    error!(error = %e, "stream error");
+                    on_event(ChatEvent::Error {
+                        stream_id: stream_id.clone(),
+                        message: e.to_string(),
+                    });
+                    return Err(e);
+                }
+            }
+        }
+
+        // 5. Store assistant message
+        if !full_response.is_empty() {
+            let mut assistant_msg = new_message(session_id, MessageRole::Assistant, &full_response);
+            assistant_msg.model = Some(model.to_string());
+            assistant_msg.token_count = Some(usage.total_tokens as i32);
+            assistant_msg.cost_usd = if usage.total_cost_usd > 0.0 {
+                Some(usage.total_cost_usd)
+            } else {
+                None
+            };
+            self.db.lock().unwrap().insert_message(&assistant_msg)?;
+
+            // 6. Index in FTS for search
+            let _ = self.search.lock().unwrap().index_message(
+                &full_response,
+                session_id,
+                &assistant_msg.id,
+                "", // session title — we don't have it here
+                "assistant",
+                &assistant_msg.created_at.to_rfc3339(),
+            );
+        }
+
+        // 7. Emit Done
         on_event(ChatEvent::Done {
             stream_id: stream_id.clone(),
-            usage: UsageSummary::default(),
+            usage,
         });
 
-        Ok(stream_id)
+        Ok(stream_id.clone())
     }
 }

--- a/rust/crates/candela-harness-rpc/Cargo.toml
+++ b/rust/crates/candela-harness-rpc/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 candela-core = { workspace = true }
+candela-harness-chat = { workspace = true }
 candela-harness-storage = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -1,20 +1,35 @@
 //! JSON-RPC request handler — dispatches method calls.
 
-use candela_core::harness::{HarnessError, new_session};
+use candela_core::harness::{ChatEvent, HarnessError, new_session};
+use candela_harness_chat::ChatRuntime;
 use candela_harness_storage::Database;
+use std::sync::Arc;
+use tokio::sync::mpsc;
 use tracing::info;
 
 use crate::protocol::*;
 
 /// Handles JSON-RPC requests from IDE plugins.
 pub struct RpcHandler {
-    db: std::sync::Arc<std::sync::Mutex<Database>>,
+    db: Arc<std::sync::Mutex<Database>>,
+    chat: Arc<ChatRuntime>,
+    notify_tx: mpsc::UnboundedSender<JsonRpcNotification>,
     default_model: String,
 }
 
 impl RpcHandler {
-    pub fn new(db: std::sync::Arc<std::sync::Mutex<Database>>, default_model: String) -> Self {
-        Self { db, default_model }
+    pub fn new(
+        db: Arc<std::sync::Mutex<Database>>,
+        chat: Arc<ChatRuntime>,
+        notify_tx: mpsc::UnboundedSender<JsonRpcNotification>,
+        default_model: String,
+    ) -> Self {
+        Self {
+            db,
+            chat,
+            notify_tx,
+            default_model,
+        }
     }
 
     /// Dispatch a JSON-RPC request to the appropriate handler.
@@ -134,14 +149,59 @@ impl RpcHandler {
     async fn handle_chat_send(
         &self,
         id: Option<serde_json::Value>,
-        _params: serde_json::Value,
+        params: serde_json::Value,
     ) -> JsonRpcResponse {
-        // TODO: Wire up ChatRuntime
+        let session_id = match params.get("session_id").and_then(|v| v.as_str()) {
+            Some(sid) => sid.to_string(),
+            None => {
+                return JsonRpcResponse::error(
+                    id,
+                    INVALID_PARAMS,
+                    "session_id required".to_string(),
+                );
+            }
+        };
+        let content = match params.get("content").and_then(|v| v.as_str()) {
+            Some(c) => c.to_string(),
+            None => {
+                return JsonRpcResponse::error(id, INVALID_PARAMS, "content required".to_string());
+            }
+        };
+
+        let stream_id = uuid::Uuid::new_v4().to_string();
+        let chat = self.chat.clone();
+        let tx = self.notify_tx.clone();
+        let sid = stream_id.clone();
+
+        // Spawn the streaming task — response comes back immediately
+        tokio::spawn(async move {
+            let notify_tx = tx.clone();
+            let on_event = move |event: ChatEvent| {
+                let notif = JsonRpcNotification::new(
+                    "chat.event",
+                    serde_json::to_value(&event).unwrap_or_default(),
+                );
+                let _ = notify_tx.send(notif);
+            };
+
+            if let Err(e) = chat.send_message(&session_id, &content, on_event).await {
+                let error_notif = JsonRpcNotification::new(
+                    "chat.event",
+                    serde_json::json!({
+                        "type": "error",
+                        "stream_id": sid,
+                        "message": e.to_string(),
+                    }),
+                );
+                let _ = tx.send(error_notif);
+            }
+        });
+
         JsonRpcResponse::success(
             id,
             serde_json::json!({
                 "status": "accepted",
-                "stream_id": uuid::Uuid::new_v4().to_string(),
+                "stream_id": stream_id,
             }),
         )
     }
@@ -150,19 +210,27 @@ impl RpcHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use candela_core::harness::HarnessConfig;
+    use candela_harness_storage::SearchIndex;
 
-    fn test_handler() -> RpcHandler {
+    fn test_handler() -> (RpcHandler, mpsc::UnboundedReceiver<JsonRpcNotification>) {
         let db = Database::open_in_memory().unwrap();
-        RpcHandler::new(
-            Arc::new(std::sync::Mutex::new(db)),
-            "test-model".to_string(),
-        )
+        let db = Arc::new(std::sync::Mutex::new(db));
+        let search = SearchIndex::open_in_memory().unwrap();
+        let search = Arc::new(std::sync::Mutex::new(search));
+        let config = HarnessConfig {
+            model: "test-model".to_string(),
+            ..Default::default()
+        };
+        let chat = Arc::new(ChatRuntime::new(config, db.clone(), search));
+        let (tx, rx) = mpsc::unbounded_channel();
+        let handler = RpcHandler::new(db, chat, tx, "test-model".to_string());
+        (handler, rx)
     }
 
     #[tokio::test]
     async fn test_initialize() {
-        let handler = test_handler();
+        let (handler, _rx) = test_handler();
         let req = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
             id: Some(serde_json::json!(1)),
@@ -178,7 +246,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_notification_returns_none() {
-        let handler = test_handler();
+        let (handler, _rx) = test_handler();
         let req = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
             id: None,
@@ -191,7 +259,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_lifecycle() {
-        let handler = test_handler();
+        let (handler, _rx) = test_handler();
 
         // Create
         let req = JsonRpcRequest {
@@ -227,7 +295,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_delete_not_found() {
-        let handler = test_handler();
+        let (handler, _rx) = test_handler();
         let req = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
             id: Some(serde_json::json!(1)),
@@ -241,7 +309,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_unknown_method() {
-        let handler = test_handler();
+        let (handler, _rx) = test_handler();
         let req = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
             id: Some(serde_json::json!(1)),
@@ -255,7 +323,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_create_uses_default_model() {
-        let handler = test_handler();
+        let (handler, _rx) = test_handler();
         let req = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
             id: Some(serde_json::json!(1)),
@@ -269,7 +337,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_negative_limit_clamped() {
-        let handler = test_handler();
+        let (handler, _rx) = test_handler();
         let req = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
             id: Some(serde_json::json!(1)),
@@ -279,5 +347,63 @@ mod tests {
         let resp = handler.handle(req).await.unwrap();
         // Should not error — clamped to 0
         assert!(resp.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_chat_send_validates_params() {
+        let (handler, _rx) = test_handler();
+
+        // Missing session_id
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: "chat.send".to_string(),
+            params: serde_json::json!({ "content": "hello" }),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        assert!(resp.error.is_some());
+        assert_eq!(resp.error.unwrap().code, INVALID_PARAMS);
+
+        // Missing content
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(2)),
+            method: "chat.send".to_string(),
+            params: serde_json::json!({ "session_id": "test" }),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        assert!(resp.error.is_some());
+        assert_eq!(resp.error.unwrap().code, INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn test_chat_send_returns_accepted() {
+        let (handler, _rx) = test_handler();
+
+        // Create a session first
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: "session.create".to_string(),
+            params: serde_json::json!({}),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        let session_id = resp.result.unwrap()["id"].as_str().unwrap().to_string();
+
+        // Send chat — should immediately return accepted (even though model call will fail)
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(2)),
+            method: "chat.send".to_string(),
+            params: serde_json::json!({
+                "session_id": session_id,
+                "content": "hello"
+            }),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        assert!(resp.error.is_none());
+        let result = resp.result.unwrap();
+        assert_eq!(result["status"], "accepted");
+        assert!(result["stream_id"].is_string());
     }
 }


### PR DESCRIPTION
## Summary

Replaces the echo stub in `candela-harness-chat` with a real streaming LLM client. This is **Phase 3** of the harness build-out — the part that makes it actually useful.

## Architecture

```
IDE ←stdio→ candela-harness (bin)
                ↓ JSON-RPC
            RpcHandler → ChatRuntime
                              ↓ HTTP/SSE
                         ModelClient → OpenAI-compatible API
```

## What's new

### `client.rs` (NEW — ~250 LOC)
- `ModelClient`: HTTP client for OpenAI-compatible chat completions with `stream: true`
- `SseStream`: Custom `Stream` impl using `pin_project` that parses SSE `data:` lines into `ChatEvent` variants
- Handles split byte chunks, `data: [DONE]`, usage extraction
- API key resolution: `CANDELA_API_KEY` > `GEMINI_API_KEY` > `OPENAI_API_KEY`

### `runtime.rs` (rewritten)
Full `send_message` flow:
1. Store user message in DB
2. Load conversation history
3. Stream from model via `ModelClient`
4. Accumulate response + emit `ChatEvent::Chunk` callbacks
5. Store assistant message with token counts
6. Index response in FTS5 for search

### `handler.rs` (modified)
- `RpcHandler` now holds `Arc<ChatRuntime>` + `mpsc::UnboundedSender<JsonRpcNotification>`
- `chat.send` validates `session_id` + `content` params
- Spawns async streaming task, returns `{ status: "accepted", stream_id }` immediately
- Streaming events emitted as `chat.event` JSON-RPC notifications

### `main.rs` (modified)
- `--proxy-url` flag (env: `CANDELA_PROXY_URL`) for LLM API base URL
- Notification writer task on stdout (separate from request/response loop)
- `SearchIndex` initialization

### Dependencies
- `reqwest`: added `stream` feature
- New: `futures-core`, `tokio-stream`, `pin-project-lite`, `bytes`
- `clap`: added `env` feature

## Tests
- 275 pass, 0 fail
- 4 new SSE parser tests (chunked bytes, split across frames, [DONE] handling)
- 2 new `chat.send` param validation tests
- All existing handler tests updated for new constructor signature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streamed chat completions with live incremental updates and final token-usage summaries.
  * Chat processing now persists conversation history and automatically indexes assistant replies for search.
  * JSON-RPC execution now emits chat event notifications during request handling, with optional proxy URL configuration.
* **Bug Fixes**
  * Improved robustness of streaming parsing (including empty/malformed chunk handling) and stream error reporting.
  * Added validation for chat requests to require session ID and content.
* **Chores**
  * Updated HTTP client and related streaming support to enable reliable streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->