### PR TITLE
fix(rust): remove unused tokio_stream::iter import

### DIFF
--- a/rust/crates/candela-harness-chat/src/client.rs
+++ b/rust/crates/candela-harness-chat/src/client.rs
@@ -338,8 +338,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_sse_stream_skips_empty_delta() {
-        use tokio_stream::iter;
-
         // Role-only chunk (no content field) should be skipped
         let sse_data = "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n\
                         data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n\


### PR DESCRIPTION
Removes redundant `use tokio_stream::iter` in test — the call site already uses the fully qualified path `tokio_stream::iter()`. Eliminates warning on every test run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming chat responses so empty or role-only SSE updates are ignored, preventing blank intermediate events from appearing.
  * Ensured only meaningful content chunks and the final completion event are delivered to the client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->