### PR TITLE
test: add ConnectRPC integration tests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -805,16 +805,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,15 +902,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,21 +963,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1272,22 +1238,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -1646,23 +1596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,49 +1668,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -2107,21 +1997,16 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2132,7 +2017,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -2263,42 +2147,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -2497,7 +2349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.4",
+ "core-foundation",
  "system-configuration-sys",
 ]
 
@@ -2635,16 +2487,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "futures-core",
  "http-body",
  "hyper",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -804,6 +805,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +912,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +982,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1237,6 +1272,22 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1595,6 +1646,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +1735,49 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -1996,16 +2107,21 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2016,6 +2132,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -2146,10 +2263,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2348,7 +2497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2486,6 +2635,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/rust/crates/candela-harness-connect/Cargo.toml
+++ b/rust/crates/candela-harness-connect/Cargo.toml
@@ -44,4 +44,4 @@ connectrpc-build = "0.7"
 anyhow = { workspace = true }
 
 [dev-dependencies]
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/rust/crates/candela-harness-connect/Cargo.toml
+++ b/rust/crates/candela-harness-connect/Cargo.toml
@@ -42,3 +42,6 @@ candela-harness-storage = { workspace = true }
 [build-dependencies]
 connectrpc-build = "0.7"
 anyhow = { workspace = true }
+
+[dev-dependencies]
+reqwest = { version = "0.12", features = ["json"] }

--- a/rust/crates/candela-harness-connect/src/server.rs
+++ b/rust/crates/candela-harness-connect/src/server.rs
@@ -11,6 +11,18 @@ use tracing::info;
 use crate::proto::candela::harness::v1::HarnessServiceExt;
 use crate::service::HarnessServiceImpl;
 
+/// Build the ConnectRPC router without starting a server.
+///
+/// Useful for testing or embedding in a custom Axum app.
+pub fn build_router(
+    chat: Arc<ChatRuntime>,
+    db: Arc<Mutex<Database>>,
+    search: Arc<Mutex<SearchIndex>>,
+) -> connectrpc::Router {
+    let service = Arc::new(HarnessServiceImpl { chat, db, search });
+    service.register(connectrpc::Router::new())
+}
+
 /// Start the ConnectRPC server.
 ///
 /// Serves Connect, gRPC, and gRPC-Web protocols on the given port.
@@ -20,10 +32,7 @@ pub async fn serve(
     db: Arc<Mutex<Database>>,
     search: Arc<Mutex<SearchIndex>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let service = Arc::new(HarnessServiceImpl { chat, db, search });
-
-    // Register the service with a ConnectRPC router, then convert to Axum
-    let connect_router = service.register(connectrpc::Router::new());
+    let connect_router = build_router(chat, db, search);
 
     let app = axum::Router::new()
         .merge(connect_router.into_axum_router())

--- a/rust/crates/candela-harness-connect/tests/integration.rs
+++ b/rust/crates/candela-harness-connect/tests/integration.rs
@@ -50,7 +50,10 @@ async fn start_test_server() -> String {
 
 /// POST a Connect unary RPC and return the response body.
 async fn connect_post(base: &str, method: &str, body: &str) -> reqwest::Response {
-    reqwest::Client::new()
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .expect("build client")
         .post(format!("{base}/candela.harness.v1.HarnessService/{method}"))
         .header("Content-Type", "application/json")
         .body(body.to_string())
@@ -182,7 +185,10 @@ async fn test_send_message_streams_error_without_proxy() {
 
     // SendMessage — no proxy URL configured, so the LLM call will fail.
     // We should get a stream that contains an error event.
-    let resp = reqwest::Client::new()
+    let resp = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .expect("build client")
         .post(format!(
             "{base}/candela.harness.v1.HarnessService/SendMessage"
         ))
@@ -199,6 +205,11 @@ async fn test_send_message_streams_error_without_proxy() {
         !body.is_empty(),
         "expected streaming response body, got empty"
     );
-    // The stream should contain an error since no LLM proxy is configured.
-    // This validates the full plumbing: request → spawn → callback → channel → stream → response.
+    // Verify the error event is present — the stream should contain an error
+    // since no LLM proxy is configured. This validates the full plumbing:
+    // request → spawn → callback → channel → stream → response.
+    assert!(
+        body.contains("error") || body.contains("Error"),
+        "expected error event in streaming response, got: {body}"
+    );
 }

--- a/rust/crates/candela-harness-connect/tests/integration.rs
+++ b/rust/crates/candela-harness-connect/tests/integration.rs
@@ -1,0 +1,204 @@
+//! Integration tests for the ConnectRPC harness server.
+//!
+//! These tests spin up the full Axum+ConnectRPC stack in-process using an
+//! ephemeral port and in-memory storage, then exercise the RPC surface via
+//! HTTP using the Connect protocol (application/json).
+
+use std::sync::{Arc, Mutex};
+
+use candela_core::harness::HarnessConfig;
+use candela_harness_chat::ChatRuntime;
+use candela_harness_storage::{Database, SearchIndex};
+
+/// Start the ConnectRPC server on an OS-assigned port, returning the base URL.
+async fn start_test_server() -> String {
+    let db = Database::open_in_memory().expect("open in-memory db");
+    let db = Arc::new(Mutex::new(db));
+
+    let search = SearchIndex::open_in_memory().expect("open in-memory search");
+    let search = Arc::new(Mutex::new(search));
+
+    let config = HarnessConfig {
+        model: "test-model".to_string(),
+        ..Default::default()
+    };
+    let chat = Arc::new(ChatRuntime::new(config, db.clone(), search.clone()));
+
+    // Bind to port 0 → OS picks an available port.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let port = listener.local_addr().unwrap().port();
+
+    // Build the server exactly like the production path but with our listener.
+    let connect_router = candela_harness_connect::server::build_router(chat, db, search);
+
+    use tower_http::cors::CorsLayer;
+    use tower_http::trace::TraceLayer;
+
+    let app = axum::Router::new()
+        .merge(connect_router.into_axum_router())
+        .layer(CorsLayer::permissive())
+        .layer(TraceLayer::new_for_http());
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    format!("http://127.0.0.1:{port}")
+}
+
+/// POST a Connect unary RPC and return the response body.
+async fn connect_post(base: &str, method: &str, body: &str) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("{base}/candela.harness.v1.HarnessService/{method}"))
+        .header("Content-Type", "application/json")
+        .body(body.to_string())
+        .send()
+        .await
+        .expect("HTTP request failed")
+}
+
+#[tokio::test]
+async fn test_health() {
+    let base = start_test_server().await;
+    let resp = connect_post(&base, "Health", "{}").await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], "ok");
+}
+
+#[tokio::test]
+async fn test_create_and_get_session() {
+    let base = start_test_server().await;
+
+    // Create
+    let resp = connect_post(&base, "CreateSession", r#"{"model":"test-model"}"#).await;
+    assert_eq!(resp.status(), 200);
+    let session: serde_json::Value = resp.json().await.unwrap();
+    let session_id = session["id"].as_str().expect("session id");
+    assert!(!session_id.is_empty());
+    assert_eq!(session["model"], "test-model");
+
+    // Get
+    let resp = connect_post(
+        &base,
+        "GetSession",
+        &format!(r#"{{"session_id":"{session_id}"}}"#),
+    )
+    .await;
+    assert_eq!(resp.status(), 200);
+    let got: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(got["id"], session_id);
+}
+
+#[tokio::test]
+async fn test_list_sessions_pagination() {
+    let base = start_test_server().await;
+
+    // Create 3 sessions
+    for _ in 0..3 {
+        connect_post(&base, "CreateSession", r#"{"model":"m"}"#).await;
+    }
+
+    // List with limit
+    let resp = connect_post(&base, "ListSessions", r#"{"limit":2,"offset":0}"#).await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let sessions = body["sessions"].as_array().expect("sessions array");
+    assert_eq!(sessions.len(), 2);
+}
+
+#[tokio::test]
+async fn test_delete_session() {
+    let base = start_test_server().await;
+
+    // Create
+    let resp = connect_post(&base, "CreateSession", r#"{"model":"m"}"#).await;
+    let session: serde_json::Value = resp.json().await.unwrap();
+    let id = session["id"].as_str().unwrap();
+
+    // Delete
+    let resp = connect_post(
+        &base,
+        "DeleteSession",
+        &format!(r#"{{"session_id":"{id}"}}"#),
+    )
+    .await;
+    assert_eq!(resp.status(), 200);
+
+    // Get should 404
+    let resp = connect_post(&base, "GetSession", &format!(r#"{{"session_id":"{id}"}}"#)).await;
+    // Connect protocol returns HTTP 200 with error in body, or non-200
+    // depending on implementation. Check for error.
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("not_found") || body.contains("not found") || body.contains("NOT_FOUND"),
+        "expected not_found error, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_edit_session_title() {
+    let base = start_test_server().await;
+
+    // Create
+    let resp = connect_post(&base, "CreateSession", r#"{"model":"m"}"#).await;
+    let session: serde_json::Value = resp.json().await.unwrap();
+    let id = session["id"].as_str().unwrap();
+
+    // Edit title
+    let resp = connect_post(
+        &base,
+        "EditSessionTitle",
+        &format!(r#"{{"session_id":"{id}","title":"Updated Title"}}"#),
+    )
+    .await;
+    assert_eq!(resp.status(), 200);
+    let updated: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(updated["title"], "Updated Title");
+}
+
+#[tokio::test]
+async fn test_get_nonexistent_session_returns_not_found() {
+    let base = start_test_server().await;
+
+    let resp = connect_post(&base, "GetSession", r#"{"session_id":"does-not-exist"}"#).await;
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("not_found") || body.contains("not found") || body.contains("NOT_FOUND"),
+        "expected not_found, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_send_message_streams_error_without_proxy() {
+    let base = start_test_server().await;
+
+    // Create a session first
+    let resp = connect_post(&base, "CreateSession", r#"{"model":"m"}"#).await;
+    let session: serde_json::Value = resp.json().await.unwrap();
+    let id = session["id"].as_str().unwrap();
+
+    // SendMessage — no proxy URL configured, so the LLM call will fail.
+    // We should get a stream that contains an error event.
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "{base}/candela.harness.v1.HarnessService/SendMessage"
+        ))
+        .header("Content-Type", "application/connect+json")
+        .body(format!(r#"{{"session_id":"{id}","content":"hello"}}"#))
+        .send()
+        .await
+        .expect("streaming request");
+
+    // For server-streaming Connect, the response body contains newline-delimited
+    // JSON envelopes. We should get at least one message (the error event).
+    let body = resp.text().await.unwrap();
+    assert!(
+        !body.is_empty(),
+        "expected streaming response body, got empty"
+    );
+    // The stream should contain an error since no LLM proxy is configured.
+    // This validates the full plumbing: request → spawn → callback → channel → stream → response.
+}


### PR DESCRIPTION
## Summary

7 integration tests covering the full ConnectRPC harness surface:

| Test | Validates |
|------|-----------|
| `test_health` | Health endpoint returns ok |
| `test_create_and_get_session` | Session CRUD round-trip |
| `test_list_sessions_pagination` | Pagination with limit/offset |
| `test_delete_session` | Delete + not_found on re-fetch |
| `test_edit_session_title` | Title update |
| `test_get_nonexistent_session_returns_not_found` | Error mapping |
| `test_send_message_streams_error_without_proxy` | Streaming plumbing (request→spawn→channel→stream) |

### Changes
- **`server.rs`**: Extract `build_router()` for test reuse
- **`Cargo.toml`**: Add `reqwest` dev-dependency
- **`tests/integration.rs`**: New integration test file

### ToolCall mapping
Also validated that `ChatEvent::ToolCall` is fully mapped in `domain_chat_event_to_proto` — no code changes needed, the mapping already handles all 5 `ChatEvent` variants (Chunk, Done, Error, Status, ToolCall).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server setup by exposing a reusable Connect router builder, while keeping runtime startup behavior the same.
* **Tests**
  * Added end-to-end integration coverage for health checks, session create/retrieve, pagination, deletion and missing-session handling, title editing, and server-streaming error responses.
* **Chores**
  * Added an HTTP client dependency to support the integration test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->