### PR TITLE
refactor: return Stream from send_message instead of callback

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -460,6 +460,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "uuid",
 ]

--- a/rust/crates/candela-harness-chat/src/client.rs
+++ b/rust/crates/candela-harness-chat/src/client.rs
@@ -13,6 +13,7 @@ use std::task::{Context, Poll};
 use tracing::{debug, warn};
 
 /// Client for streaming chat completions from an OpenAI-compatible API.
+#[derive(Clone)]
 pub struct ModelClient {
     http: Client,
     base_url: String,
@@ -37,7 +38,7 @@ impl ModelClient {
         messages: &[Message],
         model: &str,
         stream_id: &str,
-    ) -> Result<impl Stream<Item = Result<ChatEvent, HarnessError>>, HarnessError> {
+    ) -> Result<impl Stream<Item = Result<ChatEvent, HarnessError>> + use<>, HarnessError> {
         let url = format!("{}/v1/chat/completions", self.base_url);
 
         // Build OpenAI-compatible message array

--- a/rust/crates/candela-harness-chat/src/runtime.rs
+++ b/rust/crates/candela-harness-chat/src/runtime.rs
@@ -76,7 +76,7 @@ impl ChatRuntime {
     ///
     /// Returns `(stream_id, event_stream)`.
     pub async fn send_message(
-        &self,
+        self: Arc<Self>,
         session_id: &str,
         content: &str,
     ) -> Result<(String, Pin<Box<dyn Stream<Item = ChatEvent> + Send>>), HarnessError> {
@@ -110,15 +110,11 @@ impl ChatRuntime {
         // 4. Bridge via channel — spawned task starts model stream + consumes it.
         let (tx, rx) = tokio::sync::mpsc::channel::<ChatEvent>(64);
 
+        let this = self.clone();
         let sid = stream_id.clone();
-        let model = self.config.model.clone();
+        let model = this.config.model.clone();
         let session_id_owned = session_id.to_string();
         let content_owned = content.to_string();
-        let db = self.db.clone();
-        let search = self.search.clone();
-        let config = self.config.clone();
-        let client = self.client.clone();
-        let title_candidates = self.title_model_candidates.read().await.clone();
 
         tokio::spawn(async move {
             // Emit initial status
@@ -133,7 +129,7 @@ impl ChatRuntime {
                 .await;
 
             // Start model stream — connection failures become error events
-            let model_stream = match client.stream_chat(&history, &model, &sid).await {
+            let model_stream = match this.client.stream_chat(&history, &model, &sid).await {
                 Ok(s) => s,
                 Err(e) => {
                     error!(error = %e, "failed to start model stream");
@@ -208,12 +204,12 @@ impl ChatRuntime {
                 } else {
                     None
                 };
-                if let Err(e) = db.lock().unwrap().insert_message(&assistant_msg) {
+                if let Err(e) = this.db.lock().unwrap().insert_message(&assistant_msg) {
                     warn!(error = %e, "failed to store assistant message");
                 }
 
                 // Index in FTS for search
-                let _ = search.lock().unwrap().index_message(
+                let _ = this.search.lock().unwrap().index_message(
                     &full_response,
                     &session_id_owned,
                     &assistant_msg.id,
@@ -233,16 +229,13 @@ impl ChatRuntime {
                 })
                 .await;
 
-            // Auto-title (non-blocking for stream consumer — runs after Done is sent)
+            // Drop sender so the consumer's stream closes immediately after Done.
+            // Auto-titling continues in this task but no longer blocks the stream.
+            drop(tx);
+
+            // Auto-title on the real shared runtime — cache mutations persist
             if !full_response.is_empty() {
-                let rt = ChatRuntime {
-                    config,
-                    db,
-                    search,
-                    client,
-                    title_model_candidates: RwLock::new(title_candidates),
-                };
-                rt.auto_title_session(&session_id_owned, &content_owned, &full_response)
+                this.auto_title_session(&session_id_owned, &content_owned, &full_response)
                     .await;
             }
         });

--- a/rust/crates/candela-harness-chat/src/runtime.rs
+++ b/rust/crates/candela-harness-chat/src/runtime.rs
@@ -5,6 +5,8 @@ use candela_core::harness::{
     StatusEvent, UsageSummary, new_message,
 };
 use candela_harness_storage::{Database, SearchIndex};
+use futures_core::Stream;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
@@ -66,16 +68,18 @@ impl ChatRuntime {
         Ok(())
     }
 
-    /// Send a message and stream the response.
+    /// Send a message and return a stream of chat events.
     ///
-    /// Returns the stream ID. Events will be sent via the `on_event` callback
-    /// as they arrive from the model.
+    /// Setup (budget check, store user message, load history) happens eagerly
+    /// and returns an error if it fails. The model stream is started lazily
+    /// inside the returned stream — connection failures appear as error events.
+    ///
+    /// Returns `(stream_id, event_stream)`.
     pub async fn send_message(
         &self,
         session_id: &str,
         content: &str,
-        on_event: impl Fn(ChatEvent) + Send + 'static,
-    ) -> Result<String, HarnessError> {
+    ) -> Result<(String, Pin<Box<dyn Stream<Item = ChatEvent> + Send>>), HarnessError> {
         let stream_id = uuid::Uuid::new_v4().to_string();
         info!(
             session_id,
@@ -84,16 +88,7 @@ impl ChatRuntime {
             "chat.send"
         );
 
-        // 1. Emit status
-        on_event(ChatEvent {
-            stream_id: stream_id.clone(),
-            event: Some(ChatEventEvent::Status(Box::new(StatusEvent {
-                text: "Thinking...".to_string(),
-                agent: None,
-            }))),
-        });
-
-        // 2. Budget check — reject before incurring cost
+        // 1. Budget check — reject before incurring cost
         let budget_limit = self.config.budget_limit_usd;
         if budget_limit > 0.0 {
             let session = self.db.lock().unwrap().get_session(session_id)?;
@@ -105,97 +100,155 @@ impl ChatRuntime {
             }
         }
 
-        // 3. Store user message
+        // 2. Store user message
         let user_msg = new_message(session_id, MessageRole::User, content);
         self.db.lock().unwrap().insert_message(&user_msg)?;
 
-        // 4. Load conversation history
+        // 3. Load conversation history
         let history = self.db.lock().unwrap().get_messages(session_id, 100)?;
 
-        // 5. Stream from model
-        let model = &self.config.model;
-        let mut full_response = String::new();
-        let mut usage = UsageSummary::default();
+        // 4. Bridge via channel — spawned task starts model stream + consumes it.
+        let (tx, rx) = tokio::sync::mpsc::channel::<ChatEvent>(64);
 
-        let stream = self.client.stream_chat(&history, model, &stream_id).await?;
-        tokio::pin!(stream);
+        let sid = stream_id.clone();
+        let model = self.config.model.clone();
+        let session_id_owned = session_id.to_string();
+        let content_owned = content.to_string();
+        let db = self.db.clone();
+        let search = self.search.clone();
+        let config = self.config.clone();
+        let client = self.client.clone();
+        let title_candidates = self.title_model_candidates.read().await.clone();
 
-        while let Some(event) = stream.next().await {
-            match event {
-                Ok(ChatEvent {
-                    event: Some(ChatEventEvent::Chunk(c)),
-                    ..
-                }) => {
-                    full_response.push_str(&c.delta);
-                    on_event(ChatEvent {
-                        stream_id: stream_id.clone(),
-                        event: Some(ChatEventEvent::Chunk(c)),
-                    });
-                }
-                Ok(ChatEvent {
-                    event: Some(ChatEventEvent::Done(d)),
-                    ..
-                }) => {
-                    if let Some(u) = d.usage {
-                        usage = *u;
-                    }
-                    usage.model = model.to_string();
-                }
-                Ok(other) => on_event(other),
+        tokio::spawn(async move {
+            // Emit initial status
+            let _ = tx
+                .send(ChatEvent {
+                    stream_id: sid.clone(),
+                    event: Some(ChatEventEvent::Status(Box::new(StatusEvent {
+                        text: "Thinking...".to_string(),
+                        agent: None,
+                    }))),
+                })
+                .await;
+
+            // Start model stream — connection failures become error events
+            let model_stream = match client.stream_chat(&history, &model, &sid).await {
+                Ok(s) => s,
                 Err(e) => {
-                    error!(error = %e, "stream error");
-                    on_event(ChatEvent {
-                        stream_id: stream_id.clone(),
-                        event: Some(ChatEventEvent::Error(Box::new(ErrorEvent {
-                            message: e.to_string(),
-                            code: None,
-                        }))),
-                    });
-                    return Err(e);
+                    error!(error = %e, "failed to start model stream");
+                    let _ = tx
+                        .send(ChatEvent {
+                            stream_id: sid.clone(),
+                            event: Some(ChatEventEvent::Error(Box::new(ErrorEvent {
+                                message: e.to_string(),
+                                code: None,
+                            }))),
+                        })
+                        .await;
+                    return;
+                }
+            };
+
+            // Stream from model
+            let mut full_response = String::new();
+            let mut usage = UsageSummary::default();
+
+            tokio::pin!(model_stream);
+            while let Some(event) = model_stream.next().await {
+                match event {
+                    Ok(ChatEvent {
+                        event: Some(ChatEventEvent::Chunk(c)),
+                        ..
+                    }) => {
+                        full_response.push_str(&c.delta);
+                        let _ = tx
+                            .send(ChatEvent {
+                                stream_id: sid.clone(),
+                                event: Some(ChatEventEvent::Chunk(c)),
+                            })
+                            .await;
+                    }
+                    Ok(ChatEvent {
+                        event: Some(ChatEventEvent::Done(d)),
+                        ..
+                    }) => {
+                        if let Some(u) = d.usage {
+                            usage = *u;
+                        }
+                        usage.model = model.clone();
+                    }
+                    Ok(other) => {
+                        let _ = tx.send(other).await;
+                    }
+                    Err(e) => {
+                        error!(error = %e, "stream error");
+                        let _ = tx
+                            .send(ChatEvent {
+                                stream_id: sid.clone(),
+                                event: Some(ChatEventEvent::Error(Box::new(ErrorEvent {
+                                    message: e.to_string(),
+                                    code: None,
+                                }))),
+                            })
+                            .await;
+                        return; // stop on error
+                    }
                 }
             }
-        }
 
-        // 6. Store assistant message
-        if !full_response.is_empty() {
-            let mut assistant_msg = new_message(session_id, MessageRole::Assistant, &full_response);
-            assistant_msg.model = Some(model.to_string());
-            assistant_msg.token_count = Some(usage.total_tokens as i32);
-            assistant_msg.cost_usd = if usage.total_cost_usd > 0.0 {
-                Some(usage.total_cost_usd)
-            } else {
-                None
-            };
-            self.db.lock().unwrap().insert_message(&assistant_msg)?;
+            // Store assistant message
+            if !full_response.is_empty() {
+                let mut assistant_msg =
+                    new_message(&session_id_owned, MessageRole::Assistant, &full_response);
+                assistant_msg.model = Some(model.clone());
+                assistant_msg.token_count = Some(usage.total_tokens as i32);
+                assistant_msg.cost_usd = if usage.total_cost_usd > 0.0 {
+                    Some(usage.total_cost_usd)
+                } else {
+                    None
+                };
+                if let Err(e) = db.lock().unwrap().insert_message(&assistant_msg) {
+                    warn!(error = %e, "failed to store assistant message");
+                }
 
-            // 7. Index in FTS for search
-            let _ = self.search.lock().unwrap().index_message(
-                &full_response,
-                session_id,
-                &assistant_msg.id,
-                "", // title populated asynchronously by auto-titling
-                "assistant",
-                &assistant_msg.created_at.to_rfc3339(),
-            );
-        }
+                // Index in FTS for search
+                let _ = search.lock().unwrap().index_message(
+                    &full_response,
+                    &session_id_owned,
+                    &assistant_msg.id,
+                    "",
+                    "assistant",
+                    &assistant_msg.created_at.to_rfc3339(),
+                );
+            }
 
-        // 8. Emit Done immediately — don't block UI on title generation
-        on_event(ChatEvent {
-            stream_id: stream_id.clone(),
-            event: Some(ChatEventEvent::Done(Box::new(DoneEvent {
-                usage: Some(Box::new(usage)),
-            }))),
+            // Emit Done event
+            let _ = tx
+                .send(ChatEvent {
+                    stream_id: sid.clone(),
+                    event: Some(ChatEventEvent::Done(Box::new(DoneEvent {
+                        usage: Some(Box::new(usage)),
+                    }))),
+                })
+                .await;
+
+            // Auto-title (non-blocking for stream consumer — runs after Done is sent)
+            if !full_response.is_empty() {
+                let rt = ChatRuntime {
+                    config,
+                    db,
+                    search,
+                    client,
+                    title_model_candidates: RwLock::new(title_candidates),
+                };
+                rt.auto_title_session(&session_id_owned, &content_owned, &full_response)
+                    .await;
+            }
         });
 
-        // 9. Auto-title in background (non-blocking)
-        if !full_response.is_empty() {
-            let user_content = content.to_string();
-            // auto_title_session borrows &self, so we call it directly but after Done
-            self.auto_title_session(session_id, &user_content, &full_response)
-                .await;
-        }
-
-        Ok(stream_id.clone())
+        let event_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+        Ok((stream_id, Box::pin(event_stream)))
     }
 
     /// Auto-title a session if it still has the default "New Chat" title.

--- a/rust/crates/candela-harness-connect/src/service.rs
+++ b/rust/crates/candela-harness-connect/src/service.rs
@@ -137,7 +137,10 @@ impl HarnessService for HarnessServiceImpl {
                 .clone()
                 .send_message(&session_id, &content)
                 .await
-                .map_err(|e| ConnectError::internal(e.to_string()))?;
+                .map_err(|e| match e {
+                    HarnessError::SessionNotFound(msg) => ConnectError::not_found(msg),
+                    other => ConnectError::internal(other.to_string()),
+                })?;
 
             use tokio_stream::StreamExt;
             let stream = event_stream.map(|event| Ok(domain_chat_event_to_proto(&event)));

--- a/rust/crates/candela-harness-connect/src/service.rs
+++ b/rust/crates/candela-harness-connect/src/service.rs
@@ -134,6 +134,7 @@ impl HarnessService for HarnessServiceImpl {
 
         async move {
             let (_stream_id, event_stream) = chat
+                .clone()
                 .send_message(&session_id, &content)
                 .await
                 .map_err(|e| ConnectError::internal(e.to_string()))?;

--- a/rust/crates/candela-harness-connect/src/service.rs
+++ b/rust/crates/candela-harness-connect/src/service.rs
@@ -14,7 +14,6 @@ use candela_harness_storage::{Database, SearchIndex};
 use connectrpc::{
     ConnectError, RequestContext, Response, ServiceRequest, ServiceResult, ServiceStream,
 };
-use tracing::error;
 
 use crate::proto::candela::types as proto_types;
 use crate::proto::candela::v1::*;
@@ -134,42 +133,13 @@ impl HarnessService for HarnessServiceImpl {
         let chat = self.chat.clone();
 
         async move {
-            // Buffer sized generously: the callback is sync (Fn, not async),
-            // so we cannot await inside it — try_send is required.  A large
-            // buffer makes channel-full drops practically impossible during
-            // normal streaming; if it does happen we log a warning so it's
-            // visible in traces rather than silently lost.
-            let (tx, rx) = tokio::sync::mpsc::channel::<SendMessageResponse>(256);
-
-            tokio::spawn(async move {
-                let tx_err = tx.clone();
-                let result = chat
-                    .send_message(&session_id, &content, move |event| {
-                        let proto_event = domain_chat_event_to_proto(&event);
-                        if let Err(e) = tx.try_send(proto_event) {
-                            tracing::warn!("stream event dropped (channel full or closed): {e}");
-                        }
-                    })
-                    .await;
-
-                if let Err(e) = result {
-                    error!(?e, "send_message failed");
-                    let mut err = proto_types::ErrorEvent::default();
-                    err.message = e.to_string().into();
-                    let mut ce = proto_types::ChatEvent::default();
-                    ce.event = Some(proto_types::__buffa::oneof::chat_event::Event::Error(
-                        Box::new(err),
-                    ));
-                    let mut resp = SendMessageResponse::default();
-                    resp.event = MessageField::some(ce);
-                    if let Err(e) = tx_err.send(resp).await {
-                        tracing::warn!("failed to send error event (receiver dropped): {e}");
-                    }
-                }
-            });
+            let (_stream_id, event_stream) = chat
+                .send_message(&session_id, &content)
+                .await
+                .map_err(|e| ConnectError::internal(e.to_string()))?;
 
             use tokio_stream::StreamExt;
-            let stream = tokio_stream::wrappers::ReceiverStream::new(rx).map(Ok);
+            let stream = event_stream.map(|event| Ok(domain_chat_event_to_proto(&event)));
             Ok(Response::new(Box::pin(stream) as ServiceStream<_>))
         }
     }

--- a/rust/crates/candela-harness-rpc/Cargo.toml
+++ b/rust/crates/candela-harness-rpc/Cargo.toml
@@ -11,6 +11,7 @@ candela-harness-storage = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -437,8 +437,13 @@ mod tests {
         let stream_id = result["stream_id"].as_str().unwrap().to_string();
 
         // Collect all notifications — every event must have the same stream_id
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         let mut events = Vec::new();
+        events.push(
+            tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+                .await
+                .expect("timed out waiting for first event")
+                .expect("notification channel closed"),
+        );
         while let Ok(notif) = rx.try_recv() {
             events.push(notif);
         }
@@ -481,11 +486,14 @@ mod tests {
         let resp = handler.handle(req).await.unwrap();
         assert!(resp.error.is_none(), "should return accepted, not error");
 
-        // Wait for background streaming to complete
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
         // Collect events and verify error event is present
         let mut events = Vec::new();
+        events.push(
+            tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+                .await
+                .expect("timed out waiting for first event")
+                .expect("notification channel closed"),
+        );
         while let Ok(notif) = rx.try_recv() {
             events.push(notif);
         }

--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -1,6 +1,6 @@
 //! JSON-RPC request handler — dispatches method calls.
 
-use candela_core::harness::{ChatEvent, HarnessError, chat_event_to_json_value, new_session};
+use candela_core::harness::{HarnessError, chat_event_to_json_value, new_session};
 use candela_harness_chat::ChatRuntime;
 use candela_harness_storage::Database;
 use std::sync::Arc;
@@ -168,30 +168,30 @@ impl RpcHandler {
             }
         };
 
-        let stream_id = uuid::Uuid::new_v4().to_string();
         let chat = self.chat.clone();
         let tx = self.notify_tx.clone();
-        let sid = stream_id.clone();
+
+        // Setup is synchronous — budget check, store user msg, start model stream.
+        // Errors here are returned as JSON-RPC errors (not stream events).
+        let (stream_id, event_stream) = match chat.send_message(&session_id, &content).await {
+            Ok(result) => result,
+            Err(e) => {
+                return JsonRpcResponse::error(
+                    id,
+                    -32000, // server error
+                    e.to_string(),
+                );
+            }
+        };
 
         // Spawn the streaming task — response comes back immediately
         tokio::spawn(async move {
-            let notify_tx = tx.clone();
-            let on_event = move |event: ChatEvent| {
+            use tokio_stream::StreamExt;
+            tokio::pin!(event_stream);
+            while let Some(event) = event_stream.next().await {
                 let notif =
                     JsonRpcNotification::new("chat.event", chat_event_to_json_value(&event));
-                let _ = notify_tx.send(notif);
-            };
-
-            if let Err(e) = chat.send_message(&session_id, &content, on_event).await {
-                let error_notif = JsonRpcNotification::new(
-                    "chat.event",
-                    serde_json::json!({
-                        "type": "error",
-                        "stream_id": sid,
-                        "message": e.to_string(),
-                    }),
-                );
-                let _ = tx.send(error_notif);
+                let _ = tx.send(notif);
             }
         });
 

--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -173,7 +173,8 @@ impl RpcHandler {
 
         // Setup is synchronous — budget check, store user msg, start model stream.
         // Errors here are returned as JSON-RPC errors (not stream events).
-        let (stream_id, event_stream) = match chat.send_message(&session_id, &content).await {
+        let (stream_id, event_stream) = match chat.clone().send_message(&session_id, &content).await
+        {
             Ok(result) => result,
             Err(e) => {
                 return JsonRpcResponse::error(
@@ -191,7 +192,9 @@ impl RpcHandler {
             while let Some(event) = event_stream.next().await {
                 let notif =
                     JsonRpcNotification::new("chat.event", chat_event_to_json_value(&event));
-                let _ = tx.send(notif);
+                if tx.send(notif).is_err() {
+                    break; // client disconnected — stop polling the stream
+                }
             }
         });
 
@@ -403,5 +406,118 @@ mod tests {
         let result = resp.result.unwrap();
         assert_eq!(result["status"], "accepted");
         assert!(result["stream_id"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_chat_send_stream_id_consistent() {
+        let (handler, mut rx) = test_handler();
+
+        // Create session
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: "session.create".to_string(),
+            params: serde_json::json!({}),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        let session_id = resp.result.unwrap()["id"].as_str().unwrap().to_string();
+
+        // Send message
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(2)),
+            method: "chat.send".to_string(),
+            params: serde_json::json!({
+                "session_id": session_id,
+                "content": "hello"
+            }),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        let result = resp.result.unwrap();
+        let stream_id = result["stream_id"].as_str().unwrap().to_string();
+
+        // Collect all notifications — every event must have the same stream_id
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        let mut events = Vec::new();
+        while let Ok(notif) = rx.try_recv() {
+            events.push(notif);
+        }
+
+        assert!(!events.is_empty(), "should receive at least one event");
+        for notif in &events {
+            let params = &notif.params;
+            let event_stream_id = params["stream_id"].as_str().unwrap();
+            assert_eq!(
+                event_stream_id, stream_id,
+                "event stream_id must match the response stream_id"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_chat_send_error_event_on_model_failure() {
+        let (handler, mut rx) = test_handler();
+
+        // Create session
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: "session.create".to_string(),
+            params: serde_json::json!({}),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        let session_id = resp.result.unwrap()["id"].as_str().unwrap().to_string();
+
+        // Send message — model call will fail (no proxy configured)
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(2)),
+            method: "chat.send".to_string(),
+            params: serde_json::json!({
+                "session_id": session_id,
+                "content": "hello"
+            }),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        assert!(resp.error.is_none(), "should return accepted, not error");
+
+        // Wait for background streaming to complete
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        // Collect events and verify error event is present
+        let mut events = Vec::new();
+        while let Ok(notif) = rx.try_recv() {
+            events.push(notif);
+        }
+
+        let has_error = events
+            .iter()
+            .any(|n| n.params.get("error").is_some() || n.params.to_string().contains("error"));
+        assert!(
+            has_error,
+            "stream should contain an error event when model call fails, got: {:?}",
+            events.iter().map(|n| &n.params).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_chat_send_nonexistent_session() {
+        let (handler, _rx) = test_handler();
+
+        // Send to nonexistent session — should return JSON-RPC error
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: "chat.send".to_string(),
+            params: serde_json::json!({
+                "session_id": "nonexistent-session",
+                "content": "hello"
+            }),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        assert!(
+            resp.error.is_some(),
+            "should return error for nonexistent session"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Refactors `ChatRuntime::send_message` to return a `(String, Pin<Box<dyn Stream<Item = ChatEvent> + Send>>)` instead of taking an `on_event` callback. This is the stream-return refactor tracked in #469.

## Changes

### `candela-harness-chat` (runtime.rs)
- `send_message` now returns `(stream_id, event_stream)` — no more callback parameter
- Setup (budget check, store user msg, load history) is synchronous and returns errors immediately
- Model connection + streaming happens lazily inside a spawned task; connection failures become `ChatEvent::Error` on the stream
- Auto-titling runs after `Done` event, non-blocking for the stream consumer

### `candela-harness-chat` (client.rs)
- `ModelClient` now derives `Clone` for spawned task usage
- `stream_chat` uses Rust 2024 `use<>` precise capturing to avoid false lifetime captures on the returned `impl Stream`

### `candela-harness-rpc` (handler.rs)
- `stream_id` now comes from the runtime (fixes the stream_id mismatch bug flagged in #470 CodeRabbit review)
- Simplified: just consumes the stream and forwards events as JSON-RPC notifications
- Setup errors returned as JSON-RPC error responses (budget exceeded, session not found)

### `candela-harness-connect` (service.rs)
- Eliminated the mpsc(256) channel bridge + spawned task (~30 lines removed)
- Maps the returned stream directly to proto events: `event_stream.map(|e| Ok(domain_chat_event_to_proto(&e)))`

## Testing
- All 314 workspace tests pass
- All pre-commit hooks (clippy, fmt, cargo-test) pass
- Integration test `test_send_message_streams_error_without_proxy` validates end-to-end error propagation

Closes #469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat message streaming now emits an initial “Thinking...” status, followed by streamed chat events, and concludes with a clear completion event tied to a returned stream ID.
  * Each sent message now provides its own event stream, improving consistency for streaming clients.

* **Bug Fixes**
  * Streaming no longer silently omits events when model streaming fails; failures are reported within the event stream.
  * Streaming behavior across the RPC and service layers was aligned so notifications and error handling match the same streaming contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->