### PR TITLE
feat: improve ListSessions pagination — add page_size, total_count, index

### DIFF
--- a/rust/crates/candela-harness-chat/src/runtime.rs
+++ b/rust/crates/candela-harness-chat/src/runtime.rs
@@ -152,6 +152,7 @@ impl ChatRuntime {
 
             tokio::pin!(model_stream);
             let mut client_disconnected = false;
+            let mut stream_failed = false;
             while let Some(event) = model_stream.next().await {
                 match event {
                     Ok(ChatEvent {
@@ -196,6 +197,7 @@ impl ChatRuntime {
                                 }))),
                             })
                             .await;
+                        stream_failed = true;
                         break; // stop on error, but still persist what we have
                     }
                 }
@@ -227,15 +229,17 @@ impl ChatRuntime {
                 );
             }
 
-            // Emit Done event
-            let _ = tx
-                .send(ChatEvent {
-                    stream_id: sid.clone(),
-                    event: Some(ChatEventEvent::Done(Box::new(DoneEvent {
-                        usage: Some(Box::new(usage)),
-                    }))),
-                })
-                .await;
+            // Emit Done event only if stream completed without errors
+            if !stream_failed {
+                let _ = tx
+                    .send(ChatEvent {
+                        stream_id: sid.clone(),
+                        event: Some(ChatEventEvent::Done(Box::new(DoneEvent {
+                            usage: Some(Box::new(usage)),
+                        }))),
+                    })
+                    .await;
+            }
 
             // Drop sender so the consumer's stream closes immediately after Done.
             // Auto-titling continues in this task but no longer blocks the stream.

--- a/rust/crates/candela-harness-chat/src/runtime.rs
+++ b/rust/crates/candela-harness-chat/src/runtime.rs
@@ -151,6 +151,7 @@ impl ChatRuntime {
             let mut usage = UsageSummary::default();
 
             tokio::pin!(model_stream);
+            let mut client_disconnected = false;
             while let Some(event) = model_stream.next().await {
                 match event {
                     Ok(ChatEvent {
@@ -158,12 +159,17 @@ impl ChatRuntime {
                         ..
                     }) => {
                         full_response.push_str(&c.delta);
-                        let _ = tx
-                            .send(ChatEvent {
-                                stream_id: sid.clone(),
-                                event: Some(ChatEventEvent::Chunk(c)),
-                            })
-                            .await;
+                        if !client_disconnected
+                            && tx
+                                .send(ChatEvent {
+                                    stream_id: sid.clone(),
+                                    event: Some(ChatEventEvent::Chunk(c)),
+                                })
+                                .await
+                                .is_err()
+                        {
+                            client_disconnected = true;
+                        }
                     }
                     Ok(ChatEvent {
                         event: Some(ChatEventEvent::Done(d)),
@@ -175,7 +181,9 @@ impl ChatRuntime {
                         usage.model = model.clone();
                     }
                     Ok(other) => {
-                        let _ = tx.send(other).await;
+                        if !client_disconnected && tx.send(other).await.is_err() {
+                            client_disconnected = true;
+                        }
                     }
                     Err(e) => {
                         error!(error = %e, "stream error");
@@ -188,7 +196,7 @@ impl ChatRuntime {
                                 }))),
                             })
                             .await;
-                        return; // stop on error
+                        break; // stop on error, but still persist what we have
                     }
                 }
             }

--- a/rust/crates/candela-harness-connect/proto/candela/v1/harness_service.proto
+++ b/rust/crates/candela-harness-connect/proto/candela/v1/harness_service.proto
@@ -47,13 +47,27 @@ message SendMessageResponse {
 // ── Session CRUD ──
 
 message ListSessionsRequest {
-  int32 limit = 1;
-  int32 offset = 2;
+  // Maximum number of sessions to return. Default: 50, max: 200.
+  // Deprecated: use page_size instead.
+  int32 limit = 1 [deprecated = true];
+  // Offset for pagination. Deprecated: use page_token instead.
+  int32 offset = 2 [deprecated = true];
+  // Maximum number of sessions to return (default 50, max 200).
+  int32 page_size = 3;
+  // Cursor token from a previous ListSessionsResponse.next_page_token.
+  // Reserved for future cursor-based pagination.
+  string page_token = 4;
 }
 
 message ListSessionsResponse {
   repeated candela.types.Session sessions = 1;
-  int32 total = 2;
+  // Deprecated: was page length, not total count. Use total_count instead.
+  int32 total = 2 [deprecated = true];
+  // Cursor token for the next page. Empty when there are no more results.
+  // Reserved for future cursor-based pagination.
+  string next_page_token = 3;
+  // Total number of sessions (not just this page).
+  int32 total_count = 4;
 }
 
 message GetSessionRequest {

--- a/rust/crates/candela-harness-connect/src/service.rs
+++ b/rust/crates/candela-harness-connect/src/service.rs
@@ -155,13 +155,15 @@ impl HarnessService for HarnessServiceImpl {
     ) -> impl std::future::Future<
         Output = ServiceResult<impl connectrpc::Encodable<ListSessionsResponse> + Send + use<'a>>,
     > + Send {
-        // page_size takes precedence over deprecated limit
-        let limit = (if request.page_size > 0 {
+        // page_size takes precedence over deprecated limit; default 50
+        let raw = if request.page_size > 0 {
             request.page_size
-        } else {
+        } else if request.limit > 0 {
             request.limit
-        })
-        .clamp(0, 200) as i64;
+        } else {
+            50
+        };
+        let limit = raw.clamp(0, 200) as i64;
         let offset = request.offset.max(0) as i64;
 
         async move {

--- a/rust/crates/candela-harness-connect/src/service.rs
+++ b/rust/crates/candela-harness-connect/src/service.rs
@@ -155,7 +155,13 @@ impl HarnessService for HarnessServiceImpl {
     ) -> impl std::future::Future<
         Output = ServiceResult<impl connectrpc::Encodable<ListSessionsResponse> + Send + use<'a>>,
     > + Send {
-        let limit = request.limit.max(0) as i64;
+        // page_size takes precedence over deprecated limit
+        let limit = (if request.page_size > 0 {
+            request.page_size
+        } else {
+            request.limit
+        })
+        .clamp(0, 200) as i64;
         let offset = request.offset.max(0) as i64;
 
         async move {
@@ -163,6 +169,9 @@ impl HarnessService for HarnessServiceImpl {
                 .db
                 .lock()
                 .map_err(|e| ConnectError::internal(format!("lock failed: {e}")))?;
+            let total_count =
+                db.count_sessions()
+                    .map_err(|e| ConnectError::internal(e.to_string()))? as i32;
             let sessions = db
                 .list_sessions(limit, offset)
                 .map_err(|e| ConnectError::internal(e.to_string()))?;
@@ -173,7 +182,8 @@ impl HarnessService for HarnessServiceImpl {
 
             let mut resp = ListSessionsResponse::default();
             resp.sessions = proto_sessions;
-            resp.total = total;
+            resp.total = total; // deprecated — kept for backward compat
+            resp.total_count = total_count;
             Ok(Response::new(resp))
         }
     }

--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -77,13 +77,19 @@ impl RpcHandler {
         id: Option<serde_json::Value>,
         params: serde_json::Value,
     ) -> JsonRpcResponse {
-        // page_size takes precedence over deprecated limit when present
+        // page_size takes precedence over deprecated limit when present and > 0
         let limit = params
             .get("page_size")
             .and_then(|v| v.as_i64())
-            .or_else(|| params.get("limit").and_then(|v| v.as_i64()))
+            .filter(|&v| v > 0)
+            .or_else(|| {
+                params
+                    .get("limit")
+                    .and_then(|v| v.as_i64())
+                    .filter(|&v| v > 0)
+            })
             .unwrap_or(50)
-            .clamp(0, 200);
+            .clamp(1, 200);
         let offset = params
             .get("offset")
             .and_then(|v| v.as_i64())

--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -77,11 +77,10 @@ impl RpcHandler {
         id: Option<serde_json::Value>,
         params: serde_json::Value,
     ) -> JsonRpcResponse {
-        // page_size takes precedence over deprecated limit
+        // page_size takes precedence over deprecated limit when present
         let limit = params
             .get("page_size")
             .and_then(|v| v.as_i64())
-            .filter(|&v| v > 0)
             .or_else(|| params.get("limit").and_then(|v| v.as_i64()))
             .unwrap_or(50)
             .clamp(0, 200);

--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -92,7 +92,10 @@ impl RpcHandler {
             .max(0);
 
         let db = self.db.lock().unwrap();
-        let total_count = db.count_sessions().unwrap_or(0);
+        let total_count = match db.count_sessions() {
+            Ok(c) => c,
+            Err(e) => return JsonRpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
+        };
 
         match db.list_sessions(limit, offset) {
             Ok(sessions) => JsonRpcResponse::success(

--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -81,6 +81,7 @@ impl RpcHandler {
         let limit = params
             .get("page_size")
             .and_then(|v| v.as_i64())
+            .filter(|&v| v > 0)
             .or_else(|| params.get("limit").and_then(|v| v.as_i64()))
             .unwrap_or(50)
             .clamp(0, 200);
@@ -177,17 +178,14 @@ impl RpcHandler {
         let chat = self.chat.clone();
         let tx = self.notify_tx.clone();
 
-        // Setup is synchronous — budget check, store user msg, start model stream.
-        // Errors here are returned as JSON-RPC errors (not stream events).
+        // Eager setup (budget check, store user msg, load history) runs here.
+        // The model stream starts lazily in the spawned task.
+        // Setup errors are returned as JSON-RPC errors (not stream events).
         let (stream_id, event_stream) = match chat.clone().send_message(&session_id, &content).await
         {
             Ok(result) => result,
             Err(e) => {
-                return JsonRpcResponse::error(
-                    id,
-                    -32000, // server error
-                    e.to_string(),
-                );
+                return JsonRpcResponse::error(id, SERVER_ERROR, e.to_string());
             }
         };
 
@@ -509,16 +507,13 @@ mod tests {
         let result = resp.result.unwrap();
         let stream_id = result["stream_id"].as_str().unwrap().to_string();
 
-        // Collect all notifications — every event must have the same stream_id
+        // Collect all notifications with bounded recv
         let mut events = Vec::new();
-        events.push(
-            tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
-                .await
-                .expect("timed out waiting for first event")
-                .expect("notification channel closed"),
-        );
-        while let Ok(notif) = rx.try_recv() {
-            events.push(notif);
+        loop {
+            match tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv()).await {
+                Ok(Some(notif)) => events.push(notif),
+                _ => break,
+            }
         }
 
         assert!(!events.is_empty(), "should receive at least one event");
@@ -559,16 +554,13 @@ mod tests {
         let resp = handler.handle(req).await.unwrap();
         assert!(resp.error.is_none(), "should return accepted, not error");
 
-        // Collect events and verify error event is present
+        // Collect events with bounded recv — keeps polling until idle timeout
         let mut events = Vec::new();
-        events.push(
-            tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
-                .await
-                .expect("timed out waiting for first event")
-                .expect("notification channel closed"),
-        );
-        while let Ok(notif) = rx.try_recv() {
-            events.push(notif);
+        loop {
+            match tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv()).await {
+                Ok(Some(notif)) => events.push(notif),
+                _ => break, // timeout or channel closed
+            }
         }
 
         let has_error = events

--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -77,23 +77,29 @@ impl RpcHandler {
         id: Option<serde_json::Value>,
         params: serde_json::Value,
     ) -> JsonRpcResponse {
+        // page_size takes precedence over deprecated limit
         let limit = params
-            .get("limit")
+            .get("page_size")
             .and_then(|v| v.as_i64())
+            .or_else(|| params.get("limit").and_then(|v| v.as_i64()))
             .unwrap_or(50)
-            .max(0);
+            .clamp(0, 200);
         let offset = params
             .get("offset")
             .and_then(|v| v.as_i64())
             .unwrap_or(0)
             .max(0);
 
-        match self.db.lock().unwrap().list_sessions(limit, offset) {
+        let db = self.db.lock().unwrap();
+        let total_count = db.count_sessions().unwrap_or(0);
+
+        match db.list_sessions(limit, offset) {
             Ok(sessions) => JsonRpcResponse::success(
                 id,
                 serde_json::json!({
                     "sessions": sessions,
-                    "total": sessions.len(),
+                    "total": sessions.len(), // deprecated — kept for backward compat
+                    "total_count": total_count,
                 }),
             ),
             Err(e) => JsonRpcResponse::error(id, INTERNAL_ERROR, e.to_string()),
@@ -358,6 +364,63 @@ mod tests {
         let resp = handler.handle(req).await.unwrap();
         // Should not error — clamped to 0
         assert!(resp.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_session_list_total_count() {
+        let (handler, _rx) = test_handler();
+
+        // Create 3 sessions
+        for i in 1..=3 {
+            let req = JsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: Some(serde_json::json!(i)),
+                method: "session.create".to_string(),
+                params: serde_json::json!({}),
+            };
+            handler.handle(req).await.unwrap();
+        }
+
+        // List with limit=2 — should return 2 sessions but total_count=3
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(10)),
+            method: "session.list".to_string(),
+            params: serde_json::json!({ "limit": 2 }),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        let result = resp.result.unwrap();
+        assert_eq!(result["sessions"].as_array().unwrap().len(), 2);
+        assert_eq!(result["total"], 2); // deprecated: page length
+        assert_eq!(result["total_count"], 3); // actual total
+    }
+
+    #[tokio::test]
+    async fn test_session_list_page_size_over_limit() {
+        let (handler, _rx) = test_handler();
+
+        // Create 3 sessions
+        for i in 1..=3 {
+            let req = JsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: Some(serde_json::json!(i)),
+                method: "session.create".to_string(),
+                params: serde_json::json!({}),
+            };
+            handler.handle(req).await.unwrap();
+        }
+
+        // page_size should take precedence over limit
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(10)),
+            method: "session.list".to_string(),
+            params: serde_json::json!({ "page_size": 1, "limit": 50 }),
+        };
+        let resp = handler.handle(req).await.unwrap();
+        let result = resp.result.unwrap();
+        assert_eq!(result["sessions"].as_array().unwrap().len(), 1);
+        assert_eq!(result["total_count"], 3);
     }
 
     #[tokio::test]

--- a/rust/crates/candela-harness-rpc/src/protocol.rs
+++ b/rust/crates/candela-harness-rpc/src/protocol.rs
@@ -74,3 +74,6 @@ pub const INVALID_REQUEST: i32 = -32600;
 pub const METHOD_NOT_FOUND: i32 = -32601;
 pub const INVALID_PARAMS: i32 = -32602;
 pub const INTERNAL_ERROR: i32 = -32603;
+
+// Application-level server error (JSON-RPC reserved range)
+pub const SERVER_ERROR: i32 = -32000;

--- a/rust/crates/candela-harness-storage/src/db.rs
+++ b/rust/crates/candela-harness-storage/src/db.rs
@@ -99,6 +99,9 @@ impl Database {
                 CREATE INDEX idx_messages_session
                     ON messages(session_id, sequence);
 
+                CREATE INDEX idx_sessions_updated_at
+                    ON sessions(updated_at DESC);
+
                 PRAGMA user_version = 1;
             ",
                 )
@@ -166,6 +169,17 @@ impl Database {
             .map_err(|e| HarnessError::Storage(e.to_string()))?;
 
         Ok(sessions)
+    }
+
+    /// Count all non-deleted sessions.
+    pub fn count_sessions(&self) -> Result<i64, HarnessError> {
+        self.conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE deleted_at IS NULL",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| HarnessError::Storage(e.to_string()))
     }
 
     /// Get a single session by ID.

--- a/rust/crates/candela-harness-storage/src/db.rs
+++ b/rust/crates/candela-harness-storage/src/db.rs
@@ -99,10 +99,26 @@ impl Database {
                 CREATE INDEX idx_messages_session
                     ON messages(session_id, sequence);
 
-                CREATE INDEX idx_sessions_updated_at
-                    ON sessions(updated_at DESC);
+                CREATE INDEX idx_sessions_deleted_updated_at
+                    ON sessions(deleted_at, updated_at DESC);
 
-                PRAGMA user_version = 1;
+                PRAGMA user_version = 2;
+            ",
+                )
+                .map_err(|e| HarnessError::Storage(e.to_string()))?;
+        }
+
+        // v1 → v2: add composite index for existing databases.
+        if (1..2).contains(&version) {
+            self.conn
+                .execute_batch(
+                    "
+                DROP INDEX IF EXISTS idx_sessions_updated_at;
+
+                CREATE INDEX IF NOT EXISTS idx_sessions_deleted_updated_at
+                    ON sessions(deleted_at, updated_at DESC);
+
+                PRAGMA user_version = 2;
             ",
                 )
                 .map_err(|e| HarnessError::Storage(e.to_string()))?;


### PR DESCRIPTION
## Summary

Pragmatic pagination improvements for ListSessions. Fixes the misleading `total` field, adds proper `total_count`, reserves AIP-158 fields for future cursor pagination, and adds a sort index.

**Why not full cursor pagination?** This is a local SQLite harness with <500 sessions. LIMIT/OFFSET is sub-millisecond. Cursor pagination on `updated_at` (mutable sort key) would actually give *worse* results — sessions can be skipped or duplicated when updated mid-pagination. The proto fields are reserved so we can add cursor support later if needed.

## Changes

### Proto (`harness_service.proto`)
- Add `page_size` (preferred over deprecated `limit`)
- Add `page_token` / `next_page_token` (reserved for future cursor pagination)
- Add `total_count` (actual DB count — replaces misleading `total` which was page length)
- Deprecate `limit`, `offset`, `total` (kept for backward compat)

### Database (`db.rs`)
- Add index on `sessions(updated_at DESC)` for sort performance
- Add `count_sessions()` method

### RPC Handler (`handler.rs`)
- Accept `page_size` with precedence over `limit`, cap at 200
- Return `total_count` alongside deprecated `total`

### Connect Service (`service.rs`)
- Same `page_size` / `total_count` changes

## Testing
- 319 workspace tests pass (14 in RPC — 2 new pagination tests)
- New: `test_session_list_total_count` — verifies total vs total_count semantics
- New: `test_session_list_page_size_over_limit` — page_size takes precedence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session lists now support cursor-based pagination with `page_size` and `page_token`, returning `next_page_token` plus `total_count`.
  * `chat.send` continues streaming live chat events and returns a JSON-RPC error immediately if the request can’t start.

* **Bug Fixes**
  * Improved chat streaming so it stops forwarding events promptly when the client disconnects.
  * Pagination totals are now clearer: deprecated `limit/offset` are overridden by `page_size`, values are clamped, and `total` reflects the current page while `total_count` reflects overall sessions.

* **Chores**
  * Added an application-level JSON-RPC server error code for consistent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->