### PR TITLE
fix: update stale comment referencing deleted chat_event_to_json_value

### DIFF
--- a/rust/crates/candela-core/src/harness.rs
+++ b/rust/crates/candela-core/src/harness.rs
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_chat_event_all_variants_json_rpc() {
-        // Verify chat_event_to_json_value produces the correct flat format
+        // Verify ChatEventRpc::from produces the correct flat format
         // for each variant.
         let cases: Vec<(ChatEvent, &str)> = vec![
             (


### PR DESCRIPTION
One-liner: stale test comment still referenced `chat_event_to_json_value` (deleted in #473). Updated to `ChatEventRpc::from`.

From: https://github.com/candelahq/candela/pull/473#pullrequestreview-4621629699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a test comment to reflect the current JSON-RPC formatting expectation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->