### PR TITLE
fix(rpc): return INVALID_PARAMS for SessionNotFound in send_message

### DIFF
--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -192,8 +192,15 @@ impl RpcHandler {
         let (stream_id, event_stream) = match chat.clone().send_message(&session_id, &content).await
         {
             Ok(result) => result,
+            Err(HarnessError::SessionNotFound(sid)) => {
+                return JsonRpcResponse::error(
+                    id,
+                    INVALID_PARAMS,
+                    format!("session not found: {sid}"),
+                );
+            }
             Err(e) => {
-                return JsonRpcResponse::error(id, SERVER_ERROR, e.to_string());
+                return JsonRpcResponse::error(id, INTERNAL_ERROR, e.to_string());
             }
         };
 


### PR DESCRIPTION
`send_message` was returning a generic `SERVER_ERROR` (-32000) for all failures. Now `SessionNotFound` returns `INVALID_PARAMS` (-32602) matching the `session.delete` handler, and other errors return `INTERNAL_ERROR` (-32603).

One-line change in `handler.rs` — adds pattern match on `HarnessError::SessionNotFound` before the generic `Err(e)` arm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat send error responses so a missing session now returns a clearer “session not found” invalid-parameters error.
  * Other chat send failures now return the standard internal error response, making API behavior more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->