### PR TITLE
test(rpc): assert INVALID_PARAMS error code for nonexistent session

### DIFF
--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -603,9 +603,13 @@ mod tests {
             }),
         };
         let resp = handler.handle(req).await.unwrap();
-        assert!(
-            resp.error.is_some(),
-            "should return error for nonexistent session"
+        let err = resp
+            .error
+            .expect("should return error for nonexistent session");
+        assert_eq!(
+            err.code, INVALID_PARAMS,
+            "nonexistent session should return INVALID_PARAMS, got {}",
+            err.code
         );
     }
 }


### PR DESCRIPTION
Strengthens `test_chat_send_nonexistent_session` to assert the specific JSON-RPC error code (`INVALID_PARAMS` / -32602) instead of just `error.is_some()`.

Follow-up to #475 per [CodeRabbit review](https://github.com/candelahq/candela/pull/475#pullrequestreview-4622186824).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Tightened validation for chat-session error responses to ensure nonexistent session requests return the expected invalid-parameter error code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->