### PR TITLE
fix(rpc): return SERVER_ERROR for BudgetExceeded instead of INTERNAL_ERROR

### DIFF
--- a/rust/crates/candela-harness-rpc/src/handler.rs
+++ b/rust/crates/candela-harness-rpc/src/handler.rs
@@ -199,6 +199,9 @@ impl RpcHandler {
                     format!("session not found: {sid}"),
                 );
             }
+            Err(e @ HarnessError::BudgetExceeded { .. }) => {
+                return JsonRpcResponse::error(id, SERVER_ERROR, e.to_string());
+            }
             Err(e) => {
                 return JsonRpcResponse::error(id, INTERNAL_ERROR, e.to_string());
             }


### PR DESCRIPTION
## Problem

When a user's budget is exceeded, `send_message` returns `HarnessError::BudgetExceeded`. The catch-all error handler was returning `INTERNAL_ERROR` (-32603) for this case, which is misleading — budget limits are expected application-level behavior, not internal server failures.

## Fix

Add an explicit match arm for `BudgetExceeded` that returns `SERVER_ERROR` (-32000), keeping the catch-all for genuine internal errors.

```rust
Err(e @ HarnessError::BudgetExceeded { .. }) => {
    return JsonRpcResponse::error(id, SERVER_ERROR, e.to_string());
}
```

## Context

Addresses CodeRabbit review feedback on #475.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Budget-exceeded chat requests now return a more appropriate server error response instead of a generic internal error.
  * Existing error handling for other chat failures remains unchanged, including session-related validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->