### PR TITLE
test(harness-storage): add 18 unit tests for db + search coverage gaps (#397)

### DIFF
--- a/rust/crates/candela-harness-storage/src/db.rs
+++ b/rust/crates/candela-harness-storage/src/db.rs
@@ -598,4 +598,199 @@ mod tests {
             "should reject title update on soft-deleted session"
         );
     }
+
+    #[test]
+    fn test_count_sessions() {
+        let db = Database::open_in_memory().unwrap();
+        assert_eq!(db.count_sessions().unwrap(), 0);
+
+        db.create_session(&new_session("m", "d")).unwrap();
+        assert_eq!(db.count_sessions().unwrap(), 1);
+
+        db.create_session(&new_session("m", "d")).unwrap();
+        db.create_session(&new_session("m", "d")).unwrap();
+        assert_eq!(db.count_sessions().unwrap(), 3);
+    }
+
+    #[test]
+    fn test_count_sessions_excludes_deleted() {
+        let db = Database::open_in_memory().unwrap();
+        let s1 = new_session("m", "d");
+        let s2 = new_session("m", "d");
+        db.create_session(&s1).unwrap();
+        db.create_session(&s2).unwrap();
+        assert_eq!(db.count_sessions().unwrap(), 2);
+
+        db.delete_session(&s1.id).unwrap();
+        assert_eq!(db.count_sessions().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_list_sessions_pagination() {
+        let db = Database::open_in_memory().unwrap();
+        for _ in 0..5 {
+            let s = new_session("m", "d");
+            db.create_session(&s).unwrap();
+            // Small delay so updated_at ordering is deterministic.
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        // Page 1: first 2
+        let page1 = db.list_sessions(2, 0).unwrap();
+        assert_eq!(page1.len(), 2);
+
+        // Page 2: next 2
+        let page2 = db.list_sessions(2, 2).unwrap();
+        assert_eq!(page2.len(), 2);
+
+        // Pages should not overlap.
+        assert_ne!(page1[0].id, page2[0].id);
+        assert_ne!(page1[1].id, page2[1].id);
+
+        // Page 3: last 1
+        let page3 = db.list_sessions(2, 4).unwrap();
+        assert_eq!(page3.len(), 1);
+
+        // Past the end: empty
+        let page4 = db.list_sessions(2, 10).unwrap();
+        assert!(page4.is_empty());
+    }
+
+    #[test]
+    fn test_list_sessions_ordered_by_updated_at() {
+        let db = Database::open_in_memory().unwrap();
+        let s1 = new_session("m", "d");
+        let s2 = new_session("m", "d");
+        let s3 = new_session("m", "d");
+        db.create_session(&s1).unwrap();
+        db.create_session(&s2).unwrap();
+        db.create_session(&s3).unwrap();
+
+        // Touch s1 last so it appears first in the listing.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        db.update_session_title(&s1.id, "Updated").unwrap();
+
+        let sessions = db.list_sessions(10, 0).unwrap();
+        assert_eq!(
+            sessions[0].id, s1.id,
+            "most recently updated session should be first"
+        );
+    }
+
+    #[test]
+    fn test_create_session_duplicate_id() {
+        let db = Database::open_in_memory().unwrap();
+        let session = new_session("m", "d");
+        db.create_session(&session).unwrap();
+
+        // Inserting the same session again should fail (PRIMARY KEY constraint).
+        let err = db.create_session(&session).unwrap_err();
+        assert!(
+            matches!(err, HarnessError::Storage(ref s) if s.contains("UNIQUE")),
+            "expected UNIQUE constraint error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_delete_session_not_found() {
+        let db = Database::open_in_memory().unwrap();
+        let err = db.delete_session("nonexistent").unwrap_err();
+        assert!(matches!(err, HarnessError::SessionNotFound(_)));
+    }
+
+    #[test]
+    fn test_delete_session_already_deleted() {
+        let db = Database::open_in_memory().unwrap();
+        let session = new_session("m", "d");
+        db.create_session(&session).unwrap();
+        db.delete_session(&session.id).unwrap();
+
+        // Second delete should fail — already soft-deleted.
+        let err = db.delete_session(&session.id).unwrap_err();
+        assert!(
+            matches!(err, HarnessError::SessionNotFound(_)),
+            "double-delete should return SessionNotFound"
+        );
+    }
+
+    #[test]
+    fn test_insert_message_updates_session_counters() {
+        let mut db = Database::open_in_memory().unwrap();
+        let session = new_session("m", "d");
+        db.create_session(&session).unwrap();
+
+        // Build a message with token_count and cost_usd set.
+        let mut msg1 = new_message(&session.id, MessageRole::User, "hello");
+        msg1.token_count = Some(100);
+        msg1.cost_usd = Some(0.001);
+        db.insert_message(&msg1).unwrap();
+
+        let s = db.get_session(&session.id).unwrap();
+        assert_eq!(s.message_count, 1);
+        assert_eq!(s.total_tokens, 100);
+        assert!((s.total_cost_usd - 0.001).abs() < 1e-9);
+
+        // Second message should accumulate.
+        let mut msg2 = new_message(&session.id, MessageRole::Assistant, "world");
+        msg2.token_count = Some(200);
+        msg2.cost_usd = Some(0.002);
+        db.insert_message(&msg2).unwrap();
+
+        let s = db.get_session(&session.id).unwrap();
+        assert_eq!(s.message_count, 2);
+        assert_eq!(s.total_tokens, 300);
+        assert!((s.total_cost_usd - 0.003).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_insert_message_on_deleted_session() {
+        let mut db = Database::open_in_memory().unwrap();
+        let session = new_session("m", "d");
+        db.create_session(&session).unwrap();
+        db.delete_session(&session.id).unwrap();
+
+        let msg = new_message(&session.id, MessageRole::User, "hello");
+        let err = db.insert_message(&msg).unwrap_err();
+        assert!(
+            matches!(err, HarnessError::SessionNotFound(_)),
+            "insert on deleted session should return SessionNotFound, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_get_messages_respects_limit() {
+        let mut db = Database::open_in_memory().unwrap();
+        let session = new_session("m", "d");
+        db.create_session(&session).unwrap();
+
+        for i in 0..5 {
+            let msg = new_message(&session.id, MessageRole::User, &format!("msg-{i}"));
+            db.insert_message(&msg).unwrap();
+        }
+
+        let messages = db.get_messages(&session.id, 3).unwrap();
+        assert_eq!(messages.len(), 3);
+        // Should return the first 3 by sequence order.
+        assert_eq!(messages[0].content, "msg-0");
+        assert_eq!(messages[1].content, "msg-1");
+        assert_eq!(messages[2].content, "msg-2");
+    }
+
+    #[test]
+    fn test_get_messages_empty_session() {
+        let db = Database::open_in_memory().unwrap();
+        let session = new_session("m", "d");
+        db.create_session(&session).unwrap();
+
+        let messages = db.get_messages(&session.id, 50).unwrap();
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_get_messages_nonexistent_session() {
+        let db = Database::open_in_memory().unwrap();
+        // Querying messages for a session that doesn't exist returns empty, not error.
+        let messages = db.get_messages("no-such-session", 50).unwrap();
+        assert!(messages.is_empty());
+    }
 }

--- a/rust/crates/candela-harness-storage/src/search.rs
+++ b/rust/crates/candela-harness-storage/src/search.rs
@@ -326,4 +326,140 @@ mod tests {
         let results = idx.search("goodbye", 10).unwrap();
         assert_eq!(results[0].session_title, "New Title");
     }
+
+    #[test]
+    fn test_search_no_results() {
+        let idx = SearchIndex::open_in_memory().unwrap();
+        idx.index_message(
+            "Rust is a systems programming language",
+            "s1",
+            "m1",
+            "Rust Chat",
+            "user",
+            "2025-01-01T00:00:00Z",
+        )
+        .unwrap();
+
+        let results = idx.search("javascript", 10).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_mark_session_deleted_idempotent() {
+        let idx = SearchIndex::open_in_memory().unwrap();
+        idx.index_message(
+            "some content",
+            "s1",
+            "m1",
+            "Title",
+            "user",
+            "2025-01-01T00:00:00Z",
+        )
+        .unwrap();
+
+        // Mark deleted twice — INSERT OR IGNORE should not error.
+        idx.mark_session_deleted("s1").unwrap();
+        idx.mark_session_deleted("s1").unwrap();
+
+        let results = idx.search("content", 10).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_update_session_title_no_messages() {
+        let idx = SearchIndex::open_in_memory().unwrap();
+        // Updating title for a session with no indexed messages should be a no-op.
+        idx.update_session_title("nonexistent-session", "New Title")
+            .unwrap();
+    }
+
+    #[test]
+    fn test_search_result_role_round_trip() {
+        let idx = SearchIndex::open_in_memory().unwrap();
+
+        let roles = [
+            ("user", MessageRole::User),
+            ("assistant", MessageRole::Assistant),
+            ("system", MessageRole::System),
+            ("tool", MessageRole::Tool),
+            ("unspecified", MessageRole::Unspecified),
+        ];
+
+        for (i, (role_str, _)) in roles.iter().enumerate() {
+            // Each message needs a unique searchable term.
+            let content = format!("unique_role_test_{i} conversation");
+            idx.index_message(
+                &content,
+                "s1",
+                &format!("m{i}"),
+                "Roles",
+                role_str,
+                "2025-01-01T00:00:00Z",
+            )
+            .unwrap();
+        }
+
+        for (i, (_, expected_role)) in roles.iter().enumerate() {
+            let query = format!("unique_role_test_{i}");
+            let results = idx.search(&query, 10).unwrap();
+            assert_eq!(results.len(), 1, "expected 1 result for {query}");
+            assert_eq!(
+                results[0].role, *expected_role,
+                "role mismatch for query {query}: got {:?}, expected {:?}",
+                results[0].role, expected_role
+            );
+        }
+    }
+
+    #[test]
+    fn test_search_result_created_at_fidelity() {
+        let idx = SearchIndex::open_in_memory().unwrap();
+        let ts = "2025-06-15T14:30:00Z";
+        idx.index_message("timestamp fidelity test", "s1", "m1", "Title", "user", ts)
+            .unwrap();
+
+        let results = idx.search("timestamp fidelity", 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].created_at.to_rfc3339(),
+            "2025-06-15T14:30:00+00:00",
+            "created_at should survive the index→search round-trip"
+        );
+    }
+
+    #[test]
+    fn test_search_multiple_results_ordering() {
+        let idx = SearchIndex::open_in_memory().unwrap();
+
+        // Index messages where "Rust" appears with varying frequency
+        // to create different FTS5 relevance scores.
+        idx.index_message(
+            "Rust Rust Rust is incredibly fast and safe",
+            "s1",
+            "m1",
+            "Heavy Rust",
+            "user",
+            "2025-01-01T00:00:00Z",
+        )
+        .unwrap();
+        idx.index_message(
+            "I heard Rust is good",
+            "s2",
+            "m2",
+            "Light Rust",
+            "user",
+            "2025-01-02T00:00:00Z",
+        )
+        .unwrap();
+
+        let results = idx.search("Rust", 10).unwrap();
+        assert_eq!(results.len(), 2, "both messages should match");
+        // FTS5 rank is negative; more relevant = more negative score.
+        assert!(
+            results[0].score <= results[1].score,
+            "results should be ordered by FTS5 rank (most relevant first): {:?} vs {:?}",
+            results[0].score,
+            results[1].score
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds **18 new unit tests** to `candela-harness-storage`, bringing the total from 20 → 38. Closes #397 for the Rust harness storage layer.

## Context

Issue #397 requests storage backend driver unit tests for duckdb, sqlite, bigquery, and pubsub. The Go backends in `pkg/storage/` already have substantial coverage (63/60/18/7 tests respectively). The Rust `candela-harness-storage` crate is SQLite-only and had 20 tests with several coverage gaps — this PR fills them.

## Changes

### `db.rs` — 12 new tests

| Test | Coverage |
|------|----------|
| `test_count_sessions` | `count_sessions()` with 0, 1, and 3 sessions |
| `test_count_sessions_excludes_deleted` | Soft-deleted sessions excluded from count |
| `test_list_sessions_pagination` | `offset` parameter: pages of 2 across 5 sessions |
| `test_list_sessions_ordered_by_updated_at` | Newest-first ordering after title update |
| `test_create_session_duplicate_id` | PRIMARY KEY constraint on duplicate ID |
| `test_delete_session_not_found` | Error on deleting non-existent session |
| `test_delete_session_already_deleted` | Double-delete returns `SessionNotFound` |
| `test_insert_message_updates_session_counters` | `message_count`, `total_tokens`, `total_cost_usd` accumulate |
| `test_insert_message_on_deleted_session` | Insert on soft-deleted session → `SessionNotFound` |
| `test_get_messages_respects_limit` | Limit=3 returns first 3 of 5 in sequence order |
| `test_get_messages_empty_session` | Valid session, no messages → empty vec |
| `test_get_messages_nonexistent_session` | Non-existent session → empty vec (not error) |

### `search.rs` — 6 new tests

| Test | Coverage |
|------|----------|
| `test_search_no_results` | No matches → empty vec |
| `test_mark_session_deleted_idempotent` | Double `mark_session_deleted` doesn't error |
| `test_update_session_title_no_messages` | Title update with no indexed messages is a no-op |
| `test_search_result_role_round_trip` | All 5 `MessageRole` variants survive index→search |
| `test_search_result_created_at_fidelity` | Timestamp survives the FTS5 round-trip |
| `test_search_multiple_results_ordering` | Results ordered by FTS5 rank |

## Testing

```
cargo test -p candela-harness-storage
# 38 passed, 0 failed
```

Pre-commit: cargo-fmt ✅ cargo-clippy ✅ cargo-test ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for session counting and listing pagination/ordering, plus duplicate-creation, not-found, and idempotent delete behaviors.
  * Verified message insertion updates session metrics (message count, tokens, cost) and rejects writes to soft-deleted sessions; ensured message retrieval respects limits and returns empty for missing sessions.
  * Added search index tests for empty matches, idempotent deletions, title updates on no messages, role round-tripping, metadata preservation, and relevance-based ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->