### PR TITLE
ci: add path-based filtering to skip irrelevant jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ on:
 
 permissions:
   contents: read
-  packages: read   # pull ghcr.io/candelahq/candela-dev
+  packages: read        # pull ghcr.io/candelahq/candela-dev
+  pull-requests: read   # dorny/paths-filter needs PR file list
 
 # All jobs run inside the pre-baked CI container:
 #   Ubuntu 24.04 + Determinate Nix + dev shell pre-warmed in Nix store.
@@ -16,8 +17,51 @@ permissions:
 # Rebuild the image via dev-container.yml when flake.nix / flake.lock changes.
 
 jobs:
+  # ── change detection ─────────────────────────────────────────────────────────
+  # Detects which tracks (go/rust/ui) are affected by the PR.
+  # Push to main always runs everything.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ github.event_name == 'push' || steps.filter.outputs.go }}
+      rust: ${{ github.event_name == 'push' || steps.filter.outputs.rust }}
+      ui: ${{ github.event_name == 'push' || steps.filter.outputs.ui }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            go:
+              - 'pkg/**'
+              - 'cmd/**'
+              - 'go.mod'
+              - 'go.sum'
+              - 'gen/**'
+              - 'proto/**'
+              - '.github/workflows/ci.yml'
+              - 'flake.nix'
+              - 'flake.lock'
+              - 'Dockerfile.ci'
+            rust:
+              - 'rust/**'
+              - 'proto/**'
+              - '.github/workflows/ci.yml'
+              - 'flake.nix'
+              - 'flake.lock'
+              - 'Dockerfile.ci'
+            ui:
+              - 'ui/**'
+              - 'proto/**'
+              - '.github/workflows/ci.yml'
+              - 'flake.nix'
+              - 'flake.lock'
+              - 'Dockerfile.ci'
+
   # ── build, vet, and lint ────────────────────────────────────────────────────
   build-and-lint:
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/candelahq/candela-dev:latest
@@ -57,6 +101,8 @@ jobs:
 
   # ── tests — parallel matrix by package group ────────────────────────────────
   go-test:
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/candelahq/candela-dev:latest
@@ -112,7 +158,8 @@ jobs:
 
   # ── merge coverage and govulncheck ──────────────────────────────────────────
   build-and-test:
-    needs: [go-test]
+    needs: [changes, go-test]
+    if: always() && needs.changes.outputs.go == 'true' && needs.go-test.result == 'success'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/candelahq/candela-dev:latest
@@ -149,6 +196,8 @@ jobs:
 
   # ── Windows native CLI smoke ────────────────────────────────────────────────
   windows-candela:
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
@@ -185,6 +234,8 @@ jobs:
 
   # ── UI build + lint ─────────────────────────────────────────────────────────
   ui-build-and-lint:
+    needs: changes
+    if: needs.changes.outputs.ui == 'true'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/candelahq/candela-dev:latest
@@ -214,8 +265,9 @@ jobs:
 
   # ── UI E2E ──────────────────────────────────────────────────────────────────
   ui-e2e:
+    needs: [changes, ui-build-and-lint]
+    if: always() && needs.changes.outputs.ui == 'true' && needs.ui-build-and-lint.result == 'success'
     runs-on: ubuntu-latest
-    needs: [ui-build-and-lint]
     container:
       image: ghcr.io/candelahq/candela-dev:latest
       credentials:
@@ -254,6 +306,8 @@ jobs:
 
   # ── Rust check ──────────────────────────────────────────────────────────────
   rust-check:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/candelahq/candela-dev:latest


### PR DESCRIPTION
## Summary

Adds a `changes` detection job using [`dorny/paths-filter`](https://github.com/dorny/paths-filter) to skip irrelevant CI jobs on PRs. Each track (Go, Rust, UI) only runs when its files are affected.

## Motivation

A Rust-only PR (e.g. #481) currently runs **all 11 CI jobs** including 5 Go test shards, Go lint, Windows build, and UI E2E — none of which are relevant. This wastes ~40 minutes of billable runner time and adds ~3 minutes to the critical path (sequential `build-and-test` dependency chain).

## How It Works

| Track | Triggers on |
|-------|------------|
| **Go** | `pkg/**`, `cmd/**`, `go.mod`, `go.sum`, `gen/**`, `proto/**` |
| **Rust** | `rust/**`, `proto/**` |
| **UI** | `ui/**`, `proto/**` |
| **All** | `.github/workflows/ci.yml`, `flake.nix`, `flake.lock`, `Dockerfile.ci` |

Push to `main` always runs everything.

## Jobs Affected

| Job | Track |
|-----|-------|
| `build-and-lint` | Go |
| `go-test` (5 matrix shards) | Go |
| `build-and-test` | Go |
| `windows-candela` | Go |
| `rust-check` | Rust |
| `ui-build-and-lint` | UI |
| `ui-e2e` | UI |

## Impact

- Rust-only PRs: skip ~10 jobs, wall clock drops from ~9 min to ~6 min
- Go-only PRs: skip Rust + UI jobs
- UI-only PRs: skip Go + Rust jobs
- No change to push-to-main behavior

## Testing

- `actionlint` passes on the modified workflow
- This PR itself only changes `ci.yml`, which is in the all-tracks trigger list, so all jobs will run to validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI to run only the relevant backend, UI, and Rust checks based on which parts of the code were changed.
  * Added change-detection logic so jobs are automatically gated and downstream test/build steps run only when prerequisites succeed.
  * Reduced unnecessary builds and tests for unrelated changes, improving feedback speed and efficiency.
  * Updated CI workflow permissions to support the new change-detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->