### PR TITLE
chore: make DoneEvent.usage explicitly optional + add vendor script

### DIFF
--- a/rust/crates/candela-harness-connect/proto/candela/types/chat.proto
+++ b/rust/crates/candela-harness-connect/proto/candela/types/chat.proto
@@ -40,7 +40,7 @@ message StatusEvent {
 
 // DoneEvent signals successful completion of the stream.
 message DoneEvent {
-  UsageSummary usage = 1;
+  optional UsageSummary usage = 1;
 }
 
 // ErrorEvent signals that the stream terminated with an error.

--- a/rust/crates/candela-types/src/lib.rs
+++ b/rust/crates/candela-types/src/lib.rs
@@ -7,7 +7,11 @@
 //! buf generate --template buf.gen.rust.yaml
 //! ```
 //!
-//! Then copy the relevant files from gen/rust/.../ into this crate.
+//! Then vendor into this repo:
+//!
+//! ```bash
+//! ./scripts/vendor-types.sh
+//! ```
 
 pub mod chat;
 pub mod chat_jsonrpc;

--- a/scripts/vendor-types.sh
+++ b/scripts/vendor-types.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# vendor-types.sh — Vendor proto2type-generated Rust types from candela-protos.
+#
+# Vendors domain types and SQLite converters from candela-protos into
+# candela-types. Buffa converters are NOT vendored — they are generated
+# locally in candela-harness-connect via `cd rust/crates/candela-harness-connect
+# && buf generate` because they use a different domain_module path.
+#
+# Usage:
+#   ./scripts/vendor-types.sh [PROTOS_DIR]
+#
+# PROTOS_DIR defaults to ../candela-protos (sibling checkout).
+# Run `buf generate --template buf.gen.rust.yaml` in candela-protos first.
+set -euo pipefail
+unset CDPATH
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PROTOS_DIR="${1:-${REPO_DIR}/../candela-protos}"
+GEN_DIR="${PROTOS_DIR}/gen/rust/github.com/candelahq/candela/gen/go/candela/types"
+
+if [ ! -d "${GEN_DIR}" ]; then
+  echo "Error: generated types not found at ${GEN_DIR}" >&2
+  echo "Run 'buf generate --template buf.gen.rust.yaml' in candela-protos first." >&2
+  exit 1
+fi
+
+TYPES_DIR="${REPO_DIR}/rust/crates/candela-types/src"
+
+echo "Vendoring proto2type domain types from: ${GEN_DIR}"
+echo ""
+
+copy() {
+  local src="${GEN_DIR}/$1"
+  local dst="$2"
+  if [ ! -f "${src}" ]; then
+    echo "Error: missing generated file: $1" >&2
+    exit 1
+  fi
+  cp "${src}" "${dst}"
+  echo "  COPY  $1 → ${dst#"${REPO_DIR}"/}"
+}
+
+# Domain types + SQLite converters → candela-types
+copy "chat.type.rs"                  "${TYPES_DIR}/chat.rs"
+copy "chat_sqlite.type.rs"           "${TYPES_DIR}/chat_sqlite.rs"
+copy "session.type.rs"               "${TYPES_DIR}/session.rs"
+copy "session_sqlite.type.rs"        "${TYPES_DIR}/session_sqlite.rs"
+copy "model_catalog.type.rs"         "${TYPES_DIR}/model_catalog.rs"
+copy "model_catalog_sqlite.type.rs"  "${TYPES_DIR}/model_catalog_sqlite.rs"
+
+echo ""
+echo "Note: buffa converters are generated locally — run:"
+echo "  cd rust/crates/candela-harness-connect && buf generate"
+echo ""
+echo "Done. Run 'cargo test --workspace' to verify."


### PR DESCRIPTION
## Summary

Two small improvements to the proto/codegen workflow:

### 1. Make `DoneEvent.usage` explicitly `optional`

The proto field `UsageSummary usage = 1` was a regular message field, but the domain type uses `Option<UsageSummary>` because usage is not always available when a DoneEvent is emitted (e.g. the SSE client emits `DoneEvent::default()` on `data: [DONE]` without usage data).

Adding `optional` makes the schema consistent with `StatusEvent.agent` and `ErrorEvent.code` which already use `optional`. In proto3 message fields already have implicit presence, so this is a semantic/documentation improvement — no wire format change.

### 2. Add `scripts/vendor-types.sh`

Automates the manual "copy generated files from candela-protos" workflow. Vendors domain types + SQLite converters from `candela-protos/gen/rust/` into `candela-types/src/`.

Buffa converters are **not** vendored — they are generated locally in `candela-harness-connect` via `buf generate` because they use a different `domain_module` path.

Updated the `lib.rs` doc comment to reference the script.

## Testing

- `cargo test --workspace` — all pass
- Pre-commit: cargo-fmt ✅ cargo-clippy ✅ cargo-test ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream completion events can now omit usage details when they aren’t available.

* **Documentation**
  * Updated vendoring instructions to guide refreshing shared type definitions using an automated script.
  * Added a clear helper workflow for syncing generated types and running workspace tests to confirm everything builds cleanly.

* **Chores**
  * Introduced a script to safely vendor the generated shared Rust and SQLite converter type definitions into the repo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->