### PR TITLE
chore: add post-generate fixup for proto2type Clone() shadowing

### DIFF
--- a/scripts/fix-proto2type-clone.sh
+++ b/scripts/fix-proto2type-clone.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# fix-proto2type-clone.sh — Fix proto2type v0.4.2 Clone() receiver shadowing.
+#
+# proto2type v0.4.2 generates Clone() methods like:
+#
+#   func (c *Foo) Clone() *Foo {
+#       if c == nil { return nil }
+#       c := &Foo{ ... }       // ← shadows receiver
+#       return c
+#   }
+#
+# This causes "c declared and not used" / infinite recursion because the inner
+# `c` shadows the receiver. This script rewrites `c :=` → `clone :=` and
+# `return c` → `return clone` in the Clone() function body.
+#
+# Upstream issue: https://github.com/protocgen/proto2type/issues/125
+# Remove this script once proto2type is fixed and upgraded.
+#
+# Usage:
+#   ./scripts/fix-proto2type-clone.sh [DIR]
+#
+# DIR defaults to gen/go/candela/types/domain/
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TARGET_DIR="${1:-${REPO_DIR}/gen/go/candela/types/domain}"
+
+TAB=$'\t'
+
+if [ ! -d "${TARGET_DIR}" ]; then
+  echo "Error: directory not found: ${TARGET_DIR}" >&2
+  exit 1
+fi
+
+fixed=0
+for f in "${TARGET_DIR}"/*.type.go; do
+  [ -f "$f" ] || continue
+
+  # Only process files that have the bug pattern
+  if grep -q 'func (c \*.*) Clone()' "$f" && grep -q "${TAB}c := &" "$f"; then
+    # Use sed to fix within Clone() method bodies:
+    # 1. Replace `c := &` with `clone := &` (variable declaration)
+    # 2. Replace `c.Field = ` with `clone.Field = ` (field assignments)
+    # 3. Replace `return c` with `return clone` (return statement)
+    # Write to temp file + mv for portability (BSD vs GNU sed -i differs).
+    sed \
+      -e "/func (c \\*.*) Clone()/,/^}/ {
+        s/${TAB}c := \&/${TAB}clone := \&/g
+        s/${TAB}c\.\([A-Z]\)/${TAB}clone.\1/g
+        s/${TAB}return c$/${TAB}return clone/
+      }" "$f" > "$f.tmp"
+    # Only count as fixed if the content actually changed.
+    if ! cmp -s "$f" "$f.tmp"; then
+      mv "$f.tmp" "$f"
+      fixed=$((fixed + 1))
+      echo "  FIXED  ${f#"${REPO_DIR}/"}"
+    else
+      rm -f "$f.tmp"
+    fi
+  fi
+done
+
+if [ "$fixed" -eq 0 ]; then
+  echo "No Clone() shadowing bugs found — proto2type may have been fixed upstream."
+else
+  echo ""
+  echo "Fixed ${fixed} file(s). Run 'go vet ./...' to verify."
+fi


### PR DESCRIPTION
Adds `scripts/fix-proto2type-clone.sh` to automatically patch the receiver shadowing bug in proto2type v0.4.2 generated `Clone()` methods.

Run after `buf generate --template buf.gen.proto2type.yaml` until upstream fix lands ([protocgen/proto2type#125](https://github.com/protocgen/proto2type/issues/125)).

Idempotent — safe to run multiple times. Only touches `*.type.go` files in `gen/go/candela/types/domain/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a command-line utility that automatically detects and corrects a receiver-shadowing issue in generated Go type files affecting `Clone()` behavior.
  * The tool scans the specified directory, applies targeted edits only when needed, reports which files were updated, and summarizes whether any fixes were applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->