### PR TITLE
fix: treat service accounts as individuals for access tag gating

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -862,7 +862,13 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	var isAdmin bool
 	var userRecord *storage.UserRecord
 	if p.users != nil && effectiveUserID != "" {
-		if u, err := p.users.GetUser(r.Context(), effectiveUserID); err == nil && u != nil {
+		u, err := p.users.GetUser(r.Context(), effectiveUserID)
+		if err != nil {
+			if !errors.Is(err, storage.ErrNotFound) {
+				slog.Error("failed to look up user record",
+					"user_id", effectiveUserID, "error", err)
+			}
+		} else if u != nil {
 			userRecord = u
 			if u.Role == storage.RoleAdmin {
 				isAdmin = true

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -855,10 +855,13 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if user is admin — admins bypass rate limits, budget, and access gates.
+	// Look up user record — needed for admin check and access tag gating.
+	// Service accounts are included: they get access tags from their
+	// UserRecord just like regular users. SAs without a UserRecord
+	// will have nil tags and can only access unrestricted models.
 	var isAdmin bool
 	var userRecord *storage.UserRecord
-	if p.users != nil && effectiveUserID != "" && !isServiceAccount {
+	if p.users != nil && effectiveUserID != "" {
 		if u, err := p.users.GetUser(r.Context(), effectiveUserID); err == nil && u != nil {
 			userRecord = u
 			if u.Role == storage.RoleAdmin {


### PR DESCRIPTION
Removes the `!isServiceAccount` guard from the user record lookup in the proxy, so SAs get their `AccessTags` from Firestore `UserRecords` just like regular users.

**Before:** SAs always had nil `userRecord` → nil tags → blocked from any model with `required_access`.
**After:** SAs are looked up in the user store. If they have a `UserRecord` with `access_tags`, those tags are used. If no record exists, they can only access unrestricted models (fail-closed).

Rate limiting and budget deduction remain SA-exempt via their own `!isServiceAccount` guards.

1 file changed, +5 −2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Service accounts can now receive user-record–derived access tags when an associated user record exists, enabling tag-based access gating to behave consistently.
  * Service accounts without a user record will receive no user-derived tags and therefore remain restricted to unrestricted models only.
  * Updated admin/user-record lookup behavior so service accounts are included in the same user-record flow when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->