### PR TITLE
test: add hurl E2E tests for access tag and tenant gating

### DIFF
--- a/test/functional/proxy/proxy_access_gates.hurl
+++ b/test/functional/proxy/proxy_access_gates.hurl
@@ -1,0 +1,151 @@
+# ACCESS-01..08: Access tag gating — model-level access control
+#
+# These tests verify that the proxy enforces access_tags on users and
+# required_access on model catalog entries. The proxy returns 403 with
+# error type "access_denied" when a user lacks the required tags.
+#
+# Tests requiring pre-provisioned Firestore state (catalog entries with
+# required_access + users with access_tags) are documented but commented
+# out. Live tests cover the contract shape and unauthenticated behavior.
+#
+# Error shape (403 access denied):
+# {
+#   "error": {
+#     "message": "model requires access tags: [pro]; user has: []",
+#     "type": "access_denied",
+#     "code": "403"
+#   }
+# }
+#
+# Prerequisites for commented tests:
+#   1. Firestore catalog backend with model entries:
+#      - openai/gpt-4o:         required_access: []       (open)
+#      - openai/gpt-4.1:        required_access: ["pro"]
+#      - openai/o3-pro:         required_access: ["enterprise"]
+#      - openai/gemma-preview:  required_access: ["experimental"]
+#   2. Users provisioned via admin API:
+#      - basic-user:    access_tags: []
+#      - pro-user:      access_tags: ["pro"]
+#      - admin-user:    role: admin
+#
+# Run:
+#   hurl --variable CANDELA_URL=http://localhost:8080 \
+#        test/functional/proxy/proxy_access_gates.hurl
+
+
+# ── ACCESS-01: Open model (no required_access) → always succeeds ─────────────
+# Models with empty required_access are accessible to everyone.
+# This works with the default config store (no catalog entries = ErrNotFound = skip gate).
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+{"model":"gpt-4o","messages":[{"role":"user","content":"open model test"}]}
+
+HTTP 200
+[Asserts]
+status == 200
+jsonpath "$.choices" count == 1
+
+
+# ── ACCESS-02: Unknown model (not in catalog) → gate skipped ──────────────────
+# Models not in the catalog are treated as unmanaged — the gate is skipped.
+# This verifies the ErrNotFound → skip behavior.
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+{"model":"gpt-unknown-model","messages":[{"role":"user","content":"unknown model"}]}
+
+HTTP 200
+[Asserts]
+status == 200
+
+
+# ── ACCESS-03: User without matching tag → 403 ───────────────────────────────
+# Requires: catalog with gpt-4.1 required_access: ["pro"],
+#           authenticated user with access_tags: [] (or no tags)
+#
+# POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+# Authorization: Bearer basic-user-token
+# Content-Type: application/json
+# {"model":"gpt-4.1","messages":[{"role":"user","content":"access denied test"}]}
+#
+# HTTP 403
+# [Asserts]
+# header "Content-Type" contains "application/json"
+# jsonpath "$.error.type" == "access_denied"
+# jsonpath "$.error.code" == "403"
+# jsonpath "$.error.message" contains "access tags"
+
+
+# ── ACCESS-04: User with matching tag → 200 ──────────────────────────────────
+# Requires: catalog with gpt-4.1 required_access: ["pro"],
+#           authenticated user with access_tags: ["pro"]
+#
+# POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+# Authorization: Bearer pro-user-token
+# Content-Type: application/json
+# {"model":"gpt-4.1","messages":[{"role":"user","content":"access granted test"}]}
+#
+# HTTP 200
+# [Asserts]
+# status == 200
+# jsonpath "$.choices" count == 1
+
+
+# ── ACCESS-05: Admin bypasses access gate → 200 ──────────────────────────────
+# Requires: catalog with o3-pro required_access: ["enterprise"],
+#           admin user (role=admin, no enterprise tag needed)
+#
+# POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+# Authorization: Bearer admin-user-token
+# Content-Type: application/json
+# {"model":"o3-pro","messages":[{"role":"user","content":"admin bypass test"}]}
+#
+# HTTP 200
+# [Asserts]
+# status == 200
+# jsonpath "$.choices" count == 1
+
+
+# ── ACCESS-06: SA without UserRecord → 403 on gated model ────────────────────
+# Requires: catalog with gpt-4.1 required_access: ["pro"],
+#           SA email on allowlist but no UserRecord in Firestore
+#
+# POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+# Authorization: Bearer sa-no-record-token
+# Content-Type: application/json
+# {"model":"gpt-4.1","messages":[{"role":"user","content":"sa no record"}]}
+#
+# HTTP 403
+# [Asserts]
+# jsonpath "$.error.type" == "access_denied"
+
+
+# ── ACCESS-07: SA with UserRecord + tags → 200 ───────────────────────────────
+# Requires: catalog with gpt-4.1 required_access: ["pro"],
+#           SA with UserRecord containing access_tags: ["pro"]
+#
+# POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+# Authorization: Bearer sa-with-tags-token
+# Content-Type: application/json
+# {"model":"gpt-4.1","messages":[{"role":"user","content":"sa with tags"}]}
+#
+# HTTP 200
+# [Asserts]
+# status == 200
+
+
+# ── ACCESS-08: Catalog lookup error → 500 (fail-closed) ──────────────────────
+# When the catalog store returns a transient error (not ErrNotFound),
+# the proxy must return 500, NOT silently pass through.
+# This is difficult to trigger in E2E — validated via unit tests in
+# pkg/proxy/access_gates_test.go instead.
+#
+# Expected error shape:
+# {
+#   "error": {
+#     "message": "catalog lookup failed",
+#     "type": "internal",
+#     "code": "500"
+#   }
+# }

--- a/test/functional/proxy/proxy_tenant_gates.hurl
+++ b/test/functional/proxy/proxy_tenant_gates.hurl
@@ -1,0 +1,116 @@
+# TENANT-GATE-01..06: Tenant isolation — model-level tenant restrictions
+#
+# These tests verify that the proxy enforces allowed_tenants on model
+# catalog entries. When a model has allowed_tenants set, only requests
+# from those tenants are allowed. The proxy returns 403 with error type
+# "tenant_access_denied" when the request's tenant is not in the list.
+#
+# Tenant ID is extracted from (in priority order):
+#   1. W3C Baggage: candela.tenant_id=...
+#   2. X-Candela-Tenant-Id header
+#
+# Error shape (403 tenant denied):
+# {
+#   "error": {
+#     "message": "model restricted to tenants: [acme-corp]; request tenant: other-corp",
+#     "type": "tenant_access_denied",
+#     "code": "403"
+#   }
+# }
+#
+# Prerequisites for commented tests:
+#   1. Firestore catalog backend with model entries:
+#      - openai/gpt-4o:    allowed_tenants: []           (no restriction)
+#      - openai/gpt-4.1:   allowed_tenants: ["acme-corp"]
+#   2. Authenticated non-admin user
+#
+# Run:
+#   hurl --variable CANDELA_URL=http://localhost:8080 \
+#        test/functional/proxy/proxy_tenant_gates.hurl
+
+
+# ── TENANT-GATE-01: Model with no tenant restriction → any tenant passes ─────
+# Models with empty allowed_tenants accept requests from any tenant.
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+X-Candela-Tenant-Id: any-tenant
+{"model":"gpt-4o","messages":[{"role":"user","content":"no tenant restriction"}]}
+
+HTTP 200
+[Asserts]
+status == 200
+
+
+# ── TENANT-GATE-02: Model with no tenant restriction + no tenant header ───────
+# Requests without a tenant ID also pass when the model has no restriction.
+POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+Authorization: Bearer sk-test
+Content-Type: application/json
+{"model":"gpt-4o","messages":[{"role":"user","content":"no tenant header"}]}
+
+HTTP 200
+[Asserts]
+status == 200
+
+
+# ── TENANT-GATE-03: Wrong tenant → 403 ───────────────────────────────────────
+# Requires: catalog with gpt-4.1 allowed_tenants: ["acme-corp"],
+#           authenticated non-admin user
+#
+# POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+# Authorization: Bearer user-token
+# Content-Type: application/json
+# X-Candela-Tenant-Id: other-corp
+# {"model":"gpt-4.1","messages":[{"role":"user","content":"wrong tenant test"}]}
+#
+# HTTP 403
+# [Asserts]
+# header "Content-Type" contains "application/json"
+# jsonpath "$.error.type" == "tenant_access_denied"
+# jsonpath "$.error.code" == "403"
+# jsonpath "$.error.message" contains "tenants"
+
+
+# ── TENANT-GATE-04: Correct tenant → 200 ─────────────────────────────────────
+# Requires: catalog with gpt-4.1 allowed_tenants: ["acme-corp"]
+#
+# POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+# Authorization: Bearer user-token
+# Content-Type: application/json
+# X-Candela-Tenant-Id: acme-corp
+# {"model":"gpt-4.1","messages":[{"role":"user","content":"correct tenant test"}]}
+#
+# HTTP 200
+# [Asserts]
+# status == 200
+
+
+# ── TENANT-GATE-05: Tenant via Baggage header → 403 ──────────────────────────
+# Requires: catalog with gpt-4.1 allowed_tenants: ["acme-corp"]
+# Verifies that tenant extracted from Baggage is also enforced by the gate.
+#
+# POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+# Authorization: Bearer user-token
+# Content-Type: application/json
+# Baggage: candela.tenant_id=wrong-tenant
+# {"model":"gpt-4.1","messages":[{"role":"user","content":"baggage tenant denied"}]}
+#
+# HTTP 403
+# [Asserts]
+# jsonpath "$.error.type" == "tenant_access_denied"
+
+
+# ── TENANT-GATE-06: Admin bypasses tenant gate → 200 ─────────────────────────
+# Requires: catalog with gpt-4.1 allowed_tenants: ["acme-corp"],
+#           admin user with different tenant
+#
+# POST {{CANDELA_URL}}/proxy/openai/v1/chat/completions
+# Authorization: Bearer admin-token
+# Content-Type: application/json
+# X-Candela-Tenant-Id: other-corp
+# {"model":"gpt-4.1","messages":[{"role":"user","content":"admin bypasses tenant"}]}
+#
+# HTTP 200
+# [Asserts]
+# status == 200


### PR DESCRIPTION
Adds functional test contracts for the access gate feature (PRs #488, #490).

## Files

### `test/functional/proxy/proxy_access_gates.hurl` — 8 test cases
| ID | Status | Description |
|---|---|---|
| ACCESS-01 | ✅ Live | Open model (no required_access) → 200 |
| ACCESS-02 | ✅ Live | Unknown model (not in catalog) → 200 (gate skipped) |
| ACCESS-03 | 📝 Documented | User without matching tag → 403 |
| ACCESS-04 | 📝 Documented | User with matching tag → 200 |
| ACCESS-05 | 📝 Documented | Admin bypasses gate → 200 |
| ACCESS-06 | 📝 Documented | SA without UserRecord → 403 |
| ACCESS-07 | 📝 Documented | SA with tags → 200 |
| ACCESS-08 | 📝 Documented | Catalog error → 500 (fail-closed) |

### `test/functional/proxy/proxy_tenant_gates.hurl` — 6 test cases
| ID | Status | Description |
|---|---|---|
| TENANT-GATE-01 | ✅ Live | No tenant restriction → any tenant passes |
| TENANT-GATE-02 | ✅ Live | No tenant restriction + no header → passes |
| TENANT-GATE-03 | 📝 Documented | Wrong tenant → 403 |
| TENANT-GATE-04 | 📝 Documented | Correct tenant → 200 |
| TENANT-GATE-05 | 📝 Documented | Tenant via Baggage → 403 |
| TENANT-GATE-06 | 📝 Documented | Admin bypasses tenant gate → 200 |

## Pattern

Follows `billing/budget_gate.hurl` — live tests for paths that work with the default config store, documented assertions for paths requiring a Firestore environment with pre-provisioned catalog entries and users.

Closes #491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end proxy functional tests for model access tag gating and tenant isolation on chat completions.
  * Validate success for unrestricted models, proper denial for gated models when access tags don’t match (service-account case), and success when matching tags are provided.
  * Confirm tenant enforcement via the tenant header and W3C Baggage, returning `tenant_access_denied` (HTTP 403) on mismatch, and that admin requests bypass tenant gating (HTTP 200).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->