### PR TITLE
docs: update documentation for v0.10.0 access control release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to Candela are documented here, organized by development phase. PRs are merged to `main`.
 
+## v0.10.0 — 2026-07-05
+
+### Feature — Tag-Based Model Access Control
+
+- **Per-user access tags**: `User.access_tags` field enables fine-grained, tag-based model access control. Admins assign tags (e.g., `["sonnet", "opus"]`) to users via `CreateUser` / `UpdateUser`
+- **Per-model required access**: `ModelCatalogEntry.required_access` gates individual models behind specific tags. Access is granted when the user holds **any** matching tag (set intersection)
+- **Tenant isolation**: `ModelCatalogEntry.allowed_tenants` restricts model access to specific tenants, enabling multi-tenant model segregation
+- **Service accounts treated as individuals**: SAs are subject to the same access tag and tenant gating as human users — no implicit bypass
+- **Fail-closed error handling**: Storage errors during access checks result in request denial rather than permissive fallthrough
+
+### Tooling
+
+- **Proto2type `Clone()` fixup script**: Automated script to patch generated protobuf types with proper `Clone()` methods
+
+### Tests
+
+- **14 hurl E2E access gate tests**: `proxy_access_gates.hurl` and `proxy_tenant_gates.hurl` covering tag intersection, empty tags, admin bypass, SA gating, tenant isolation, and error scenarios
+- **29 unit tests**: Comprehensive Go unit test coverage for access tag evaluation, tenant matching, and edge cases
+
+### Follow-Up
+
+- 7 GitHub issues filed for follow-up work (UI integration, audit log enrichment, bulk tag management, etc.)
+
 ## v0.9.6 — 2026-06-28
 
 ### Bug Fix — JetBrains "unexpected EOF" resolved

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For deep observability into agent frameworks (**ADK**, **LangChain**, **CrewAI**
 - **🕯️ OTel-Native**: OTLP is our native language. No proprietary SDKs.
 - **💰 Real-time Cost Tracking**: Automatic token extraction and USD calculation for OpenAI, Google, and Anthropic — including Anthropic prompt caching (1.25× write at 5m TTL, 2× write at 1h TTL, 0.1× read). Pricing is config-driven via [`pricing.yaml`](pkg/costcalc/pricing.yaml) with `//go:embed`.
 - **🚫 Model Allowlist/Blocklist**: `policy.allowed_models` restricts which models users can access, with glob pattern support and audit logging for blocked requests.
+- **🏷️ Tag-Based Model Access Control**: Per-user `access_tags`, per-model `required_access`, and tenant isolation via `allowed_tenants` — fail-closed on errors, SAs treated as individuals.
 - **🔐 Role-Based Access Control**: Admin vs Developer roles with budget enforcement and grant-based spending with reset countdowns.
 - **🔑 Multi-Cloud Auth**: `candela auth login --provider gcp|aws` — native OAuth2 for GCP, SSO/access keys for AWS. No `gcloud` or `aws` CLI dependency.
 - **🗄️ Pluggable Storage**: **DuckDB** for high-performance local/edge; **BigQuery** for serverless production scale (with `GROUPING SETS` combined queries); **SQLite** for lightweight dev.

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,4 +29,11 @@ There is intentional overlap in some areas (e.g., deployment). The Astro site is
 | `proxy.md` | Proxy architecture |
 | `security.md` | Security model |
 | `testing.md` | Testing guide |
+| `multitenancy.md` | Per-tenant LLM cost attribution |
+| `user-management.md` | User management & access control |
+| `candela.md` | Developer proxy & runtime manager |
+| `harness-architecture.md` | Harness architecture decisions |
+| `adk-integration.md` | Google ADK integration guide |
+| `otel-collector.md` | OTel Collector agent-native ingestion |
+| `audit-report-batch9.md` | Deep engineering audit — Batch 9 |
 | `adr/` | Architecture Decision Records |

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -381,6 +381,48 @@ proxy:
 
 ---
 
+## 🏷️ Access Tag Gating (Per-User, Per-Model)
+
+While `policy.allowed_models` is a **config-level allowlist** that applies uniformly to all users (all-or-nothing), **access tag gating** provides **per-user, per-model** granular control.
+
+| Mechanism | Scope | Granularity | Configuration |
+|-----------|-------|-------------|---------------|
+| `policy.allowed_models` | Global (all users) | Per-provider model list | `config.yaml` |
+| `access_tags` / `required_access` | Per-user, per-model | Tag-based intersection | User record + Model catalog |
+| `allowed_tenants` | Per-tenant, per-model | Tenant membership | Model catalog |
+
+### How They Interact
+
+Both gates are evaluated **independently** and both must pass:
+
+1. **`allowed_models`** — Is this model allowed at the config level? (If omitted, all models pass.)
+2. **Access tag gate** — Does this user have the required tags for this model? (If `required_access` is empty, all users pass.)
+3. **Tenant gate** — Does this user's tenant match `allowed_tenants`? (If empty, all tenants pass.)
+
+A request is blocked if **any** gate denies it.
+
+### Example
+
+```yaml
+# config.yaml — global allowlist (all users)
+proxy:
+  policy:
+    allowed_models:
+      - provider: anthropic
+        models: ["claude-sonnet-4-*", "claude-opus-4-*"]
+```
+
+```
+# Model catalog — per-model gate
+claude-opus-4-20250514:
+  required_access: ["opus"]        # only users with "opus" tag
+  allowed_tenants: ["acme-corp"]   # only acme-corp tenant
+```
+
+For full details on tag semantics, admin bypass, and SA behavior, see [Access Tag Gating in security.md](security.md#access-tag-gating).
+
+---
+
 ## 🛠️ Advanced Proxy Config
 
 Configuration is done via `config.yaml`:

--- a/docs/security.md
+++ b/docs/security.md
@@ -92,6 +92,46 @@ Request → Auth Middleware → Admin Interceptor → Handler
 
 ---
 
+## Access Tag Gating
+
+Beyond RBAC roles, Candela provides **tag-based model access control** for fine-grained, per-user, per-model authorization.
+
+### How It Works
+
+| Concept | Field | Description |
+|---------|-------|-------------|
+| **User access tags** | `User.access_tags` | String tags assigned to a user (e.g., `["sonnet", "opus", "internal"]`) |
+| **Model required access** | `ModelCatalogEntry.required_access` | Tags required to use a specific model |
+| **Tenant isolation** | `ModelCatalogEntry.allowed_tenants` | Restricts a model to specific tenants |
+
+### Tag Intersection (Any-Match)
+
+A user is granted access to a model when **any** of the user's `access_tags` matches **any** of the model's `required_access` tags (set intersection). If `required_access` is empty, the model is unrestricted.
+
+```
+User: access_tags = ["sonnet", "experimental"]
+Model: required_access = ["opus", "experimental"]
+Result: ✅ ALLOWED (intersection: "experimental")
+```
+
+### Tenant Isolation via `allowed_tenants`
+
+When `ModelCatalogEntry.allowed_tenants` is set, only users belonging to a listed tenant can access the model. This enables multi-tenant model segregation — e.g., restricting expensive models to specific business units.
+
+### Admin Bypass
+
+Users with `role = admin` bypass all access tag and tenant checks. Admins always have unrestricted model access.
+
+### Service Account Behavior
+
+Service accounts (SAs) are treated as **individual users** for access gating purposes. SAs must have the appropriate `access_tags` and belong to an allowed tenant — there is no implicit SA bypass.
+
+### Fail-Closed on Errors
+
+If the storage backend returns an error during access tag or tenant evaluation (e.g., database timeout), the request is **denied** rather than allowed. This prevents accidental access grants during transient failures.
+
+---
+
 ## Data Isolation — Per-User Trace Scoping
 
 Non-admin developers can only see their own traces and spans. This is enforced at two levels:

--- a/docs/user-management.md
+++ b/docs/user-management.md
@@ -111,6 +111,7 @@ firestore/
 │   ├── display_name: string
 │   ├── role: "admin" | "developer"
 │   ├── status: "provisioned" | "active" | "inactive"
+│   ├── access_tags: []string          # tag-based model access control (e.g., ["sonnet", "opus"])
 │   ├── last_seen_at: timestamp
 │   └── created_at: timestamp
 ├── budgets/{userId}

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -32,8 +32,8 @@ test/functional/
 │   ├── proxy_anthropic.hurl← PROXY-02: Anthropic/Vertex AI path + translation
 │   ├── proxy_streaming.hurl← PROXY-03: SSE streaming, [DONE] terminator
 │   ├── proxy_errors.hurl   ← PROXY-04/05: 413, unknown provider, 4xx shapes
-│   ├── proxy_access_gates.hurl ← ACCESS-01..07: tag-based model access control
-│   └── proxy_tenant_gates.hurl ← TENANT-01..07: tenant isolation gating
+│   ├── proxy_access_gates.hurl ← ACCESS-01..08: tag-based model access control
+│   └── proxy_tenant_gates.hurl ← TENANT-GATE-01..06: tenant isolation gating
 ├── billing/
 │   ├── budget_gate.hurl    ← BILLING-01/02: budget exhausted → 402
 │   ├── pricing_gate.hurl   ← BILLING-03/04: unknown model, local bypass

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -31,7 +31,9 @@ test/functional/
 │   ├── proxy_openai.hurl   ← PROXY-01: OpenAI round-trip
 │   ├── proxy_anthropic.hurl← PROXY-02: Anthropic/Vertex AI path + translation
 │   ├── proxy_streaming.hurl← PROXY-03: SSE streaming, [DONE] terminator
-│   └── proxy_errors.hurl   ← PROXY-04/05: 413, unknown provider, 4xx shapes
+│   ├── proxy_errors.hurl   ← PROXY-04/05: 413, unknown provider, 4xx shapes
+│   ├── proxy_access_gates.hurl ← ACCESS-01..07: tag-based model access control
+│   └── proxy_tenant_gates.hurl ← TENANT-01..07: tenant isolation gating
 ├── billing/
 │   ├── budget_gate.hurl    ← BILLING-01/02: budget exhausted → 402
 │   ├── pricing_gate.hurl   ← BILLING-03/04: unknown model, local bypass


### PR DESCRIPTION
Updates all docs across the repo for the access control feature shipped in PRs #488–#498.

## Changes (7 files)

| File | Update |
|---|---|
| `CHANGELOG.md` | v0.10.0 entry with features, tooling, tests, follow-up issues |
| `README.md` | Added 🏷️ Tag-Based Model Access Control to Key Features |
| `docs/security.md` | New "Access Tag Gating" section (tags, tenants, admin bypass, SAs, fail-closed) |
| `docs/proxy.md` | New per-user/per-model gating section + comparison with policy.allowed_models |
| `docs/user-management.md` | Added `access_tags` to User data model |
| `docs/README.md` | Added 7 missing files to index |
| `test/functional/README.md` | Added proxy_access_gates.hurl + proxy_tenant_gates.hurl |

Companion PR in candela-docs updates the user-facing site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced tag-based model access control using per-user access tags and per-model required access, with tenant-based restrictions and deny-by-default (fail-closed) behavior on access evaluation errors.
  * Service accounts are now treated the same as individual users for access tag and tenant checks.

* **Documentation**
  * Updated the main and security/proxy/user-management documentation with the new access-tag and tenant-gating concepts and examples.

* **Tests**
  * Added and expanded end-to-end and unit tests for access-tag matching, tenant isolation, and edge cases.

* **Chores**
  * Applied a generated protobuf type cloning fixup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->