### PR TITLE
test: audit package coverage and proxy benchmarks

### DIFF
--- a/pkg/audit/bq_logger_test.go
+++ b/pkg/audit/bq_logger_test.go
@@ -1,0 +1,125 @@
+package audit
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// newTestBQLogger creates a BQLogger with only the events channel initialized
+// (no BigQuery client). This lets us test buffer behavior without cloud deps.
+func newTestBQLogger(bufSize int) *BQLogger {
+	return &BQLogger{
+		events: make(chan bqRow, bufSize),
+		done:   make(chan struct{}),
+	}
+}
+
+func TestBQLogger_Log_EnqueuesEvent(t *testing.T) {
+	l := newTestBQLogger(10)
+
+	l.Log(context.Background(), Event{
+		ActorEmail: "admin@test.com",
+		Service:    "UserService",
+		Method:     "CreateUser",
+		Procedure:  "/candela.v1.UserService/CreateUser",
+		StatusCode: "ok",
+		Timestamp:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+
+	if len(l.events) != 1 {
+		t.Fatalf("events channel length = %d, want 1", len(l.events))
+	}
+
+	row := <-l.events
+	if row.ActorEmail != "admin@test.com" {
+		t.Errorf("ActorEmail = %q, want %q", row.ActorEmail, "admin@test.com")
+	}
+	if row.Service != "UserService" {
+		t.Errorf("Service = %q, want %q", row.Service, "UserService")
+	}
+	if row.Method != "CreateUser" {
+		t.Errorf("Method = %q, want %q", row.Method, "CreateUser")
+	}
+	if row.Procedure != "/candela.v1.UserService/CreateUser" {
+		t.Errorf("Procedure = %q, want %q", row.Procedure, "/candela.v1.UserService/CreateUser")
+	}
+	if row.StatusCode != "ok" {
+		t.Errorf("StatusCode = %q, want %q", row.StatusCode, "ok")
+	}
+	if !row.Timestamp.Valid {
+		t.Error("Timestamp.Valid = false, want true")
+	}
+}
+
+func TestBQLogger_Log_BufferFullDropsEvent(t *testing.T) {
+	l := newTestBQLogger(1) // buffer of 1
+
+	// Fill the buffer.
+	l.Log(context.Background(), Event{Method: "first"})
+
+	// This should be dropped (buffer full).
+	l.Log(context.Background(), Event{Method: "dropped"})
+
+	if len(l.events) != 1 {
+		t.Fatalf("events channel length = %d, want 1 (second event should be dropped)", len(l.events))
+	}
+
+	row := <-l.events
+	if row.Method != "first" {
+		t.Errorf("Method = %q, want %q (first event should be preserved)", row.Method, "first")
+	}
+}
+
+func TestBQLogger_Log_AllFieldsMapped(t *testing.T) {
+	l := newTestBQLogger(10)
+	ts := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+
+	l.Log(context.Background(), Event{
+		Timestamp:  ts,
+		ActorEmail: "user@example.com",
+		ActorID:    "uid-456",
+		Service:    "ProjectService",
+		Method:     "DeleteProject",
+		Procedure:  "/candela.v1.ProjectService/DeleteProject",
+		StatusCode: "permission_denied",
+		Error:      "not allowed",
+	})
+
+	row := <-l.events
+	if row.Timestamp.Timestamp != ts {
+		t.Errorf("Timestamp = %v, want %v", row.Timestamp.Timestamp, ts)
+	}
+	if row.ActorEmail != "user@example.com" {
+		t.Errorf("ActorEmail = %q, want %q", row.ActorEmail, "user@example.com")
+	}
+	if row.ActorID != "uid-456" {
+		t.Errorf("ActorID = %q, want %q", row.ActorID, "uid-456")
+	}
+	if row.Error != "not allowed" {
+		t.Errorf("Error = %q, want %q", row.Error, "not allowed")
+	}
+}
+
+func TestBQLogger_Log_MultipleEvents(t *testing.T) {
+	l := newTestBQLogger(10)
+
+	for i := 0; i < 5; i++ {
+		l.Log(context.Background(), Event{Method: "op"})
+	}
+
+	if len(l.events) != 5 {
+		t.Fatalf("events channel length = %d, want 5", len(l.events))
+	}
+}
+
+func TestBQLogger_Log_ZeroTimestamp(t *testing.T) {
+	l := newTestBQLogger(10)
+
+	l.Log(context.Background(), Event{Method: "no-ts"})
+
+	row := <-l.events
+	if !row.Timestamp.Valid {
+		t.Error("Timestamp.Valid = false, want true (even for zero time)")
+	}
+}

--- a/pkg/audit/slog_logger_test.go
+++ b/pkg/audit/slog_logger_test.go
@@ -1,0 +1,90 @@
+package audit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+)
+
+func TestSlogLogger_OutputFields(t *testing.T) {
+	// Capture slog output.
+	var buf bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(oldLogger)
+
+	l := NewSlogLogger()
+	l.Log(context.Background(), Event{
+		ActorEmail: "admin@test.com",
+		ActorID:    "uid-789",
+		Service:    "UserService",
+		Method:     "DeleteUser",
+		Procedure:  "/candela.v1.UserService/DeleteUser",
+		StatusCode: "ok",
+		Error:      "",
+	})
+
+	var entry map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse slog output: %v\nraw: %s", err, buf.String())
+	}
+
+	want := map[string]string{
+		"actor_email": "admin@test.com",
+		"actor_id":    "uid-789",
+		"service":     "UserService",
+		"method":      "DeleteUser",
+		"procedure":   "/candela.v1.UserService/DeleteUser",
+		"status":      "ok",
+		"error":       "",
+	}
+	for key, expected := range want {
+		got, ok := entry[key].(string)
+		if !ok {
+			t.Errorf("key %q not found or not a string in output", key)
+			continue
+		}
+		if got != expected {
+			t.Errorf("%s = %q, want %q", key, got, expected)
+		}
+	}
+
+	// Verify it's an INFO-level audit message.
+	if level, ok := entry["level"].(string); !ok || level != "INFO" {
+		t.Errorf("level = %v, want %q", entry["level"], "INFO")
+	}
+	if msg, ok := entry["msg"].(string); !ok || msg != "audit" {
+		t.Errorf("msg = %v, want %q", entry["msg"], "audit")
+	}
+}
+
+func TestSlogLogger_ErrorEvent(t *testing.T) {
+	var buf bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(oldLogger)
+
+	l := NewSlogLogger()
+	l.Log(context.Background(), Event{
+		ActorEmail: "hacker@evil.com",
+		Service:    "UserService",
+		Method:     "DeleteUser",
+		Procedure:  "/candela.v1.UserService/DeleteUser",
+		StatusCode: "permission_denied",
+		Error:      "not allowed",
+	})
+
+	var entry map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse slog output: %v", err)
+	}
+
+	if got := entry["status"]; got != "permission_denied" {
+		t.Errorf("status = %v, want %q", got, "permission_denied")
+	}
+	if got := entry["error"]; got != "not allowed" {
+		t.Errorf("error = %v, want %q", got, "not allowed")
+	}
+}

--- a/pkg/proxy/benchmark_test.go
+++ b/pkg/proxy/benchmark_test.go
@@ -1,0 +1,152 @@
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/costcalc"
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// benchSubmitter is a no-op span submitter for benchmarks.
+type benchSubmitter struct {
+	mu    sync.Mutex
+	spans []storage.Span
+}
+
+func (s *benchSubmitter) SubmitBatch(spans []storage.Span) {
+	s.mu.Lock()
+	s.spans = append(s.spans, spans...)
+	s.mu.Unlock()
+}
+
+// setupBenchProxy creates a mock upstream, proxy, and test server for benchmarking.
+// Returns the proxy URL for the given provider. Cleanup is handled via b.Cleanup.
+func setupBenchProxy(b *testing.B, providerName, upstreamBody string) string {
+	b.Helper()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(upstreamBody))
+	}))
+	b.Cleanup(upstream.Close)
+
+	p, err := New(Config{
+		Providers: []Provider{{Name: providerName, UpstreamURL: upstream.URL}},
+		ProjectID: "bench-project",
+	}, &benchSubmitter{}, costcalc.New())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	b.Cleanup(srv.Close)
+
+	return srv.URL
+}
+
+const benchOpenAIBody = `{
+	"id": "chatcmpl-bench",
+	"object": "chat.completion",
+	"model": "gpt-4o",
+	"choices": [{"index": 0, "message": {"role": "assistant", "content": "Hello!"}, "finish_reason": "stop"}],
+	"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+}`
+
+const benchAnthropicBody = `{
+	"id": "msg-bench",
+	"type": "message",
+	"role": "assistant",
+	"content": [{"type": "text", "text": "Hello!"}],
+	"model": "claude-sonnet-4-20250514",
+	"stop_reason": "end_turn",
+	"usage": {"input_tokens": 10, "output_tokens": 5}
+}`
+
+// BenchmarkHandleProxy_OpenAI benchmarks the full proxy hot path
+// for an OpenAI-compatible request (no format translation, no path rewriting).
+func BenchmarkHandleProxy_OpenAI(b *testing.B) {
+	proxyURL := setupBenchProxy(b, "openai", benchOpenAIBody)
+	url := fmt.Sprintf("%s/proxy/openai/v1/chat/completions", proxyURL)
+	body := `{"model": "gpt-4o", "messages": [{"role": "user", "content": "Hi"}]}`
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		req, _ := http.NewRequest("POST", url, strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer sk-bench")
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			b.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+	}
+}
+
+// BenchmarkHandleProxy_AnthropicDirect benchmarks the proxy hot path
+// for Anthropic direct (native passthrough, no format translation).
+func BenchmarkHandleProxy_AnthropicDirect(b *testing.B) {
+	proxyURL := setupBenchProxy(b, "anthropic-direct", benchAnthropicBody)
+	url := fmt.Sprintf("%s/proxy/anthropic-direct/v1/messages", proxyURL)
+	body := `{"model": "claude-sonnet-4-20250514", "messages": [{"role": "user", "content": "Hi"}], "max_tokens": 100}`
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		req, _ := http.NewRequest("POST", url, strings.NewReader(body))
+		req.Header.Set("X-Api-Key", "sk-ant-bench")
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Anthropic-Version", "2023-06-01")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			b.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+	}
+}
+
+// BenchmarkHandleProxy_Parallel measures throughput under concurrent load.
+func BenchmarkHandleProxy_Parallel(b *testing.B) {
+	proxyURL := setupBenchProxy(b, "openai", benchOpenAIBody)
+	url := fmt.Sprintf("%s/proxy/openai/v1/chat/completions", proxyURL)
+	body := `{"model": "gpt-4o", "messages": [{"role": "user", "content": "Hi"}]}`
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req, _ := http.NewRequest("POST", url, strings.NewReader(body))
+			req.Header.Set("Authorization", "Bearer sk-bench")
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				// b.Error is safe from goroutines (unlike b.Fatal).
+				b.Error(err)
+				return
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fills test gaps identified in the test audit (#509, #511).

### New Files

| File | Count | Coverage |
|---|---|---|
| `pkg/audit/bq_logger_test.go` | 5 tests | BQLogger buffer enqueue, buffer-full drop, field mapping, multiple events |
| `pkg/audit/slog_logger_test.go` | 2 tests | Structured JSON output verification, error event fields |
| `pkg/proxy/benchmark_test.go` | 3 benchmarks | OpenAI hot path, Anthropic Direct, parallel throughput |

### Proxy Benchmark Baselines (Apple M2)

```
BenchmarkHandleProxy_OpenAI-8     23227   92833 ns/op   30475 B/op   442 allocs/op
```

Closes #509, closes #511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded audit logging coverage to verify event-to-row field mapping, including correct timestamp validity behavior.
  * Added assertions that structured logger output includes the expected event fields and error/status values.
  * Confirmed that logging behavior drops excess events when internal buffers are full.
* **Benchmarks**
  * Added end-to-end proxy performance benchmarks for OpenAI-compatible and Anthropic direct request handling, including a parallel concurrency scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->