### PR TITLE
refactor: extend BQClient interface for write-path testability (#510 Phase 2)

### DIFF
--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -378,7 +378,7 @@ func (s *Store) IngestSpans(ctx context.Context, spans []storage.Span) error {
 
 	// 1. Process optimistic spans via streaming insert (fast path)
 	if len(optimisticSpans) > 0 {
-		inserter := s.rawClient.Dataset(s.config.Dataset).Table(s.config.Table).Inserter()
+		inserter := s.client.Dataset(s.config.Dataset).Table(s.config.Table).Inserter()
 		var rows []*bigquery.StructSaver
 		for _, span := range optimisticSpans {
 			row := spanToRow(span)
@@ -416,10 +416,10 @@ func (s *Store) IngestSpans(ctx context.Context, spans []storage.Span) error {
 				)
 		`, quoteTable(s.tableID))
 
-		q := s.rawClient.Query(query)
-		q.Parameters = []bigquery.QueryParameter{
+		q := s.client.Query(query)
+		q.SetParameters([]bigquery.QueryParameter{
 			{Name: "spans", Value: pessimisticRows},
-		}
+		})
 
 		job, err := q.Run(ctx)
 		if err != nil {

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -30,8 +30,8 @@ type Config struct {
 
 // Store implements storage.TraceStore for BigQuery.
 type Store struct {
-	client    BQClient         // interface — used by all read-path methods
-	rawClient *bigquery.Client // concrete — used by write-path (IngestSpans, ensureSchema, evolveSchema)
+	client    BQClient         // interface — used by read-path methods and IngestSpans (insert + MERGE)
+	rawClient *bigquery.Client // concrete — used by schema management (ensureSchema, evolveSchema)
 	config    Config
 	tableID   string // fully-qualified: project.dataset.table
 }

--- a/pkg/storage/bigquery/bq_client.go
+++ b/pkg/storage/bigquery/bq_client.go
@@ -6,9 +6,10 @@ import (
 	"cloud.google.com/go/bigquery"
 )
 
-// BQClient abstracts *bigquery.Client for the read path.
-// This interface covers only the methods needed by read-path queries
-// (QueryTraces, SearchSpans, GetUsageSummary, etc.) and Ping.
+// BQClient abstracts *bigquery.Client for the read and write paths.
+// This interface covers methods needed by read-path queries
+// (QueryTraces, SearchSpans, GetUsageSummary, etc.), Ping, and
+// IngestSpans (streaming insert + MERGE DML).
 //
 // Implementations:
 //   - bqClientWrapper (production, wraps *bigquery.Client)
@@ -24,17 +25,31 @@ type BQDataset interface {
 	Table(string) BQTable
 }
 
-// BQTable abstracts *bigquery.Table (Ping reads table metadata).
+// BQTable abstracts *bigquery.Table.
+// Ping reads table metadata; IngestSpans uses the inserter.
 type BQTable interface {
 	Metadata(ctx context.Context) (*bigquery.TableMetadata, error)
+	Inserter() BQInserter
 }
 
-// BQQuery abstracts *bigquery.Query for parameterized read queries.
+// BQInserter abstracts *bigquery.Inserter for streaming inserts.
+type BQInserter interface {
+	Put(ctx context.Context, src interface{}) error
+}
+
+// BQQuery abstracts *bigquery.Query for parameterized queries.
 // SetParameters wraps the field assignment q.Parameters = [...] as a method
 // call so the interface stays clean.
+// Read is used by read-path queries; Run is used by write-path DML.
 type BQQuery interface {
 	SetParameters([]bigquery.QueryParameter)
 	Read(ctx context.Context) (BQRowIterator, error)
+	Run(ctx context.Context) (BQJob, error)
+}
+
+// BQJob abstracts *bigquery.Job (used by IngestSpans pessimistic MERGE path).
+type BQJob interface {
+	Wait(ctx context.Context) (*bigquery.JobStatus, error)
 }
 
 // BQRowIterator abstracts *bigquery.RowIterator for scanning query results.
@@ -48,7 +63,9 @@ type BQRowIterator interface {
 var _ BQClient = (*bqClientWrapper)(nil)
 var _ BQDataset = (*bqDatasetWrapper)(nil)
 var _ BQTable = (*bqTableWrapper)(nil)
+var _ BQInserter = (*bqInserterWrapper)(nil)
 var _ BQQuery = (*bqQueryWrapper)(nil)
+var _ BQJob = (*bqJobWrapper)(nil)
 var _ BQRowIterator = (*bqRowIteratorWrapper)(nil)
 
 type bqClientWrapper struct{ c *bigquery.Client }
@@ -67,6 +84,16 @@ func (w *bqTableWrapper) Metadata(ctx context.Context) (*bigquery.TableMetadata,
 	return w.t.Metadata(ctx)
 }
 
+func (w *bqTableWrapper) Inserter() BQInserter {
+	return &bqInserterWrapper{w.t.Inserter()}
+}
+
+type bqInserterWrapper struct{ i *bigquery.Inserter }
+
+func (w *bqInserterWrapper) Put(ctx context.Context, src interface{}) error {
+	return w.i.Put(ctx, src)
+}
+
 type bqQueryWrapper struct{ q *bigquery.Query }
 
 func (w *bqQueryWrapper) SetParameters(params []bigquery.QueryParameter) {
@@ -79,6 +106,20 @@ func (w *bqQueryWrapper) Read(ctx context.Context) (BQRowIterator, error) {
 		return nil, err
 	}
 	return &bqRowIteratorWrapper{it}, nil
+}
+
+func (w *bqQueryWrapper) Run(ctx context.Context) (BQJob, error) {
+	job, err := w.q.Run(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &bqJobWrapper{job}, nil
+}
+
+type bqJobWrapper struct{ j *bigquery.Job }
+
+func (w *bqJobWrapper) Wait(ctx context.Context) (*bigquery.JobStatus, error) {
+	return w.j.Wait(ctx)
 }
 
 type bqRowIteratorWrapper struct{ it *bigquery.RowIterator }

--- a/pkg/storage/bigquery/bq_mock_test.go
+++ b/pkg/storage/bigquery/bq_mock_test.go
@@ -80,6 +80,7 @@ type mockBQTable struct {
 	id             string
 	metadataCalled bool
 	metadataErr    error
+	inserter       *mockBQInserter
 }
 
 func (t *mockBQTable) Metadata(_ context.Context) (*bigquery.TableMetadata, error) {
@@ -90,6 +91,30 @@ func (t *mockBQTable) Metadata(_ context.Context) (*bigquery.TableMetadata, erro
 	return &bigquery.TableMetadata{}, nil
 }
 
+func (t *mockBQTable) Inserter() BQInserter {
+	if t.inserter != nil {
+		return t.inserter
+	}
+	return &mockBQInserter{}
+}
+
+// ── Mock Inserter ────────────────────────────────────────────────────
+
+type mockBQInserter struct {
+	putCalled bool
+	putSrc    interface{}
+	putErr    error
+}
+
+func (i *mockBQInserter) Put(_ context.Context, src interface{}) error {
+	i.putCalled = true
+	i.putSrc = src
+	if i.putErr != nil {
+		return i.putErr
+	}
+	return nil
+}
+
 // ── Mock Query ───────────────────────────────────────────────────────
 
 type mockBQQuery struct {
@@ -97,6 +122,8 @@ type mockBQQuery struct {
 	params  []bigquery.QueryParameter
 	iter    *mockBQRowIterator
 	readErr error
+	job     *mockBQJob
+	runErr  error
 }
 
 func (q *mockBQQuery) SetParameters(params []bigquery.QueryParameter) {
@@ -111,6 +138,33 @@ func (q *mockBQQuery) Read(_ context.Context) (BQRowIterator, error) {
 		return &mockBQRowIterator{}, nil
 	}
 	return q.iter, nil
+}
+
+func (q *mockBQQuery) Run(_ context.Context) (BQJob, error) {
+	if q.runErr != nil {
+		return nil, q.runErr
+	}
+	if q.job == nil {
+		return &mockBQJob{}, nil
+	}
+	return q.job, nil
+}
+
+// ── Mock Job ─────────────────────────────────────────────────────────
+
+type mockBQJob struct {
+	waitErr   error
+	statusErr error
+}
+
+func (j *mockBQJob) Wait(_ context.Context) (*bigquery.JobStatus, error) {
+	if j.waitErr != nil {
+		return nil, j.waitErr
+	}
+	if j.statusErr != nil {
+		return &bigquery.JobStatus{Errors: []*bigquery.Error{{Message: j.statusErr.Error()}}}, nil
+	}
+	return &bigquery.JobStatus{}, nil
 }
 
 // ── Mock Row Iterator ────────────────────────────────────────────────

--- a/pkg/storage/bigquery/bq_mock_test.go
+++ b/pkg/storage/bigquery/bq_mock_test.go
@@ -151,18 +151,17 @@ func (q *mockBQQuery) Run(_ context.Context) (BQJob, error) {
 }
 
 // ── Mock Job ─────────────────────────────────────────────────────────
+// NOTE: JobStatus.Err() reads a private field that cannot be set externally,
+// so we can only test the waitErr path (job.Wait returning an error).
+// The status.Err() branch in IngestSpans is not exercisable via mock.
 
 type mockBQJob struct {
-	waitErr   error
-	statusErr error
+	waitErr error
 }
 
 func (j *mockBQJob) Wait(_ context.Context) (*bigquery.JobStatus, error) {
 	if j.waitErr != nil {
 		return nil, j.waitErr
-	}
-	if j.statusErr != nil {
-		return &bigquery.JobStatus{Errors: []*bigquery.Error{{Message: j.statusErr.Error()}}}, nil
 	}
 	return &bigquery.JobStatus{}, nil
 }

--- a/pkg/storage/bigquery/ingest_test.go
+++ b/pkg/storage/bigquery/ingest_test.go
@@ -1,0 +1,196 @@
+package bigquery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	bq "cloud.google.com/go/bigquery"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// makeSpan creates a minimal test span with configurable retry attribute.
+func makeSpan(id string, isRetry bool) storage.Span {
+	attrs := map[string]string{}
+	if isRetry {
+		attrs["candela.is_retry"] = "true"
+	}
+	return storage.Span{
+		SpanID:     "span-" + id,
+		TraceID:    "trace-" + id,
+		Name:       "test.span." + id,
+		StartTime:  time.Now().Add(-1 * time.Second),
+		EndTime:    time.Now(),
+		Attributes: attrs,
+	}
+}
+
+// ── Optimistic Path ──────────────────────────────────────────────────
+
+func TestIngestSpans_OptimisticPath(t *testing.T) {
+	client := newMockBQClient()
+	inserter := &mockBQInserter{}
+	client.dataset.tables["spans"] = &mockBQTable{id: "spans", inserter: inserter}
+
+	s := testStore(client)
+	spans := []storage.Span{makeSpan("1", false), makeSpan("2", false)}
+
+	err := s.IngestSpans(context.Background(), spans)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !inserter.putCalled {
+		t.Fatal("expected inserter.Put to be called")
+	}
+
+	// Verify the rows passed to Put are StructSavers.
+	rows, ok := inserter.putSrc.([]*bq.StructSaver)
+	if !ok {
+		t.Fatalf("expected []*bigquery.StructSaver, got %T", inserter.putSrc)
+	}
+	if len(rows) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(rows))
+	}
+	// Verify dedup key format: traceID-spanID.
+	for _, r := range rows {
+		if !strings.Contains(r.InsertID, "-span-") {
+			t.Errorf("unexpected InsertID format: %s", r.InsertID)
+		}
+	}
+}
+
+// ── Pessimistic Path ─────────────────────────────────────────────────
+
+func TestIngestSpans_PessimisticPath(t *testing.T) {
+	client := newMockBQClient()
+	inserter := &mockBQInserter{}
+	client.dataset.tables["spans"] = &mockBQTable{id: "spans", inserter: inserter}
+
+	mergeQuery := &mockBQQuery{job: &mockBQJob{}}
+	client.enqueueQuery(mergeQuery)
+
+	s := testStore(client)
+	spans := []storage.Span{makeSpan("1", true), makeSpan("2", true)}
+
+	err := s.IngestSpans(context.Background(), spans)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Inserter should NOT be called (all pessimistic).
+	if inserter.putCalled {
+		t.Error("inserter.Put should not be called for pessimistic spans")
+	}
+
+	// Verify MERGE SQL.
+	assertContains(t, mergeQuery.sql, "MERGE")
+	assertContains(t, mergeQuery.sql, "WHEN NOT MATCHED THEN")
+	assertParam(t, mergeQuery.params, "spans")
+}
+
+// ── Mixed Batch ──────────────────────────────────────────────────────
+
+func TestIngestSpans_MixedBatch(t *testing.T) {
+	client := newMockBQClient()
+	inserter := &mockBQInserter{}
+	client.dataset.tables["spans"] = &mockBQTable{id: "spans", inserter: inserter}
+
+	mergeQuery := &mockBQQuery{job: &mockBQJob{}}
+	client.enqueueQuery(mergeQuery)
+
+	s := testStore(client)
+	spans := []storage.Span{
+		makeSpan("opt-1", false),
+		makeSpan("pess-1", true),
+		makeSpan("opt-2", false),
+	}
+
+	err := s.IngestSpans(context.Background(), spans)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Optimistic: inserter called with 2 rows.
+	if !inserter.putCalled {
+		t.Fatal("expected inserter.Put to be called for optimistic spans")
+	}
+	rows, ok := inserter.putSrc.([]*bq.StructSaver)
+	if !ok {
+		t.Fatalf("expected []*bigquery.StructSaver, got %T", inserter.putSrc)
+	}
+	if len(rows) != 2 {
+		t.Errorf("expected 2 optimistic rows, got %d", len(rows))
+	}
+
+	// Pessimistic: MERGE query called with 1 span.
+	assertContains(t, mergeQuery.sql, "MERGE")
+	assertParam(t, mergeQuery.params, "spans")
+}
+
+// ── Insert Error ─────────────────────────────────────────────────────
+
+func TestIngestSpans_InsertError(t *testing.T) {
+	client := newMockBQClient()
+	inserter := &mockBQInserter{putErr: fmt.Errorf("quota exceeded")}
+	client.dataset.tables["spans"] = &mockBQTable{id: "spans", inserter: inserter}
+
+	s := testStore(client)
+	err := s.IngestSpans(context.Background(), []storage.Span{makeSpan("1", false)})
+
+	if err == nil {
+		t.Fatal("expected error from IngestSpans")
+	}
+	if !strings.Contains(err.Error(), "quota exceeded") {
+		t.Errorf("error = %v, want to contain 'quota exceeded'", err)
+	}
+	if !strings.Contains(err.Error(), "optimistic") {
+		t.Errorf("error = %v, want to contain 'optimistic'", err)
+	}
+}
+
+// ── Merge Error ──────────────────────────────────────────────────────
+
+func TestIngestSpans_MergeError(t *testing.T) {
+	client := newMockBQClient()
+	inserter := &mockBQInserter{}
+	client.dataset.tables["spans"] = &mockBQTable{id: "spans", inserter: inserter}
+
+	mergeQuery := &mockBQQuery{
+		job: &mockBQJob{waitErr: fmt.Errorf("deadline exceeded")},
+	}
+	client.enqueueQuery(mergeQuery)
+
+	s := testStore(client)
+	err := s.IngestSpans(context.Background(), []storage.Span{makeSpan("1", true)})
+
+	if err == nil {
+		t.Fatal("expected error from IngestSpans")
+	}
+	if !strings.Contains(err.Error(), "deadline exceeded") {
+		t.Errorf("error = %v, want to contain 'deadline exceeded'", err)
+	}
+	if !strings.Contains(err.Error(), "pessimistic") {
+		t.Errorf("error = %v, want to contain 'pessimistic'", err)
+	}
+}
+
+// ── Empty Input ──────────────────────────────────────────────────────
+
+func TestIngestSpans_EmptyInput(t *testing.T) {
+	client := newMockBQClient()
+	s := testStore(client)
+
+	err := s.IngestSpans(context.Background(), []storage.Span{})
+	if err != nil {
+		t.Fatalf("unexpected error for empty input: %v", err)
+	}
+
+	err = s.IngestSpans(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error for nil input: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of BigQuery test coverage. Extends the BQClient interfaces to cover IngestSpans, enabling mock-based testing of both the optimistic (streaming insert) and pessimistic (MERGE DML) write paths.

### Interface additions (`bq_client.go`)

| Interface | Method | Wraps |
|-----------|--------|-------|
| `BQTable` | `Inserter() BQInserter` | `*bigquery.Table.Inserter()` |
| `BQInserter` | `Put(ctx, src) error` | `*bigquery.Inserter.Put()` |
| `BQQuery` | `Run(ctx) (BQJob, error)` | `*bigquery.Query.Run()` |
| `BQJob` | `Wait(ctx) (*JobStatus, error)` | `*bigquery.Job.Wait()` |

### Changes to `bigquery.go`

- `IngestSpans` now uses `s.client` (interface) instead of `s.rawClient`
- `q.Parameters = [...]` → `q.SetParameters([...])` for MERGE query
- `rawClient` only used by `ensureSchema`/`evolveSchema` now (1 remaining usage)

### Tests added (`ingest_test.go`)

| Test | Verifies |
|------|----------|
| `TestIngestSpans_OptimisticPath` | Streaming insert: inserter.Put called with StructSaver rows, correct dedup keys |
| `TestIngestSpans_PessimisticPath` | MERGE DML: query contains MERGE SQL, inserter not called |
| `TestIngestSpans_MixedBatch` | Both paths in one call: 2 optimistic + 1 pessimistic |
| `TestIngestSpans_InsertError` | inserter.Put failure propagates with 'optimistic' context |
| `TestIngestSpans_MergeError` | job.Wait failure propagates with 'pessimistic' context |
| `TestIngestSpans_EmptyInput` | No-op for empty/nil input |

### Verification

- ✅ `go build ./pkg/storage/bigquery/...`
- ✅ `go test ./pkg/storage/bigquery/... -v -count=1` (35 tests pass)
- ✅ `golangci-lint run ./pkg/storage/bigquery/...` (0 issues)
- ✅ All pre-commit hooks pass

Builds on Phase 1 (#516). Closes #510 Phase 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BigQuery span ingestion now supports streaming inserts plus retry deduplication via a retry-aware MERGE approach, including mixed batches.

* **Bug Fixes**
  * Improved ingestion error messages to clearly indicate whether failures occurred during streaming inserts or retry MERGE processing.
  * Nil/empty span inputs now return successfully without performing any ingestion work.

* **Tests**
  * Added unit tests covering optimistic inserts, pessimistic MERGE behavior, mixed batches, insert/MERGE failure scenarios, and empty input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->