### PR TITLE
refactor: extend BQClient interface for schema management (#510 Phase 3)

### DIFF
--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -321,8 +321,10 @@ func (s *Store) evolveSchema(ctx context.Context, table BQTable, desired bigquer
 	var missing bigquery.Schema
 	for _, field := range desired {
 		if !existing[field.Name] {
-			field.Required = false
-			missing = append(missing, field)
+			// Shallow copy to avoid mutating the caller's desired schema.
+			f := *field
+			f.Required = false
+			missing = append(missing, &f)
 		}
 	}
 

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -30,10 +30,9 @@ type Config struct {
 
 // Store implements storage.TraceStore for BigQuery.
 type Store struct {
-	client    BQClient         // interface — used by read-path methods and IngestSpans (insert + MERGE)
-	rawClient *bigquery.Client // concrete — used by schema management (ensureSchema, evolveSchema)
-	config    Config
-	tableID   string // fully-qualified: project.dataset.table
+	client  BQClient // interface — all operations (read, write, schema) go through this
+	config  Config
+	tableID string // fully-qualified: project.dataset.table
 }
 
 var _ storage.SpanWriter = (*Store)(nil)
@@ -60,10 +59,9 @@ func New(ctx context.Context, cfg Config) (*Store, error) {
 	}
 
 	s := &Store{
-		client:    &bqClientWrapper{client},
-		rawClient: client,
-		config:    cfg,
-		tableID:   fmt.Sprintf("%s.%s.%s", cfg.ProjectID, cfg.Dataset, cfg.Table),
+		client:  &bqClientWrapper{client},
+		config:  cfg,
+		tableID: fmt.Sprintf("%s.%s.%s", cfg.ProjectID, cfg.Dataset, cfg.Table),
 	}
 
 	if err := s.ensureSchema(ctx); err != nil {
@@ -76,9 +74,6 @@ func New(ctx context.Context, cfg Config) (*Store, error) {
 
 // NewWithClient creates a Store with a pre-configured BQClient for testing.
 // It skips schema setup and does not require a real BigQuery connection.
-//
-// WARNING: rawClient is nil — write-path methods (IngestSpans, ensureSchema,
-// evolveSchema) will panic if called. This constructor is read-path only.
 func NewWithClient(client BQClient, cfg Config) *Store {
 	if cfg.Table == "" {
 		cfg.Table = "spans"
@@ -255,7 +250,7 @@ func rowToSpan(row spanRow) storage.Span {
 // ensureSchema creates the dataset and table if they don't exist,
 // and evolves the schema by adding any missing columns to existing tables.
 func (s *Store) ensureSchema(ctx context.Context) error {
-	dataset := s.rawClient.Dataset(s.config.Dataset)
+	dataset := s.client.Dataset(s.config.Dataset)
 
 	// Create dataset if not exists.
 	meta := &bigquery.DatasetMetadata{Location: s.config.Location}
@@ -308,7 +303,7 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 // Limitation: this only detects missing top-level columns. Changes to nested
 // STRUCT fields (e.g. adding a field inside the "attributes" REPEATED STRUCT)
 // are not detected and must be handled manually or via a migration tool.
-func (s *Store) evolveSchema(ctx context.Context, table *bigquery.Table, desired bigquery.Schema) error {
+func (s *Store) evolveSchema(ctx context.Context, table BQTable, desired bigquery.Schema) error {
 	md, err := table.Metadata(ctx)
 	if err != nil {
 		return fmt.Errorf("reading table metadata: %w", err)

--- a/pkg/storage/bigquery/bq_client.go
+++ b/pkg/storage/bigquery/bq_client.go
@@ -6,10 +6,9 @@ import (
 	"cloud.google.com/go/bigquery"
 )
 
-// BQClient abstracts *bigquery.Client for the read and write paths.
-// This interface covers methods needed by read-path queries
-// (QueryTraces, SearchSpans, GetUsageSummary, etc.), Ping, and
-// IngestSpans (streaming insert + MERGE DML).
+// BQClient abstracts *bigquery.Client for all Store operations.
+// This interface covers read-path queries, IngestSpans (streaming insert +
+// MERGE DML), Ping, and schema management (ensureSchema, evolveSchema).
 //
 // Implementations:
 //   - bqClientWrapper (production, wraps *bigquery.Client)
@@ -20,16 +19,22 @@ type BQClient interface {
 	Query(string) BQQuery
 }
 
-// BQDataset abstracts *bigquery.Dataset (used by Ping).
+// BQDataset abstracts *bigquery.Dataset.
+// Used by Ping, IngestSpans, and ensureSchema.
 type BQDataset interface {
+	Create(ctx context.Context, md *bigquery.DatasetMetadata) error
 	Table(string) BQTable
 }
 
 // BQTable abstracts *bigquery.Table.
-// Ping reads table metadata; IngestSpans uses the inserter.
+// Used by Ping (Metadata), IngestSpans (Inserter), and schema management
+// (Create, Metadata, Update, FullyQualifiedName).
 type BQTable interface {
+	Create(ctx context.Context, md *bigquery.TableMetadata) error
 	Metadata(ctx context.Context) (*bigquery.TableMetadata, error)
+	Update(ctx context.Context, md bigquery.TableMetadataToUpdate, etag string) (*bigquery.TableMetadata, error)
 	Inserter() BQInserter
+	FullyQualifiedName() string
 }
 
 // BQInserter abstracts *bigquery.Inserter for streaming inserts.
@@ -76,16 +81,32 @@ func (w *bqClientWrapper) Query(q string) BQQuery      { return &bqQueryWrapper{
 
 type bqDatasetWrapper struct{ d *bigquery.Dataset }
 
+func (w *bqDatasetWrapper) Create(ctx context.Context, md *bigquery.DatasetMetadata) error {
+	return w.d.Create(ctx, md)
+}
+
 func (w *bqDatasetWrapper) Table(id string) BQTable { return &bqTableWrapper{w.d.Table(id)} }
 
 type bqTableWrapper struct{ t *bigquery.Table }
+
+func (w *bqTableWrapper) Create(ctx context.Context, md *bigquery.TableMetadata) error {
+	return w.t.Create(ctx, md)
+}
 
 func (w *bqTableWrapper) Metadata(ctx context.Context) (*bigquery.TableMetadata, error) {
 	return w.t.Metadata(ctx)
 }
 
+func (w *bqTableWrapper) Update(ctx context.Context, md bigquery.TableMetadataToUpdate, etag string) (*bigquery.TableMetadata, error) {
+	return w.t.Update(ctx, md, etag)
+}
+
 func (w *bqTableWrapper) Inserter() BQInserter {
 	return &bqInserterWrapper{w.t.Inserter()}
+}
+
+func (w *bqTableWrapper) FullyQualifiedName() string {
+	return w.t.FullyQualifiedName()
 }
 
 type bqInserterWrapper struct{ i *bigquery.Inserter }

--- a/pkg/storage/bigquery/bq_mock_test.go
+++ b/pkg/storage/bigquery/bq_mock_test.go
@@ -64,7 +64,17 @@ func (m *mockBQClient) enqueueQuery(q *mockBQQuery) {
 // ── Mock Dataset / Table ─────────────────────────────────────────────
 
 type mockBQDataset struct {
-	tables map[string]*mockBQTable
+	tables       map[string]*mockBQTable
+	createCalled bool
+	createErr    error
+}
+
+func (d *mockBQDataset) Create(_ context.Context, _ *bigquery.DatasetMetadata) error {
+	d.createCalled = true
+	if d.createErr != nil {
+		return d.createErr
+	}
+	return nil
 }
 
 func (d *mockBQDataset) Table(id string) BQTable {
@@ -78,9 +88,23 @@ func (d *mockBQDataset) Table(id string) BQTable {
 
 type mockBQTable struct {
 	id             string
+	createCalled   bool
+	createErr      error
 	metadataCalled bool
 	metadataErr    error
+	metadataResult *bigquery.TableMetadata
+	updateCalled   bool
+	updateErr      error
+	updateSchema   bigquery.Schema // captures the schema passed to Update
 	inserter       *mockBQInserter
+}
+
+func (t *mockBQTable) Create(_ context.Context, _ *bigquery.TableMetadata) error {
+	t.createCalled = true
+	if t.createErr != nil {
+		return t.createErr
+	}
+	return nil
 }
 
 func (t *mockBQTable) Metadata(_ context.Context) (*bigquery.TableMetadata, error) {
@@ -88,7 +112,19 @@ func (t *mockBQTable) Metadata(_ context.Context) (*bigquery.TableMetadata, erro
 	if t.metadataErr != nil {
 		return nil, t.metadataErr
 	}
+	if t.metadataResult != nil {
+		return t.metadataResult, nil
+	}
 	return &bigquery.TableMetadata{}, nil
+}
+
+func (t *mockBQTable) Update(_ context.Context, md bigquery.TableMetadataToUpdate, _ string) (*bigquery.TableMetadata, error) {
+	t.updateCalled = true
+	t.updateSchema = md.Schema
+	if t.updateErr != nil {
+		return nil, t.updateErr
+	}
+	return &bigquery.TableMetadata{Schema: md.Schema}, nil
 }
 
 func (t *mockBQTable) Inserter() BQInserter {
@@ -96,6 +132,10 @@ func (t *mockBQTable) Inserter() BQInserter {
 		return t.inserter
 	}
 	return &mockBQInserter{}
+}
+
+func (t *mockBQTable) FullyQualifiedName() string {
+	return "test-project.test_dataset." + t.id
 }
 
 // ── Mock Inserter ────────────────────────────────────────────────────

--- a/pkg/storage/bigquery/schema_test.go
+++ b/pkg/storage/bigquery/schema_test.go
@@ -3,6 +3,7 @@ package bigquery
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	bq "cloud.google.com/go/bigquery"
@@ -175,6 +176,15 @@ func TestEvolveSchema_AddsNewColumns(t *testing.T) {
 			}
 		}
 	}
+
+	// Input schema must not be mutated (Required fields should stay true).
+	for _, field := range desiredSchema {
+		if field.Name == "name" || field.Name == "kind" {
+			if !field.Required {
+				t.Errorf("input schema field %q was mutated: Required should still be true", field.Name)
+			}
+		}
+	}
 }
 
 func TestEvolveSchema_NoChanges(t *testing.T) {
@@ -202,5 +212,71 @@ func TestEvolveSchema_NoChanges(t *testing.T) {
 
 	if table.updateCalled {
 		t.Error("table.Update should NOT be called when schema matches")
+	}
+}
+
+// ── Error Propagation Tests ──────────────────────────────────────────
+
+func TestEnsureSchema_DatasetCreateError(t *testing.T) {
+	client := newMockBQClient()
+	client.dataset.createErr = fmt.Errorf("permission denied")
+
+	s := schemaStore(client)
+	err := s.ensureSchema(context.Background())
+	if err == nil {
+		t.Fatal("expected error from ensureSchema")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("error = %v, want to contain 'permission denied'", err)
+	}
+}
+
+func TestEnsureSchema_TableCreateError(t *testing.T) {
+	client := newMockBQClient()
+	// Dataset succeeds.
+	table := &mockBQTable{
+		id:        "spans",
+		createErr: fmt.Errorf("quota exceeded"),
+	}
+	client.dataset.tables["spans"] = table
+
+	s := schemaStore(client)
+	err := s.ensureSchema(context.Background())
+	if err == nil {
+		t.Fatal("expected error from ensureSchema")
+	}
+	if !strings.Contains(err.Error(), "quota exceeded") {
+		t.Errorf("error = %v, want to contain 'quota exceeded'", err)
+	}
+}
+
+func TestEvolveSchema_UpdateError(t *testing.T) {
+	client := newMockBQClient()
+
+	existingSchema := bq.Schema{
+		{Name: "span_id", Type: bq.StringFieldType},
+	}
+	desiredSchema := bq.Schema{
+		{Name: "span_id", Type: bq.StringFieldType},
+		{Name: "new_col", Type: bq.StringFieldType},
+	}
+
+	table := &mockBQTable{
+		id: "spans",
+		metadataResult: &bq.TableMetadata{
+			Schema: existingSchema,
+			ETag:   "etag-5",
+		},
+		updateErr: fmt.Errorf("concurrent modification"),
+	}
+	client.dataset.tables["spans"] = table
+
+	s := schemaStore(client)
+	err := s.evolveSchema(context.Background(), table, desiredSchema)
+	if err == nil {
+		t.Fatal("expected error from evolveSchema")
+	}
+	if !strings.Contains(err.Error(), "concurrent modification") {
+		t.Errorf("error = %v, want to contain 'concurrent modification'", err)
 	}
 }

--- a/pkg/storage/bigquery/schema_test.go
+++ b/pkg/storage/bigquery/schema_test.go
@@ -1,0 +1,206 @@
+package bigquery
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	bq "cloud.google.com/go/bigquery"
+)
+
+// schemaStore creates a Store that can call ensureSchema/evolveSchema.
+func schemaStore(client *mockBQClient) *Store {
+	return NewWithClient(client, Config{
+		ProjectID: "test-project",
+		Dataset:   "test_dataset",
+		Table:     "spans",
+		Location:  "US",
+	})
+}
+
+// ── ensureSchema Tests ───────────────────────────────────────────────
+
+func TestEnsureSchema_CreatesDatasetAndTable(t *testing.T) {
+	client := newMockBQClient()
+	table := &mockBQTable{id: "spans"}
+	client.dataset.tables["spans"] = table
+
+	s := schemaStore(client)
+	err := s.ensureSchema(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !client.dataset.createCalled {
+		t.Error("expected dataset.Create to be called")
+	}
+	if !table.createCalled {
+		t.Error("expected table.Create to be called")
+	}
+}
+
+func TestEnsureSchema_DatasetExists_CreatesTable(t *testing.T) {
+	client := newMockBQClient()
+	client.dataset.createErr = fmt.Errorf("googleapi: Error 409: Already Exists: Dataset")
+	table := &mockBQTable{id: "spans"}
+	client.dataset.tables["spans"] = table
+
+	s := schemaStore(client)
+	err := s.ensureSchema(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !client.dataset.createCalled {
+		t.Error("expected dataset.Create to be called")
+	}
+	if !table.createCalled {
+		t.Error("expected table.Create to be called")
+	}
+}
+
+func TestEnsureSchema_TableExists_EvolvesSchema(t *testing.T) {
+	client := newMockBQClient()
+	client.dataset.createErr = fmt.Errorf("googleapi: Error 409: Already Exists: Dataset")
+
+	// Table exists — return "Already Exists" on Create.
+	// evolveSchema will be called; provide metadata with one column fewer
+	// than the inferred schema.
+	existingSchema := bq.Schema{
+		{Name: "span_id", Type: bq.StringFieldType},
+		{Name: "trace_id", Type: bq.StringFieldType},
+	}
+	table := &mockBQTable{
+		id:        "spans",
+		createErr: fmt.Errorf("googleapi: Error 409: Already Exists: Table"),
+		metadataResult: &bq.TableMetadata{
+			Schema: existingSchema,
+			ETag:   "etag-1",
+		},
+	}
+	client.dataset.tables["spans"] = table
+
+	s := schemaStore(client)
+	err := s.ensureSchema(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !table.updateCalled {
+		t.Error("expected table.Update to be called for schema evolution")
+	}
+	// Updated schema should have MORE fields than existing.
+	if len(table.updateSchema) <= len(existingSchema) {
+		t.Errorf("updated schema should have more fields than existing: got %d, existing %d",
+			len(table.updateSchema), len(existingSchema))
+	}
+}
+
+func TestEnsureSchema_TableExists_NoSchemaChange(t *testing.T) {
+	client := newMockBQClient()
+	client.dataset.createErr = fmt.Errorf("googleapi: Error 409: Already Exists: Dataset")
+
+	// Infer the full schema so it matches — no evolution needed.
+	fullSchema, err := bq.InferSchema(spanRow{})
+	if err != nil {
+		t.Fatalf("failed to infer schema: %v", err)
+	}
+
+	table := &mockBQTable{
+		id:        "spans",
+		createErr: fmt.Errorf("googleapi: Error 409: Already Exists: Table"),
+		metadataResult: &bq.TableMetadata{
+			Schema: fullSchema,
+			ETag:   "etag-2",
+		},
+	}
+	client.dataset.tables["spans"] = table
+
+	s := schemaStore(client)
+	err = s.ensureSchema(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if table.updateCalled {
+		t.Error("table.Update should NOT be called when schema is current")
+	}
+}
+
+// ── evolveSchema Tests ───────────────────────────────────────────────
+
+func TestEvolveSchema_AddsNewColumns(t *testing.T) {
+	client := newMockBQClient()
+
+	existingSchema := bq.Schema{
+		{Name: "span_id", Type: bq.StringFieldType},
+		{Name: "trace_id", Type: bq.StringFieldType},
+	}
+	desiredSchema := bq.Schema{
+		{Name: "span_id", Type: bq.StringFieldType},
+		{Name: "trace_id", Type: bq.StringFieldType},
+		{Name: "name", Type: bq.StringFieldType, Required: true},
+		{Name: "kind", Type: bq.StringFieldType, Required: true},
+	}
+
+	table := &mockBQTable{
+		id: "spans",
+		metadataResult: &bq.TableMetadata{
+			Schema: existingSchema,
+			ETag:   "etag-3",
+		},
+	}
+	client.dataset.tables["spans"] = table
+
+	s := schemaStore(client)
+	err := s.evolveSchema(context.Background(), table, desiredSchema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !table.updateCalled {
+		t.Fatal("expected table.Update to be called")
+	}
+
+	// Should have all 4 columns (2 existing + 2 new).
+	if len(table.updateSchema) != 4 {
+		t.Errorf("expected 4 columns in updated schema, got %d", len(table.updateSchema))
+	}
+
+	// New columns should be forced NULLABLE (Required=false).
+	for _, field := range table.updateSchema {
+		if field.Name == "name" || field.Name == "kind" {
+			if field.Required {
+				t.Errorf("new column %q should be NULLABLE (Required=false)", field.Name)
+			}
+		}
+	}
+}
+
+func TestEvolveSchema_NoChanges(t *testing.T) {
+	client := newMockBQClient()
+
+	schema := bq.Schema{
+		{Name: "span_id", Type: bq.StringFieldType},
+		{Name: "trace_id", Type: bq.StringFieldType},
+	}
+
+	table := &mockBQTable{
+		id: "spans",
+		metadataResult: &bq.TableMetadata{
+			Schema: schema,
+			ETag:   "etag-4",
+		},
+	}
+	client.dataset.tables["spans"] = table
+
+	s := schemaStore(client)
+	err := s.evolveSchema(context.Background(), table, schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if table.updateCalled {
+		t.Error("table.Update should NOT be called when schema matches")
+	}
+}


### PR DESCRIPTION
## Summary

Final phase of BigQuery interface extraction. Extends BQClient interfaces to cover `ensureSchema` and `evolveSchema`, **eliminating the `rawClient` field entirely**. All Store operations now go through the `BQClient` interface.

### Interface additions (`bq_client.go`)

| Interface | Method | Used by |
|-----------|--------|---------|
| `BQDataset` | `Create(ctx, *DatasetMetadata) error` | `ensureSchema` |
| `BQTable` | `Create(ctx, *TableMetadata) error` | `ensureSchema` |
| `BQTable` | `Update(ctx, TableMetadataToUpdate, etag)` | `evolveSchema` |
| `BQTable` | `FullyQualifiedName() string` | `evolveSchema` logging |

### Changes to `bigquery.go`

- **`rawClient` field removed** from `Store` struct — single `client BQClient` field handles everything
- `ensureSchema` uses `s.client.Dataset()` instead of `s.rawClient.Dataset()`
- `evolveSchema` takes `BQTable` (interface) instead of `*bigquery.Table`
- `New()` constructor no longer stores `rawClient`
- `NewWithClient()` doc simplified (no more rawClient warning)

### Tests added (`schema_test.go`)

| Test | Verifies |
|------|----------|
| `TestEnsureSchema_CreatesDatasetAndTable` | Happy path: both create calls made |
| `TestEnsureSchema_DatasetExists_CreatesTable` | 409 on dataset → still creates table |
| `TestEnsureSchema_TableExists_EvolvesSchema` | 409 on both → evolveSchema adds missing columns |
| `TestEnsureSchema_TableExists_NoSchemaChange` | 409 on both, schema matches → no Update call |
| `TestEvolveSchema_AddsNewColumns` | New columns detected, added as NULLABLE |
| `TestEvolveSchema_NoChanges` | Schema matches → no Update call |

### Verification

- ✅ `go build ./pkg/storage/bigquery/...`
- ✅ `go test ./pkg/storage/bigquery/... -v -count=1` (41 tests pass)
- ✅ `golangci-lint run ./pkg/storage/bigquery/...` (0 issues)
- ✅ `rawClient` has zero remaining references
- ✅ All pre-commit hooks pass

Completes #510 — all Store operations (read, write, schema) now go through the `BQClient` interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BigQuery schema management reliability: datasets and tables are created when missing and schema updates occur only when evolution is required.
  * Safer schema evolution when adding new columns, including correct NULLABLE handling without altering the original desired definition.

* **Tests**
  * Added comprehensive unit tests covering dataset/table creation, schema evolution, and error propagation.
  * Enhanced BigQuery mocks to verify create, metadata, update, and fully-qualified table naming behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->