### PR TITLE
fix(costcalc): resolve pricing for dated+hyphenated Vertex AI model IDs

### DIFF
--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -687,16 +687,24 @@ func isAllDigits(s string) bool {
 // false positives on model names that contain the tag mid-name (e.g. a
 // hypothetical "text-expander-3b" should NOT match "-exp").
 //
+// Scans right-to-left so that "text-expander-flash-exp" correctly matches the
+// trailing "-exp" rather than the mid-word "-exp" in "expander".
+//
 // Returns the index of the tag in m, or -1 if not found in a valid position.
 func hasSuffixTag(m, tag string) int {
-	idx := strings.Index(m, tag)
-	if idx <= 0 {
-		return -1
-	}
-	rest := m[idx+len(tag):]
-	// Valid positions: tag is at end of string, or followed by "-" (sub-suffix).
-	if rest == "" || rest[0] == '-' {
-		return idx
+	// Scan backwards through all occurrences.
+	for end := len(m); end > 0; {
+		idx := strings.LastIndex(m[:end], tag)
+		if idx <= 0 {
+			return -1
+		}
+		rest := m[idx+len(tag):]
+		// Valid positions: tag is at end of string, or followed by "-" (sub-suffix).
+		if rest == "" || rest[0] == '-' {
+			return idx
+		}
+		// This occurrence is mid-word; keep scanning left.
+		end = idx
 	}
 	return -1
 }

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -527,6 +527,23 @@ func (c *Calculator) GlobalDiscount() float64 {
 	return c.globalDiscount
 }
 
+// lookupCandidate performs the three-tier pricing lookup (overrides → defaults
+// → provider-agnostic fallback) for a single candidate model name. Extracted
+// to avoid repeating this pattern across every resolution step.
+func (c *Calculator) lookupCandidate(provider, candidate string) (ModelPricing, bool) {
+	key := c.key(provider, candidate)
+	if p, ok := c.overrides[key]; ok {
+		return p, true
+	}
+	if p, ok := c.defaults[key]; ok {
+		return p, true
+	}
+	if p, ok := c.fallback[strings.ToLower(candidate)]; ok {
+		return p, true
+	}
+	return ModelPricing{}, false
+}
+
 // resolve looks up pricing: config overrides first, then built-in defaults,
 // then precomputed provider-agnostic fallback, then model ID normalization
 // (hyphen→dot version suffix), then prefix-based fuzzy match.
@@ -538,20 +555,8 @@ func (c *Calculator) resolve(provider, model string) (ModelPricing, bool) {
 		provider = canonical
 	}
 
-	key := c.key(provider, model)
-
-	// 1. Config override (exact match)
-	if p, ok := c.overrides[key]; ok {
-		return p, true
-	}
-
-	// 2. Built-in default (exact match)
-	if p, ok := c.defaults[key]; ok {
-		return p, true
-	}
-
-	// 3. Precomputed provider-agnostic fallback (deterministic)
-	if p, ok := c.fallback[strings.ToLower(model)]; ok {
+	// 1-3. Exact match: config override → built-in default → fallback.
+	if p, ok := c.lookupCandidate(provider, model); ok {
 		return p, true
 	}
 
@@ -560,14 +565,7 @@ func (c *Calculator) resolve(provider, model string) (ModelPricing, bool) {
 	// to our canonical dotted entries (claude-opus-4.7) without duplicating
 	// every pricing entry.
 	if normalized := normalizeModelID(model); normalized != model {
-		normKey := c.key(provider, normalized)
-		if p, ok := c.overrides[normKey]; ok {
-			return p, true
-		}
-		if p, ok := c.defaults[normKey]; ok {
-			return p, true
-		}
-		if p, ok := c.fallback[strings.ToLower(normalized)]; ok {
+		if p, ok := c.lookupCandidate(provider, normalized); ok {
 			return p, true
 		}
 	}
@@ -576,14 +574,7 @@ func (c *Calculator) resolve(provider, model string) (ModelPricing, bool) {
 	// Handles: date suffixes (gpt-4.1-2025-04-14), preview tags
 	// (gemini-2.5-pro-preview-05-06), and OpenAI fine-tunes (ft:gpt-4.1:org:name:id).
 	if base := extractBaseModel(model); base != "" && base != strings.ToLower(model) {
-		baseKey := c.key(provider, base)
-		if p, ok := c.overrides[baseKey]; ok {
-			return p, true
-		}
-		if p, ok := c.defaults[baseKey]; ok {
-			return p, true
-		}
-		if p, ok := c.fallback[base]; ok {
+		if p, ok := c.lookupCandidate(provider, base); ok {
 			return p, true
 		}
 
@@ -592,14 +583,7 @@ func (c *Calculator) resolve(provider, model string) (ModelPricing, bool) {
 		//   "claude-haiku-4-5-20251001" → strip date → "claude-haiku-4-5"
 		//   → normalize → "claude-haiku-4.5" → matches pricing.yaml.
 		if normBase := normalizeModelID(base); normBase != base {
-			normKey := c.key(provider, normBase)
-			if p, ok := c.overrides[normKey]; ok {
-				return p, true
-			}
-			if p, ok := c.defaults[normKey]; ok {
-				return p, true
-			}
-			if p, ok := c.fallback[strings.ToLower(normBase)]; ok {
+			if p, ok := c.lookupCandidate(provider, normBase); ok {
 				return p, true
 			}
 		}
@@ -648,13 +632,16 @@ func extractBaseModel(model string) string {
 		}
 	}
 
-	// Strip -preview* suffix (e.g. "-preview-05-06", "-preview")
-	if idx := strings.Index(m, "-preview"); idx > 0 {
+	// Strip -preview* suffix (e.g. "-preview-05-06", "-preview").
+	// Use hasSuffixTag to avoid false positives on model names that
+	// contain "-preview" mid-name (e.g. a hypothetical "preview-model").
+	if idx := hasSuffixTag(m, "-preview"); idx > 0 {
 		return m[:idx]
 	}
 
-	// Strip -exp* suffix (e.g. "-exp-0827")
-	if idx := strings.Index(m, "-exp"); idx > 0 {
+	// Strip -exp* suffix (e.g. "-exp-0827", "-exp").
+	// Same word-boundary guard as -preview above.
+	if idx := hasSuffixTag(m, "-exp"); idx > 0 {
 		return m[:idx]
 	}
 
@@ -692,6 +679,26 @@ func isAllDigits(s string) bool {
 		}
 	}
 	return true
+}
+
+// hasSuffixTag finds a tag like "-preview" or "-exp" in model name m and returns
+// the index of the tag, but only if the tag appears as a word-boundary suffix
+// (i.e. it's at the end of the string or followed by a hyphen). This prevents
+// false positives on model names that contain the tag mid-name (e.g. a
+// hypothetical "text-expander-3b" should NOT match "-exp").
+//
+// Returns the index of the tag in m, or -1 if not found in a valid position.
+func hasSuffixTag(m, tag string) int {
+	idx := strings.Index(m, tag)
+	if idx <= 0 {
+		return -1
+	}
+	rest := m[idx+len(tag):]
+	// Valid positions: tag is at end of string, or followed by "-" (sub-suffix).
+	if rest == "" || rest[0] == '-' {
+		return idx
+	}
+	return -1
 }
 
 // normalizeModelID converts trailing hyphen-digit version suffixes to dot-digit.

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -586,6 +586,23 @@ func (c *Calculator) resolve(provider, model string) (ModelPricing, bool) {
 		if p, ok := c.fallback[base]; ok {
 			return p, true
 		}
+
+		// 5b. Normalize the extracted base (hyphen→dot) for Vertex AI
+		// dated IDs. Example chain:
+		//   "claude-haiku-4-5-20251001" → strip date → "claude-haiku-4-5"
+		//   → normalize → "claude-haiku-4.5" → matches pricing.yaml.
+		if normBase := normalizeModelID(base); normBase != base {
+			normKey := c.key(provider, normBase)
+			if p, ok := c.overrides[normKey]; ok {
+				return p, true
+			}
+			if p, ok := c.defaults[normKey]; ok {
+				return p, true
+			}
+			if p, ok := c.fallback[strings.ToLower(normBase)]; ok {
+				return p, true
+			}
+		}
 	}
 
 	return ModelPricing{}, false

--- a/pkg/costcalc/calculator_test.go
+++ b/pkg/costcalc/calculator_test.go
@@ -746,3 +746,33 @@ func TestNormalizeModelID(t *testing.T) {
 		}
 	}
 }
+
+// TestDatedHyphenatedModelPricing verifies that Vertex AI model IDs with
+// both a date suffix and a hyphenated version (e.g. "claude-haiku-4-5-20251001")
+// correctly resolve pricing. This requires extractBaseModel (strip date) followed
+// by normalizeModelID (hyphen→dot) — the step 5b chain.
+func TestDatedHyphenatedModelPricing(t *testing.T) {
+	c := New()
+	models := []struct {
+		model      string
+		wantPriced bool
+	}{
+		{"claude-haiku-4-5-20251001", true},
+		{"claude-opus-4-7-20260301", true},
+		{"claude-sonnet-4-6-20250514", true},
+		{"claude-opus-4-8-20260601", true},
+	}
+	for _, tt := range models {
+		t.Run(tt.model, func(t *testing.T) {
+			if got := c.HasPricing("anthropic", tt.model); got != tt.wantPriced {
+				t.Errorf("HasPricing(anthropic, %q) = %v, want %v", tt.model, got, tt.wantPriced)
+			}
+			if tt.wantPriced {
+				cost := c.Calculate("anthropic", tt.model, 1_000_000, 0)
+				if cost == 0 {
+					t.Errorf("Calculate(anthropic, %q, 1M, 0) = $0.00 — pricing not applied", tt.model)
+				}
+			}
+		})
+	}
+}

--- a/pkg/costcalc/openai_test.go
+++ b/pkg/costcalc/openai_test.go
@@ -124,6 +124,12 @@ func TestExtractBaseModel(t *testing.T) {
 		{"exact model no suffix 2", "claude-sonnet-4", ""},
 		{"exact model no suffix 3", "gemini-2.5-pro", ""},
 		{"empty string", "", ""},
+
+		// False-positive guards: -exp and -preview mid-name must NOT match.
+		{"exp mid-name no strip", "text-expander-3b", ""},
+		{"exp mid-name no strip 2", "expert-model-v2", ""},
+		{"preview mid-name no strip", "model-previewer-v1", ""},
+		{"preview mid-name partial", "deepseek-previewable", ""},
 	}
 
 	for _, tt := range tests {
@@ -131,6 +137,42 @@ func TestExtractBaseModel(t *testing.T) {
 			got := extractBaseModel(tt.input)
 			if got != tt.want {
 				t.Errorf("extractBaseModel(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ── hasSuffixTag ─────────────────────────────────────────────────────────────
+
+func TestHasSuffixTag(t *testing.T) {
+	tests := []struct {
+		name string
+		m    string
+		tag  string
+		want int
+	}{
+		// Valid suffix positions.
+		{"exp at end", "gemini-2.0-flash-exp", "-exp", 16},
+		{"exp before sub-suffix", "gemini-2.0-flash-exp-0827", "-exp", 16},
+		{"preview at end", "gemini-2.5-pro-preview", "-preview", 14},
+		{"preview before sub-suffix", "gemini-2.5-pro-preview-05-06", "-preview", 14},
+
+		// Invalid: tag appears mid-word (not at boundary).
+		{"exp mid-word expander", "text-expander-3b", "-exp", -1},
+		{"exp mid-word expert", "expert-model-v2", "-exp", -1},
+		{"preview mid-word previewer", "model-previewer-v1", "-preview", -1},
+		{"preview mid-word previewable", "deepseek-previewable", "-preview", -1},
+
+		// Tag not present at all.
+		{"no tag", "gpt-4.1", "-exp", -1},
+		// Tag at very start (idx==0) should return -1.
+		{"tag at start", "-exp-model", "-exp", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasSuffixTag(tt.m, tt.tag)
+			if got != tt.want {
+				t.Errorf("hasSuffixTag(%q, %q) = %d, want %d", tt.m, tt.tag, got, tt.want)
 			}
 		})
 	}

--- a/pkg/costcalc/openai_test.go
+++ b/pkg/costcalc/openai_test.go
@@ -130,6 +130,10 @@ func TestExtractBaseModel(t *testing.T) {
 		{"exp mid-name no strip 2", "expert-model-v2", ""},
 		{"preview mid-name no strip", "model-previewer-v1", ""},
 		{"preview mid-name partial", "deepseek-previewable", ""},
+
+		// Mid-word tag + valid suffix — must strip at the valid suffix.
+		{"exp mid-word then suffix", "text-expander-flash-exp", "text-expander-flash"},
+		{"preview mid-word then suffix", "model-previewer-v1-preview-05-06", "model-previewer-v1"},
 	}
 
 	for _, tt := range tests {
@@ -167,6 +171,12 @@ func TestHasSuffixTag(t *testing.T) {
 		{"no tag", "gpt-4.1", "-exp", -1},
 		// Tag at very start (idx==0) should return -1.
 		{"tag at start", "-exp-model", "-exp", -1},
+
+		// Tag appears mid-word AND as a valid suffix — must match the suffix.
+		{"exp mid-word then valid suffix", "text-expander-flash-exp", "-exp", 19},
+		{"exp mid-word then valid sub-suffix", "text-expander-flash-exp-0827", "-exp", 19},
+		{"preview mid-word then valid suffix", "model-previewer-v1-preview", "-preview", 18},
+		{"preview mid-word then valid sub-suffix", "model-previewer-v1-preview-05-06", "-preview", 18},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes 402 `no pricing configured for model claude-haiku-4-5-20251001`.

## Root Cause

The `resolve()` chain in `calculator.go` strips date suffixes (step 5 via `extractBaseModel`) but never re-ran `normalizeModelID` on the result. So `claude-haiku-4-5` was never converted to the dotted form `claude-haiku-4.5` that `pricing.yaml` uses.

**Resolution chain that was broken:**
```
claude-haiku-4-5-20251001
  → extractBaseModel strips date → claude-haiku-4-5
  → (missing) normalizeModelID    → claude-haiku-4.5  ← pricing.yaml entry
```

## Fix

Add step 5b: after `extractBaseModel` strips the date suffix, also try `normalizeModelID` (hyphen→dot) before giving up. Handles all current and future dated Vertex AI Anthropic model IDs.

## Why OpenCode works

OpenCode sends short-form IDs (`claude-haiku-4.5` or `claude-haiku-4-5`) which resolve fine via existing step 4. The bug only hits when the client sends the full Vertex AI dated form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pricing resolution for dated, hyphenated model IDs, including more reliable matching across fuzzy candidates and normalized model IDs.
  * Prevented incorrect stripping of `-preview`/`-exp`-like parts when they appear mid-name, reducing cases where pricing wasn’t found.
* **Tests**
  * Added regression coverage for Vertex-style dated hyphenated models to ensure pricing resolves and costs compute correctly.
  * Expanded coverage for base-model extraction and suffix-tag detection to eliminate false positives and confirm valid stripping at proper boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->