### PR TITLE
refactor: move Anthropic caching config to vertex_ai.anthropic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to Candela are documented here, organized by development phase. PRs are merged to `main`.
 
+## v0.10.1 — 2026-07-07
+
+### Breaking Change — Anthropic Caching Config Restructured
+
+- **`vertex_ai.anthropic` block**: `caching_mode`, `cache_ttl`, and `prompt_caching` moved from flat `vertex_ai.*` fields into `vertex_ai.anthropic.*`. The `prompt_caching` bool shorthand is removed.
+
+  **Before:**
+  ```yaml
+  vertex_ai:
+    caching_mode: auto
+    cache_ttl: 5m
+    prompt_caching: true
+  ```
+
+  **After:**
+  ```yaml
+  vertex_ai:
+    anthropic:
+      caching_mode: auto    # auto | system-only | off
+      cache_ttl: 1h         # 5m | 1h
+  ```
+
+  > ⚠️ Old flat fields are silently ignored. If you had `caching_mode: off`, caching will revert to the default (`auto`). Update your config to preserve your setting.
+
+- **Team Mode per-developer caching**: Local `vertex_ai.anthropic.caching_mode` and `vertex_ai.anthropic.cache_ttl` are now piped through to the remote server via `X-Candela-Caching` / `X-Candela-Cache-TTL` headers. Developers can now control their own Anthropic caching preferences in Team Mode without affecting other users.
+
 ## v0.10.0 — 2026-07-05
 
 ### Feature — Tag-Based Model Access Control

--- a/README.md
+++ b/README.md
@@ -394,8 +394,9 @@ proxy:
   vertex_ai:
     project_id: "my-gcp-project"
     region: "us-east5"
-    caching_mode: "auto"      # off | auto | system-only
-    cache_ttl: 5m             # 5m (default) or 1h
+    anthropic:
+      caching_mode: "auto"    # off | auto | system-only
+      cache_ttl: 5m           # 5m (default) or 1h
   # policy:
   #   allowed_models:
   #     - provider: openai
@@ -533,9 +534,9 @@ providers:
 
 vertex_ai:
   project: my-gcp-project
-  prompt_caching: true    # Inject cache_control for Anthropic (~10x cost reduction)
-  cache_ttl: 5m           # 5m (default, 1.25x write cost) or 1h (2x write, ideal for long coding sessions)
-  caching_mode: auto      # off | auto | system-only
+  anthropic:
+    caching_mode: auto    # off | auto | system-only — injects cache_control (~10x cost reduction)
+    cache_ttl: 5m         # 5m (default, 1.25x write cost) or 1h (2x write, ideal for long coding sessions)
 ```
 
 - Local + cloud models merged into `/v1/models`

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -96,6 +96,10 @@ type Config struct {
 				CachingMode string `yaml:"caching_mode"` // off|auto|system-only (default: auto)
 				CacheTTL    string `yaml:"cache_ttl"`    // 5m|1h (default: 5m)
 			} `yaml:"anthropic"`
+			// Deprecated fields — kept for detection only, not wired to logic.
+			DeprecatedCachingMode   string `yaml:"caching_mode"`   // moved to anthropic.caching_mode
+			DeprecatedCacheTTL      string `yaml:"cache_ttl"`      // moved to anthropic.cache_ttl
+			DeprecatedPromptCaching *bool  `yaml:"prompt_caching"` // removed
 			// ProviderOverrides allows per-provider region and endpoint overrides.
 			// MaaS models (Mistral, DeepSeek, Qwen) have limited regional availability;
 			// this lets each provider target the correct region independently.
@@ -218,6 +222,18 @@ func main() {
 	if err != nil {
 		slog.Error("failed to load config", "error", err)
 		os.Exit(1)
+	}
+	// Check for deprecated config fields and warn the operator.
+	if v := cfg.Proxy.VertexAI; v.DeprecatedCachingMode != "" || v.DeprecatedCacheTTL != "" || v.DeprecatedPromptCaching != nil {
+		if v.DeprecatedCachingMode != "" {
+			slog.Warn("⚠️  DEPRECATED CONFIG: proxy.vertex_ai.caching_mode has moved to proxy.vertex_ai.anthropic.caching_mode — update your config")
+		}
+		if v.DeprecatedCacheTTL != "" {
+			slog.Warn("⚠️  DEPRECATED CONFIG: proxy.vertex_ai.cache_ttl has moved to proxy.vertex_ai.anthropic.cache_ttl — update your config")
+		}
+		if v.DeprecatedPromptCaching != nil {
+			slog.Warn("⚠️  DEPRECATED CONFIG: proxy.vertex_ai.prompt_caching has been removed — use proxy.vertex_ai.anthropic.caching_mode instead")
+		}
 	}
 
 	// Initialize storage backend.

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -97,6 +97,8 @@ type Config struct {
 				CacheTTL    string `yaml:"cache_ttl"`    // 5m|1h (default: 5m)
 			} `yaml:"anthropic"`
 			// Deprecated fields — kept for detection only, not wired to logic.
+			// WARNING: Same YAML key names as Anthropic sub-struct fields.
+			// Safe because Anthropic is behind yaml:"anthropic". Do NOT inline it.
 			DeprecatedCachingMode   string `yaml:"caching_mode"`   // moved to anthropic.caching_mode
 			DeprecatedCacheTTL      string `yaml:"cache_ttl"`      // moved to anthropic.cache_ttl
 			DeprecatedPromptCaching *bool  `yaml:"prompt_caching"` // removed

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -90,11 +90,12 @@ type Config struct {
 		DailyLimits    []proxy.SpendLimitConfig `yaml:"daily_limits"`         // Per-model daily spend limits
 		Policy         *proxy.PolicyConfig      `yaml:"policy"`               // Model allowlist policy (#207)
 		VertexAI       struct {
-			ProjectID     string `yaml:"project_id"`     // GCP project for Vertex AI
-			Region        string `yaml:"region"`         // default region (e.g. "us-central1")
-			CachingMode   string `yaml:"caching_mode"`   // off|auto|system-only (default: auto)
-			PromptCaching bool   `yaml:"prompt_caching"` // enable prompt caching (maps to CachingMode: auto)
-			CacheTTL      string `yaml:"cache_ttl"`      // Vertex AI cache TTL ("5m" or "1h")
+			ProjectID string `yaml:"project_id"` // GCP project for Vertex AI
+			Region    string `yaml:"region"`     // default region (e.g. "us-central1")
+			Anthropic struct {
+				CachingMode string `yaml:"caching_mode"` // off|auto|system-only (default: auto)
+				CacheTTL    string `yaml:"cache_ttl"`    // 5m|1h (default: 5m)
+			} `yaml:"anthropic"`
 			// ProviderOverrides allows per-provider region and endpoint overrides.
 			// MaaS models (Mistral, DeepSeek, Qwen) have limited regional availability;
 			// this lets each provider target the correct region independently.
@@ -567,15 +568,11 @@ func main() {
 					// anthropic-vertex is a native Messages API passthrough (for Claude Code).
 					if p.Name == "anthropic" {
 						ft := &proxy.AnthropicFormatTranslator{}
-						if cfg.Proxy.VertexAI.CachingMode != "" {
-							ft.SetCachingMode(proxy.ParseCachingMode(cfg.Proxy.VertexAI.CachingMode))
+						if cfg.Proxy.VertexAI.Anthropic.CachingMode != "" {
+							ft.SetCachingMode(proxy.ParseCachingMode(cfg.Proxy.VertexAI.Anthropic.CachingMode))
 						}
-						// prompt_caching: true is a shorthand for caching_mode: auto
-						if cfg.Proxy.VertexAI.CachingMode == "" && cfg.Proxy.VertexAI.PromptCaching {
-							ft.SetCachingMode(proxy.CachingAuto)
-						}
-						if cfg.Proxy.VertexAI.CacheTTL != "" {
-							ft.SetCacheTTL(proxy.ParseCacheTTL(cfg.Proxy.VertexAI.CacheTTL))
+						if cfg.Proxy.VertexAI.Anthropic.CacheTTL != "" {
+							ft.SetCacheTTL(proxy.ParseCacheTTL(cfg.Proxy.VertexAI.Anthropic.CacheTTL))
 						}
 						allProviders[i].FormatTranslator = ft
 					}
@@ -585,7 +582,7 @@ func main() {
 						"region", region,
 						"adc", tokenSource != nil,
 						"format_translation", p.Name == "anthropic",
-						"caching_mode", cfg.Proxy.VertexAI.CachingMode)
+						"caching_mode", cfg.Proxy.VertexAI.Anthropic.CachingMode)
 				}
 			}
 		}

--- a/cmd/candela/config_api_test.go
+++ b/cmd/candela/config_api_test.go
@@ -170,3 +170,82 @@ func TestConfigAPI_SetCaching_EmptyBody(t *testing.T) {
 		t.Fatalf("status = %d, want 503", w.Code)
 	}
 }
+
+func TestConfigAPI_GetConfig_WarningsPresent(t *testing.T) {
+	warnings := []string{
+		"vertex_ai.caching_mode has moved to vertex_ai.anthropic.caching_mode — update your config",
+		"vertex_ai.cache_ttl has moved to vertex_ai.anthropic.cache_ttl — update your config",
+	}
+	api := &localAPI{cloudProxy: nil, configWarnings: warnings}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /_local/api/config", api.handleGetConfig)
+
+	req := httptest.NewRequest(http.MethodGet, "/_local/api/config", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp cachingConfigResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(resp.Warnings) != 2 {
+		t.Fatalf("got %d warnings, want 2", len(resp.Warnings))
+	}
+	if resp.Warnings[0] != warnings[0] {
+		t.Errorf("warnings[0] = %q, want %q", resp.Warnings[0], warnings[0])
+	}
+	if resp.Warnings[1] != warnings[1] {
+		t.Errorf("warnings[1] = %q, want %q", resp.Warnings[1], warnings[1])
+	}
+}
+
+func TestConfigAPI_GetConfig_NoWarnings_OmitsField(t *testing.T) {
+	api := &localAPI{cloudProxy: nil}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /_local/api/config", api.handleGetConfig)
+
+	req := httptest.NewRequest(http.MethodGet, "/_local/api/config", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	// When no warnings, the "warnings" key should be omitted (omitempty).
+	body := w.Body.String()
+	if strings.Contains(body, `"warnings"`) {
+		t.Error("response should not contain 'warnings' key when no warnings are set")
+	}
+}
+
+func TestConfigAPI_SetCaching_ResponseIncludesWarnings(t *testing.T) {
+	warnings := []string{"vertex_ai.prompt_caching has been removed — use vertex_ai.anthropic.caching_mode instead"}
+	ft := &proxy.AnthropicFormatTranslator{}
+	p := proxy.NewProxyForTest(map[string]proxy.Provider{
+		"anthropic": {Name: "anthropic", FormatTranslator: ft},
+	})
+	api := &localAPI{cloudProxy: p, configWarnings: warnings}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /_local/api/config/caching", api.handleSetCaching)
+
+	req := httptest.NewRequest(http.MethodPost, "/_local/api/config/caching", strings.NewReader(`{"anthropic": "auto"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp cachingConfigResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(resp.Warnings) != 1 {
+		t.Fatalf("got %d warnings, want 1", len(resp.Warnings))
+	}
+	if resp.Warnings[0] != warnings[0] {
+		t.Errorf("warnings[0] = %q, want %q", resp.Warnings[0], warnings[0])
+	}
+}

--- a/cmd/candela/config_warnings_test.go
+++ b/cmd/candela/config_warnings_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfigWarnings_DeprecatedFields(t *testing.T) {
+	tests := []struct {
+		name         string
+		yaml         string
+		wantWarnings int
+		wantModes    []string // expected warning substrings
+	}{
+		{
+			name: "no deprecated fields — no warnings",
+			yaml: `
+vertex_ai:
+  project: test
+  anthropic:
+    caching_mode: auto
+    cache_ttl: 1h
+`,
+			wantWarnings: 0,
+		},
+		{
+			name: "deprecated caching_mode only",
+			yaml: `
+vertex_ai:
+  project: test
+  caching_mode: auto
+`,
+			wantWarnings: 1,
+			wantModes:    []string{"caching_mode has moved"},
+		},
+		{
+			name: "deprecated cache_ttl only",
+			yaml: `
+vertex_ai:
+  project: test
+  cache_ttl: 1h
+`,
+			wantWarnings: 1,
+			wantModes:    []string{"cache_ttl has moved"},
+		},
+		{
+			name: "deprecated prompt_caching bool",
+			yaml: `
+vertex_ai:
+  project: test
+  prompt_caching: true
+`,
+			wantWarnings: 1,
+			wantModes:    []string{"prompt_caching has been removed"},
+		},
+		{
+			name: "all three deprecated fields",
+			yaml: `
+vertex_ai:
+  project: test
+  caching_mode: off
+  cache_ttl: 5m
+  prompt_caching: false
+`,
+			wantWarnings: 3,
+		},
+		{
+			name: "new + deprecated coexist — both parsed independently",
+			yaml: `
+vertex_ai:
+  project: test
+  caching_mode: off
+  anthropic:
+    caching_mode: auto
+    cache_ttl: 1h
+`,
+			wantWarnings: 1,
+			wantModes:    []string{"caching_mode has moved"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg Config
+			if err := yaml.Unmarshal([]byte(tt.yaml), &cfg); err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+
+			warnings := configWarnings(cfg)
+			if len(warnings) != tt.wantWarnings {
+				t.Errorf("got %d warnings, want %d: %v", len(warnings), tt.wantWarnings, warnings)
+			}
+
+			for _, substr := range tt.wantModes {
+				found := false
+				for _, w := range warnings {
+					if contains(w, substr) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected warning containing %q, got %v", substr, warnings)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigWarnings_NewFieldsNotAffected(t *testing.T) {
+	// Verify that using the new structure populates Anthropic fields
+	// and does NOT trigger deprecated field warnings.
+	yamlInput := `
+vertex_ai:
+  project: test
+  anthropic:
+    caching_mode: system-only
+    cache_ttl: 1h
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlInput), &cfg); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if cfg.VertexAI.Anthropic.CachingMode != "system-only" {
+		t.Errorf("Anthropic.CachingMode = %q, want %q", cfg.VertexAI.Anthropic.CachingMode, "system-only")
+	}
+	if cfg.VertexAI.Anthropic.CacheTTL != "1h" {
+		t.Errorf("Anthropic.CacheTTL = %q, want %q", cfg.VertexAI.Anthropic.CacheTTL, "1h")
+	}
+
+	warnings := configWarnings(cfg)
+	if len(warnings) != 0 {
+		t.Errorf("expected 0 warnings for new config, got %d: %v", len(warnings), warnings)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/candela/config_warnings_test.go
+++ b/cmd/candela/config_warnings_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -95,7 +96,7 @@ vertex_ai:
 			for _, substr := range tt.wantModes {
 				found := false
 				for _, w := range warnings {
-					if contains(w, substr) {
+					if strings.Contains(w, substr) {
 						found = true
 						break
 					}
@@ -134,17 +135,4 @@ vertex_ai:
 	if len(warnings) != 0 {
 		t.Errorf("expected 0 warnings for new config, got %d: %v", len(warnings), warnings)
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
-}
-
-func containsStr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/candela/local_api.go
+++ b/cmd/candela/local_api.go
@@ -234,7 +234,8 @@ func (a *localAPI) handleSetCaching(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, cachingConfigResponse{
-		Caching: a.buildCachingConfig(),
+		Caching:  a.buildCachingConfig(),
+		Warnings: a.configWarnings,
 	})
 }
 

--- a/cmd/candela/local_api.go
+++ b/cmd/candela/local_api.go
@@ -24,9 +24,10 @@ import (
 //	GET  /_local/api/config          — current runtime configuration
 //	POST /_local/api/config/caching  — set caching mode at runtime (provider-agnostic)
 type localAPI struct {
-	mgr        *runtime.Manager
-	cloudProxy *proxy.Proxy
-	calc       *costcalc.Calculator // optional: for Gemini cache discount overrides
+	mgr            *runtime.Manager
+	cloudProxy     *proxy.Proxy
+	calc           *costcalc.Calculator // optional: for Gemini cache discount overrides
+	configWarnings []string             // deprecated config field warnings (surfaced in Desktop)
 }
 
 // registerLocalAPI mounts the /_local/* routes on the mux.
@@ -123,7 +124,8 @@ func (a *localAPI) handleBackends(w http.ResponseWriter, _ *http.Request) {
 // cachingConfigResponse is the canonical config response for GET and POST.
 // Having a shared type ensures the response shape is identical.
 type cachingConfigResponse struct {
-	Caching cachingProviders `json:"caching"`
+	Caching  cachingProviders `json:"caching"`
+	Warnings []string         `json:"warnings,omitempty"` // deprecated config field warnings
 }
 
 type cachingProviders struct {
@@ -171,7 +173,8 @@ func (a *localAPI) buildCachingConfig() cachingProviders {
 // GET /_local/api/config — returns current runtime configuration state.
 func (a *localAPI) handleGetConfig(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, cachingConfigResponse{
-		Caching: a.buildCachingConfig(),
+		Caching:  a.buildCachingConfig(),
+		Warnings: a.configWarnings,
 	})
 }
 

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -843,11 +843,11 @@ func runForeground() {
 				// before forwarding to upstream LLM providers.
 				// Only inject if the request doesn't already carry them
 				// (allowing per-request SDK overrides to take precedence).
-				if cfg.VertexAI.Anthropic.CacheTTL != "" && req.Header.Get("X-Candela-Cache-TTL") == "" {
-					req.Header.Set("X-Candela-Cache-TTL", cfg.VertexAI.Anthropic.CacheTTL)
+				if cfg.VertexAI.Anthropic.CacheTTL != "" && req.Header.Get(proxy.CacheTTLHeader) == "" {
+					req.Header.Set(proxy.CacheTTLHeader, cfg.VertexAI.Anthropic.CacheTTL)
 				}
-				if cfg.VertexAI.Anthropic.CachingMode != "" && req.Header.Get("X-Candela-Caching") == "" {
-					req.Header.Set("X-Candela-Caching", cfg.VertexAI.Anthropic.CachingMode)
+				if cfg.VertexAI.Anthropic.CachingMode != "" && req.Header.Get(proxy.CachingHeader) == "" {
+					req.Header.Set(proxy.CachingHeader, cfg.VertexAI.Anthropic.CachingMode)
 				}
 			},
 			ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -96,10 +96,12 @@ type LocalProvider struct {
 
 // VertexAIConfig holds GCP Vertex AI settings for direct cloud providers.
 type VertexAIConfig struct {
-	Project     string `yaml:"project"`      // GCP project ID (required)
-	Region      string `yaml:"region"`       // GCP region (default: us-central1)
-	CachingMode string `yaml:"caching_mode"` // off|auto|system-only (default: auto)
-	CacheTTL    string `yaml:"cache_ttl"`    // 5m|1h (default: 5m)
+	Project   string `yaml:"project"` // GCP project ID (required)
+	Region    string `yaml:"region"`  // GCP region (default: us-central1)
+	Anthropic struct {
+		CachingMode string `yaml:"caching_mode"` // off|auto|system-only (default: auto)
+		CacheTTL    string `yaml:"cache_ttl"`    // 5m|1h (default: 5m)
+	} `yaml:"anthropic"`
 }
 
 // AWSConfig holds AWS settings for Bedrock cloud providers.
@@ -805,6 +807,18 @@ func runForeground() {
 				req.Header.Del("Upgrade")
 				req.Header.Del("Connection")
 				req.Header.Del("HTTP2-Settings")
+
+				// Inject developer's Anthropic cache preferences for Team Mode.
+				// These headers are read by the server's proxy and stripped
+				// before forwarding to upstream LLM providers.
+				// Only inject if the request doesn't already carry them
+				// (allowing per-request SDK overrides to take precedence).
+				if cfg.VertexAI.Anthropic.CacheTTL != "" && req.Header.Get("X-Candela-Cache-TTL") == "" {
+					req.Header.Set("X-Candela-Cache-TTL", cfg.VertexAI.Anthropic.CacheTTL)
+				}
+				if cfg.VertexAI.Anthropic.CachingMode != "" && req.Header.Get("X-Candela-Caching") == "" {
+					req.Header.Set("X-Candela-Caching", cfg.VertexAI.Anthropic.CachingMode)
+				}
 			},
 			ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 				slog.Error("proxy error", "path", r.URL.Path, "error", err)
@@ -1346,11 +1360,11 @@ func buildCloudProxy(cfg Config, submitter *processor.SpanProcessor) (*proxy.Pro
 			p.UpstreamURL = proxy.VertexAIUpstreamURL(region)
 			p.TokenSource = tokenSource
 			ft := &proxy.AnthropicFormatTranslator{}
-			if cfg.VertexAI.CachingMode != "" {
-				ft.SetCachingMode(proxy.ParseCachingMode(cfg.VertexAI.CachingMode))
+			if cfg.VertexAI.Anthropic.CachingMode != "" {
+				ft.SetCachingMode(proxy.ParseCachingMode(cfg.VertexAI.Anthropic.CachingMode))
 			}
-			if cfg.VertexAI.CacheTTL != "" {
-				ft.SetCacheTTL(proxy.ParseCacheTTL(cfg.VertexAI.CacheTTL))
+			if cfg.VertexAI.Anthropic.CacheTTL != "" {
+				ft.SetCacheTTL(proxy.ParseCacheTTL(cfg.VertexAI.Anthropic.CacheTTL))
 			}
 			p.FormatTranslator = ft
 			p.PathRewriter = &proxy.VertexAIPathRewriter{

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -105,6 +105,12 @@ type VertexAIConfig struct {
 
 	// Deprecated fields — kept for detection only. Values are NOT wired
 	// to any logic. When populated, configWarnings() returns migration hints.
+	//
+	// WARNING: These fields share YAML key names ("caching_mode", "cache_ttl")
+	// with fields inside the Anthropic sub-struct. This works because Anthropic
+	// is namespaced behind `yaml:"anthropic"`, so they resolve at different YAML
+	// nesting levels. Do NOT use yaml:",inline" on Anthropic — it would create
+	// ambiguous duplicate keys at the same level.
 	DeprecatedCachingMode   string `yaml:"caching_mode"`   // moved to anthropic.caching_mode
 	DeprecatedCacheTTL      string `yaml:"cache_ttl"`      // moved to anthropic.cache_ttl
 	DeprecatedPromptCaching *bool  `yaml:"prompt_caching"` // removed — use anthropic.caching_mode
@@ -125,6 +131,19 @@ func configWarnings(cfg Config) []string {
 		warnings = append(warnings, "vertex_ai.prompt_caching has been removed — use vertex_ai.anthropic.caching_mode instead")
 	}
 	return warnings
+}
+
+// injectCacheHeaders sets Team Mode caching headers on the outbound request.
+// Only injects if the request doesn't already carry the header (allowing
+// per-request SDK overrides to take precedence). Called from the remoteProxy
+// Director closure.
+func injectCacheHeaders(req *http.Request, cfg VertexAIConfig) {
+	if cfg.Anthropic.CacheTTL != "" && req.Header.Get(proxy.CacheTTLHeader) == "" {
+		req.Header.Set(proxy.CacheTTLHeader, cfg.Anthropic.CacheTTL)
+	}
+	if cfg.Anthropic.CachingMode != "" && req.Header.Get(proxy.CachingHeader) == "" {
+		req.Header.Set(proxy.CachingHeader, cfg.Anthropic.CachingMode)
+	}
 }
 
 // AWSConfig holds AWS settings for Bedrock cloud providers.
@@ -841,14 +860,7 @@ func runForeground() {
 				// Inject developer's Anthropic cache preferences for Team Mode.
 				// These headers are read by the server's proxy and stripped
 				// before forwarding to upstream LLM providers.
-				// Only inject if the request doesn't already carry them
-				// (allowing per-request SDK overrides to take precedence).
-				if cfg.VertexAI.Anthropic.CacheTTL != "" && req.Header.Get(proxy.CacheTTLHeader) == "" {
-					req.Header.Set(proxy.CacheTTLHeader, cfg.VertexAI.Anthropic.CacheTTL)
-				}
-				if cfg.VertexAI.Anthropic.CachingMode != "" && req.Header.Get(proxy.CachingHeader) == "" {
-					req.Header.Set(proxy.CachingHeader, cfg.VertexAI.Anthropic.CachingMode)
-				}
+				injectCacheHeaders(req, cfg.VertexAI)
 			},
 			ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 				slog.Error("proxy error", "path", r.URL.Path, "error", err)

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -102,6 +102,29 @@ type VertexAIConfig struct {
 		CachingMode string `yaml:"caching_mode"` // off|auto|system-only (default: auto)
 		CacheTTL    string `yaml:"cache_ttl"`    // 5m|1h (default: 5m)
 	} `yaml:"anthropic"`
+
+	// Deprecated fields — kept for detection only. Values are NOT wired
+	// to any logic. When populated, configWarnings() returns migration hints.
+	DeprecatedCachingMode   string `yaml:"caching_mode"`   // moved to anthropic.caching_mode
+	DeprecatedCacheTTL      string `yaml:"cache_ttl"`      // moved to anthropic.cache_ttl
+	DeprecatedPromptCaching *bool  `yaml:"prompt_caching"` // removed — use anthropic.caching_mode
+}
+
+// configWarnings checks for deprecated config fields and returns
+// human-readable migration warnings. Used for startup logging and
+// the /_local/api/config response (surfaced in Desktop).
+func configWarnings(cfg Config) []string {
+	var warnings []string
+	if cfg.VertexAI.DeprecatedCachingMode != "" {
+		warnings = append(warnings, "vertex_ai.caching_mode has moved to vertex_ai.anthropic.caching_mode — update your config")
+	}
+	if cfg.VertexAI.DeprecatedCacheTTL != "" {
+		warnings = append(warnings, "vertex_ai.cache_ttl has moved to vertex_ai.anthropic.cache_ttl — update your config")
+	}
+	if cfg.VertexAI.DeprecatedPromptCaching != nil {
+		warnings = append(warnings, "vertex_ai.prompt_caching has been removed — use vertex_ai.anthropic.caching_mode instead")
+	}
+	return warnings
 }
 
 // AWSConfig holds AWS settings for Bedrock cloud providers.
@@ -651,6 +674,13 @@ func runForeground() {
 		cfg.Port = 8181
 	}
 
+	// Check for deprecated config fields and warn the user.
+	if warnings := configWarnings(*cfg); len(warnings) > 0 {
+		for _, w := range warnings {
+			slog.Warn("⚠️  DEPRECATED CONFIG: " + w)
+		}
+	}
+
 	// ── Validate & mode detection ──
 	ctx := context.Background()
 	soloMode := cfg.Remote == ""
@@ -1074,6 +1104,7 @@ func runForeground() {
 	// Wire the cloud proxy into the config API for runtime caching control.
 	configAPI.cloudProxy = cloudProxy
 	configAPI.calc = cloudCalc
+	configAPI.configWarnings = configWarnings(*cfg)
 	// Create a calc for pricing-based model filtering.
 	// Uses the same defaults as the cloud proxy's embedded calc.
 	if len(cloudModels) > 0 {

--- a/cmd/candela/remote_proxy_test.go
+++ b/cmd/candela/remote_proxy_test.go
@@ -2,22 +2,11 @@ package main
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/candelahq/candela/pkg/proxy"
 )
-
-// injectCacheHeaders mirrors the logic from the remoteProxy Director.
-// Extracted here for testability — the Director closure in runForeground()
-// is not directly testable without a full server setup.
-func injectCacheHeaders(req *http.Request, cfg VertexAIConfig) {
-	if cfg.Anthropic.CacheTTL != "" && req.Header.Get(proxy.CacheTTLHeader) == "" {
-		req.Header.Set(proxy.CacheTTLHeader, cfg.Anthropic.CacheTTL)
-	}
-	if cfg.Anthropic.CachingMode != "" && req.Header.Get(proxy.CachingHeader) == "" {
-		req.Header.Set(proxy.CachingHeader, cfg.Anthropic.CachingMode)
-	}
-}
 
 func TestInjectCacheHeaders(t *testing.T) {
 	tests := []struct {
@@ -81,7 +70,7 @@ func TestInjectCacheHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req, _ := http.NewRequest(http.MethodPost, "http://example.com/v1/messages", nil)
+			req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/messages", nil)
 			for k, v := range tt.existingHeader {
 				req.Header.Set(k, v)
 			}

--- a/cmd/candela/remote_proxy_test.go
+++ b/cmd/candela/remote_proxy_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/proxy"
+)
+
+// injectCacheHeaders mirrors the logic from the remoteProxy Director.
+// Extracted here for testability — the Director closure in runForeground()
+// is not directly testable without a full server setup.
+func injectCacheHeaders(req *http.Request, cfg VertexAIConfig) {
+	if cfg.Anthropic.CacheTTL != "" && req.Header.Get(proxy.CacheTTLHeader) == "" {
+		req.Header.Set(proxy.CacheTTLHeader, cfg.Anthropic.CacheTTL)
+	}
+	if cfg.Anthropic.CachingMode != "" && req.Header.Get(proxy.CachingHeader) == "" {
+		req.Header.Set(proxy.CachingHeader, cfg.Anthropic.CachingMode)
+	}
+}
+
+func TestInjectCacheHeaders(t *testing.T) {
+	tests := []struct {
+		name           string
+		cachingMode    string
+		cacheTTL       string
+		existingHeader map[string]string // pre-set headers on request
+		wantCaching    string            // expected X-Candela-Caching value ("" = absent)
+		wantCacheTTL   string            // expected X-Candela-Cache-TTL value ("" = absent)
+	}{
+		{
+			name:         "both set, no existing headers",
+			cachingMode:  "auto",
+			cacheTTL:     "1h",
+			wantCaching:  "auto",
+			wantCacheTTL: "1h",
+		},
+		{
+			name:         "only caching mode set",
+			cachingMode:  "system-only",
+			wantCaching:  "system-only",
+			wantCacheTTL: "",
+		},
+		{
+			name:         "only cache TTL set",
+			cacheTTL:     "5m",
+			wantCaching:  "",
+			wantCacheTTL: "5m",
+		},
+		{
+			name:         "empty config — no headers injected",
+			wantCaching:  "",
+			wantCacheTTL: "",
+		},
+		{
+			name:           "existing TTL header — not overwritten (SDK override wins)",
+			cacheTTL:       "1h",
+			existingHeader: map[string]string{proxy.CacheTTLHeader: "5m"},
+			wantCacheTTL:   "5m", // original preserved
+			wantCaching:    "",
+		},
+		{
+			name:           "existing caching header — not overwritten",
+			cachingMode:    "auto",
+			existingHeader: map[string]string{proxy.CachingHeader: "off"},
+			wantCaching:    "off", // original preserved
+			wantCacheTTL:   "",
+		},
+		{
+			name:        "both existing — config does not overwrite either",
+			cachingMode: "auto",
+			cacheTTL:    "1h",
+			existingHeader: map[string]string{
+				proxy.CachingHeader:  "off",
+				proxy.CacheTTLHeader: "5m",
+			},
+			wantCaching:  "off",
+			wantCacheTTL: "5m",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodPost, "http://example.com/v1/messages", nil)
+			for k, v := range tt.existingHeader {
+				req.Header.Set(k, v)
+			}
+
+			var cfg VertexAIConfig
+			cfg.Anthropic.CachingMode = tt.cachingMode
+			cfg.Anthropic.CacheTTL = tt.cacheTTL
+
+			injectCacheHeaders(req, cfg)
+
+			gotCaching := req.Header.Get(proxy.CachingHeader)
+			gotTTL := req.Header.Get(proxy.CacheTTLHeader)
+
+			if gotCaching != tt.wantCaching {
+				t.Errorf("X-Candela-Caching = %q, want %q", gotCaching, tt.wantCaching)
+			}
+			if gotTTL != tt.wantCacheTTL {
+				t.Errorf("X-Candela-Cache-TTL = %q, want %q", gotTTL, tt.wantCacheTTL)
+			}
+		})
+	}
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -26,8 +26,9 @@ proxy:
   vertex_ai:
     project_id: "your-gcp-project-id"
     region: "us-east5"      # Vertex AI region (Claude available here)
-    prompt_caching: true    # Inject cache_control for Anthropic prompt caching (~10x cost reduction)
-    cache_ttl: 5m           # Cache entry lifetime: 5m (default, 1.25x write cost) or 1h (2x write cost, ideal for coding sessions)
+    anthropic:
+      caching_mode: auto    # off | auto | system-only — injects cache_control for Anthropic prompt caching (~10x cost reduction)
+      cache_ttl: 5m         # 5m (default, 1.25x write cost) or 1h (2x write cost, ideal for long coding sessions)
 
   # AWS Bedrock configuration (required for anthropic-bedrock provider).
   # Auth is automatic via standard AWS credential chain

--- a/deploy/entrypoint-server.sh
+++ b/deploy/entrypoint-server.sh
@@ -28,8 +28,9 @@ proxy:
   vertex_ai:
     project_id: "${CANDELA_VERTEX_PROJECT:-}"
     region: "${CANDELA_VERTEX_REGION:-us-east5}"
-    caching_mode: "${CANDELA_CACHING_MODE:-auto}"
-    cache_ttl: "${CANDELA_CACHE_TTL:-}"
+    anthropic:
+      caching_mode: "${CANDELA_CACHING_MODE:-auto}"
+      cache_ttl: "${CANDELA_CACHE_TTL:-}"
     provider_overrides:
       mistral:
         region: "${CANDELA_MISTRAL_REGION:-us-central1}"


### PR DESCRIPTION
## Summary

Move Anthropic-specific caching config from flat fields under `vertex_ai:` into a dedicated `vertex_ai.anthropic:` block. Also wires local developer config through Team Mode via `X-Candela-*` headers.

## Breaking Change

```diff
 vertex_ai:
   project_id: my-project
   region: us-east5
-  caching_mode: auto
-  cache_ttl: 5m
-  prompt_caching: true
+  anthropic:
+    caching_mode: auto
+    cache_ttl: 1h
```

## Why

- `caching_mode` and `cache_ttl` only affect Anthropic/Claude — naming them under `vertex_ai:` was misleading
- `prompt_caching` bool existed on the server but not the CLI, causing silent config ignoring
- Local developer cache preferences had no effect in Team Mode

## Changes

| File | Change |
|------|--------|
| `cmd/candela-server/main.go` | Config struct: `Anthropic` sub-struct replaces flat fields. `PromptCaching` bool removed. |
| `cmd/candela/main.go` | Same restructure + new Team Mode header injection |
| `deploy/entrypoint-server.sh` | YAML template nests under `anthropic:` |
| `config.example.yaml` | Updated to new structure |
| `README.md` | Both config snippets updated |

## Team Mode Header Injection

The local CLI now injects `X-Candela-Caching` and `X-Candela-Cache-TTL` headers when forwarding to the remote server. Each developer can set their own caching preferences locally. SDK-level headers still override.

## Testing

All pre-commit hooks pass (45+ test packages).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README, example config, and generated server config to use nested Anthropic caching settings (`anthropic.caching_mode`, `anthropic.cache_ttl`), removing the legacy `prompt_caching` key.
  * Refreshed the changelog to document the new caching structure and Team Mode cache-header forwarding.

* **Bug Fixes**
  * Cache settings are now consistently read from the nested Anthropic configuration.
  * Startup and config API now emit warnings when legacy caching keys are detected; legacy values are ignored.
  * Team Mode forwards per-request Anthropic cache headers only when not already set.

* **Tests**
  * Added/extended tests for warning behavior in config API responses and for cache-header injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->