### PR TITLE
feat(proxy): add retry with exponential backoff and provider fallback chains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,16 @@ jobs:
             fi
           '
 
+      - name: Download modules
+        run: |
+          nix develop . --command bash -c "
+            for attempt in 1 2 3; do
+              go mod download && break
+              echo \"::warning::go mod download failed (attempt $attempt/3), retrying...\"
+              sleep 5
+            done
+          "
+
       - name: Build
         run: nix develop . --command go build ./...
 
@@ -154,6 +164,16 @@ jobs:
 
       - name: Generate proto stubs
         run: nix develop . --command buf generate
+
+      - name: Download modules
+        run: |
+          nix develop . --command bash -c "
+            for attempt in 1 2 3; do
+              go mod download && break
+              echo \"::warning::go mod download failed (attempt $attempt/3), retrying...\"
+              sleep 5
+            done
+          "
 
       - name: Test (${{ matrix.group.name }})
         run: nix develop . --command go test ${{ matrix.group.pkgs }} -v -race -count=1 -p 4 -parallel 4 -coverprofile=coverage-${{ matrix.group.name }}.out -timeout 180s

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -23,8 +23,6 @@ import (
 	"cloud.google.com/go/firestore"
 	firebase "firebase.google.com/go/v4"
 	fbauth "firebase.google.com/go/v4/auth"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"golang.org/x/oauth2/google"
 	"gopkg.in/yaml.v3"
 
@@ -586,11 +584,21 @@ func main() {
 					// anthropic-vertex is a native Messages API passthrough (for Claude Code).
 					if p.Name == "anthropic" {
 						ft := &proxy.AnthropicFormatTranslator{}
-						if cfg.Proxy.VertexAI.Anthropic.CachingMode != "" {
-							ft.SetCachingMode(proxy.ParseCachingMode(cfg.Proxy.VertexAI.Anthropic.CachingMode))
+						// Fall back to deprecated top-level fields if new sub-struct fields are empty.
+						cachingMode := cfg.Proxy.VertexAI.Anthropic.CachingMode
+						if cachingMode == "" && cfg.Proxy.VertexAI.DeprecatedCachingMode != "" {
+							cachingMode = cfg.Proxy.VertexAI.DeprecatedCachingMode
 						}
-						if cfg.Proxy.VertexAI.Anthropic.CacheTTL != "" {
-							ft.SetCacheTTL(proxy.ParseCacheTTL(cfg.Proxy.VertexAI.Anthropic.CacheTTL))
+						if cachingMode != "" {
+							ft.SetCachingMode(proxy.ParseCachingMode(cachingMode))
+						}
+
+						cacheTTL := cfg.Proxy.VertexAI.Anthropic.CacheTTL
+						if cacheTTL == "" && cfg.Proxy.VertexAI.DeprecatedCacheTTL != "" {
+							cacheTTL = cfg.Proxy.VertexAI.DeprecatedCacheTTL
+						}
+						if cacheTTL != "" {
+							ft.SetCacheTTL(proxy.ParseCacheTTL(cacheTTL))
 						}
 						allProviders[i].FormatTranslator = ft
 					}
@@ -1003,9 +1011,15 @@ func main() {
 		slog.Info("🔓 Running in dev mode — auth disabled")
 	}
 
+	// Enable both HTTP/1 and unencrypted HTTP/2 (replaces deprecated h2c package).
+	var protocols http.Protocols
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           h2c.NewHandler(authedMux, &http2.Server{}),
+		Handler:           authedMux,
+		Protocols:         &protocols,
 		ReadHeaderTimeout: 10 * time.Second,
 		WriteTimeout:      10 * time.Minute, // generous for streaming LLM responses
 		IdleTimeout:       120 * time.Second,

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.53.0
-	golang.org/x/net v0.56.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	google.golang.org/api v0.275.0
@@ -134,6 +133,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
 	golang.org/x/mod v0.36.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/pkg/connecthandlers/trace_handler.go
+++ b/pkg/connecthandlers/trace_handler.go
@@ -80,12 +80,14 @@ func (h *TraceHandler) ListTraces(
 		Environment: msg.Environment,
 		Model:       msg.Model,
 		Provider:    msg.Provider,
+		Status:      storage.SpanStatus(msg.Status),
 		Search:      msg.Search,
 		OrderBy:     msg.OrderBy,
 		Descending:  msg.Descending,
 		UserID:      scopeUserID(ctx, h.users),
 		JobID:       getAttribution(req).JobID,
 		TenantID:    getAttribution(req).TenantID,
+		TraceGroup:  msg.TraceGroup,
 	}
 
 	if msg.TimeRange != nil {

--- a/pkg/costcalc/testdata/pricing_snapshot.json
+++ b/pkg/costcalc/testdata/pricing_snapshot.json
@@ -54,6 +54,12 @@
     "output_per_million": 15
   },
   {
+    "model": "claude-sonnet-5",
+    "provider": "anthropic",
+    "input_per_million": 2,
+    "output_per_million": 10
+  },
+  {
     "model": "deepseek-r1-0528-maas",
     "provider": "deepseek",
     "input_per_million": 0.14,

--- a/pkg/proxy/circuit_breaker.go
+++ b/pkg/proxy/circuit_breaker.go
@@ -130,6 +130,16 @@ func (cb *CircuitBreaker) State() CircuitState {
 	return cb.state
 }
 
+// IsOpen returns true if the circuit breaker is in the Open state and the
+// reset timeout has NOT elapsed. Unlike AllowRequest, this does not transition
+// the state — it's a pure read used for routing decisions (e.g., skipping
+// a provider with a tripped circuit in a fallback chain).
+func (cb *CircuitBreaker) IsOpen() bool {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	return cb.state == CircuitOpen && time.Since(cb.lastFailureTime) <= cb.resetTimeout
+}
+
 // String returns a human-readable state name.
 func (s CircuitState) String() string {
 	switch s {

--- a/pkg/proxy/fallback.go
+++ b/pkg/proxy/fallback.go
@@ -42,7 +42,7 @@ func NewFallbackResolver(cfg FallbackConfig, providers []*Provider) *FallbackRes
 	// Sort chains by prefix length descending for most-specific-first matching.
 	chains := make([]FallbackChain, len(cfg.Chains))
 	copy(chains, cfg.Chains)
-	sort.Slice(chains, func(i, j int) bool {
+	sort.SliceStable(chains, func(i, j int) bool {
 		return len(chains[i].ModelPrefix) > len(chains[j].ModelPrefix)
 	})
 

--- a/pkg/proxy/fallback.go
+++ b/pkg/proxy/fallback.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"sort"
 	"strings"
 )
 
@@ -30,13 +31,23 @@ type FallbackResolver struct {
 
 // NewFallbackResolver creates a resolver from the given config and available
 // providers. The provider slice is indexed by name for O(1) lookups.
+// Chains are sorted by prefix length descending so more-specific prefixes
+// (e.g. "claude-sonnet-4") match before less-specific ones (e.g. "claude-").
 func NewFallbackResolver(cfg FallbackConfig, providers []*Provider) *FallbackResolver {
 	pm := make(map[string]*Provider, len(providers))
 	for _, p := range providers {
 		pm[strings.ToLower(p.Name)] = p
 	}
+
+	// Sort chains by prefix length descending for most-specific-first matching.
+	chains := make([]FallbackChain, len(cfg.Chains))
+	copy(chains, cfg.Chains)
+	sort.Slice(chains, func(i, j int) bool {
+		return len(chains[i].ModelPrefix) > len(chains[j].ModelPrefix)
+	})
+
 	return &FallbackResolver{
-		chains:    cfg.Chains,
+		chains:    chains,
 		providers: pm,
 		enabled:   cfg.Enabled,
 	}

--- a/pkg/proxy/fallback.go
+++ b/pkg/proxy/fallback.go
@@ -1,0 +1,104 @@
+package proxy
+
+import (
+	"strings"
+)
+
+// FallbackConfig controls automatic provider fallback for failed upstream
+// requests. When enabled and a primary provider fails, the proxy tries
+// alternate providers in the order defined by the matching chain.
+type FallbackConfig struct {
+	Enabled bool            `yaml:"enabled"`
+	Chains  []FallbackChain `yaml:"chains"`
+}
+
+// FallbackChain maps a model-name prefix to an ordered list of provider names.
+// When a request's model matches the prefix (case-insensitive), the chain
+// defines which providers to try and in what order.
+type FallbackChain struct {
+	ModelPrefix string   `yaml:"model_prefix"` // e.g. "gpt-4", "claude-"
+	Providers   []string `yaml:"providers"`    // ordered provider names
+}
+
+// FallbackResolver holds pre-indexed fallback chains and a provider lookup
+// table. It is safe for concurrent use after construction (read-only).
+type FallbackResolver struct {
+	chains    []FallbackChain
+	providers map[string]*Provider
+	enabled   bool
+}
+
+// NewFallbackResolver creates a resolver from the given config and available
+// providers. The provider slice is indexed by name for O(1) lookups.
+func NewFallbackResolver(cfg FallbackConfig, providers []*Provider) *FallbackResolver {
+	pm := make(map[string]*Provider, len(providers))
+	for _, p := range providers {
+		pm[strings.ToLower(p.Name)] = p
+	}
+	return &FallbackResolver{
+		chains:    cfg.Chains,
+		providers: pm,
+		enabled:   cfg.Enabled,
+	}
+}
+
+// FallbackProviders returns the providers to try after the primary provider
+// has failed. The returned slice preserves chain ordering and excludes the
+// primary.
+//
+// If the primary is not found in the matching chain, all chain providers are
+// returned (the caller already tried the primary outside the chain).
+//
+// Returns nil when fallback is disabled, no chains are configured, or no
+// chain matches the model.
+func (r *FallbackResolver) FallbackProviders(model, primaryName string) []*Provider {
+	if !r.enabled {
+		return nil
+	}
+	if len(r.chains) == 0 {
+		return nil
+	}
+
+	modelLower := strings.ToLower(model)
+	primaryLower := strings.ToLower(primaryName)
+
+	for _, chain := range r.chains {
+		prefix := strings.ToLower(chain.ModelPrefix)
+		if !strings.HasPrefix(modelLower, prefix) {
+			continue
+		}
+
+		// Find primary's position in the chain.
+		primaryIdx := -1
+		for i, name := range chain.Providers {
+			if strings.ToLower(name) == primaryLower {
+				primaryIdx = i
+				break
+			}
+		}
+
+		var result []*Provider
+		if primaryIdx < 0 {
+			// Primary not in chain — return all chain providers.
+			for _, name := range chain.Providers {
+				if p, ok := r.providers[strings.ToLower(name)]; ok {
+					result = append(result, p)
+				}
+			}
+		} else {
+			// Return providers after primary in chain order.
+			for i := primaryIdx + 1; i < len(chain.Providers); i++ {
+				if p, ok := r.providers[strings.ToLower(chain.Providers[i])]; ok {
+					result = append(result, p)
+				}
+			}
+		}
+
+		if len(result) == 0 {
+			return nil
+		}
+		return result
+	}
+
+	return nil
+}

--- a/pkg/proxy/fallback_test.go
+++ b/pkg/proxy/fallback_test.go
@@ -150,3 +150,37 @@ func TestFallbackEmptyProviders(t *testing.T) {
 		t.Errorf("empty providers should return nil, got %v", got)
 	}
 }
+
+// TestFallbackPrefixLengthSorting verifies that more-specific prefixes match
+// before less-specific ones when chains overlap (e.g. "claude-sonnet-4" vs "claude-").
+func TestFallbackPrefixLengthSorting(t *testing.T) {
+	r := NewFallbackResolver(FallbackConfig{
+		Enabled: true,
+		Chains: []FallbackChain{
+			// Less-specific chain listed first in config.
+			{ModelPrefix: "claude-", Providers: []string{"anthropic", "generic-fallback"}},
+			// More-specific chain listed second.
+			{ModelPrefix: "claude-sonnet-4", Providers: []string{"anthropic", "anthropic-vertex"}},
+		},
+	}, makeFallbackProviders("anthropic", "anthropic-vertex", "generic-fallback"))
+
+	// "claude-sonnet-4-1234" should match the more-specific "claude-sonnet-4" chain.
+	got := r.FallbackProviders("claude-sonnet-4-1234", "anthropic")
+	if len(got) != 1 || got[0].Name != "anthropic-vertex" {
+		names := make([]string, len(got))
+		for i, p := range got {
+			names[i] = p.Name
+		}
+		t.Errorf("expected [anthropic-vertex] from specific chain, got %v", names)
+	}
+
+	// "claude-haiku" should match the less-specific "claude-" chain.
+	got2 := r.FallbackProviders("claude-haiku", "anthropic")
+	if len(got2) != 1 || got2[0].Name != "generic-fallback" {
+		names := make([]string, len(got2))
+		for i, p := range got2 {
+			names[i] = p.Name
+		}
+		t.Errorf("expected [generic-fallback] from generic chain, got %v", names)
+	}
+}

--- a/pkg/proxy/fallback_test.go
+++ b/pkg/proxy/fallback_test.go
@@ -1,0 +1,152 @@
+package proxy
+
+import (
+	"testing"
+)
+
+func makeFallbackProviders(names ...string) []*Provider {
+	providers := make([]*Provider, len(names))
+	for i, n := range names {
+		providers[i] = &Provider{Name: n}
+	}
+	return providers
+}
+
+func TestFallbackDisabledReturnsNil(t *testing.T) {
+	r := NewFallbackResolver(FallbackConfig{
+		Enabled: false,
+		Chains: []FallbackChain{
+			{ModelPrefix: "gpt-4", Providers: []string{"openai", "azure"}},
+		},
+	}, makeFallbackProviders("openai", "azure"))
+
+	if got := r.FallbackProviders("gpt-4-turbo", "openai"); got != nil {
+		t.Errorf("disabled resolver returned %v, want nil", got)
+	}
+}
+
+func TestFallbackNoChainsReturnsNil(t *testing.T) {
+	r := NewFallbackResolver(FallbackConfig{Enabled: true}, makeFallbackProviders("openai"))
+
+	if got := r.FallbackProviders("gpt-4", "openai"); got != nil {
+		t.Errorf("no-chains resolver returned %v, want nil", got)
+	}
+}
+
+func TestFallbackMatchingChainReturnsFallbacks(t *testing.T) {
+	r := NewFallbackResolver(FallbackConfig{
+		Enabled: true,
+		Chains: []FallbackChain{
+			{ModelPrefix: "gpt-4", Providers: []string{"openai", "azure", "anyscale"}},
+		},
+	}, makeFallbackProviders("openai", "azure", "anyscale"))
+
+	got := r.FallbackProviders("gpt-4-turbo", "openai")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 fallbacks, got %d", len(got))
+	}
+	if got[0].Name != "azure" || got[1].Name != "anyscale" {
+		t.Errorf("expected [azure, anyscale], got [%s, %s]", got[0].Name, got[1].Name)
+	}
+}
+
+func TestFallbackCaseInsensitive(t *testing.T) {
+	r := NewFallbackResolver(FallbackConfig{
+		Enabled: true,
+		Chains: []FallbackChain{
+			{ModelPrefix: "GPT-4", Providers: []string{"OpenAI", "Azure"}},
+		},
+	}, makeFallbackProviders("openai", "azure"))
+
+	got := r.FallbackProviders("gpt-4-turbo", "OPENAI")
+	if len(got) != 1 || got[0].Name != "azure" {
+		t.Errorf("case-insensitive match failed, got %v", got)
+	}
+}
+
+func TestFallbackPrimaryNotInChain(t *testing.T) {
+	r := NewFallbackResolver(FallbackConfig{
+		Enabled: true,
+		Chains: []FallbackChain{
+			{ModelPrefix: "gpt-4", Providers: []string{"azure", "anyscale"}},
+		},
+	}, makeFallbackProviders("openai", "azure", "anyscale"))
+
+	// "openai" is not in the chain — should return all chain providers.
+	got := r.FallbackProviders("gpt-4-turbo", "openai")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 providers, got %d", len(got))
+	}
+	if got[0].Name != "azure" || got[1].Name != "anyscale" {
+		t.Errorf("expected [azure, anyscale], got [%s, %s]", got[0].Name, got[1].Name)
+	}
+}
+
+func TestFallbackPrimaryIsLast(t *testing.T) {
+	r := NewFallbackResolver(FallbackConfig{
+		Enabled: true,
+		Chains: []FallbackChain{
+			{ModelPrefix: "gpt-4", Providers: []string{"azure", "openai"}},
+		},
+	}, makeFallbackProviders("openai", "azure"))
+
+	got := r.FallbackProviders("gpt-4-turbo", "openai")
+	if got != nil {
+		t.Errorf("primary-is-last should return nil, got %v", got)
+	}
+}
+
+func TestFallbackMissingProviderSkipped(t *testing.T) {
+	r := NewFallbackResolver(FallbackConfig{
+		Enabled: true,
+		Chains: []FallbackChain{
+			{ModelPrefix: "gpt-4", Providers: []string{"openai", "ghost", "azure"}},
+		},
+	}, makeFallbackProviders("openai", "azure")) // "ghost" not registered
+
+	got := r.FallbackProviders("gpt-4-turbo", "openai")
+	if len(got) != 1 || got[0].Name != "azure" {
+		t.Errorf("expected [azure] (ghost skipped), got %v", got)
+	}
+}
+
+func TestFallbackNoMatchReturnsNil(t *testing.T) {
+	r := NewFallbackResolver(FallbackConfig{
+		Enabled: true,
+		Chains: []FallbackChain{
+			{ModelPrefix: "gpt-4", Providers: []string{"openai", "azure"}},
+		},
+	}, makeFallbackProviders("openai", "azure"))
+
+	if got := r.FallbackProviders("claude-3-opus", "openai"); got != nil {
+		t.Errorf("no-match should return nil, got %v", got)
+	}
+}
+
+func TestFallbackMultipleChainsFirstMatch(t *testing.T) {
+	r := NewFallbackResolver(FallbackConfig{
+		Enabled: true,
+		Chains: []FallbackChain{
+			{ModelPrefix: "gpt-4", Providers: []string{"openai", "azure"}},
+			{ModelPrefix: "gpt-4", Providers: []string{"openai", "anyscale"}},
+		},
+	}, makeFallbackProviders("openai", "azure", "anyscale"))
+
+	got := r.FallbackProviders("gpt-4-turbo", "openai")
+	if len(got) != 1 || got[0].Name != "azure" {
+		t.Errorf("expected first chain match [azure], got %v", got)
+	}
+}
+
+func TestFallbackEmptyProviders(t *testing.T) {
+	r := NewFallbackResolver(FallbackConfig{
+		Enabled: true,
+		Chains: []FallbackChain{
+			{ModelPrefix: "gpt-4", Providers: []string{}},
+		},
+	}, makeFallbackProviders("openai"))
+
+	if got := r.FallbackProviders("gpt-4-turbo", "openai"); got != nil {
+		t.Errorf("empty providers should return nil, got %v", got)
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -424,10 +424,13 @@ func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) (*Proxy
 	}
 
 	// Initialize fallback resolver if configured.
+	// Build provider pointers from p.providers (owned map) rather than
+	// &cfg.Providers[i] which would dangle after New() returns (cfg is by-value).
 	if cfg.Fallback.Enabled && len(cfg.Fallback.Chains) > 0 {
-		providerPtrs := make([]*Provider, 0, len(cfg.Providers))
-		for i := range cfg.Providers {
-			providerPtrs = append(providerPtrs, &cfg.Providers[i])
+		providerPtrs := make([]*Provider, 0, len(p.providers))
+		for name := range p.providers {
+			prov := p.providers[name]
+			providerPtrs = append(providerPtrs, &prov)
 		}
 		p.fallbackResolver = NewFallbackResolver(cfg.Fallback, providerPtrs)
 	}
@@ -1122,6 +1125,8 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 	// ── Retry/Fallback loop ──
 	// Build the provider attempt list: primary, then fallbacks (if configured).
+	// Each fallback candidate is checked against pricing and policy gates
+	// before inclusion — unchecked fallbacks could bypass authorization.
 	providerAttempts := []Provider{provider}
 	if p.fallbackResolver != nil {
 		if fps := p.fallbackResolver.FallbackProviders(requestModel, providerName); len(fps) > 0 {
@@ -1129,6 +1134,21 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 				// Skip fallback providers whose circuit breaker is open.
 				if cb, ok := p.breakers[fp.Name]; ok && cb.IsOpen() {
 					slog.Info("skipping fallback provider: circuit breaker open",
+						"provider", fp.Name, "model", requestModel,
+						"request_id", requestID)
+					continue
+				}
+				// Gate: pricing must be configured for the fallback provider.
+				if requestModel != "" && strings.ToLower(fp.Name) != "local" &&
+					!p.calc.HasPricing(pricingProvider(fp.Name), requestModel) {
+					slog.Info("skipping fallback provider: no pricing",
+						"provider", fp.Name, "model", requestModel,
+						"request_id", requestID)
+					continue
+				}
+				// Gate: model must be allowed by policy for the fallback provider.
+				if requestModel != "" && !p.policy.IsAllowed(fp.Name, requestModel) {
+					slog.Info("skipping fallback provider: blocked by policy",
 						"provider", fp.Name, "model", requestModel,
 						"request_id", requestID)
 					continue
@@ -1194,7 +1214,13 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 						"provider", activeProvName, "attempt", attemptCount,
 						"backoff_ms", backoff.Milliseconds(),
 						"request_id", requestID, "model", requestModel)
-					time.Sleep(backoff)
+					// Context-aware backoff: abort if the client disconnects
+					// during the wait instead of consuming upstream quota.
+					select {
+					case <-time.After(backoff):
+					case <-r.Context().Done():
+						return
+					}
 				}
 			}
 
@@ -1405,8 +1431,12 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 			// Record circuit breaker state.
 			p.recordCircuitBreaker(activeProvName, resp.StatusCode >= 500)
 
-			// Check if this response is retryable at all.
-			isRetryableResp := p.retryConfig.Enabled && p.retryConfig.IsRetryableStatus(resp.StatusCode)
+			// Check if this response should trigger retry or fallback.
+			// Fallback eligibility is decoupled from retryConfig.Enabled so
+			// that fallback chains fire even when same-provider retry is off.
+			isRetryableStatus := p.retryConfig.IsRetryableStatus(resp.StatusCode)
+			hasFallbacks := len(providerAttempts) > 1
+			isRetryableResp := (p.retryConfig.Enabled || hasFallbacks) && isRetryableStatus
 
 			// Non-retryable status (200, 400, 401, etc.) — accept it immediately.
 			if !isRetryableResp {
@@ -1424,11 +1454,13 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// Retryable status but max attempts exhausted — break to try next fallback.
+			// Do NOT cancel the response context here: if this is the last provider,
+			// resp will be forwarded to the client and its context must stay alive.
+			// The outer fallback branch (lines below) handles cancellation for
+			// discarded intermediate responses only.
 			slog.Info("retryable upstream error (attempts exhausted)",
 				"provider", activeProvName, "status", resp.StatusCode,
 				"attempt", attemptCount, "request_id", requestID)
-			streamCancel()
-			winningStreamCancel = nil
 			break
 		}
 		// Exhausted retries for this provider. If we got a response (even an error one),

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -424,13 +424,12 @@ func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) (*Proxy
 	}
 
 	// Initialize fallback resolver if configured.
-	// Build provider pointers from p.providers (owned map) rather than
-	// &cfg.Providers[i] which would dangle after New() returns (cfg is by-value).
+	// Build provider pointers from p.config.Providers (stored on struct) rather
+	// than &cfg.Providers[i] which would dangle after New() returns (cfg is by-value).
 	if cfg.Fallback.Enabled && len(cfg.Fallback.Chains) > 0 {
-		providerPtrs := make([]*Provider, 0, len(p.providers))
-		for name := range p.providers {
-			prov := p.providers[name]
-			providerPtrs = append(providerPtrs, &prov)
+		providerPtrs := make([]*Provider, 0, len(p.config.Providers))
+		for i := range p.config.Providers {
+			providerPtrs = append(providerPtrs, &p.config.Providers[i])
 		}
 		p.fallbackResolver = NewFallbackResolver(cfg.Fallback, providerPtrs)
 	}
@@ -1198,9 +1197,12 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		for attempt := 1; attempt <= maxAttempts; attempt++ {
 			attemptCount++
 
-			// Backoff before retries (not before the first attempt).
-			if attempt > 1 || providerIdx > 0 {
-				backoff := p.retryConfig.BackoffDuration(attemptCount - 2)
+			// Backoff before retries on the same provider (not before the
+			// first attempt, and not when switching to a fallback provider —
+			// fallback providers are independent upstreams and should be
+			// tried immediately).
+			if attempt > 1 {
+				backoff := p.retryConfig.BackoffDuration(attempt - 2)
 				// Honour Retry-After from the previous response if it's longer.
 				if resp != nil {
 					if ra := ParseRetryAfter(resp); ra > backoff {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -251,6 +251,10 @@ type Proxy struct {
 	spanSem   chan struct{} // bounds concurrent async span-creation goroutines
 	asyncSem  chan struct{} // bounds best-effort async goroutines (touch-active, budget notify)
 
+	// Retry/fallback support.
+	retryConfig      RetryConfig
+	fallbackResolver *FallbackResolver
+
 	// Optional dependencies for team-mode features.
 	users    storage.UserStore         // Budget deduction (nil = no budget tracking)
 	budgetCk *notify.BudgetChecker     // Budget threshold notifications (nil = no alerts)
@@ -298,6 +302,10 @@ type Config struct {
 	DailyLimits    []SpendLimitConfig        `yaml:"daily_limits"`         // Per-model daily spend limits
 	Policy         *PolicyConfig             `yaml:"policy"`               // Model allowlist policy (nil = all allowed)
 	Catalog        catalog.ModelCatalogStore `yaml:"-"`                    // Injected; used for access gate lookups
+
+	// Retry/fallback configuration for upstream requests.
+	Retry    RetryConfig    `yaml:"retry"`
+	Fallback FallbackConfig `yaml:"fallback"`
 
 	// HTTP transport tuning for upstream LLM provider connections.
 	MaxIdleConns        int `yaml:"max_idle_conns"`          // default: 200
@@ -407,11 +415,21 @@ func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) (*Proxy
 		projectID:    cfg.ProjectID,
 		config:       cfg,
 		breakers:     breakers,
+		retryConfig:  cfg.Retry,
 		spanSem:      make(chan struct{}, 200), // CRIT-16: cap concurrent span goroutines
 		asyncSem:     make(chan struct{}, 50),  // #333: cap best-effort async goroutines
 		saRL:         newSARateLimiter(0),      // default 120 RPM per SA
 		pendingSpend: newPendingSpendTracker(),
 		client:       newUpstreamHTTPClient(cfg),
+	}
+
+	// Initialize fallback resolver if configured.
+	if cfg.Fallback.Enabled && len(cfg.Fallback.Chains) > 0 {
+		providerPtrs := make([]*Provider, 0, len(cfg.Providers))
+		for i := range cfg.Providers {
+			providerPtrs = append(providerPtrs, &cfg.Providers[i])
+		}
+		p.fallbackResolver = NewFallbackResolver(cfg.Fallback, providerPtrs)
 	}
 
 	// Initialize spend tracker if daily limits are configured.
@@ -1093,7 +1111,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// If the provider has a FormatTranslator, convert the request format
 	// (e.g. OpenAI Chat Completions → Anthropic Messages).
 	var translatedModel string
-	upstreamBody := reqBody
+	var upstreamBody []byte
 
 	// Always strip Candela-internal headers before forwarding — they must
 	// never leak to any upstream (Anthropic, Gemini, etc.).
@@ -1102,259 +1120,353 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	ttlOverride := r.Header.Get(CacheTTLHeader)
 	r.Header.Del(CacheTTLHeader)
 
-	if provider.FormatTranslator != nil {
-		// Per-request caching override via X-Candela-Caching / X-Candela-Cache-TTL headers.
-		// Uses TranslateRequestWithModeAndTTL to avoid mutating shared translator
-		// state, which would race with concurrent requests.
-		if ft, ok := provider.FormatTranslator.(*AnthropicFormatTranslator); ok && (cachingOverride != "" || ttlOverride != "") {
-			mode := ft.GetCachingMode()
-			ttl := ft.GetCacheTTL()
-			if cachingOverride != "" {
-				mode = ParseCachingMode(cachingOverride)
-			}
-			if ttlOverride != "" {
-				ttl = ParseCacheTTL(ttlOverride)
-			}
-			upstreamBody, translatedModel, err = ft.TranslateRequestWithModeAndTTL(reqBody, mode, ttl)
-		} else {
-			upstreamBody, translatedModel, err = provider.FormatTranslator.TranslateRequest(reqBody)
-		}
-		if err != nil {
-			ProxyErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("request translation error: %v", err), "invalid_request_error")
-			return
-		}
-
-		// For translated providers, also check streaming against the translated body.
-		isStreaming = isStreamingRequest(providerName, upstreamBody)
-
-		slog.Debug("translated request",
-			"provider", providerName,
-			"model", translatedModel,
-			"streaming", isStreaming)
-	}
-
-	// --- Vertex AI body enrichment for native Anthropic passthrough ---
-	// When there's no FormatTranslator (e.g. anthropic-vertex), the body is
-	// forwarded as-is. But Vertex AI rawPredict requires:
-	//   1. `anthropic_version` in the body (Claude Code sends it as a header)
-	//   2. `model` NOT in the body (Vertex AI identifies model from URL path)
-	// NOTE: Bedrock also has a PathRewriter but doesn't need anthropic_version
-	// or model stripping — Bedrock accepts the model in the URL and ignores
-	// extra body fields. Use RequestSigner to distinguish: Bedrock uses SigV4
-	// signing, Vertex uses Bearer tokens.
-	// NOTE: This block is scoped to Anthropic providers — Gemini providers with
-	// PathRewriter have different body requirements (model prefix, no stripping).
-	isAnthropicPassthrough := providerName == "anthropic-vertex"
-	if provider.FormatTranslator == nil && provider.PathRewriter != nil && provider.RequestSigner == nil && isAnthropicPassthrough {
-		var bodyMap map[string]interface{}
-		if json.Unmarshal(upstreamBody, &bodyMap) == nil && bodyMap != nil {
-			modified := false
-			// Inject anthropic_version — Vertex AI rawPredict requires
-			// a specific version, not the standard "2023-06-01" that
-			// Claude Code / @ai-sdk/anthropic sends. Always override.
-			wantVersion := provider.AnthropicVersion
-			if wantVersion == "" {
-				wantVersion = DefaultVertexAnthropicVersion
-			}
-			if v, _ := bodyMap["anthropic_version"].(string); v != wantVersion {
-				bodyMap["anthropic_version"] = wantVersion
-				modified = true
-			}
-			// Strip model — Vertex AI gets it from the URL path and
-			// rejects extra fields in the body.
-			if _, hasModel := bodyMap["model"]; hasModel {
-				delete(bodyMap, "model")
-				modified = true
-			}
-			if modified {
-				if enriched, err := json.Marshal(bodyMap); err == nil {
-					upstreamBody = enriched
+	// ── Retry/Fallback loop ──
+	// Build the provider attempt list: primary, then fallbacks (if configured).
+	providerAttempts := []Provider{provider}
+	if p.fallbackResolver != nil {
+		if fps := p.fallbackResolver.FallbackProviders(requestModel, providerName); len(fps) > 0 {
+			for _, fp := range fps {
+				// Skip fallback providers whose circuit breaker is open.
+				if cb, ok := p.breakers[fp.Name]; ok && cb.IsOpen() {
+					slog.Info("skipping fallback provider: circuit breaker open",
+						"provider", fp.Name, "model", requestModel,
+						"request_id", requestID)
+					continue
 				}
-			}
-
-			// Debug: log upstream body when CANDELA_DEBUG=proxy is set.
-			if os.Getenv("CANDELA_DEBUG") == "proxy" {
-				// Log top-level keys and cache_control presence for debugging.
-				keys := make([]string, 0, len(bodyMap))
-				for k := range bodyMap {
-					keys = append(keys, k)
-				}
-				// Check system for cache_control.
-				var systemSnippet string
-				if sys, ok := bodyMap["system"]; ok {
-					if b, err := json.Marshal(sys); err == nil {
-						if len(b) > 500 {
-							systemSnippet = string(b[:500]) + "..."
-						} else {
-							systemSnippet = string(b)
-						}
-					}
-				}
-				slog.Info("CANDELA_DEBUG: passthrough body",
-					"provider", providerName,
-					"keys", keys,
-					"anthropic_version", bodyMap["anthropic_version"],
-					"system_snippet", systemSnippet,
-					"body_len", len(upstreamBody))
+				providerAttempts = append(providerAttempts, *fp)
 			}
 		}
 	}
 
-	// --- Vertex AI Gemini model prefix injection ---
-	// Vertex AI's OpenAI-compat endpoint requires model names to include the
-	// publisher prefix (e.g. "google/gemini-2.5-flash"). Transparently inject
-	// the "google/" prefix so clients can send bare model names.
-	// Uses requestModel (extracted once above) to avoid redundant JSON parsing.
-	// Uses rewriteModelField (regex) to avoid expensive JSON round-trip.
-	// --- Vertex AI publisher prefix injection ---
-	// Vertex AI's OpenAI-compat endpoint requires model names to include the
-	// publisher prefix (e.g. "google/gemini-2.5-flash"). Transparently inject
-	// the prefix so clients can send bare model names.
-	if provider.PathRewriter != nil && requestModel != "" {
-		switch providerName {
-		case "gemini-oai":
-			if !strings.HasPrefix(requestModel, "google/") {
-				upstreamBody = rewriteModelField(upstreamBody, "google/"+requestModel)
-			}
-		case "deepseek", "deepseek-v3":
-			if !strings.HasPrefix(requestModel, "deepseek-ai/") {
-				upstreamBody = rewriteModelField(upstreamBody, "deepseek-ai/"+requestModel)
-			}
-		case "qwen":
-			if !strings.HasPrefix(requestModel, "qwen/") {
-				upstreamBody = rewriteModelField(upstreamBody, "qwen/"+requestModel)
-			}
-		case "zai":
-			if !strings.HasPrefix(requestModel, "zai-org/") {
-				upstreamBody = rewriteModelField(upstreamBody, "zai-org/"+requestModel)
-			}
+	var (
+		resp           *http.Response
+		upstreamPath2  string // may be rewritten per provider
+		activeProvider Provider
+		activeProvName string
+		cbAllow        bool
+		ttfb           time.Duration
+		extendedTTL    bool
+		proxySpanID    string
+		lastErr        error
+		attemptCount   int
+		// streamCancel for the winning response — deferred so the context
+		// lives through handleStreamingResponse/handleStandardResponse.
+		winningStreamCancel context.CancelFunc
+	)
+	defer func() {
+		if winningStreamCancel != nil {
+			winningStreamCancel()
 		}
-	}
-
-	// --- Path rewriting ---
-	// If the provider has a PathRewriter, rewrite the upstream URL path
-	// (e.g. Vertex AI project-scoped model endpoints).
-	// Uses translatedModel (from FormatTranslator) or requestModel
-	// (extracted once above from body or URL path).
-	modelForPath := translatedModel
-	if modelForPath == "" {
-		modelForPath = requestModel
-	}
-	// SECURITY: Reject model names with path traversal characters before
-	// they're interpolated into Vertex AI URL paths. Without this, a crafted
-	// model name like "../../other-project/locations/.../models/gemini-2.5-flash"
-	// could SSRF into arbitrary Vertex AI resources the SA has access to.
-	// See safeModelNameRe definition for the full threat model.
-	if modelForPath != "" && !isSafeModelName(modelForPath) {
-		slog.Warn("blocked request: invalid model name (possible path traversal)",
-			"model", modelForPath, "provider", providerName, "user_id", effectiveUserID)
-		ProxyErrorResponse(w, http.StatusBadRequest, "invalid model name", "invalid_request_error")
-		return
-	}
-	if provider.PathRewriter != nil && modelForPath != "" {
-		upstreamPath = provider.PathRewriter.RewritePath(modelForPath, isStreaming)
-	}
-
-	// --- Stream usage injection ---
-	// OpenAI/Gemini-OAI only include usage data in the final SSE chunk when
-	// stream_options.include_usage is set. Without this, streaming responses
-	// return 0 tokens. Inject it transparently so token counting always works.
-	if isStreaming && provider.FormatTranslator == nil {
-		upstreamBody = injectStreamUsageOption(providerName, upstreamBody)
-	}
-
-	// Build the upstream request.
-	upstreamURL := provider.UpstreamURL + upstreamPath
-	// SECURITY: Only forward client query params for passthrough providers
-	// (openai, anthropic-direct) where the client provides their own API key.
-	// For managed-auth providers (Vertex AI, Bedrock), strip the query string
-	// to prevent parameter injection (?key=..., ?alt=media, etc.).
-	if r.URL.RawQuery != "" && provider.TokenSource == nil && provider.RequestSigner == nil {
-		upstreamURL += "?" + r.URL.RawQuery
-	}
-
-	// SECURITY: Use a detached context for the upstream request so that a
-	// client disconnect doesn't cancel the upstream call. This ensures we
-	// always receive the final usage chunk (with token counts) from the
-	// upstream provider, preventing cost evasion by aborting mid-stream.
-	// The 5-minute client timeout on p.client still applies.
-	upstreamCtx, streamCancel := context.WithTimeout(context.WithoutCancel(r.Context()), maxStreamDuration)
-	defer streamCancel()
-	upstreamReq, err := http.NewRequestWithContext(upstreamCtx, r.Method, upstreamURL, bytes.NewReader(upstreamBody))
-	if err != nil {
-		ProxyErrorResponse(w, http.StatusInternalServerError, "failed to create upstream request", "server_error")
-		return
-	}
-
-	// Forward headers (auth, content-type, etc).
-	forwardHeaders(r, upstreamReq, providerName, provider.TokenSource != nil || provider.RequestSigner != nil || provider.APIKey != "")
-
-	// Pre-generate the span ID that buildSpan will use for this proxy span.
-	// We need it now so the outgoing traceparent to the upstream LLM
-	// references the sidecar's span as its parent.
-	proxySpanID := GenerateSpanID()
+	}()
 
 	// Ensure we always have a trace context — either from the caller's
-	// incoming traceparent or a freshly-generated root trace ID. This
-	// guarantees every upstream request gets a traceparent, enabling
-	// end-to-end trace correlation even when the caller has no OTel.
+	// incoming traceparent or a freshly-generated root trace ID.
 	if traceCtx == nil {
 		traceCtx = &traceContext{traceID: GenerateTraceID()}
 	}
 
-	// Inject an outgoing traceparent so the upstream LLM API (if it
-	// supports OTel) creates spans as children of the sidecar span.
-	upstreamReq.Header.Set("Traceparent",
-		fmt.Sprintf("00-%s-%s-01", traceCtx.traceID, proxySpanID))
+	for providerIdx, attemptProvider := range providerAttempts {
+		activeProvider = attemptProvider
+		activeProvName = attemptProvider.Name
 
-	// --- Auth injection ---
-	// RequestSigner (e.g., AWS SigV4) takes precedence over TokenSource (Bearer tokens).
-	if provider.RequestSigner != nil {
-		if signErr := provider.RequestSigner.SignRequest(r.Context(), upstreamReq, upstreamBody); signErr != nil {
-			slog.Error("failed to sign request", "provider", providerName, "error", signErr)
-			ProxyErrorResponse(w, http.StatusInternalServerError, "failed to sign upstream request", "server_error")
-			return
+		// Per-provider retry loop.
+		maxAttempts := 1
+		if p.retryConfig.Enabled {
+			maxAttempts = p.retryConfig.effectiveMaxAttempts()
 		}
-	} else if provider.TokenSource != nil {
-		token, tokenErr := provider.TokenSource.Token()
-		if tokenErr != nil {
-			slog.Error("failed to get auth token", "provider", providerName, "error", tokenErr)
-			ProxyErrorResponse(w, http.StatusInternalServerError, "failed to obtain cloud credentials", "server_error")
-			return
+
+		for attempt := 1; attempt <= maxAttempts; attempt++ {
+			attemptCount++
+
+			// Backoff before retries (not before the first attempt).
+			if attempt > 1 || providerIdx > 0 {
+				backoff := p.retryConfig.BackoffDuration(attemptCount - 2)
+				// Honour Retry-After from the previous response if it's longer.
+				if resp != nil {
+					if ra := ParseRetryAfter(resp); ra > backoff {
+						backoff = ra
+					}
+					_ = resp.Body.Close()
+					resp = nil
+				}
+				if backoff > 0 {
+					slog.Info("retrying upstream request",
+						"provider", activeProvName, "attempt", attemptCount,
+						"backoff_ms", backoff.Milliseconds(),
+						"request_id", requestID, "model", requestModel)
+					time.Sleep(backoff)
+				}
+			}
+
+			// --- Per-attempt translation ---
+			// Each provider may have a different FormatTranslator, so re-translate.
+			translatedModel = ""
+			upstreamBody = reqBody
+			upstreamPath2 = upstreamPath
+
+			if attemptProvider.FormatTranslator != nil {
+				if ft, ok := attemptProvider.FormatTranslator.(*AnthropicFormatTranslator); ok && (cachingOverride != "" || ttlOverride != "") {
+					mode := ft.GetCachingMode()
+					ttl := ft.GetCacheTTL()
+					if cachingOverride != "" {
+						mode = ParseCachingMode(cachingOverride)
+					}
+					if ttlOverride != "" {
+						ttl = ParseCacheTTL(ttlOverride)
+					}
+					upstreamBody, translatedModel, err = ft.TranslateRequestWithModeAndTTL(reqBody, mode, ttl)
+				} else {
+					upstreamBody, translatedModel, err = attemptProvider.FormatTranslator.TranslateRequest(reqBody)
+				}
+				if err != nil {
+					// Translation errors are not retryable — the body is malformed.
+					ProxyErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("request translation error: %v", err), "invalid_request_error")
+					return
+				}
+				isStreaming = isStreamingRequest(activeProvName, upstreamBody)
+
+				slog.Debug("translated request",
+					"provider", activeProvName,
+					"model", translatedModel,
+					"streaming", isStreaming)
+			}
+
+			// --- Vertex AI body enrichment for native Anthropic passthrough ---
+			isAnthropicPassthrough := activeProvName == "anthropic-vertex"
+			if attemptProvider.FormatTranslator == nil && attemptProvider.PathRewriter != nil && attemptProvider.RequestSigner == nil && isAnthropicPassthrough {
+				var bodyMap map[string]interface{}
+				if json.Unmarshal(upstreamBody, &bodyMap) == nil && bodyMap != nil {
+					modified := false
+					wantVersion := attemptProvider.AnthropicVersion
+					if wantVersion == "" {
+						wantVersion = DefaultVertexAnthropicVersion
+					}
+					if v, _ := bodyMap["anthropic_version"].(string); v != wantVersion {
+						bodyMap["anthropic_version"] = wantVersion
+						modified = true
+					}
+					if _, hasModel := bodyMap["model"]; hasModel {
+						delete(bodyMap, "model")
+						modified = true
+					}
+					if modified {
+						if enriched, jsonErr := json.Marshal(bodyMap); jsonErr == nil {
+							upstreamBody = enriched
+						}
+					}
+
+					if os.Getenv("CANDELA_DEBUG") == "proxy" {
+						keys := make([]string, 0, len(bodyMap))
+						for k := range bodyMap {
+							keys = append(keys, k)
+						}
+						var systemSnippet string
+						if sys, ok := bodyMap["system"]; ok {
+							if b, jsonErr := json.Marshal(sys); jsonErr == nil {
+								if len(b) > 500 {
+									systemSnippet = string(b[:500]) + "..."
+								} else {
+									systemSnippet = string(b)
+								}
+							}
+						}
+						slog.Info("CANDELA_DEBUG: passthrough body",
+							"provider", activeProvName,
+							"keys", keys,
+							"anthropic_version", bodyMap["anthropic_version"],
+							"system_snippet", systemSnippet,
+							"body_len", len(upstreamBody))
+					}
+				}
+			}
+
+			// --- Publisher prefix injection ---
+			if attemptProvider.PathRewriter != nil && requestModel != "" {
+				switch activeProvName {
+				case "gemini-oai":
+					if !strings.HasPrefix(requestModel, "google/") {
+						upstreamBody = rewriteModelField(upstreamBody, "google/"+requestModel)
+					}
+				case "deepseek", "deepseek-v3":
+					if !strings.HasPrefix(requestModel, "deepseek-ai/") {
+						upstreamBody = rewriteModelField(upstreamBody, "deepseek-ai/"+requestModel)
+					}
+				case "qwen":
+					if !strings.HasPrefix(requestModel, "qwen/") {
+						upstreamBody = rewriteModelField(upstreamBody, "qwen/"+requestModel)
+					}
+				case "zai":
+					if !strings.HasPrefix(requestModel, "zai-org/") {
+						upstreamBody = rewriteModelField(upstreamBody, "zai-org/"+requestModel)
+					}
+				}
+			}
+
+			// --- Path rewriting ---
+			modelForPath := translatedModel
+			if modelForPath == "" {
+				modelForPath = requestModel
+			}
+			if modelForPath != "" && !isSafeModelName(modelForPath) {
+				slog.Warn("blocked request: invalid model name (possible path traversal)",
+					"model", modelForPath, "provider", activeProvName, "user_id", effectiveUserID)
+				ProxyErrorResponse(w, http.StatusBadRequest, "invalid model name", "invalid_request_error")
+				return
+			}
+			if attemptProvider.PathRewriter != nil && modelForPath != "" {
+				upstreamPath2 = attemptProvider.PathRewriter.RewritePath(modelForPath, isStreaming)
+			}
+
+			// --- Stream usage injection ---
+			if isStreaming && attemptProvider.FormatTranslator == nil {
+				upstreamBody = injectStreamUsageOption(activeProvName, upstreamBody)
+			}
+
+			// Build the upstream request.
+			upstreamURL := attemptProvider.UpstreamURL + upstreamPath2
+			if r.URL.RawQuery != "" && attemptProvider.TokenSource == nil && attemptProvider.RequestSigner == nil {
+				upstreamURL += "?" + r.URL.RawQuery
+			}
+
+			upstreamCtx, streamCancel := context.WithTimeout(context.WithoutCancel(r.Context()), maxStreamDuration)
+			upstreamReq, reqErr := http.NewRequestWithContext(upstreamCtx, r.Method, upstreamURL, bytes.NewReader(upstreamBody))
+			if reqErr != nil {
+				streamCancel()
+				ProxyErrorResponse(w, http.StatusInternalServerError, "failed to create upstream request", "server_error")
+				return
+			}
+
+			// Forward headers.
+			forwardHeaders(r, upstreamReq, activeProvName, attemptProvider.TokenSource != nil || attemptProvider.RequestSigner != nil || attemptProvider.APIKey != "")
+
+			// Pre-generate span ID for traceparent.
+			proxySpanID = GenerateSpanID()
+
+			// Inject traceparent.
+			upstreamReq.Header.Set("Traceparent",
+				fmt.Sprintf("00-%s-%s-01", traceCtx.traceID, proxySpanID))
+
+			// --- Auth injection ---
+			if attemptProvider.RequestSigner != nil {
+				if signErr := attemptProvider.RequestSigner.SignRequest(r.Context(), upstreamReq, upstreamBody); signErr != nil {
+					streamCancel()
+					slog.Error("failed to sign request", "provider", activeProvName, "error", signErr)
+					// Auth errors on fallback: try next provider.
+					if providerIdx < len(providerAttempts)-1 || attempt < maxAttempts {
+						continue
+					}
+					ProxyErrorResponse(w, http.StatusInternalServerError, "failed to sign upstream request", "server_error")
+					return
+				}
+			} else if attemptProvider.TokenSource != nil {
+				token, tokenErr := attemptProvider.TokenSource.Token()
+				if tokenErr != nil {
+					streamCancel()
+					slog.Error("failed to get auth token", "provider", activeProvName, "error", tokenErr)
+					if providerIdx < len(providerAttempts)-1 || attempt < maxAttempts {
+						continue
+					}
+					ProxyErrorResponse(w, http.StatusInternalServerError, "failed to obtain cloud credentials", "server_error")
+					return
+				}
+				upstreamReq.Header.Set("Authorization", "Bearer "+token.AccessToken)
+			} else if attemptProvider.APIKey != "" {
+				if attemptProvider.AuthHeader != "" {
+					upstreamReq.Header.Set(attemptProvider.AuthHeader, attemptProvider.APIKey)
+				} else {
+					upstreamReq.Header.Set("Authorization", "Bearer "+attemptProvider.APIKey)
+				}
+			}
+
+			// Propagate request ID to upstream.
+			upstreamReq.Header.Set("X-Request-ID", requestID)
+
+			// Execute the upstream request.
+			resp, lastErr = p.client.Do(upstreamReq)
+			if lastErr != nil {
+				streamCancel()
+				slog.Error("upstream request failed", "provider", activeProvName, "error", lastErr,
+					"attempt", attemptCount, "request_id", requestID)
+				p.recordCircuitBreaker(activeProvName, true)
+
+				if p.retryConfig.ShouldRetry(attempt, nil, lastErr, false) {
+					continue
+				}
+				// Exhausted retries for this provider — try fallback.
+				break
+			}
+			// Connection succeeded.
+			// Do NOT cancel streamCancel here — the response body needs the
+			// context alive for streaming. Transfer ownership to outer scope.
+			winningStreamCancel = streamCancel
+
+			ttfb = time.Since(startTime)
+
+			// Record circuit breaker state.
+			p.recordCircuitBreaker(activeProvName, resp.StatusCode >= 500)
+
+			// Check if this response is retryable at all.
+			isRetryableResp := p.retryConfig.Enabled && p.retryConfig.IsRetryableStatus(resp.StatusCode)
+
+			// Non-retryable status (200, 400, 401, etc.) — accept it immediately.
+			if !isRetryableResp {
+				goto done
+			}
+
+			// Retryable status but still have attempts left — retry this provider.
+			if attempt < maxAttempts {
+				slog.Info("retryable upstream error",
+					"provider", activeProvName, "status", resp.StatusCode,
+					"attempt", attemptCount, "request_id", requestID)
+				streamCancel()
+				winningStreamCancel = nil
+				continue
+			}
+
+			// Retryable status but max attempts exhausted — break to try next fallback.
+			slog.Info("retryable upstream error (attempts exhausted)",
+				"provider", activeProvName, "status", resp.StatusCode,
+				"attempt", attemptCount, "request_id", requestID)
+			streamCancel()
+			winningStreamCancel = nil
+			break
 		}
-		upstreamReq.Header.Set("Authorization", "Bearer "+token.AccessToken)
-	} else if provider.APIKey != "" {
-		// Static API key auth (custom providers configured via YAML).
-		if provider.AuthHeader != "" {
-			upstreamReq.Header.Set(provider.AuthHeader, provider.APIKey)
-		} else {
-			upstreamReq.Header.Set("Authorization", "Bearer "+provider.APIKey)
+		// Exhausted retries for this provider. If we got a response (even an error one),
+		// and it's the last provider, use it. Otherwise try next fallback.
+		if resp != nil && providerIdx < len(providerAttempts)-1 {
+			_ = resp.Body.Close()
+			resp = nil
+			if winningStreamCancel != nil {
+				winningStreamCancel()
+				winningStreamCancel = nil
+			}
 		}
 	}
 
-	// Propagate request ID to upstream.
-	upstreamReq.Header.Set("X-Request-ID", requestID)
-
-	// Execute the upstream request.
-	resp, err := p.client.Do(upstreamReq)
-	if err != nil {
-		// CRITICAL: Don't leak internal URLs/DNS/network info to the client.
-		slog.Error("upstream request failed", "provider", providerName, "error", err)
+done:
+	// All attempts exhausted — return the last error to the client.
+	if resp == nil {
 		ProxyErrorResponse(w, http.StatusBadGateway, "upstream provider unavailable", "upstream_error")
-		p.recordCircuitBreaker(providerName, true)
 		return
 	}
-	ttfb := time.Since(startTime)
 	defer func() { _ = resp.Body.Close() }()
 
-	// Record circuit breaker state based on upstream response.
-	p.recordCircuitBreaker(providerName, resp.StatusCode >= 500)
+	// Use the provider that actually succeeded (or was last attempted).
+	provider = activeProvider
+	providerName = activeProvName
+
+	// Log retry outcome if we retried.
+	if attemptCount > 1 {
+		slog.Info("retry outcome",
+			"final_provider", providerName, "final_status", resp.StatusCode,
+			"total_attempts", attemptCount, "request_id", requestID)
+	}
 
 	// Return request ID to the client.
 	w.Header().Set("X-Request-ID", requestID)
 
 	// Check circuit breaker — if open, skip observability but still forward.
-	cbAllow := p.breakers[providerName].AllowRequest()
+	cbAllow = p.breakers[providerName].AllowRequest()
 
 	// CRIT-17: Skip observability for utility endpoints (e.g. count_tokens,
 	// tokenize) that don't generate tokens. Parsing their response as a chat
@@ -1367,18 +1479,12 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ── Resolve effective cache TTL for Anthropic cost normalization (#191) ──
-	// Determines whether cache creation tokens should be charged at 2.0× (1h)
-	// or the default 1.25× (5m). Three sources, in priority order:
-	//   1. Per-request header override (X-Candela-Cache-TTL)
-	//   2. Translator config (AnthropicFormatTranslator.GetCacheTTL)
-	//   3. Request body inspection (passthrough routes: cache_control.ttl)
-	extendedTTL := false
+	extendedTTL = false
 	if ttlOverride != "" {
 		extendedTTL = ParseCacheTTL(ttlOverride) == CacheTTL1h
 	} else if ft, ok := provider.FormatTranslator.(*AnthropicFormatTranslator); ok {
 		extendedTTL = ft.GetCacheTTL() == CacheTTL1h
 	} else if provider.FormatTranslator == nil && isAnthropicProvider(providerName) {
-		// Passthrough Anthropic routes — inspect request body.
 		extendedTTL = extractAnthropicCacheTTL(reqBody)
 	}
 

--- a/pkg/proxy/proxy_retry_test.go
+++ b/pkg/proxy/proxy_retry_test.go
@@ -1,0 +1,396 @@
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/costcalc"
+)
+
+// TestRetry_500ThenSuccess verifies that when retry is enabled and the upstream
+// returns 500 on the first attempt, the proxy retries and succeeds on the second.
+func TestRetry_500ThenSuccess(t *testing.T) {
+	var attempts atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = fmt.Fprint(w, `{"error":"temporary failure"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"choices":[{"message":{"role":"assistant","content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer upstream.Close()
+
+	calc := newCalcWithTestModels()
+
+	p, err := New(Config{
+		Providers: []Provider{{
+			Name:        "openai",
+			UpstreamURL: upstream.URL,
+		}},
+		ProjectID: "test",
+		Retry: RetryConfig{
+			Enabled:              true,
+			MaxAttempts:          3,
+			RetryableStatusCodes: []int{500, 502, 503},
+			RetryOnTimeout:       true,
+			Backoff:              BackoffConfig{InitialMs: 1, MaxMs: 10, Multiplier: 2.0},
+		},
+	}, &mockSubmitter{}, calc)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST",
+		srv.URL+"/proxy/openai/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("expected 2 upstream attempts, got %d", got)
+	}
+}
+
+// TestRetry_Disabled verifies that with retry disabled, a 500 is immediately
+// forwarded to the client without retry.
+func TestRetry_Disabled(t *testing.T) {
+	var attempts atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"error":"failure"}`)
+	}))
+	defer upstream.Close()
+
+	calc := newCalcWithTestModels()
+
+	p, err := New(Config{
+		Providers: []Provider{{
+			Name:        "openai",
+			UpstreamURL: upstream.URL,
+		}},
+		ProjectID: "test",
+		// Retry is disabled by default (Enabled: false).
+	}, &mockSubmitter{}, calc)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST",
+		srv.URL+"/proxy/openai/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 500 {
+		t.Fatalf("expected 500, got %d", resp.StatusCode)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("expected 1 upstream attempt (no retry), got %d", got)
+	}
+}
+
+// TestRetry_MaxAttemptsExhausted verifies that the proxy stops retrying after
+// MaxAttempts and returns the last error to the client.
+func TestRetry_MaxAttemptsExhausted(t *testing.T) {
+	var attempts atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"error":"always fails"}`)
+	}))
+	defer upstream.Close()
+
+	calc := newCalcWithTestModels()
+
+	p, err := New(Config{
+		Providers: []Provider{{
+			Name:        "openai",
+			UpstreamURL: upstream.URL,
+		}},
+		ProjectID: "test",
+		Retry: RetryConfig{
+			Enabled:              true,
+			MaxAttempts:          3,
+			RetryableStatusCodes: []int{500},
+			Backoff:              BackoffConfig{InitialMs: 1, MaxMs: 5, Multiplier: 2.0},
+		},
+	}, &mockSubmitter{}, calc)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST",
+		srv.URL+"/proxy/openai/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	// Should get the 500 from the last attempt.
+	if resp.StatusCode != 500 {
+		t.Fatalf("expected 500 after exhausting retries, got %d", resp.StatusCode)
+	}
+	// Should have tried exactly MaxAttempts times.
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("expected 3 attempts, got %d", got)
+	}
+}
+
+// TestRetry_400NotRetried verifies that 400 errors are never retried.
+func TestRetry_400NotRetried(t *testing.T) {
+	var attempts atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = fmt.Fprint(w, `{"error":"bad request"}`)
+	}))
+	defer upstream.Close()
+
+	calc := newCalcWithTestModels()
+
+	p, err := New(Config{
+		Providers: []Provider{{
+			Name:        "openai",
+			UpstreamURL: upstream.URL,
+		}},
+		ProjectID: "test",
+		Retry: RetryConfig{
+			Enabled:              true,
+			MaxAttempts:          3,
+			RetryableStatusCodes: []int{500, 502, 503},
+			Backoff:              BackoffConfig{InitialMs: 1, MaxMs: 5, Multiplier: 2.0},
+		},
+	}, &mockSubmitter{}, calc)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST",
+		srv.URL+"/proxy/openai/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 400 {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 attempt (400 not retried), got %d", got)
+	}
+}
+
+// TestRetry_429WithRetryAfter verifies that the proxy respects Retry-After headers.
+func TestRetry_429WithRetryAfter(t *testing.T) {
+	var attempts atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = fmt.Fprint(w, `{"error":"rate limited"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"choices":[{"message":{"role":"assistant","content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer upstream.Close()
+
+	calc := newCalcWithTestModels()
+
+	p, err := New(Config{
+		Providers: []Provider{{
+			Name:        "openai",
+			UpstreamURL: upstream.URL,
+		}},
+		ProjectID: "test",
+		Retry: RetryConfig{
+			Enabled:              true,
+			MaxAttempts:          3,
+			RetryableStatusCodes: []int{429, 500},
+			Backoff:              BackoffConfig{InitialMs: 1, MaxMs: 5, Multiplier: 2.0},
+		},
+	}, &mockSubmitter{}, calc)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST",
+		srv.URL+"/proxy/openai/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200 after retry, got %d", resp.StatusCode)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("expected 2 attempts, got %d", got)
+	}
+}
+
+// TestFallback_PrimaryDownSecondaryUp verifies that when the primary provider
+// fails and a fallback chain is configured, the proxy falls back to the secondary.
+func TestFallback_PrimaryDownSecondaryUp(t *testing.T) {
+	// Primary always returns 500.
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"error":"primary down"}`)
+	}))
+	defer primary.Close()
+
+	// Secondary always succeeds.
+	secondary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"choices":[{"message":{"role":"assistant","content":"from secondary"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer secondary.Close()
+
+	calc := newCalcWithTestModels()
+	// Use "openai" (primary) and "deepseek" (fallback) — both have registered
+	// parsers so the model can be extracted from the request body.
+	calc.SetPricing(costcalc.ModelPricing{Provider: "openai", Model: "gpt-4o", InputPerMillion: 2.50, OutputPerMillion: 10.00})
+	calc.SetPricing(costcalc.ModelPricing{Provider: "deepseek", Model: "gpt-4o", InputPerMillion: 2.50, OutputPerMillion: 10.00})
+
+	p, err := New(Config{
+		Providers: []Provider{
+			{Name: "openai", UpstreamURL: primary.URL},
+			{Name: "deepseek", UpstreamURL: secondary.URL},
+		},
+		ProjectID: "test",
+		Retry: RetryConfig{
+			Enabled:              true,
+			MaxAttempts:          1, // No retry per-provider, just fallback.
+			RetryableStatusCodes: []int{500},
+			Backoff:              BackoffConfig{InitialMs: 1, MaxMs: 5, Multiplier: 2.0},
+		},
+		Fallback: FallbackConfig{
+			Enabled: true,
+			Chains: []FallbackChain{{
+				ModelPrefix: "gpt-4o",
+				Providers:   []string{"openai", "deepseek"},
+			}},
+		},
+	}, &mockSubmitter{}, calc)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST",
+		srv.URL+"/proxy/openai/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200 from fallback, got %d, body: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "from secondary") {
+		t.Fatalf("expected response from secondary provider, got: %s", body)
+	}
+}
+
+// TestCircuitBreaker_IsOpen verifies the IsOpen method.
+func TestCircuitBreaker_IsOpen(t *testing.T) {
+	cfg := CircuitBreakerConfig{
+		Threshold:    2,
+		ResetTimeout: 10 * 1e9, // 10s as Duration
+		HalfOpenMax:  1,
+	}
+	cb := NewCircuitBreaker(cfg)
+
+	// Initially closed.
+	if cb.IsOpen() {
+		t.Fatal("expected closed circuit, got open")
+	}
+
+	// Trip it.
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	if !cb.IsOpen() {
+		t.Fatal("expected open circuit after 2 failures")
+	}
+
+	// Recover.
+	cb.RecordSuccess()
+	cb.RecordSuccess()
+	// After enough successes in half-open, it should close.
+	// But IsOpen checks Open state specifically.
+}

--- a/pkg/proxy/retry.go
+++ b/pkg/proxy/retry.go
@@ -1,0 +1,164 @@
+package proxy
+
+import (
+	"math"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RetryConfig controls automatic retry behaviour for failed upstream requests.
+type RetryConfig struct {
+	Enabled              bool          `yaml:"enabled"`
+	MaxAttempts          int           `yaml:"max_attempts"`
+	RetryableStatusCodes []int         `yaml:"retryable_status_codes"`
+	RetryOnTimeout       bool          `yaml:"retry_on_timeout"`
+	Backoff              BackoffConfig `yaml:"backoff"`
+}
+
+// BackoffConfig defines exponential backoff parameters with full jitter.
+type BackoffConfig struct {
+	InitialMs  int     `yaml:"initial_ms"`
+	MaxMs      int     `yaml:"max_ms"`
+	Multiplier float64 `yaml:"multiplier"`
+}
+
+// DefaultRetryConfig returns sensible defaults with retries disabled.
+// Callers must explicitly set Enabled=true to activate retry logic.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		Enabled:              false,
+		MaxAttempts:          2,
+		RetryableStatusCodes: []int{429, 500, 502, 503, 529},
+		RetryOnTimeout:       true,
+		Backoff: BackoffConfig{
+			InitialMs:  500,
+			MaxMs:      5000,
+			Multiplier: 2.0,
+		},
+	}
+}
+
+// effectiveMaxAttempts clamps MaxAttempts to the range [1, 5].
+func (c *RetryConfig) effectiveMaxAttempts() int {
+	if c.MaxAttempts < 1 {
+		return 1
+	}
+	if c.MaxAttempts > 5 {
+		return 5
+	}
+	return c.MaxAttempts
+}
+
+// IsRetryableStatus reports whether the given HTTP status code is retryable
+// according to this configuration.
+func (c *RetryConfig) IsRetryableStatus(code int) bool {
+	for _, rc := range c.RetryableStatusCodes {
+		if rc == code {
+			return true
+		}
+	}
+	return false
+}
+
+// ShouldRetry decides whether the request should be retried for the given
+// attempt number, upstream response, connection error, and streaming state.
+//
+// SAFETY: once SSE chunks have started flowing to the client (streamStarted),
+// we must never retry — the client has already consumed partial data.
+func (c *RetryConfig) ShouldRetry(attempt int, resp *http.Response, connErr error, streamStarted bool) bool {
+	if !c.Enabled {
+		return false
+	}
+	if attempt >= c.effectiveMaxAttempts() {
+		return false
+	}
+	// SAFETY: never retry once SSE chunks have started flowing.
+	if streamStarted {
+		return false
+	}
+
+	// Connection-level error (timeout, DNS, reset).
+	if connErr != nil {
+		return c.RetryOnTimeout
+	}
+
+	// No response to inspect — don't retry blindly.
+	if resp == nil {
+		return false
+	}
+
+	return c.IsRetryableStatus(resp.StatusCode)
+}
+
+// BackoffDuration returns the backoff duration for the given attempt using
+// exponential backoff with full jitter. The result is capped at BackoffConfig.MaxMs.
+//
+// Formula: jitter in [0, min(MaxMs, InitialMs * Multiplier^attempt))
+func (c *RetryConfig) BackoffDuration(attempt int) time.Duration {
+	initialMs := c.Backoff.InitialMs
+	if initialMs <= 0 {
+		initialMs = 500
+	}
+	maxMs := c.Backoff.MaxMs
+	if maxMs <= 0 {
+		maxMs = 5000
+	}
+	multiplier := c.Backoff.Multiplier
+	if multiplier <= 0 {
+		multiplier = 2.0
+	}
+
+	uncapped := float64(initialMs) * math.Pow(multiplier, float64(attempt))
+	cap := math.Min(uncapped, float64(maxMs))
+
+	// Full jitter: uniform random in [0, cap).
+	jittered := rand.Float64() * cap //nolint:gosec // jitter does not need crypto rand
+	return time.Duration(jittered) * time.Millisecond
+}
+
+// maxRetryAfter caps the Retry-After value the proxy will honour.
+const maxRetryAfter = 60 * time.Second
+
+// ParseRetryAfter extracts a backoff duration from the Retry-After header.
+// It supports both delta-seconds ("5") and HTTP-date formats.
+// Returns 0 if the header is absent, empty, or unparseable.
+// The result is capped at 60 s to prevent adversarial providers from stalling
+// the proxy indefinitely.
+func ParseRetryAfter(resp *http.Response) time.Duration {
+	if resp == nil {
+		return 0
+	}
+	val := strings.TrimSpace(resp.Header.Get("Retry-After"))
+	if val == "" {
+		return 0
+	}
+
+	// Try delta-seconds first (most common from LLM APIs).
+	if secs, err := strconv.Atoi(val); err == nil {
+		d := time.Duration(secs) * time.Second
+		if d > maxRetryAfter {
+			d = maxRetryAfter
+		}
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+
+	// Try HTTP-date (RFC 7231 §7.1.1.1).
+	if t, err := http.ParseTime(val); err == nil {
+		d := time.Until(t)
+		if d < 0 {
+			return 0
+		}
+		if d > maxRetryAfter {
+			d = maxRetryAfter
+		}
+		return d
+	}
+
+	return 0
+}

--- a/pkg/proxy/retry.go
+++ b/pkg/proxy/retry.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"math"
 	"math/rand"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -82,7 +83,10 @@ func (c *RetryConfig) ShouldRetry(attempt int, resp *http.Response, connErr erro
 
 	// Connection-level error (timeout, DNS, reset).
 	if connErr != nil {
-		return c.RetryOnTimeout
+		// SAFETY: only retry errors provably before transmission to avoid
+		// replaying ambiguous POST requests that may have been partially
+		// processed upstream (double-charge risk).
+		return c.RetryOnTimeout && IsPreConnectionError(connErr)
 	}
 
 	// No response to inspect — don't retry blindly.
@@ -91,6 +95,54 @@ func (c *RetryConfig) ShouldRetry(attempt int, resp *http.Response, connErr erro
 	}
 
 	return c.IsRetryableStatus(resp.StatusCode)
+}
+
+// IsPreConnectionError returns true if the error provably occurred before
+// any request bytes were sent to the upstream server. Only these errors
+// are safe to retry for non-idempotent POST requests because the upstream
+// never received the request.
+//
+// Errors that occur after transmission (timeouts, connection resets during
+// response reads, EOF) are NOT safe — the upstream may have already started
+// processing and billing for the request.
+func IsPreConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Unwrap through any wrappers to find the root cause.
+	var netOpErr *net.OpError
+	if ok := errorAs(err, &netOpErr); ok {
+		// "dial" errors are pre-connection: DNS failure, connection refused,
+		// port unreachable, network unreachable.
+		return netOpErr.Op == "dial"
+	}
+
+	var dnsErr *net.DNSError
+	if ok := errorAs(err, &dnsErr); ok {
+		return true // DNS resolution failed — never connected.
+	}
+
+	// All other errors are ambiguous — assume bytes may have been sent.
+	return false
+}
+
+// errorAs is a thin wrapper around errors.As that avoids importing errors
+// in this file (it's already imported transitively via net). Using a
+// generic helper keeps the code readable.
+func errorAs[T any](err error, target *T) bool {
+	for err != nil {
+		if t, ok := err.(T); ok { //nolint:errorlint // intentional type assertion for generics
+			*target = t
+			return true
+		}
+		if u, ok := err.(interface{ Unwrap() error }); ok {
+			err = u.Unwrap()
+		} else {
+			return false
+		}
+	}
+	return false
 }
 
 // BackoffDuration returns the backoff duration for the given attempt using

--- a/pkg/proxy/retry.go
+++ b/pkg/proxy/retry.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"errors"
 	"math"
 	"math/rand"
 	"net"
@@ -112,36 +113,18 @@ func IsPreConnectionError(err error) bool {
 
 	// Unwrap through any wrappers to find the root cause.
 	var netOpErr *net.OpError
-	if ok := errorAs(err, &netOpErr); ok {
+	if errors.As(err, &netOpErr) {
 		// "dial" errors are pre-connection: DNS failure, connection refused,
 		// port unreachable, network unreachable.
 		return netOpErr.Op == "dial"
 	}
 
 	var dnsErr *net.DNSError
-	if ok := errorAs(err, &dnsErr); ok {
+	if errors.As(err, &dnsErr) {
 		return true // DNS resolution failed — never connected.
 	}
 
 	// All other errors are ambiguous — assume bytes may have been sent.
-	return false
-}
-
-// errorAs is a thin wrapper around errors.As that avoids importing errors
-// in this file (it's already imported transitively via net). Using a
-// generic helper keeps the code readable.
-func errorAs[T any](err error, target *T) bool {
-	for err != nil {
-		if t, ok := err.(T); ok { //nolint:errorlint // intentional type assertion for generics
-			*target = t
-			return true
-		}
-		if u, ok := err.(interface{ Unwrap() error }); ok {
-			err = u.Unwrap()
-		} else {
-			return false
-		}
-	}
 	return false
 }
 

--- a/pkg/proxy/retry_test.go
+++ b/pkg/proxy/retry_test.go
@@ -1,0 +1,221 @@
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Retry config defaults
+// ---------------------------------------------------------------------------
+
+func TestRetryDefaultsDisabled(t *testing.T) {
+	cfg := DefaultRetryConfig()
+	if cfg.Enabled {
+		t.Error("default config should have Enabled=false")
+	}
+	if cfg.MaxAttempts != 2 {
+		t.Errorf("expected MaxAttempts=2, got %d", cfg.MaxAttempts)
+	}
+	if len(cfg.RetryableStatusCodes) == 0 {
+		t.Error("expected non-empty retryable status codes")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// effectiveMaxAttempts clamping
+// ---------------------------------------------------------------------------
+
+func TestRetryEffectiveMaxAttempts(t *testing.T) {
+	tests := []struct {
+		name string
+		max  int
+		want int
+	}{
+		{"ZeroClampsToOne", 0, 1},
+		{"NegativeClampsToOne", -3, 1},
+		{"ThreePassthrough", 3, 3},
+		{"FivePassthrough", 5, 5},
+		{"TenClampsToFive", 10, 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := RetryConfig{MaxAttempts: tt.max}
+			if got := cfg.effectiveMaxAttempts(); got != tt.want {
+				t.Errorf("effectiveMaxAttempts(%d) = %d, want %d", tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsRetryableStatus
+// ---------------------------------------------------------------------------
+
+func TestRetryIsRetryableStatus(t *testing.T) {
+	cfg := DefaultRetryConfig()
+	tests := []struct {
+		code int
+		want bool
+	}{
+		{429, true},
+		{500, true},
+		{502, true},
+		{503, true},
+		{529, true},
+		{400, false},
+		{200, false},
+		{401, false},
+		{404, false},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("status_%d", tt.code), func(t *testing.T) {
+			if got := cfg.IsRetryableStatus(tt.code); got != tt.want {
+				t.Errorf("IsRetryableStatus(%d) = %v, want %v", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ShouldRetry
+// ---------------------------------------------------------------------------
+
+func TestShouldRetry(t *testing.T) {
+	enabled := RetryConfig{
+		Enabled:              true,
+		MaxAttempts:          3,
+		RetryableStatusCodes: []int{429, 500, 502, 503},
+		RetryOnTimeout:       true,
+		Backoff:              BackoffConfig{InitialMs: 100, MaxMs: 1000, Multiplier: 2},
+	}
+	disabled := RetryConfig{Enabled: false, MaxAttempts: 3}
+
+	connErr := errors.New("dial tcp: connection refused")
+
+	makeResp := func(code int) *http.Response {
+		return &http.Response{StatusCode: code}
+	}
+
+	tests := []struct {
+		name          string
+		cfg           RetryConfig
+		attempt       int
+		resp          *http.Response
+		connErr       error
+		streamStarted bool
+		want          bool
+	}{
+		{"Disabled", disabled, 0, makeResp(500), nil, false, false},
+		{"ExhaustedAttempts", enabled, 3, makeResp(500), nil, false, false},
+		{"StreamStarted", enabled, 0, makeResp(500), nil, true, false},
+		{"ConnErrorEnabled", enabled, 0, nil, connErr, false, true},
+		{"ConnErrorDisabledTimeout", RetryConfig{
+			Enabled: true, MaxAttempts: 3, RetryOnTimeout: false,
+		}, 0, nil, connErr, false, false},
+		{"Status500", enabled, 0, makeResp(500), nil, false, true},
+		{"Status429", enabled, 0, makeResp(429), nil, false, true},
+		{"Status400NotRetryable", enabled, 0, makeResp(400), nil, false, false},
+		{"Status401NotRetryable", enabled, 0, makeResp(401), nil, false, false},
+		{"NilResponse", enabled, 0, nil, nil, false, false},
+		{"SecondAttemptOK", enabled, 1, makeResp(502), nil, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.ShouldRetry(tt.attempt, tt.resp, tt.connErr, tt.streamStarted)
+			if got != tt.want {
+				t.Errorf("ShouldRetry() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BackoffDuration
+// ---------------------------------------------------------------------------
+
+func TestBackoffDuration_Exponential(t *testing.T) {
+	cfg := RetryConfig{
+		Backoff: BackoffConfig{InitialMs: 100, MaxMs: 10000, Multiplier: 2},
+	}
+
+	// Run multiple samples to verify statistical ordering.
+	const samples = 200
+	var sum0, sum1, sum2 float64
+	for range samples {
+		sum0 += float64(cfg.BackoffDuration(0))
+		sum1 += float64(cfg.BackoffDuration(1))
+		sum2 += float64(cfg.BackoffDuration(2))
+	}
+	avg0 := sum0 / float64(samples)
+	avg1 := sum1 / float64(samples)
+	avg2 := sum2 / float64(samples)
+
+	if avg0 >= avg1 {
+		t.Errorf("expected avg attempt 0 (%v) < avg attempt 1 (%v)", avg0, avg1)
+	}
+	if avg1 >= avg2 {
+		t.Errorf("expected avg attempt 1 (%v) < avg attempt 2 (%v)", avg1, avg2)
+	}
+}
+
+func TestBackoffDuration_CappedAtMax(t *testing.T) {
+	cfg := RetryConfig{
+		Backoff: BackoffConfig{InitialMs: 1000, MaxMs: 2000, Multiplier: 10},
+	}
+
+	for range 100 {
+		d := cfg.BackoffDuration(5)
+		if d > 2000*time.Millisecond {
+			t.Fatalf("backoff %v exceeded max 2000ms", d)
+		}
+	}
+}
+
+func TestBackoffDuration_ZeroConfig(t *testing.T) {
+	cfg := RetryConfig{}
+	d := cfg.BackoffDuration(0)
+	if d < 0 || d > 5*time.Second {
+		t.Errorf("zero-config backoff = %v, expected [0, 5s]", d)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseRetryAfter
+// ---------------------------------------------------------------------------
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name string
+		hdr  string
+		want time.Duration
+	}{
+		{"FiveSeconds", "5", 5 * time.Second},
+		{"CappedAt60", "120", 60 * time.Second},
+		{"Empty", "", 0},
+		{"Garbage", "not-a-number", 0},
+		{"Zero", "0", 0},
+		{"NegativeSeconds", "-5", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{Header: http.Header{}}
+			if tt.hdr != "" {
+				resp.Header.Set("Retry-After", tt.hdr)
+			}
+			got := ParseRetryAfter(resp)
+			if got != tt.want {
+				t.Errorf("ParseRetryAfter(%q) = %v, want %v", tt.hdr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRetryAfter_NilResponse(t *testing.T) {
+	if got := ParseRetryAfter(nil); got != 0 {
+		t.Errorf("ParseRetryAfter(nil) = %v, want 0", got)
+	}
+}

--- a/pkg/proxy/retry_test.go
+++ b/pkg/proxy/retry_test.go
@@ -3,6 +3,8 @@ package proxy
 import (
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -94,7 +96,7 @@ func TestShouldRetry(t *testing.T) {
 	}
 	disabled := RetryConfig{Enabled: false, MaxAttempts: 3}
 
-	connErr := errors.New("dial tcp: connection refused")
+	connErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
 
 	makeResp := func(code int) *http.Response {
 		return &http.Response{StatusCode: code}
@@ -217,5 +219,103 @@ func TestParseRetryAfter(t *testing.T) {
 func TestParseRetryAfter_NilResponse(t *testing.T) {
 	if got := ParseRetryAfter(nil); got != 0 {
 		t.Errorf("ParseRetryAfter(nil) = %v, want 0", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsPreConnectionError
+// ---------------------------------------------------------------------------
+
+func TestIsPreConnectionError_Nil(t *testing.T) {
+	if IsPreConnectionError(nil) {
+		t.Error("nil error should not be pre-connection")
+	}
+}
+
+func TestIsPreConnectionError_DialError(t *testing.T) {
+	err := &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Err: errors.New("connection refused"),
+	}
+	if !IsPreConnectionError(err) {
+		t.Error("dial OpError should be pre-connection")
+	}
+}
+
+func TestIsPreConnectionError_ReadError(t *testing.T) {
+	err := &net.OpError{
+		Op:  "read",
+		Net: "tcp",
+		Err: errors.New("connection reset by peer"),
+	}
+	if IsPreConnectionError(err) {
+		t.Error("read OpError should NOT be pre-connection")
+	}
+}
+
+func TestIsPreConnectionError_DNSError(t *testing.T) {
+	err := &net.DNSError{
+		Err:  "no such host",
+		Name: "api.example.com",
+	}
+	if !IsPreConnectionError(err) {
+		t.Error("DNS error should be pre-connection")
+	}
+}
+
+func TestIsPreConnectionError_WrappedDialError(t *testing.T) {
+	inner := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("refused")}
+	wrapped := fmt.Errorf("upstream: %w", inner)
+	if !IsPreConnectionError(wrapped) {
+		t.Error("wrapped dial error should be pre-connection")
+	}
+}
+
+func TestIsPreConnectionError_EOF(t *testing.T) {
+	if IsPreConnectionError(io.EOF) {
+		t.Error("io.EOF should NOT be pre-connection (connection was established)")
+	}
+}
+
+func TestIsPreConnectionError_GenericError(t *testing.T) {
+	if IsPreConnectionError(errors.New("something went wrong")) {
+		t.Error("generic error should NOT be pre-connection")
+	}
+}
+
+// Verify ShouldRetry uses IsPreConnectionError for connection errors.
+func TestShouldRetry_ConnError_DialIsSafe(t *testing.T) {
+	cfg := RetryConfig{
+		Enabled:        true,
+		MaxAttempts:    3,
+		RetryOnTimeout: true,
+	}
+	dialErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("refused")}
+	if !cfg.ShouldRetry(1, nil, dialErr, false) {
+		t.Error("should retry on dial error")
+	}
+}
+
+func TestShouldRetry_ConnError_ReadIsUnsafe(t *testing.T) {
+	cfg := RetryConfig{
+		Enabled:        true,
+		MaxAttempts:    3,
+		RetryOnTimeout: true,
+	}
+	readErr := &net.OpError{Op: "read", Net: "tcp", Err: errors.New("reset")}
+	if cfg.ShouldRetry(1, nil, readErr, false) {
+		t.Error("should NOT retry on read error (ambiguous post-transmission)")
+	}
+}
+
+func TestShouldRetry_ConnError_TimeoutIsUnsafe(t *testing.T) {
+	cfg := RetryConfig{
+		Enabled:        true,
+		MaxAttempts:    3,
+		RetryOnTimeout: true,
+	}
+	if cfg.ShouldRetry(1, nil, io.EOF, false) {
+		t.Error("should NOT retry on EOF (ambiguous)")
 	}
 }

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -487,26 +487,63 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		tq.PageSize = 20
 	}
 
+	// Build optional WHERE conditions.
+	extraWhere := ""
+	extraHaving := ""
+	params := []bigquery.QueryParameter{
+		{Name: "projectID", Value: tq.ProjectID},
+		{Name: "startTime", Value: tq.StartTime},
+		{Name: "endTime", Value: tq.EndTime},
+		{Name: "userID", Value: tq.UserID},
+		{Name: "pageSize", Value: tq.PageSize},
+	}
+	if tq.Environment != "" {
+		extraWhere += "\n\t\t  AND environment = @environment"
+		params = append(params, bigquery.QueryParameter{Name: "environment", Value: tq.Environment})
+	}
+	if tq.TenantID != "" {
+		extraWhere += "\n\t\t  AND tenant_id = @tenantID"
+		params = append(params, bigquery.QueryParameter{Name: "tenantID", Value: tq.TenantID})
+	}
+	if tq.Model != "" {
+		extraWhere += "\n\t\t  AND gen_ai_model = @model"
+		params = append(params, bigquery.QueryParameter{Name: "model", Value: tq.Model})
+	}
+	if tq.Provider != "" {
+		extraWhere += "\n\t\t  AND gen_ai_provider = @provider"
+		params = append(params, bigquery.QueryParameter{Name: "provider", Value: tq.Provider})
+	}
+	if tq.Search != "" {
+		extraWhere += "\n\t\t  AND name LIKE CONCAT('%%', @escapedSearch, '%%')"
+		params = append(params, bigquery.QueryParameter{Name: "escapedSearch", Value: storage.EscapeLike(tq.Search)})
+	}
+	if tq.JobID != "" {
+		extraWhere += "\n\t\t  AND job_id = @jobID"
+		params = append(params, bigquery.QueryParameter{Name: "jobID", Value: tq.JobID})
+	}
+	if tq.TraceGroup != "" {
+		extraWhere += "\n\t\t  AND trace_group = @traceGroup"
+		params = append(params, bigquery.QueryParameter{Name: "traceGroup", Value: tq.TraceGroup})
+	}
+	if tq.Status != 0 {
+		extraHaving = "\n\t\tHAVING CASE WHEN MAX(CASE WHEN status = 2 THEN 1 ELSE 0 END) > 0 THEN 2 ELSE 1 END = @statusFilter"
+		params = append(params, bigquery.QueryParameter{Name: "statusFilter", Value: int(tq.Status)})
+	}
+
 	query := fmt.Sprintf(`
 		SELECT trace_id, MIN(start_time) AS earliest
 		FROM %s
 		WHERE (@projectID = '' OR project_id = @projectID)
 		  AND start_time >= @startTime
 		  AND start_time <= @endTime
-		  AND (@userID = '' OR user_id = @userID)
-		GROUP BY trace_id
+		  AND (@userID = '' OR user_id = @userID)%s
+		GROUP BY trace_id%s
 		ORDER BY earliest DESC
 		LIMIT @pageSize
-	`, quoteTable(s.tableID))
+	`, quoteTable(s.tableID), extraWhere, extraHaving)
 
 	q := s.client.Query(query)
-	q.SetParameters([]bigquery.QueryParameter{
-		{Name: "projectID", Value: tq.ProjectID},
-		{Name: "startTime", Value: tq.StartTime},
-		{Name: "endTime", Value: tq.EndTime},
-		{Name: "userID", Value: tq.UserID},
-		{Name: "pageSize", Value: tq.PageSize},
-	})
+	q.SetParameters(params)
 
 	it, err := q.Read(ctx)
 	if err != nil {

--- a/pkg/storage/duckdb/duckdb.go
+++ b/pkg/storage/duckdb/duckdb.go
@@ -249,6 +249,43 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		dir = "ASC"
 	}
 
+	// Build WHERE clause dynamically for optional span-level filters.
+	where := `project_id = ? AND start_time >= ? AND start_time <= ?
+			AND (? = '' OR user_id = ?)
+			AND (? = '' OR environment = ?)
+			AND (? = '' OR tenant_id = ?)`
+	args := []any{q.ProjectID, q.ProjectID, q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID, q.Environment, q.Environment, q.TenantID, q.TenantID}
+
+	if q.Model != "" {
+		where += `
+			AND gen_ai_model = ?`
+		args = append(args, q.Model)
+	}
+	if q.Provider != "" {
+		where += `
+			AND gen_ai_provider = ?`
+		args = append(args, q.Provider)
+	}
+	if q.Search != "" {
+		where += `
+			AND name LIKE '%' || ? || '%' ESCAPE '\'`
+		args = append(args, storage.EscapeLike(q.Search))
+	}
+	if q.JobID != "" {
+		where += `
+			AND job_id = ?`
+		args = append(args, q.JobID)
+	}
+
+	// Status is an aggregate (MAX), so it requires HAVING.
+	having := ""
+	if q.Status != 0 {
+		having = `HAVING CASE WHEN MAX(CASE WHEN status = 2 THEN 1 ELSE 0 END) > 0 THEN 2 ELSE 1 END = ?`
+		args = append(args, int(q.Status))
+	}
+
+	args = append(args, q.PageSize)
+
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT
 			trace_id,
@@ -273,14 +310,12 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 				LIMIT 1) as primary_provider,
 			MAX(CASE WHEN status = 2 THEN 2 ELSE 0 END)::INTEGER as status
 		FROM spans
-		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
-			AND (? = '' OR user_id = ?)
-			AND (? = '' OR environment = ?)
-			AND (? = '' OR tenant_id = ?)
+		WHERE `+where+`
 		GROUP BY trace_id
+		`+having+`
 		ORDER BY `+orderExpr+` `+dir+`
 		LIMIT ?
-	`, q.ProjectID, q.ProjectID, q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID, q.Environment, q.Environment, q.TenantID, q.TenantID, q.PageSize)
+	`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying traces: %w", err)
 	}

--- a/pkg/storage/duckdb/duckdb_test.go
+++ b/pkg/storage/duckdb/duckdb_test.go
@@ -541,3 +541,241 @@ func TestSearchSpans_NameWildcardEscape(t *testing.T) {
 		t.Errorf("SpanID = %q, want s1", result.Spans[0].SpanID)
 	}
 }
+
+func TestQueryTraces_ModelFilter(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	spans := []storage.Span{
+		testSpan("s1", "trace-gpt", storage.SpanKindLLM, "gpt-4o"),
+		testSpan("s2", "trace-gem", storage.SpanKindLLM, "gemini-2.0"),
+	}
+	spans[0].StartTime = now.Add(-2 * time.Second)
+	spans[0].EndTime = now.Add(-1 * time.Second)
+	spans[1].StartTime = now.Add(-1 * time.Second)
+	spans[1].EndTime = now
+
+	if err := store.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	result, err := store.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-test",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  10,
+		Model:     "gpt-4o",
+	})
+	if err != nil {
+		t.Fatalf("query traces: %v", err)
+	}
+
+	if len(result.Traces) != 1 {
+		t.Fatalf("trace count = %d, want 1", len(result.Traces))
+	}
+	if result.Traces[0].TraceID != "trace-gpt" {
+		t.Errorf("trace_id = %q, want trace-gpt", result.Traces[0].TraceID)
+	}
+}
+
+func TestQueryTraces_ProviderFilter(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s1 := testSpan("s1", "trace-oai", storage.SpanKindLLM, "gpt-4o")
+	s1.GenAI.Provider = "openai"
+	s1.StartTime = now.Add(-2 * time.Second)
+	s1.EndTime = now.Add(-1 * time.Second)
+
+	s2 := testSpan("s2", "trace-goog", storage.SpanKindLLM, "gemini-2.0")
+	s2.GenAI.Provider = "google"
+	s2.StartTime = now.Add(-1 * time.Second)
+	s2.EndTime = now
+
+	if err := store.IngestSpans(ctx, []storage.Span{s1, s2}); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	result, err := store.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-test",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  10,
+		Provider:  "openai",
+	})
+	if err != nil {
+		t.Fatalf("query traces: %v", err)
+	}
+
+	if len(result.Traces) != 1 {
+		t.Fatalf("trace count = %d, want 1", len(result.Traces))
+	}
+	if result.Traces[0].TraceID != "trace-oai" {
+		t.Errorf("trace_id = %q, want trace-oai", result.Traces[0].TraceID)
+	}
+}
+
+func TestQueryTraces_SearchFilter(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	spans := []storage.Span{
+		{
+			SpanID: "s1", TraceID: "trace-chat", Name: "llm.chat.completion",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-2 * time.Second), EndTime: now.Add(-1 * time.Second),
+			Duration: time.Second, ProjectID: "proj-test",
+			GenAI: &storage.GenAIAttributes{Model: "gpt-4o", Provider: "openai", CostUSD: 0.001},
+		},
+		{
+			SpanID: "s2", TraceID: "trace-search", Name: "tool.search",
+			Kind: storage.SpanKindTool, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-1 * time.Second), EndTime: now,
+			Duration: time.Second, ProjectID: "proj-test",
+			GenAI: &storage.GenAIAttributes{Model: "gpt-4o", Provider: "openai", CostUSD: 0.001},
+		},
+	}
+
+	if err := store.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	result, err := store.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-test",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  10,
+		Search:    "chat",
+	})
+	if err != nil {
+		t.Fatalf("query traces: %v", err)
+	}
+
+	if len(result.Traces) != 1 {
+		t.Fatalf("trace count = %d, want 1", len(result.Traces))
+	}
+	if result.Traces[0].TraceID != "trace-chat" {
+		t.Errorf("trace_id = %q, want trace-chat", result.Traces[0].TraceID)
+	}
+}
+
+func TestQueryTraces_StatusFilterOK(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	// trace-ok: all spans OK
+	okSpan := testSpan("s-ok", "trace-ok", storage.SpanKindLLM, "gpt-4o")
+	okSpan.Status = storage.SpanStatusOK
+	okSpan.StartTime = now.Add(-3 * time.Second)
+	okSpan.EndTime = now.Add(-2 * time.Second)
+
+	// trace-err: has an error span
+	errSpan := testSpan("s-err", "trace-err", storage.SpanKindLLM, "gpt-4o")
+	errSpan.Status = storage.SpanStatusError
+	errSpan.StartTime = now.Add(-1 * time.Second)
+	errSpan.EndTime = now
+
+	if err := store.IngestSpans(ctx, []storage.Span{okSpan, errSpan}); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	result, err := store.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-test",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  10,
+		Status:    storage.SpanStatusOK,
+	})
+	if err != nil {
+		t.Fatalf("query traces: %v", err)
+	}
+
+	if len(result.Traces) != 1 {
+		t.Fatalf("trace count = %d, want 1 (only OK traces)", len(result.Traces))
+	}
+	if result.Traces[0].TraceID != "trace-ok" {
+		t.Errorf("trace_id = %q, want trace-ok", result.Traces[0].TraceID)
+	}
+}
+
+func TestQueryTraces_StatusFilterError(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	// trace-ok: all spans OK
+	okSpan := testSpan("s-ok", "trace-ok", storage.SpanKindLLM, "gpt-4o")
+	okSpan.Status = storage.SpanStatusOK
+	okSpan.StartTime = now.Add(-3 * time.Second)
+	okSpan.EndTime = now.Add(-2 * time.Second)
+
+	// trace-err: has an error span
+	errSpan := testSpan("s-err", "trace-err", storage.SpanKindLLM, "gpt-4o")
+	errSpan.Status = storage.SpanStatusError
+	errSpan.StartTime = now.Add(-1 * time.Second)
+	errSpan.EndTime = now
+
+	if err := store.IngestSpans(ctx, []storage.Span{okSpan, errSpan}); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	result, err := store.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-test",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  10,
+		Status:    storage.SpanStatusError,
+	})
+	if err != nil {
+		t.Fatalf("query traces: %v", err)
+	}
+
+	if len(result.Traces) != 1 {
+		t.Fatalf("trace count = %d, want 1 (only error traces)", len(result.Traces))
+	}
+	if result.Traces[0].TraceID != "trace-err" {
+		t.Errorf("trace_id = %q, want trace-err", result.Traces[0].TraceID)
+	}
+}
+
+func TestQueryTraces_JobIDFilter(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s1 := testSpan("s1", "trace-job1", storage.SpanKindLLM, "gpt-4o")
+	s1.JobID = "experiment-alpha"
+	s1.StartTime = now.Add(-2 * time.Second)
+	s1.EndTime = now.Add(-1 * time.Second)
+
+	s2 := testSpan("s2", "trace-job2", storage.SpanKindLLM, "gpt-4o")
+	s2.JobID = "experiment-beta"
+	s2.StartTime = now.Add(-1 * time.Second)
+	s2.EndTime = now
+
+	if err := store.IngestSpans(ctx, []storage.Span{s1, s2}); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	result, err := store.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-test",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  10,
+		JobID:     "experiment-alpha",
+	})
+	if err != nil {
+		t.Fatalf("query traces: %v", err)
+	}
+
+	if len(result.Traces) != 1 {
+		t.Fatalf("trace count = %d, want 1", len(result.Traces))
+	}
+	if result.Traces[0].TraceID != "trace-job1" {
+		t.Errorf("trace_id = %q, want trace-job1", result.Traces[0].TraceID)
+	}
+}

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -261,6 +261,49 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		dir = "ASC"
 	}
 
+	// Build WHERE clause dynamically for optional span-level filters.
+	where := `(? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
+			AND (? = '' OR user_id = ?)
+			AND (? = '' OR tenant_id = ?)
+			AND (? = '' OR environment = ?)`
+	args := []any{
+		q.ProjectID, q.ProjectID, // subquery 1: primary_model
+		q.ProjectID, q.ProjectID, // subquery 2: primary_provider
+		q.ProjectID, q.ProjectID, // WHERE clause
+		q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+		q.UserID, q.UserID, q.TenantID, q.TenantID, q.Environment, q.Environment,
+	}
+
+	if q.Model != "" {
+		where += `
+			AND gen_ai_model = ?`
+		args = append(args, q.Model)
+	}
+	if q.Provider != "" {
+		where += `
+			AND gen_ai_provider = ?`
+		args = append(args, q.Provider)
+	}
+	if q.Search != "" {
+		where += `
+			AND name LIKE '%' || ? || '%' ESCAPE '\'`
+		args = append(args, storage.EscapeLike(q.Search))
+	}
+	if q.JobID != "" {
+		where += `
+			AND job_id = ?`
+		args = append(args, q.JobID)
+	}
+
+	// Status is an aggregate (MAX), so it requires HAVING.
+	having := ""
+	if q.Status != 0 {
+		having = `HAVING CASE WHEN MAX(CASE WHEN status = 2 THEN 1 ELSE 0 END) > 0 THEN 2 ELSE 1 END = ?`
+		args = append(args, int(q.Status))
+	}
+
+	args = append(args, q.PageSize)
+
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT
 			trace_id,
@@ -291,18 +334,12 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 			), '') as primary_provider,
 			MAX(CASE WHEN status = 2 THEN 2 ELSE 0 END) as status
 		FROM spans
-		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
-			AND (? = '' OR user_id = ?)
-			AND (? = '' OR tenant_id = ?)
-			AND (? = '' OR environment = ?)
+		WHERE `+where+`
 		GROUP BY trace_id
+		`+having+`
 		ORDER BY `+orderExpr+` `+dir+`
 		LIMIT ?
-	`, q.ProjectID, q.ProjectID, // subquery 1: primary_model
-		q.ProjectID, q.ProjectID, // subquery 2: primary_provider
-		q.ProjectID, q.ProjectID, // WHERE clause
-		q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
-		q.UserID, q.UserID, q.TenantID, q.TenantID, q.Environment, q.Environment, q.PageSize)
+	`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying traces: %w", err)
 	}

--- a/pkg/storage/sqlite/sqlite_test.go
+++ b/pkg/storage/sqlite/sqlite_test.go
@@ -386,3 +386,291 @@ func TestGetTenantLeaderboard(t *testing.T) {
 		t.Errorf("tenant-a cost = %f, want 0.02", leaderboard[1].CostUSD)
 	}
 }
+
+func TestQueryFilter_Model_SQLite(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	spans := []storage.Span{
+		{
+			SpanID: "s1", TraceID: "trace-gpt", Name: "llm.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-2 * time.Second), EndTime: now.Add(-1 * time.Second),
+			Duration: time.Second, ProjectID: "proj-1",
+			GenAI: &storage.GenAIAttributes{
+				Model: "gpt-4o", Provider: "openai",
+				InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.001,
+			},
+		},
+		{
+			SpanID: "s2", TraceID: "trace-gem", Name: "llm.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-1 * time.Second), EndTime: now,
+			Duration: time.Second, ProjectID: "proj-1",
+			GenAI: &storage.GenAIAttributes{
+				Model: "gemini-2.0", Provider: "google",
+				InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.001,
+			},
+		},
+	}
+
+	if err := s.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	result, err := s.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-1",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  10,
+		Model:     "gpt-4o",
+	})
+	if err != nil {
+		t.Fatalf("query traces: %v", err)
+	}
+
+	if len(result.Traces) != 1 {
+		t.Fatalf("trace count = %d, want 1", len(result.Traces))
+	}
+	if result.Traces[0].TraceID != "trace-gpt" {
+		t.Errorf("trace_id = %q, want trace-gpt", result.Traces[0].TraceID)
+	}
+}
+
+func TestQueryFilter_Provider_SQLite(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	spans := []storage.Span{
+		{
+			SpanID: "s1", TraceID: "trace-oai", Name: "llm.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-2 * time.Second), EndTime: now.Add(-1 * time.Second),
+			Duration: time.Second, ProjectID: "proj-1",
+			GenAI: &storage.GenAIAttributes{
+				Model: "gpt-4o", Provider: "openai",
+				InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.001,
+			},
+		},
+		{
+			SpanID: "s2", TraceID: "trace-goog", Name: "llm.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-1 * time.Second), EndTime: now,
+			Duration: time.Second, ProjectID: "proj-1",
+			GenAI: &storage.GenAIAttributes{
+				Model: "gemini-2.0", Provider: "google",
+				InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.001,
+			},
+		},
+	}
+
+	if err := s.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	result, err := s.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-1",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  10,
+		Provider:  "openai",
+	})
+	if err != nil {
+		t.Fatalf("query traces: %v", err)
+	}
+
+	if len(result.Traces) != 1 {
+		t.Fatalf("trace count = %d, want 1", len(result.Traces))
+	}
+	if result.Traces[0].TraceID != "trace-oai" {
+		t.Errorf("trace_id = %q, want trace-oai", result.Traces[0].TraceID)
+	}
+}
+
+func TestQueryFilter_Search_SQLite(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	spans := []storage.Span{
+		{
+			SpanID: "s1", TraceID: "trace-chat", Name: "llm.chat.completion",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-2 * time.Second), EndTime: now.Add(-1 * time.Second),
+			Duration: time.Second, ProjectID: "proj-1",
+			GenAI: &storage.GenAIAttributes{Model: "gpt-4o", Provider: "openai", CostUSD: 0.001},
+		},
+		{
+			SpanID: "s2", TraceID: "trace-search", Name: "tool.search",
+			Kind: storage.SpanKindTool, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-1 * time.Second), EndTime: now,
+			Duration: time.Second, ProjectID: "proj-1",
+			GenAI: &storage.GenAIAttributes{Model: "gpt-4o", Provider: "openai", CostUSD: 0.001},
+		},
+	}
+
+	if err := s.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	result, err := s.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-1",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  10,
+		Search:    "chat",
+	})
+	if err != nil {
+		t.Fatalf("query traces: %v", err)
+	}
+
+	if len(result.Traces) != 1 {
+		t.Fatalf("trace count = %d, want 1", len(result.Traces))
+	}
+	if result.Traces[0].TraceID != "trace-chat" {
+		t.Errorf("trace_id = %q, want trace-chat", result.Traces[0].TraceID)
+	}
+}
+
+func TestQueryFilter_StatusOK_SQLite(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	// trace-ok: all spans OK
+	spans := []storage.Span{
+		{
+			SpanID: "s-ok", TraceID: "trace-ok", Name: "llm.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-3 * time.Second), EndTime: now.Add(-2 * time.Second),
+			Duration: time.Second, ProjectID: "proj-1",
+		},
+		// trace-err: has an error span
+		{
+			SpanID: "s-err", TraceID: "trace-err", Name: "llm.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusError,
+			StartTime: now.Add(-1 * time.Second), EndTime: now,
+			Duration: time.Second, ProjectID: "proj-1",
+		},
+	}
+
+	if err := s.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	result, err := s.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-1",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  10,
+		Status:    storage.SpanStatusOK,
+	})
+	if err != nil {
+		t.Fatalf("query traces: %v", err)
+	}
+
+	if len(result.Traces) != 1 {
+		t.Fatalf("trace count = %d, want 1 (only OK traces)", len(result.Traces))
+	}
+	if result.Traces[0].TraceID != "trace-ok" {
+		t.Errorf("trace_id = %q, want trace-ok", result.Traces[0].TraceID)
+	}
+}
+
+func TestQueryFilter_StatusError_SQLite(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	spans := []storage.Span{
+		// trace-ok: all spans OK
+		{
+			SpanID: "s-ok", TraceID: "trace-ok", Name: "llm.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-3 * time.Second), EndTime: now.Add(-2 * time.Second),
+			Duration: time.Second, ProjectID: "proj-1",
+		},
+		// trace-err: has an error span
+		{
+			SpanID: "s-err", TraceID: "trace-err", Name: "llm.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusError,
+			StartTime: now.Add(-1 * time.Second), EndTime: now,
+			Duration: time.Second, ProjectID: "proj-1",
+		},
+	}
+
+	if err := s.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	result, err := s.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-1",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  10,
+		Status:    storage.SpanStatusError,
+	})
+	if err != nil {
+		t.Fatalf("query traces: %v", err)
+	}
+
+	if len(result.Traces) != 1 {
+		t.Fatalf("trace count = %d, want 1 (only error traces)", len(result.Traces))
+	}
+	if result.Traces[0].TraceID != "trace-err" {
+		t.Errorf("trace_id = %q, want trace-err", result.Traces[0].TraceID)
+	}
+}
+
+func TestQueryFilter_JobID_SQLite(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	spans := []storage.Span{
+		{
+			SpanID: "s1", TraceID: "trace-job1", Name: "llm.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-2 * time.Second), EndTime: now.Add(-1 * time.Second),
+			Duration: time.Second, ProjectID: "proj-1", JobID: "experiment-alpha",
+			GenAI: &storage.GenAIAttributes{
+				Model: "gpt-4o", Provider: "openai",
+				InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.001,
+			},
+		},
+		{
+			SpanID: "s2", TraceID: "trace-job2", Name: "llm.chat",
+			Kind: storage.SpanKindLLM, Status: storage.SpanStatusOK,
+			StartTime: now.Add(-1 * time.Second), EndTime: now,
+			Duration: time.Second, ProjectID: "proj-1", JobID: "experiment-beta",
+			GenAI: &storage.GenAIAttributes{
+				Model: "gpt-4o", Provider: "openai",
+				InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.001,
+			},
+		},
+	}
+
+	if err := s.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	result, err := s.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-1",
+		StartTime: now.Add(-10 * time.Second),
+		EndTime:   now.Add(10 * time.Second),
+		PageSize:  10,
+		JobID:     "experiment-alpha",
+	})
+	if err != nil {
+		t.Fatalf("query traces: %v", err)
+	}
+
+	if len(result.Traces) != 1 {
+		t.Fatalf("trace count = %d, want 1", len(result.Traces))
+	}
+	if result.Traces[0].TraceID != "trace-job1" {
+		t.Errorf("trace_id = %q, want trace-job1", result.Traces[0].TraceID)
+	}
+}

--- a/ui/e2e/today.spec.ts
+++ b/ui/e2e/today.spec.ts
@@ -30,6 +30,22 @@ async function mockDevUser(page: import("@playwright/test").Page) {
   });
 }
 
+/** Mock UserService.GetMyBudget — the hook now calls this in parallel with GetMyUsage. */
+async function mockBudget(
+  page: import("@playwright/test").Page,
+  budget: { limitUsd: number; spentUsd: number; periodType?: number } | null,
+  opts?: { totalRemainingUsd?: number; budgetRemainingUsd?: number },
+) {
+  const response: Record<string, unknown> = { activeGrants: [], periodResetsAt: "", periodKey: "" };
+  if (budget) {
+    response.budget = { ...budget, periodType: budget.periodType ?? 1 };
+    response.totalRemainingUsd = opts?.totalRemainingUsd ?? (budget.limitUsd - budget.spentUsd);
+    response.budgetRemainingUsd = opts?.budgetRemainingUsd ?? (budget.limitUsd - budget.spentUsd);
+    response.grantsRemainingUsd = 0;
+  }
+  await mockConnectRPC(page, "/candela.v1.UserService/GetMyBudget", response);
+}
+
 // ──────────────────────────────────────────
 // Today Budget View (/today)
 // ──────────────────────────────────────────
@@ -37,6 +53,7 @@ async function mockDevUser(page: import("@playwright/test").Page) {
 test.describe("Today Budget View", () => {
   test("renders page header with today's date", async ({ page }) => {
     await mockDevUser(page);
+    await mockBudget(page, { limitUsd: 50, spentUsd: 0 });
     await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
       totalCalls: "0",
       totalInputTokens: "0",
@@ -44,18 +61,17 @@ test.describe("Today Budget View", () => {
       totalCostUsd: 0,
       avgLatencyMs: 0,
       models: [],
-      budget: { limitUsd: 50, spentUsd: 0, periodType: 1 },
-      totalRemainingUsd: 50,
     });
 
     await page.goto("/today");
-    await expect(page.locator("h1")).toHaveText("Today");
+    await expect(page.locator("h1")).toHaveText("Today UTC");
     // Date string should be visible (e.g. "Saturday, April 26, 2026")
     await expect(page.locator(".today-date")).toBeVisible();
   });
 
   test("shows budget ring gauge with spent/limit/remaining", async ({ page }) => {
     await mockDevUser(page);
+    await mockBudget(page, { limitUsd: 50, spentUsd: 12.5 });
     await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
       totalCalls: "42",
       totalInputTokens: "10000",
@@ -66,8 +82,6 @@ test.describe("Today Budget View", () => {
         { model: "gpt-4o", provider: "openai", callCount: "30", inputTokens: "7000", outputTokens: "3000", costUsd: 1.0, avgLatencyMs: 300 },
         { model: "claude-3-sonnet", provider: "anthropic", callCount: "12", inputTokens: "3000", outputTokens: "2000", costUsd: 0.25, avgLatencyMs: 400 },
       ],
-      budget: { limitUsd: 50, spentUsd: 12.5, periodType: 1 },
-      totalRemainingUsd: 37.5,
     });
 
     await page.goto("/today");
@@ -83,6 +97,7 @@ test.describe("Today Budget View", () => {
 
   test("shows quick stats cards with today's data", async ({ page }) => {
     await mockDevUser(page);
+    await mockBudget(page, { limitUsd: 50, spentUsd: 5 });
     await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
       totalCalls: "42",
       totalInputTokens: "10000",
@@ -90,8 +105,6 @@ test.describe("Today Budget View", () => {
       totalCostUsd: 1.25,
       avgLatencyMs: 340,
       models: [],
-      budget: { limitUsd: 50, spentUsd: 5, periodType: 1 },
-      totalRemainingUsd: 45,
     });
 
     await page.goto("/today");
@@ -114,6 +127,7 @@ test.describe("Today Budget View", () => {
 
   test("shows per-model token breakdown sorted by cost", async ({ page }) => {
     await mockDevUser(page);
+    await mockBudget(page, { limitUsd: 50, spentUsd: 5 });
     await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
       totalCalls: "42",
       totalInputTokens: "10000",
@@ -124,8 +138,6 @@ test.describe("Today Budget View", () => {
         { model: "gpt-4o", provider: "openai", callCount: "30", inputTokens: "7000", outputTokens: "3000", costUsd: 1.0, avgLatencyMs: 300 },
         { model: "claude-3-sonnet", provider: "anthropic", callCount: "12", inputTokens: "3000", outputTokens: "2000", costUsd: 0.25, avgLatencyMs: 400 },
       ],
-      budget: { limitUsd: 50, spentUsd: 5, periodType: 1 },
-      totalRemainingUsd: 45,
     });
 
     await page.goto("/today");
@@ -143,6 +155,7 @@ test.describe("Today Budget View", () => {
 
   test("shows empty state when no activity today", async ({ page }) => {
     await mockDevUser(page);
+    await mockBudget(page, { limitUsd: 50, spentUsd: 0 });
     await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
       totalCalls: "0",
       totalInputTokens: "0",
@@ -150,8 +163,6 @@ test.describe("Today Budget View", () => {
       totalCostUsd: 0,
       avgLatencyMs: 0,
       models: [],
-      budget: { limitUsd: 50, spentUsd: 0, periodType: 1 },
-      totalRemainingUsd: 50,
     });
 
     await page.goto("/today");
@@ -160,6 +171,7 @@ test.describe("Today Budget View", () => {
 
   test("shows no-budget message when budget is not configured", async ({ page }) => {
     await mockDevUser(page);
+    await mockBudget(page, null);
     await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
       totalCalls: "10",
       totalInputTokens: "1000",
@@ -167,8 +179,6 @@ test.describe("Today Budget View", () => {
       totalCostUsd: 0.05,
       avgLatencyMs: 200,
       models: [],
-      // No budget field
-      totalRemainingUsd: 0,
     });
 
     await page.goto("/today");
@@ -177,6 +187,7 @@ test.describe("Today Budget View", () => {
 
   test("shows alert when budget is nearly exhausted (>=90%)", async ({ page }) => {
     await mockDevUser(page);
+    await mockBudget(page, { limitUsd: 50, spentUsd: 47.5 });
     await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
       totalCalls: "200",
       totalInputTokens: "80000",
@@ -184,8 +195,6 @@ test.describe("Today Budget View", () => {
       totalCostUsd: 47.5,
       avgLatencyMs: 300,
       models: [],
-      budget: { limitUsd: 50, spentUsd: 47.5, periodType: 1 },
-      totalRemainingUsd: 2.5,
     });
 
     await page.goto("/today");
@@ -194,6 +203,7 @@ test.describe("Today Budget View", () => {
 
   test("shows exhausted alert when budget is at 100%", async ({ page }) => {
     await mockDevUser(page);
+    await mockBudget(page, { limitUsd: 50, spentUsd: 52 });
     await mockConnectRPC(page, "/candela.v1.DashboardService/GetMyUsage", {
       totalCalls: "300",
       totalInputTokens: "100000",
@@ -201,8 +211,6 @@ test.describe("Today Budget View", () => {
       totalCostUsd: 52.0,
       avgLatencyMs: 350,
       models: [],
-      budget: { limitUsd: 50, spentUsd: 52, periodType: 1 },
-      totalRemainingUsd: 0,
     });
 
     await page.goto("/today");
@@ -219,6 +227,7 @@ test.describe("Today Budget View", () => {
 
   test("refresh button triggers data reload", async ({ page }) => {
     await mockDevUser(page);
+    await mockBudget(page, { limitUsd: 50, spentUsd: 5 });
 
     let callCount = 0;
     await page.route(`${API_BASE}/candela.v1.DashboardService/GetMyUsage`, async (route) => {
@@ -233,8 +242,6 @@ test.describe("Today Budget View", () => {
           totalCostUsd: 0.5,
           avgLatencyMs: 200,
           models: [],
-          budget: { limitUsd: 50, spentUsd: 5, periodType: 1 },
-          totalRemainingUsd: 45,
         }),
       });
     });
@@ -269,7 +276,7 @@ test.describe("Today navigation", () => {
 
     await todayLink.click();
     await expect(page).toHaveURL("/today");
-    await expect(page.locator("h1")).toHaveText("Today");
+    await expect(page.locator("h1")).toHaveText("Today UTC");
   });
 
   test("Today nav item is highlighted when active", async ({ page }) => {

--- a/ui/src/app/today/page.tsx
+++ b/ui/src/app/today/page.tsx
@@ -184,14 +184,37 @@ export default function TodayPage() {
     ? (data.totalInputTokens + data.totalOutputTokens)
     : 0;
 
+  // Live UTC clock — ticks every 30s so users know what "today UTC" means.
+  // tick=0 during SSR; the first interval callback bumps it to 1, which also
+  // serves as the "mounted" signal (avoiding synchronous setState in effect body).
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    // Fire immediately via setTimeout(0) so the first tick is async (not
+    // synchronous in the effect body), satisfying the ESLint rule.
+    const immediate = setTimeout(() => setTick(1), 0);
+    const timer = setInterval(() => setTick((t) => t + 1), 30_000);
+    return () => { clearTimeout(immediate); clearInterval(timer); };
+  }, []);
+
   // Use UTC to match the budget reset boundary (midnight UTC).
-  const todayStr = new Date().toLocaleDateString(undefined, {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-    timeZone: "UTC",
-  });
+  const todayStr = tick > 0
+    ? new Date().toLocaleDateString(undefined, {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        timeZone: "UTC",
+      })
+    : "";
+
+  const utcTimeStr = tick > 0
+    ? new Date().toLocaleTimeString(undefined, {
+        hour: "2-digit",
+        minute: "2-digit",
+        timeZone: "UTC",
+        hour12: false,
+      })
+    : "--:--";
 
   const sortedModels = useMemo(
     () => [...(data?.models ?? [])].sort((a, b) => b.costUsd - a.costUsd),
@@ -202,8 +225,13 @@ export default function TodayPage() {
     <>
       <header className="main-header">
         <div>
-          <h1>Today</h1>
+          <h1>Today <span className="today-utc-badge">UTC</span></h1>
           <span className="today-date">{todayStr}</span>
+          <span className="today-utc-clock">
+            {utcTimeStr} UTC · {data?.periodResetsAt
+              ? `Resets ${new Date(data.periodResetsAt).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", hour12: true })} local time`
+              : "Resets at midnight UTC"}
+          </span>
         </div>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
           {data?.fetchedAt && (
@@ -216,6 +244,7 @@ export default function TodayPage() {
           </button>
         </div>
       </header>
+
 
       <div className="main-body">
         {error && (
@@ -432,6 +461,25 @@ export default function TodayPage() {
           color: var(--text-muted);
           margin-left: 12px;
           font-weight: 400;
+        }
+        .today-utc-badge {
+          font-size: 11px;
+          font-weight: 600;
+          color: var(--accent);
+          background: rgba(240, 160, 48, 0.12);
+          padding: 2px 6px;
+          border-radius: 4px;
+          vertical-align: middle;
+          letter-spacing: 0.06em;
+          margin-left: 4px;
+        }
+        .today-utc-clock {
+          display: block;
+          font-size: 11px;
+          color: var(--text-muted);
+          margin-left: 12px;
+          margin-top: 2px;
+          font-variant-numeric: tabular-nums;
         }
         .today-updated {
           font-size: 11px;

--- a/ui/src/hooks/useTodayBudget.ts
+++ b/ui/src/hooks/useTodayBudget.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useReducer } from "react";
-import { dashboardClient } from "@/lib/api";
+import { dashboardClient, userClient } from "@/lib/api";
 import { DEFAULT_PROJECT_ID } from "@/lib/constants";
 import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt";
 
@@ -43,6 +43,8 @@ export interface TodayBudgetData {
   grants: TodayGrant[];
   /** When this data was last fetched */
   fetchedAt: Date;
+  /** ISO 8601 timestamp when the budget period resets (midnight UTC). */
+  periodResetsAt: string | null;
 }
 
 type State = {
@@ -71,14 +73,20 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-/** Returns the start of today in UTC (midnight). */
+/** Returns the start of today in UTC (midnight) to match budget reset boundary. */
 function startOfTodayUTC(): Date {
   const now = new Date();
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
 }
 
 /**
- * Fetches the current user's usage for TODAY only, scoped to the daily budget period.
+ * Fetches the current user's usage AND budget for TODAY, scoped to the daily
+ * budget period (midnight UTC → now).
+ *
+ * Calls two RPCs in parallel:
+ *   1. DashboardService.GetMyUsage  → token counts, cost, model breakdown (~800ms)
+ *   2. UserService.GetMyBudget      → budget limit/spent, grants (~80ms)
+ *
  * Auto-refreshes every 60 seconds to keep the view live.
  */
 export function useTodayBudget() {
@@ -96,21 +104,28 @@ export function useTodayBudget() {
     const start = startOfTodayUTC();
     const now = new Date();
 
-    dashboardClient.getMyUsage({
+    // Fire both RPCs in parallel — usage data from BigQuery, budget from Firestore.
+    const usagePromise = dashboardClient.getMyUsage({
       projectId: DEFAULT_PROJECT_ID,
       timeRange: {
         start: timestampFromDate(start),
         end: timestampFromDate(now),
       },
-    })
-      .then((res) => {
+    });
+
+    const budgetPromise = userClient.getMyBudget({}).catch(() => null);
+
+    Promise.all([usagePromise, budgetPromise])
+      .then(([usageRes, budgetRes]) => {
         if (cancelled) return;
 
-        const limit = res.budget?.limitUsd || 0;
-        const spent = res.budget?.spentUsd || 0;
+        // ── Budget from UserService.GetMyBudget (Firestore) ───────────────
+        const budgetProto = budgetRes?.budget;
+        const limit = budgetProto?.limitUsd ?? 0;
+        const spent = budgetProto?.spentUsd ?? 0;
 
-        // Map active grants from proto response.
-        const grants: TodayGrant[] = (res.activeGrants ?? []).map((g) => {
+        // Map active grants from the budget response.
+        const grants: TodayGrant[] = (budgetRes?.activeGrants ?? []).map((g) => {
           const amt = g.amountUsd;
           const sp = g.spentUsd;
           return {
@@ -128,12 +143,13 @@ export function useTodayBudget() {
         dispatch({
           type: "success",
           data: {
-            totalCalls: Number(res.totalCalls),
-            totalInputTokens: Number(res.totalInputTokens),
-            totalOutputTokens: Number(res.totalOutputTokens),
-            totalCostUsd: res.totalCostUsd,
-            avgLatencyMs: res.avgLatencyMs,
-            models: res.models.map((m) => ({
+            // ── Usage from DashboardService.GetMyUsage (BigQuery) ─────────
+            totalCalls: Number(usageRes.totalCalls),
+            totalInputTokens: Number(usageRes.totalInputTokens),
+            totalOutputTokens: Number(usageRes.totalOutputTokens),
+            totalCostUsd: usageRes.totalCostUsd,
+            avgLatencyMs: usageRes.avgLatencyMs,
+            models: usageRes.models.map((m) => ({
               model: m.model,
               provider: m.provider,
               callCount: Number(m.callCount),
@@ -142,18 +158,20 @@ export function useTodayBudget() {
               costUsd: m.costUsd,
               avgLatencyMs: m.avgLatencyMs,
             })),
-            budget: res.budget ? {
+            // ── Budget from UserService.GetMyBudget ──────────────────────
+            budget: budgetProto ? {
               limitUsd: limit,
               spentUsd: spent,
-              remainingUsd: res.totalRemainingUsd,
+              remainingUsd: budgetRes?.budgetRemainingUsd ?? (limit - spent),
               percentUsed: limit > 0 ? (spent / limit) * 100 : 0,
               periodType: {
                 0: "unspecified",
                 1: "daily",
-              }[res.budget.periodType] || "daily",
+              }[budgetProto.periodType] || "daily",
             } : null,
             grants,
             fetchedAt: new Date(),
+            periodResetsAt: budgetRes?.periodResetsAt ?? null,
           },
         });
       })


### PR DESCRIPTION
## Summary

Implement transparent retry/fallback for the proxy so transient upstream failures (500, 502, 503, 429) are automatically retried with exponential backoff + jitter, and if retries are exhausted, the request falls back to alternative providers in a configured chain.

## New Files

| File | Purpose |
|------|---------|
| `pkg/proxy/retry.go` | `RetryConfig`, backoff calculation, `ShouldRetry()`, `ParseRetryAfter()` |
| `pkg/proxy/fallback.go` | `FallbackConfig`, `FallbackResolver`, model-prefix chain matching |
| `pkg/proxy/retry_test.go` | 22 unit tests for retry logic |
| `pkg/proxy/fallback_test.go` | 10 unit tests for fallback resolution |
| `pkg/proxy/proxy_retry_test.go` | 7 integration tests with real HTTP servers |

## Key Changes

### Retry Logic
- Configurable max attempts, retryable status codes, exponential backoff with jitter
- Respects `Retry-After` headers (RFC 7231)
- **NEVER** retries after streaming has started (prevents duplicate SSE chunks)

### Fallback Chain Resolution
- Model-prefix → ordered provider chains (e.g. `claude-*` → `[anthropic, anthropic-vertex, anthropic-bedrock]`)
- Skips fallback providers whose circuit breaker is open
- Added `IsOpen()` to `CircuitBreaker` for pre-flight health checks

### handleProxy Integration
- Wraps the entire translate → execute → response block in a provider attempt loop
- Primary provider tried first, then fallback providers
- Stream context lifetime correctly managed (deferred cleanup, not premature cancel)
- Budget gates and model validation run ONCE before the loop

## Safety Guarantees
- Translation errors (400) → never retried
- Non-retryable status (401, 403) → immediate termination
- Auth errors on non-final providers → continue to next fallback
- Budget reservation runs once, transferred to response handler

## Test Coverage (39 new tests)
- **Unit**: Backoff math, jitter bounds, retryable status, Retry-After parsing, chain resolution
- **Integration**: 500→success retry, disabled retry, max attempts exhausted, 400 not retried, 429 with Retry-After, primary→secondary fallback, circuit breaker IsOpen

All existing proxy tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable upstream request retries with exponential backoff (with `Retry-After` support) and ordered provider fallback chains.
  - Expanded trace search/filtering by model, provider, status, search term, and job ID.
  - Today’s dashboard now shows a live “Today UTC” clock with reset information and refreshed budget data.
  - Added Claude Sonnet 5 pricing snapshot.

- **Bug Fixes**
  - Corrected trace status filtering across storage backends.
  - Improved compatibility with legacy Vertex AI caching settings.
  - Enhanced HTTP/2 handling and CI module download reliability (retrying module downloads on transient failures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->