### PR TITLE
fix: P1 batch — CI retry loop, SQLite schema parity, AbortController hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,12 +98,19 @@ jobs:
       - name: Download modules
         run: |
           nix develop . --command bash -c "
+            success=false
             for attempt in 1 2 3; do
-              go mod download && break
+              if go mod download; then
+                success=true
+                break
+              fi
               echo \"::warning::go mod download failed (attempt \$attempt/3), retrying...\"
               sleep 5
             done
-            go mod download || { echo \"::error::go mod download failed after 3 retries\"; exit 1; }
+            if [ \"\$success\" != true ]; then
+              echo \"::error::go mod download failed after 3 retries\"
+              exit 1
+            fi
           "
 
       - name: Build
@@ -169,12 +176,19 @@ jobs:
       - name: Download modules
         run: |
           nix develop . --command bash -c "
+            success=false
             for attempt in 1 2 3; do
-              go mod download && break
+              if go mod download; then
+                success=true
+                break
+              fi
               echo \"::warning::go mod download failed (attempt \$attempt/3), retrying...\"
               sleep 5
             done
-            go mod download || { echo \"::error::go mod download failed after 3 retries\"; exit 1; }
+            if [ \"\$success\" != true ]; then
+              echo \"::error::go mod download failed after 3 retries\"
+              exit 1
+            fi
           "
 
       - name: Test (${{ matrix.group.name }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,10 @@ jobs:
           nix develop . --command bash -c "
             for attempt in 1 2 3; do
               go mod download && break
-              echo \"::warning::go mod download failed (attempt $attempt/3), retrying...\"
+              echo \"::warning::go mod download failed (attempt \$attempt/3), retrying...\"
               sleep 5
             done
+            go mod download || { echo \"::error::go mod download failed after 3 retries\"; exit 1; }
           "
 
       - name: Build
@@ -170,9 +171,10 @@ jobs:
           nix develop . --command bash -c "
             for attempt in 1 2 3; do
               go mod download && break
-              echo \"::warning::go mod download failed (attempt $attempt/3), retrying...\"
+              echo \"::warning::go mod download failed (attempt \$attempt/3), retrying...\"
               sleep 5
             done
+            go mod download || { echo \"::error::go mod download failed after 3 retries\"; exit 1; }
           "
 
       - name: Test (${{ matrix.group.name }})

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -106,6 +106,8 @@ func (s *Store) migrate() error {
 		`CREATE INDEX IF NOT EXISTS idx_spans_kind ON spans(kind)`,
 		// Migration: add user_id column to existing tables.
 		`ALTER TABLE spans ADD COLUMN user_id TEXT DEFAULT ''`,
+		// Migration: add user_id index (matches DuckDB idx_spans_user).
+		`CREATE INDEX IF NOT EXISTS idx_spans_user ON spans(user_id)`,
 		// Migration: add session_id column to existing tables.
 		`ALTER TABLE spans ADD COLUMN session_id TEXT DEFAULT ''`,
 		// Migration: add tenant_id for multitenant cost attribution.
@@ -524,7 +526,7 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, q storage.UsageQuery, li
 		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
 			AND user_id != ''
 		GROUP BY user_id
-		ORDER BY SUM(gen_ai_cost_usd) DESC
+		ORDER BY SUM(gen_ai_cost_usd) DESC, user_id ASC
 		LIMIT ?
 	`, int(storage.SpanKindLLM), q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
 		q.ProjectID, q.ProjectID, q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano), limit)

--- a/pkg/storage/sqlite/sqlite_extra_test.go
+++ b/pkg/storage/sqlite/sqlite_extra_test.go
@@ -156,16 +156,16 @@ func TestGetUserLeaderboard_SQLite(t *testing.T) {
 	if len(leaders) != 2 {
 		t.Fatalf("got %d leaders, want 2", len(leaders))
 	}
-	// Bob: $0.10 total → first
-	if leaders[0].UserID != "bob@example.com" {
-		t.Errorf("top user = %q, want bob@example.com", leaders[0].UserID)
+	// Both users have $0.10 total. Stable sort: cost DESC, user_id ASC.
+	// alice@example.com sorts before bob@example.com alphabetically.
+	if leaders[0].UserID != "alice@example.com" {
+		t.Errorf("top user = %q, want alice@example.com", leaders[0].UserID)
 	}
-	// Alice: 2 calls, $0.10 total → second
-	if leaders[1].UserID != "alice@example.com" {
-		t.Errorf("second user = %q, want alice@example.com", leaders[1].UserID)
+	if leaders[0].CallCount != 2 {
+		t.Errorf("alice call count = %d, want 2", leaders[0].CallCount)
 	}
-	if leaders[1].CallCount != 2 {
-		t.Errorf("alice call count = %d, want 2", leaders[1].CallCount)
+	if leaders[1].UserID != "bob@example.com" {
+		t.Errorf("second user = %q, want bob@example.com", leaders[1].UserID)
 	}
 }
 

--- a/ui/src/hooks/useCosts.ts
+++ b/ui/src/hooks/useCosts.ts
@@ -87,7 +87,8 @@ export function useCosts() {
   });
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
+    const signal = controller.signal;
     dispatch({ type: "fetch" });
 
     const now = new Date();
@@ -101,15 +102,15 @@ export function useCosts() {
     const summaryPromise = dashboardClient.getUsageSummary({
       projectId: DEFAULT_PROJECT_ID, // FIXME: Hardcoded - see constants.ts for evolution plan
       timeRange
-    });
+    }, { signal });
     const modelsPromise = dashboardClient.getModelBreakdown({
       projectId: DEFAULT_PROJECT_ID, // FIXME: Hardcoded - see constants.ts for evolution plan
       timeRange
-    });
+    }, { signal });
 
     Promise.all([summaryPromise, modelsPromise])
       .then(([summaryRes, modelsRes]) => {
-        if (cancelled) return;
+        if (signal.aborted) return;
         dispatch({
           type: "success",
           summary: {
@@ -138,10 +139,10 @@ export function useCosts() {
         });
       })
       .catch((err) => {
-        if (!cancelled) dispatch({ type: "error", message: err.message });
+        if (!signal.aborted) dispatch({ type: "error", message: err.message });
       });
 
-    return () => { cancelled = true; };
+    return () => controller.abort();
   }, [state.fetchCount, state.timeRange]);
 
   const refresh = useCallback(() => dispatch({ type: "refresh" }), []);

--- a/ui/src/hooks/useCurrentUser.ts
+++ b/ui/src/hooks/useCurrentUser.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useReducer} from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 import { userClient } from "@/lib/api";
 import type { User, UserBudget, BudgetGrant } from "@/gen/candela/types/user_pb";
 import { UserRole } from "@/gen/candela/types/user_pb";
@@ -55,12 +55,17 @@ const initialState: CurrentUser = {
  */
 export function useCurrentUser(): CurrentUser {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const fetchRef = useRef<AbortController | null>(null);
 
   const fetchUser = useCallback(async () => {
+    fetchRef.current?.abort();
+    const controller = new AbortController();
+    fetchRef.current = controller;
+
     dispatch({ type: "loading" });
     try {
-      const resp = await userClient.getCurrentUser({});
-      if (resp.user) {
+      const resp = await userClient.getCurrentUser({}, { signal: controller.signal });
+      if (!controller.signal.aborted && resp.user) {
         dispatch({
           type: "success",
           user: resp.user,
@@ -70,13 +75,16 @@ export function useCurrentUser(): CurrentUser {
         });
       }
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to load user";
-      dispatch({ type: "error", message });
+      if (!controller.signal.aborted) {
+        const message = err instanceof Error ? err.message : "Failed to load user";
+        dispatch({ type: "error", message });
+      }
     }
   }, []);
 
   useEffect(() => {
     fetchUser();
+    return () => fetchRef.current?.abort();
   }, [fetchUser]);
 
   return state;

--- a/ui/src/hooks/useLeaderboard.ts
+++ b/ui/src/hooks/useLeaderboard.ts
@@ -65,7 +65,8 @@ export function useLeaderboard() {
   });
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
+    const signal = controller.signal;
     dispatch({ type: "fetch" });
 
     const now = new Date();
@@ -78,9 +79,9 @@ export function useLeaderboard() {
         end: timestampFromDate(now),
       },
       limit: 20,
-    })
+    }, { signal })
       .then((res) => {
-        if (cancelled) return;
+        if (signal.aborted) return;
         dispatch({
           type: "success",
           rankings: res.users.map((u) => ({
@@ -96,10 +97,10 @@ export function useLeaderboard() {
         });
       })
       .catch((err) => {
-        if (!cancelled) dispatch({ type: "error", message: err.message });
+        if (!signal.aborted) dispatch({ type: "error", message: err.message });
       });
 
-    return () => { cancelled = true; };
+    return () => controller.abort();
   }, [state.fetchCount, state.timeRange]);
 
   const refresh = useCallback(() => dispatch({ type: "refresh" }), []);

--- a/ui/src/hooks/useTenantLeaderboard.ts
+++ b/ui/src/hooks/useTenantLeaderboard.ts
@@ -75,7 +75,8 @@ export function useTenantLeaderboard() {
   });
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
+    const signal = controller.signal;
     dispatch({ type: "fetch" });
 
     (async () => {
@@ -95,7 +96,7 @@ export function useTenantLeaderboard() {
 
         const res = await fetch(
           `${API_BASE_URL}/_local/api/leaderboard?limit=50&startTime=${encodeURIComponent(start)}&endTime=${encodeURIComponent(end)}`,
-          { headers },
+          { headers, signal },
         );
 
         if (!res.ok) {
@@ -103,7 +104,7 @@ export function useTenantLeaderboard() {
         }
 
         const data = await res.json();
-        if (cancelled) return;
+        if (signal.aborted) return;
 
         const tenants: TenantUsageRow[] = (data.tenants ?? []).map(
           (t: Record<string, unknown>) => ({
@@ -118,7 +119,7 @@ export function useTenantLeaderboard() {
 
         dispatch({ type: "success", tenants });
       } catch (err) {
-        if (!cancelled) {
+        if (!signal.aborted) {
           dispatch({
             type: "error",
             message: err instanceof Error ? err.message : "Failed to load tenant leaderboard",
@@ -127,9 +128,7 @@ export function useTenantLeaderboard() {
       }
     })();
 
-    return () => {
-      cancelled = true;
-    };
+    return () => controller.abort();
   }, [state.fetchCount, state.timeRange]);
 
   // Client-side sorting

--- a/ui/src/hooks/useTodayBudget.ts
+++ b/ui/src/hooks/useTodayBudget.ts
@@ -98,7 +98,8 @@ export function useTodayBudget() {
   });
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
+    const signal = controller.signal;
     dispatch({ type: "fetch" });
 
     const start = startOfTodayUTC();
@@ -111,13 +112,13 @@ export function useTodayBudget() {
         start: timestampFromDate(start),
         end: timestampFromDate(now),
       },
-    });
+    }, { signal });
 
-    const budgetPromise = userClient.getMyBudget({}).catch(() => null);
+    const budgetPromise = userClient.getMyBudget({}, { signal }).catch(() => null);
 
     Promise.all([usagePromise, budgetPromise])
       .then(([usageRes, budgetRes]) => {
-        if (cancelled) return;
+        if (signal.aborted) return;
 
         // ── Budget from UserService.GetMyBudget (Firestore) ───────────────
         const budgetProto = budgetRes?.budget;
@@ -176,10 +177,10 @@ export function useTodayBudget() {
         });
       })
       .catch((err) => {
-        if (!cancelled) dispatch({ type: "error", message: err.message });
+        if (!signal.aborted) dispatch({ type: "error", message: err.message });
       });
 
-    return () => { cancelled = true; };
+    return () => controller.abort();
   }, [state.fetchCount]);
 
   // Auto-refresh every 60 seconds.

--- a/ui/src/hooks/useTrace.ts
+++ b/ui/src/hooks/useTrace.ts
@@ -177,12 +177,13 @@ export function useTrace(traceId: string) {
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
+    const signal = controller.signal;
 
     traceClient
-      .getTrace({ traceId })
+      .getTrace({ traceId }, { signal })
       .then((res) => {
-        if (cancelled) return;
+        if (signal.aborted) return;
         if (!res.trace) {
           dispatch({ type: "not_found" });
           return;
@@ -211,10 +212,10 @@ export function useTrace(traceId: string) {
         });
       })
       .catch((err) => {
-        if (!cancelled) dispatch({ type: "error", message: err.message });
+        if (!signal.aborted) dispatch({ type: "error", message: err.message });
       });
 
-    return () => { cancelled = true; };
+    return () => controller.abort();
   }, [traceId]);
 
   // Filter flatSpans to hide children of collapsed nodes

--- a/ui/src/hooks/useTraces.ts
+++ b/ui/src/hooks/useTraces.ts
@@ -184,8 +184,15 @@ export function useTraces() {
       prevModeRef.current = mode;
       fetchTraces(state.filters);
     }
-    return () => fetchRef.current?.abort();
   }, [mode, fetchTraces, state.filters]);
+
+  // Abort in-flight request on unmount only. Cleanup must NOT be in the
+  // mode/filters effect — fetchTraces already updates fetchRef.current
+  // before React runs the previous effect's cleanup, so that cleanup
+  // would abort the *new* request instead of the old one.
+  useEffect(() => {
+    return () => fetchRef.current?.abort();
+  }, []);
 
   return {
     traces: state.traces,

--- a/ui/src/hooks/useTraces.ts
+++ b/ui/src/hooks/useTraces.ts
@@ -99,7 +99,13 @@ export function useTraces() {
   // Track the previous scope mode so we can detect changes
   const prevModeRef = useRef(mode);
 
+  const fetchRef = useRef<AbortController | null>(null);
+
   const fetchTraces = useCallback((f: TraceFilters) => {
+    fetchRef.current?.abort();
+    const controller = new AbortController();
+    fetchRef.current = controller;
+
     dispatch({ type: "fetch", filters: f });
 
     // Build headers — the backend interprets the auth token + this hint
@@ -120,14 +126,21 @@ export function useTraces() {
         descending: f.descending,
       }, {
         headers,
+        signal: controller.signal,
       })
       .then((res) => {
-        dispatch({
-          type: "success",
-          traces: (res.traces || []).map(mapTrace),
-        });
+        if (!controller.signal.aborted) {
+          dispatch({
+            type: "success",
+            traces: (res.traces || []).map(mapTrace),
+          });
+        }
       })
-      .catch((err) => dispatch({ type: "error", message: err.message }));
+      .catch((err) => {
+        if (!controller.signal.aborted) {
+          dispatch({ type: "error", message: err.message });
+        }
+      });
   }, [isPersonalScope]);
 
   const updateFilters = useCallback(
@@ -171,6 +184,7 @@ export function useTraces() {
       prevModeRef.current = mode;
       fetchTraces(state.filters);
     }
+    return () => fetchRef.current?.abort();
   }, [mode, fetchTraces, state.filters]);
 
   return {

--- a/ui/src/hooks/useUsage.ts
+++ b/ui/src/hooks/useUsage.ts
@@ -75,7 +75,8 @@ export function useUsage() {
   });
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
+    const signal = controller.signal;
     dispatch({ type: "fetch" });
 
     const now = new Date();
@@ -87,9 +88,9 @@ export function useUsage() {
         start: timestampFromDate(start),
         end: timestampFromDate(now),
       },
-    })
+    }, { signal })
       .then((res) => {
-        if (cancelled) return;
+        if (signal.aborted) return;
 
         const limit = res.budget?.limitUsd || 0;
         const spent = res.budget?.spentUsd || 0;
@@ -122,10 +123,10 @@ export function useUsage() {
         });
       })
       .catch((err) => {
-        if (!cancelled) dispatch({ type: "error", message: err.message });
+        if (!signal.aborted) dispatch({ type: "error", message: err.message });
       });
 
-    return () => { cancelled = true; };
+    return () => controller.abort();
   }, [state.fetchCount, state.timeRange]);
 
   const refresh = useCallback(() => dispatch({ type: "refresh" }), []);


### PR DESCRIPTION
## Three P1 fixes in one PR

### 1. CI retry loop exit code (`ci.yml`, 2 locations)
`go mod download` retry loop exited 0 even when all 3 attempts failed — the final `echo`/`sleep` succeeded, masking the failure. Build continued with missing modules → cryptic compile errors.

**Fix:** Added `go mod download || exit 1` guard after the loop.

### 2. SQLite schema parity (2 fixes)
- **Missing `idx_spans_user` index** — DuckDB had it but SQLite didn't, making user-scoped queries (leaderboard, budget) slow for local users.
- **Stable leaderboard sort** — Added `user_id ASC` tiebreaker to `GetUserLeaderboard` ORDER BY. Previous ordering was index-dependent.

### 3. AbortController for React hooks (8 hooks)
Upgraded 8 hooks from boolean-flag or no cancellation to proper `AbortController`:

| Hook | Before | After |
|------|--------|-------|
| `useCurrentUser` | ❌ None | ✅ AbortController |
| `useTraces` | ❌ None | ✅ AbortController |
| `useCosts` | ⚠️ Boolean flag | ✅ AbortController |
| `useLeaderboard` | ⚠️ Boolean flag | ✅ AbortController |
| `useTenantLeaderboard` | ⚠️ Boolean flag | ✅ AbortController |
| `useTodayBudget` | ⚠️ Boolean flag | ✅ AbortController |
| `useTrace` | ⚠️ Boolean flag | ✅ AbortController |
| `useUsage` | ⚠️ Boolean flag | ✅ AbortController |

Boolean flags prevent stale state updates but don't cancel in-flight HTTP requests. AbortController actually cancels the request, reducing bandwidth waste and race conditions during rapid navigation.

## Testing
- Full Go test suite passes (all 42 packages)
- All 10 pre-commit hooks green
- TypeScript type check passes (no new errors)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data loading reliability across usage, cost, leaderboard, trace, and user views by preventing outdated requests from overwriting current results.
  * Reduced unnecessary error messages when requests are canceled during navigation or page updates.
  * Added stable leaderboard ordering when users have matching costs.
  * Improved SQLite performance for user-related span lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->