### PR TITLE
feat: add Slack webhook budget alerts

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -142,6 +142,9 @@ type Config struct {
 	Budget struct {
 		Timezone string `yaml:"timezone"` // IANA timezone for budget period reset (default: UTC)
 	} `yaml:"budget"`
+	Notifications struct {
+		SlackWebhookURL string `yaml:"slack_webhook_url"` // Slack incoming webhook URL
+	} `yaml:"notifications"`
 }
 
 // CatalogConfig holds model catalog configuration.
@@ -811,7 +814,12 @@ func main() {
 			// Wire team-mode features if Firestore is available.
 			if userStore != nil {
 				llmProxy.SetUserStore(userStore)
-				llmProxy.SetBudgetChecker(notify.NewBudgetChecker(&notify.LogNotifier{}))
+				channels := []storage.Notifier{&notify.LogNotifier{}}
+				if cfg.Notifications.SlackWebhookURL != "" {
+					channels = append(channels, notify.NewSlackNotifier(cfg.Notifications.SlackWebhookURL))
+					slog.Info("🔔 Slack budget alerts enabled")
+				}
+				llmProxy.SetBudgetChecker(notify.NewBudgetChecker(channels...))
 
 				// CRIT-3: Wire durable spend outbox for DeductSpend retries.
 				// Prefer $HOME/.candela/ for local dev; fall back to /etc/candela/

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -186,3 +186,7 @@ sinks:
 # Default: UTC (backward compatible).
 # budget:
 #   timezone: "America/New_York"
+
+# Budget alert notifications.
+# notifications:
+#   slack_webhook_url: "https://hooks.slack.com/services/T.../B.../xxx"  # Slack incoming webhook

--- a/pkg/notify/slack.go
+++ b/pkg/notify/slack.go
@@ -1,0 +1,83 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// SlackNotifier sends budget alerts to a Slack channel via incoming webhook.
+type SlackNotifier struct {
+	WebhookURL string
+	client     *http.Client
+}
+
+// NewSlackNotifier creates a notifier that posts to the given Slack webhook URL.
+func NewSlackNotifier(webhookURL string) *SlackNotifier {
+	return &SlackNotifier{
+		WebhookURL: webhookURL,
+		client:     &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// slackPayload is the JSON body sent to the Slack webhook.
+type slackPayload struct {
+	Text string `json:"text"`
+}
+
+// thresholdEmoji returns an emoji appropriate for the alert severity.
+func thresholdEmoji(threshold float64) string {
+	switch {
+	case threshold >= 1.0:
+		return "🚨"
+	case threshold >= 0.9:
+		return "🔶"
+	default:
+		return "⚠️"
+	}
+}
+
+// NotifyBudgetThreshold posts a budget alert message to Slack.
+func (n *SlackNotifier) NotifyBudgetThreshold(ctx context.Context, alert storage.BudgetAlert) error {
+	emoji := thresholdEmoji(alert.Threshold)
+	pct := int(alert.Threshold * 100)
+
+	text := fmt.Sprintf(
+		"%s *Budget Alert — %d%% threshold reached*\n"+
+			"• *User:* %s\n"+
+			"• *Spent:* $%.2f / $%.2f\n"+
+			"• *Period:* %s",
+		emoji, pct, alert.Email, alert.SpentUSD, alert.LimitUSD, alert.PeriodKey,
+	)
+
+	payload := slackPayload{Text: text}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("slack: marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.WebhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("slack: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("slack: send request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("slack: webhook returned HTTP %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/notify/slack.go
+++ b/pkg/notify/slack.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"math"
 	"net/http"
 	"time"
 
@@ -45,7 +47,7 @@ func thresholdEmoji(threshold float64) string {
 // NotifyBudgetThreshold posts a budget alert message to Slack.
 func (n *SlackNotifier) NotifyBudgetThreshold(ctx context.Context, alert storage.BudgetAlert) error {
 	emoji := thresholdEmoji(alert.Threshold)
-	pct := int(alert.Threshold * 100)
+	pct := int(math.Round(alert.Threshold * 100))
 
 	text := fmt.Sprintf(
 		"%s *Budget Alert — %d%% threshold reached*\n"+
@@ -72,11 +74,13 @@ func (n *SlackNotifier) NotifyBudgetThreshold(ctx context.Context, alert storage
 		return fmt.Errorf("slack: send request: %w", err)
 	}
 	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("slack: webhook returned HTTP %d", resp.StatusCode)
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("slack: webhook returned HTTP %d: %s", resp.StatusCode, string(bytes.TrimSpace(bodyBytes)))
 	}
 
 	return nil

--- a/pkg/notify/slack_test.go
+++ b/pkg/notify/slack_test.go
@@ -129,8 +129,11 @@ func TestSlackNotifier_NonOKResponse(t *testing.T) {
 
 func TestSlackNotifier_ContextCancellation(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Slow handler — should be cancelled before responding.
-		time.Sleep(5 * time.Second)
+		// Block until client cancels — avoids goroutine leak from hard sleep.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(5 * time.Second):
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -147,7 +150,10 @@ func TestSlackNotifier_ContextCancellation(t *testing.T) {
 
 func TestSlackNotifier_Timeout(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(500 * time.Millisecond)
+		select {
+		case <-r.Context().Done():
+		case <-time.After(500 * time.Millisecond):
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()

--- a/pkg/notify/slack_test.go
+++ b/pkg/notify/slack_test.go
@@ -1,0 +1,184 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// testAlert returns a BudgetAlert with the given threshold for testing.
+func testAlert(threshold float64) storage.BudgetAlert {
+	return storage.BudgetAlert{
+		UserID:    "user-123",
+		Email:     "alice@example.com",
+		Threshold: threshold,
+		SpentUSD:  80.00,
+		LimitUSD:  100.00,
+		PeriodKey: "2026-07",
+		SentAt:    time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestSlackNotifier_PayloadStructure(t *testing.T) {
+	var received slackPayload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", ct)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &received); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := NewSlackNotifier(srv.URL)
+	alert := testAlert(0.8)
+
+	if err := n.NotifyBudgetThreshold(context.Background(), alert); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if received.Text == "" {
+		t.Fatal("expected non-empty text payload")
+	}
+	if !strings.Contains(received.Text, "alice@example.com") {
+		t.Error("payload missing user email")
+	}
+	if !strings.Contains(received.Text, "$80.00") {
+		t.Error("payload missing spent amount")
+	}
+	if !strings.Contains(received.Text, "$100.00") {
+		t.Error("payload missing limit amount")
+	}
+	if !strings.Contains(received.Text, "2026-07") {
+		t.Error("payload missing period key")
+	}
+	if !strings.Contains(received.Text, "80%") {
+		t.Error("payload missing threshold percentage")
+	}
+}
+
+func TestSlackNotifier_ThresholdEmoji(t *testing.T) {
+	tests := []struct {
+		name      string
+		threshold float64
+		emoji     string
+	}{
+		{"80% warning", 0.8, "⚠️"},
+		{"90% caution", 0.9, "🔶"},
+		{"100% critical", 1.0, "🚨"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var received slackPayload
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				if err := json.Unmarshal(body, &received); err != nil {
+					t.Errorf("unmarshal: %v", err)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			n := NewSlackNotifier(srv.URL)
+			alert := testAlert(tt.threshold)
+
+			if err := n.NotifyBudgetThreshold(context.Background(), alert); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !strings.Contains(received.Text, tt.emoji) {
+				t.Errorf("expected emoji %s in payload, got: %s", tt.emoji, received.Text)
+			}
+		})
+	}
+}
+
+func TestSlackNotifier_NonOKResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	n := NewSlackNotifier(srv.URL)
+	err := n.NotifyBudgetThreshold(context.Background(), testAlert(0.8))
+
+	if err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+	if !strings.Contains(err.Error(), "HTTP 403") {
+		t.Errorf("expected HTTP 403 in error, got: %v", err)
+	}
+}
+
+func TestSlackNotifier_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Slow handler — should be cancelled before responding.
+		time.Sleep(5 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := NewSlackNotifier(srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	err := n.NotifyBudgetThreshold(ctx, testAlert(0.8))
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestSlackNotifier_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := NewSlackNotifier(srv.URL)
+	// Override client with a very short timeout.
+	n.client = &http.Client{Timeout: 50 * time.Millisecond}
+
+	err := n.NotifyBudgetThreshold(context.Background(), testAlert(0.8))
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+func TestThresholdEmoji(t *testing.T) {
+	tests := []struct {
+		threshold float64
+		want      string
+	}{
+		{0.5, "⚠️"},
+		{0.8, "⚠️"},
+		{0.89, "⚠️"},
+		{0.9, "🔶"},
+		{0.99, "🔶"},
+		{1.0, "🚨"},
+		{1.5, "🚨"},
+	}
+	for _, tt := range tests {
+		got := thresholdEmoji(tt.threshold)
+		if got != tt.want {
+			t.Errorf("thresholdEmoji(%.2f) = %s, want %s", tt.threshold, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements Slack incoming webhook notifications for budget threshold alerts (80%, 90%, 100%).

## Changes

### [NEW] `pkg/notify/slack.go`
- `SlackNotifier` implementing `billing.Notifier` interface
- Posts mrkdwn-formatted messages via Slack webhook
- Threshold-based emoji: ⚠️ (80%), 🔶 (90%), 🚨 (100%)
- Context-aware HTTP with 10s timeout, proper error wrapping

### [NEW] `pkg/notify/slack_test.go` — 6 tests
- Payload structure validation
- Threshold emoji table-driven tests
- Error handling (non-200 response)
- Context cancellation
- HTTP timeout

### [MODIFY] `cmd/candela-server/main.go`
- Added `Notifications.SlackWebhookURL` to Config
- Conditionally wires `SlackNotifier` when webhook URL is set

### [MODIFY] `config.example.yaml`
- Added commented-out `notifications:` section

## Architecture
The existing `BudgetChecker` already supports multiple `Notifier` channels. This just adds a new channel:
```go
channels := []storage.Notifier{&notify.LogNotifier{}}
if cfg.Notifications.SlackWebhookURL != "" {
    channels = append(channels, notify.NewSlackNotifier(cfg.Notifications.SlackWebhookURL))
}
llmProxy.SetBudgetChecker(notify.NewBudgetChecker(channels...))
```

## Testing
- All 18 tests pass in `pkg/notify/`
- Full build + all 10 pre-commit hooks green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Slack notifications for budget threshold alerts.
  * Alerts include the affected account, spending, budget limit, period, and threshold indicator.
  * Slack delivery can be enabled through the server configuration using an incoming webhook URL.
  * Budget alerts continue to be recorded in application logs.

* **Documentation**
  * Added an example configuration section for Slack budget notifications.

* **Tests**
  * Added coverage for message formatting, delivery failures, cancellation, and timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->