### PR TITLE
feat: add CANDELA_ALLOWED_SERVICE_ACCOUNTS env var override

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -1188,6 +1189,26 @@ func loadConfig() (*Config, error) {
 	}
 	if cfg.Proxy.VertexAI.Region == "" {
 		cfg.Proxy.VertexAI.Region = "us-central1"
+	}
+
+	// Auth: allowed service accounts — env var override (comma-separated).
+	// This lets Terraform / Cloud Run inject SAs without a config.yaml mount.
+	if env := os.Getenv("CANDELA_ALLOWED_SERVICE_ACCOUNTS"); env != "" {
+		var sas []string
+		for _, s := range strings.Split(env, ",") {
+			trimmed := strings.TrimSpace(s)
+			if trimmed != "" {
+				sas = append(sas, trimmed)
+			}
+		}
+		cfg.Auth.AllowedServiceAccounts = append(cfg.Auth.AllowedServiceAccounts, sas...)
+	}
+
+	// Auth: dev mode — env var override.
+	if env := os.Getenv("CANDELA_DEV_MODE"); env != "" {
+		if val, err := strconv.ParseBool(env); err == nil {
+			cfg.Auth.DevMode = val
+		}
 	}
 
 	return &cfg, nil


### PR DESCRIPTION
## What

Adds env var override for `auth.allowed_service_accounts` — comma-separated list of SA emails.

```bash
CANDELA_ALLOWED_SERVICE_ACCOUNTS="sa1@proj.iam.gserviceaccount.com,sa2@proj.iam.gserviceaccount.com"
```

Also adds `CANDELA_DEV_MODE` env var override for consistency.

## Why

The deployed Candela server uses env vars (via Terraform) for all config — but SA allowlist had no env var override, requiring a mounted config.yaml. This unblocks adding CI service accounts (e.g., code-reviewer in sqlmesh) without changing the deploy pattern.

## Changes

- `cmd/candela-server/main.go`: Parse `CANDELA_ALLOWED_SERVICE_ACCOUNTS` (comma-separated, appended to any YAML-configured SAs) and `CANDELA_DEV_MODE` in `loadConfig()`