### PR TITLE
fix(ci): concurrency groups, job timeouts, persist-credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ permissions:
   packages: read        # pull ghcr.io/candelahq/candela-dev
   pull-requests: read   # dorny/paths-filter needs PR file list
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 # All jobs run inside the pre-baked CI container:
 #   Ubuntu 24.04 + Determinate Nix + dev shell pre-warmed in Nix store.
 # Steps use `nix develop . --command <cmd>` — identical to local dev.
@@ -22,6 +26,7 @@ jobs:
   # Push to main always runs everything.
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       go: ${{ github.event_name == 'push' || steps.filter.outputs.go }}
       rust: ${{ github.event_name == 'push' || steps.filter.outputs.rust }}
@@ -65,6 +70,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       image: ghcr.io/candelahq/candela-dev:latest
       credentials:
@@ -127,6 +133,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     container:
       image: ghcr.io/candelahq/candela-dev:latest
       credentials:
@@ -206,6 +213,7 @@ jobs:
     needs: [changes, go-test]
     if: always() && needs.changes.outputs.go == 'true' && needs.go-test.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       image: ghcr.io/candelahq/candela-dev:latest
       credentials:
@@ -246,6 +254,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.go == 'true'
     runs-on: windows-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -286,6 +295,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.ui == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container:
       image: ghcr.io/candelahq/candela-dev:latest
       credentials:
@@ -330,6 +340,7 @@ jobs:
     needs: [changes, ui-build-and-lint]
     if: always() && needs.changes.outputs.ui == 'true' && needs.ui-build-and-lint.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       image: ghcr.io/candelahq/candela-dev:latest
       credentials:
@@ -373,6 +384,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       image: ghcr.io/candelahq/candela-dev:latest
       credentials:
@@ -405,6 +417,7 @@ jobs:
   # ── Transparent proxy E2E (Linux + iptables) ────────────────────────────────
   transparent-proxy-e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Only run when proxy/transparent/e2e files change.
     if: >-
       github.event_name == 'push' ||

--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -14,9 +14,14 @@ permissions:
   contents: read
   packages: write   # needed to push to GHCR
 
+concurrency:
+  group: dev-container-${{ github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -40,6 +40,7 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -48,6 +49,8 @@ jobs:
       IMAGE_NAME: ${{ github.repository_owner }}/${{ inputs.image_name }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         if: inputs.setup_go

--- a/.github/workflows/hurl.yml
+++ b/.github/workflows/hurl.yml
@@ -19,6 +19,7 @@ jobs:
   # ── change detection ─────────────────────────────────────────────────────────
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       should_run: ${{ github.event_name == 'push' || steps.filter.outputs.e2e }}
     steps:
@@ -45,6 +46,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container:
       image: ghcr.io/candelahq/candela-dev:latest
       credentials:

--- a/.github/workflows/proxy-release.yml
+++ b/.github/workflows/proxy-release.yml
@@ -33,8 +33,11 @@ jobs:
             artifact: candela-proxy-darwin-arm64
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
@@ -69,9 +72,12 @@ jobs:
   # ── Build and push multi-arch container image ──
   build-container:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: build-binaries
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version
@@ -103,9 +109,12 @@ jobs:
   # ── Create GitHub release with binaries and checksums ──
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [build-binaries, build-container]
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,7 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Only run if CI succeeded (or if manually triggered / tag push).
     if: >
       github.event_name == 'workflow_dispatch' ||
@@ -53,6 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          persist-credentials: false
           # For workflow_run, check out the commit that triggered CI.
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: ghcr.io/candelahq/candela-dev:latest
       credentials:
@@ -20,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          persist-credentials: false
           fetch-depth: 0   # GoReleaser needs full history for changelog
 
       - name: Fix git ownership for Nix flake
@@ -42,6 +44,7 @@ jobs:
   patch-formula:
     needs: goreleaser
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/tetragon-integration.yml
+++ b/.github/workflows/tetragon-integration.yml
@@ -24,6 +24,10 @@ on:
       - 'pkg/tetragonaudit/**'
       - 'test/e2e/tetragon/**'
 
+concurrency:
+  group: tetragon-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   tetragon-e2e:
     name: Tetragon E2E
@@ -34,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Compose
         run: docker compose version


### PR DESCRIPTION
## Summary

Three CI hardening fixes applied across all workflow files.

### Fix 1: Concurrency groups (#687)
Added `concurrency` blocks to cancel in-flight runs when new commits are pushed:
- **ci.yml**: `ci-${{ github.event.pull_request.number || github.sha }}`
- **dev-container.yml**: `dev-container-${{ github.sha }}`
- **tetragon-integration.yml**: `tetragon-${{ github.event.pull_request.number || github.sha }}`

Already had concurrency: `hurl.yml`, `publish.yml`
Not applicable (tag-triggered): `release.yml`, `proxy-release.yml`

### Fix 2: Job timeouts (#686)
Added `timeout-minutes` to every job across all workflows:

| Workflow | Job | Timeout |
|----------|-----|---------|
| ci.yml | changes | 5m |
| ci.yml | build-and-lint | 15m |
| ci.yml | go-test | 20m |
| ci.yml | build-and-test | 15m |
| ci.yml | windows-candela | 15m |
| ci.yml | ui-build-and-lint | 10m |
| ci.yml | ui-e2e | 15m |
| ci.yml | rust-check | 15m |
| ci.yml | transparent-proxy-e2e | 15m |
| dev-container.yml | build-and-push | 30m |
| docker-build-push.yml | build-and-push | 30m |
| hurl.yml | changes | 10m |
| hurl.yml | hurl-e2e | 10m |
| proxy-release.yml | build-binaries | 30m |
| proxy-release.yml | build-container | 20m |
| proxy-release.yml | release | 10m |
| publish.yml | publish | 30m |
| release.yml | goreleaser | 30m |
| release.yml | patch-formula | 5m |

Already had timeouts: `ci.yml/hurl-test` (5m), `tetragon-integration.yml` (15m + 10m step)

### Fix 3: persist-credentials: false (#685)
Added `persist-credentials: false` to all remaining `actions/checkout` calls:
- **docker-build-push.yml**: 1 checkout
- **proxy-release.yml**: 3 checkouts
- **publish.yml**: 1 checkout
- **release.yml**: 1 checkout (goreleaser only — patch-formula needs creds for git push)
- **tetragon-integration.yml**: 1 checkout

Already done: `ci.yml` (all 9), `dev-container.yml`, `hurl.yml` (both)

### Validation
- ✅ `actionlint` passes with zero errors
- ✅ `check-yaml` pre-commit hook passes
- ✅ All pre-commit hooks pass

Closes #685, closes #686, closes #687

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added execution time limits to automated build, test, release, and deployment tasks.
  * Prevented redundant concurrent checks by canceling superseded runs.
  * Improved checkout security by preventing credentials from being retained in build environments.
  * Added safeguards to prevent development container, publishing, and release tasks from running indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->