### PR TITLE
fix: add -trimpath -ldflags to Dockerfile.worker and Dockerfile.combined

### DIFF
--- a/deploy/Dockerfile.combined
+++ b/deploy/Dockerfile.combined
@@ -16,7 +16,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN go build -o candela-server ./cmd/candela-server
+RUN go build -trimpath -ldflags='-s -w' -o candela-server ./cmd/candela-server
 
 # ── Stage 2: Build Next.js UI ──
 FROM node:22-alpine AS ui-builder

--- a/deploy/Dockerfile.worker
+++ b/deploy/Dockerfile.worker
@@ -6,7 +6,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 go build -o candela-worker ./cmd/candela-worker
+RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o candela-worker ./cmd/candela-worker
 
 # Runtime
 FROM alpine:3.20


### PR DESCRIPTION
## Summary

`deploy/Dockerfile` (server) already had `-trimpath -ldflags='-s -w'`. The worker and combined Dockerfiles were missing them.

### Changes
| File | Before | After |
|------|--------|-------|
| `Dockerfile.combined` | `go build -o candela-server` | `go build -trimpath -ldflags='-s -w' -o candela-server` |
| `Dockerfile.worker` | `CGO_ENABLED=0 go build -o candela-worker` | `CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o candela-worker` |

### Why
- **`-trimpath`**: Strips local file system paths from the binary — prevents information leakage about build environment
- **`-ldflags='-s -w'`**: Strips symbol table and DWARF debug info — reduces binary size ~30%

Closes #690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced the size of backend and worker deployment binaries.
  * Removed embedded build paths and symbol/debug information from production binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->