### PR TITLE
fix: batch security P1 fixes — 5 vulnerabilities

### DIFF
--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -259,30 +259,7 @@ func (h *DashboardHandler) GetTeamLeaderboard(
 			fmt.Errorf("team leaderboard is admin-only"))
 	}
 
-	msg := req.Msg
-	q := storage.UsageQuery{ProjectID: msg.ProjectId}
-	if msg.TimeRange != nil {
-		if msg.TimeRange.Start != nil {
-			q.StartTime = msg.TimeRange.Start.AsTime()
-		}
-		if msg.TimeRange.End != nil {
-			q.EndTime = msg.TimeRange.End.AsTime()
-		}
-	}
-	if q.StartTime.IsZero() {
-		q.StartTime = time.Now().Add(-30 * 24 * time.Hour) // default: last 30 days
-	}
-	if q.EndTime.IsZero() {
-		q.EndTime = time.Now()
-	}
-
-	limit := int(msg.Limit)
-	if limit <= 0 {
-		limit = 20
-	}
-	if limit > 100 {
-		limit = 100
-	}
+	q, limit := parseLeaderboardParams(req.Msg)
 
 	users, err := h.store.GetUserLeaderboard(ctx, q, limit)
 	if err != nil {

--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -280,6 +280,9 @@ func (h *DashboardHandler) GetTeamLeaderboard(
 	if limit <= 0 {
 		limit = 20
 	}
+	if limit > 100 {
+		limit = 100
+	}
 
 	users, err := h.store.GetUserLeaderboard(ctx, q, limit)
 	if err != nil {

--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -326,11 +326,11 @@ func parseLeaderboardParams(msg leaderboardRequest) (storage.UsageQuery, int) {
 			q.EndTime = msg.GetTimeRange().End.AsTime()
 		}
 	}
-	if q.StartTime.IsZero() {
-		q.StartTime = time.Now().Add(-30 * 24 * time.Hour)
-	}
 	if q.EndTime.IsZero() {
 		q.EndTime = time.Now()
+	}
+	if q.StartTime.IsZero() {
+		q.StartTime = q.EndTime.Add(-30 * 24 * time.Hour)
 	}
 	limit := int(msg.GetLimit())
 	if limit <= 0 {

--- a/pkg/connecthandlers/project_handler.go
+++ b/pkg/connecthandlers/project_handler.go
@@ -114,7 +114,10 @@ func (h *ProjectHandler) CreateAPIKey(
 			fmt.Errorf("admin access required"))
 	}
 
-	fullKey := projectdb.GenerateAPIKey()
+	fullKey, err := projectdb.GenerateAPIKey()
+	if err != nil {
+		return nil, internalError("failed to generate API key", err)
+	}
 
 	key, err := h.store.CreateAPIKey(ctx, storage.APIKey{
 		ProjectID: req.Msg.ProjectId,

--- a/pkg/connecthandlers/trace_handler.go
+++ b/pkg/connecthandlers/trace_handler.go
@@ -98,14 +98,14 @@ func (h *TraceHandler) ListTraces(
 			q.EndTime = msg.TimeRange.End.AsTime()
 		}
 	}
+	if q.EndTime.IsZero() {
+		q.EndTime = time.Now()
+	}
 	if q.StartTime.IsZero() {
 		// Default to 30 days so the list view doesn't silently exclude spans
 		// that fall outside a narrow window — GetTrace has no time filter and
 		// would otherwise show different totals for the same trace.
-		q.StartTime = time.Now().AddDate(0, 0, -30)
-	}
-	if q.EndTime.IsZero() {
-		q.EndTime = time.Now()
+		q.StartTime = q.EndTime.AddDate(0, 0, -30)
 	}
 
 	if msg.Pagination != nil {

--- a/pkg/connecthandlers/trace_handler.go
+++ b/pkg/connecthandlers/trace_handler.go
@@ -162,6 +162,13 @@ func (h *TraceHandler) SearchSpans(
 			q.EndTime = msg.TimeRange.End.AsTime()
 		}
 	}
+	// Default to last 7 days to prevent unbounded BigQuery scans.
+	if q.StartTime.IsZero() {
+		q.StartTime = time.Now().Add(-7 * 24 * time.Hour)
+	}
+	if q.EndTime.IsZero() {
+		q.EndTime = time.Now()
+	}
 
 	if msg.Pagination != nil {
 		q.PageSize = int(msg.Pagination.PageSize)

--- a/pkg/connecthandlers/trace_handler.go
+++ b/pkg/connecthandlers/trace_handler.go
@@ -163,11 +163,11 @@ func (h *TraceHandler) SearchSpans(
 		}
 	}
 	// Default to last 7 days to prevent unbounded BigQuery scans.
-	if q.StartTime.IsZero() {
-		q.StartTime = time.Now().Add(-7 * 24 * time.Hour)
-	}
 	if q.EndTime.IsZero() {
 		q.EndTime = time.Now()
+	}
+	if q.StartTime.IsZero() {
+		q.StartTime = q.EndTime.Add(-7 * 24 * time.Hour)
 	}
 
 	if msg.Pagination != nil {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1020,12 +1020,11 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// ── Budget pre-flight with model-aware floor (#7) ──
+	// ── Budget pre-flight with conservative reservation ──
 	// Only applies in team mode (UserStore configured).
 	var budgetReserved float64 // track reservation for Release in deductBudget
 	if p.users != nil && effectiveUserID != "" && !isServiceAccount && !isAdmin {
-		// #7: Budget check with a per-call floor so even a $0.001-remaining
-		// user can't fire a $50 request. Floor = minimum meaningful API cost.
+		// Budget check floor: minimum cost to allow a request through.
 		const budgetCheckFloor = 0.001 // $0.001 — lower than any cloud model's minimum call
 		check, err := p.users.CheckBudget(r.Context(), effectiveUserID, budgetCheckFloor)
 		if err != nil {
@@ -1059,10 +1058,11 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Reserve a conservative estimate so concurrent requests see lower balance.
-		// We use the floor ($0.001) because we don't know actual cost yet.
-		// This is a lower bound — the real cost will be higher, but even a
-		// small reservation prevents unlimited concurrent overdraft.
-		budgetReserved = budgetCheckFloor
+		// $0.05 is a realistic floor for most LLM API calls (a small GPT-4o
+		// request costs ~$0.01–0.10, Claude ~$0.03–0.50). This prevents the
+		// previous $0.001 reservation from allowing 1000x overdraft.
+		const reservationFloor = 0.05
+		budgetReserved = reservationFloor
 		p.pendingSpend.Reserve(effectiveUserID, budgetReserved)
 		// Release the reservation if we return before the response handlers
 		// (handleStreamingResponse / handleStandardResponse) take ownership.
@@ -1288,21 +1288,17 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 						for k := range bodyMap {
 							keys = append(keys, k)
 						}
-						var systemSnippet string
+						var systemLen int
 						if sys, ok := bodyMap["system"]; ok {
 							if b, jsonErr := json.Marshal(sys); jsonErr == nil {
-								if len(b) > 500 {
-									systemSnippet = string(b[:500]) + "..."
-								} else {
-									systemSnippet = string(b)
-								}
+								systemLen = len(b)
 							}
 						}
 						slog.Info("CANDELA_DEBUG: passthrough body",
 							"provider", activeProvName,
 							"keys", keys,
-							"anthropic_version", bodyMap["anthropic_version"],
-							"system_snippet", systemSnippet,
+							"has_system", systemLen > 0,
+							"system_len", systemLen,
 							"body_len", len(upstreamBody))
 					}
 				}

--- a/pkg/storage/projectdb/projectdb.go
+++ b/pkg/storage/projectdb/projectdb.go
@@ -93,7 +93,11 @@ func migrate(db *sql.DB) error {
 
 func (s *Store) CreateProject(ctx context.Context, p storage.Project) (*storage.Project, error) {
 	if p.ID == "" {
-		p.ID = generateID()
+		id, err := generateID()
+		if err != nil {
+			return nil, err
+		}
+		p.ID = id
 	}
 	now := time.Now().UTC()
 	p.CreatedAt = now
@@ -194,7 +198,11 @@ func (s *Store) DeleteProject(ctx context.Context, id string) error {
 
 func (s *Store) CreateAPIKey(ctx context.Context, key storage.APIKey, fullKey string) (*storage.APIKey, error) {
 	if key.ID == "" {
-		key.ID = generateID()
+		id, err := generateID()
+		if err != nil {
+			return nil, err
+		}
+		key.ID = id
 	}
 	now := time.Now().UTC()
 	key.CreatedAt = now
@@ -310,14 +318,18 @@ func (s *Store) Close() error {
 
 // GenerateAPIKey creates a cryptographically secure API key.
 // Format: cdla_<32 hex chars> (40 chars total).
-func GenerateAPIKey() string {
+func GenerateAPIKey() (string, error) {
 	b := make([]byte, 16)
-	_, _ = rand.Read(b)
-	return "cdla_" + hex.EncodeToString(b)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating API key: %w", err)
+	}
+	return "cdla_" + hex.EncodeToString(b), nil
 }
 
-func generateID() string {
+func generateID() (string, error) {
 	b := make([]byte, 12)
-	_, _ = rand.Read(b)
-	return hex.EncodeToString(b)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating ID: %w", err)
+	}
+	return hex.EncodeToString(b), nil
 }

--- a/pkg/storage/projectdb/projectdb_test.go
+++ b/pkg/storage/projectdb/projectdb_test.go
@@ -104,7 +104,10 @@ func TestAPIKeyCRUD(t *testing.T) {
 	}
 
 	// Create API key.
-	fullKey := GenerateAPIKey()
+	fullKey, err := GenerateAPIKey()
+	if err != nil {
+		t.Fatalf("GenerateAPIKey: %v", err)
+	}
 	key, err := store.CreateAPIKey(ctx, storage.APIKey{
 		ProjectID: p.ID,
 		Name:      "dev-key",
@@ -160,7 +163,7 @@ func TestCascadeDelete(t *testing.T) {
 	ctx := context.Background()
 
 	p, _ := store.CreateProject(ctx, storage.Project{Name: "Cascade Test"})
-	fullKey := GenerateAPIKey()
+	fullKey, _ := GenerateAPIKey()
 	_, _ = store.CreateAPIKey(ctx, storage.APIKey{ProjectID: p.ID, Name: "k1"}, fullKey)
 
 	// Delete project — should cascade to keys.
@@ -178,7 +181,10 @@ func TestCascadeDelete(t *testing.T) {
 }
 
 func TestGenerateAPIKey(t *testing.T) {
-	key := GenerateAPIKey()
+	key, err := GenerateAPIKey()
+	if err != nil {
+		t.Fatalf("GenerateAPIKey: %v", err)
+	}
 	if len(key) != 37 { // "cdla_" (5) + 32 hex chars
 		t.Errorf("expected 37 char key, got %d: %q", len(key), key)
 	}


### PR DESCRIPTION
## 5 Security P1 Fixes

### #636 — GetTeamLeaderboard DoS vector
**Before:** No max limit cap — client could request `limit=999999`
**After:** Capped at 100, matching `parseLeaderboardParams` used by other leaderboard endpoints

### #633 — API key gen silently discards rand.Read error
**Before:** `_, _ = rand.Read(b)` — if crypto PRNG fails, generates predictable all-zero keys
**After:** `GenerateAPIKey()` and `generateID()` return `(string, error)`. All callers updated (handler + tests)

### #635 — SearchSpans unbounded BigQuery scan
**Before:** No default time range — zero-value `StartTime`/`EndTime` caused full-table scans
**After:** Defaults to last 7 days when `TimeRange` is nil (matches `GetTeamLeaderboard` pattern)

### #615 — CANDELA_DEBUG leaks system prompts
**Before:** Logged up to 500 bytes of `system` field content + `anthropic_version` to Cloud Logging
**After:** Logs only `has_system` (bool) and `system_len` (int) — no content, no provider metadata

### #634 — Pending spend $0.001 reservation enables budget overdraft
**Before:** Fixed $0.001 reservation → 1000 concurrent requests against $1 budget = $49 overdraft
**After:** Raised to $0.05 — realistic floor for LLM API calls, limits overdraft to ~20x concurrency

---

**Not included:** #631 (IAP user registration check) — requires `UserStore` dependency in middleware signature, better as a focused follow-up PR

Closes #633, closes #634, closes #635, closes #636, closes #615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Leaderboard requests now apply consistent time-range defaults and enforce safe result limits.
  - Trace searches default to a recent seven-day window when no dates are provided.
  - API key creation now reports generation failures instead of returning incomplete credentials.
  - Project and API key identifiers are handled more reliably during creation.
  - Budget checks now reserve a more conservative minimum amount to prevent overspending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->