### PR TITLE
fix: batch backend P1 fixes — 4 reliability bugs

### DIFF
--- a/pkg/audit/bq_logger.go
+++ b/pkg/audit/bq_logger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"google.golang.org/api/googleapi"
@@ -60,16 +61,19 @@ func NewBQLogger(ctx context.Context, cfg BQConfig) (*BQLogger, error) {
 }
 
 // writeLoop drains the events channel and writes rows to BigQuery.
-// It uses context.Background() so inserts are not cancelled by request contexts.
+// Each insert gets a 30-second timeout to prevent hung BigQuery from
+// blocking the loop and causing the channel buffer to fill up.
 func (l *BQLogger) writeLoop() {
 	defer close(l.done)
 	for row := range l.events {
-		if err := l.inserter.Put(context.Background(), row); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if err := l.inserter.Put(ctx, row); err != nil {
 			slog.Warn("audit: failed to write to BigQuery",
 				"error", err,
 				"procedure", row.Procedure,
 				"actor", row.ActorEmail)
 		}
+		cancel()
 	}
 }
 

--- a/pkg/hubbleaudit/correlator.go
+++ b/pkg/hubbleaudit/correlator.go
@@ -201,10 +201,20 @@ func tupleKey(f Flow) string {
 }
 
 // removeIndex removes val from a slice of ints (preserving order).
+// When the slice shrinks well below its capacity, it is compacted to
+// reclaim memory from long-lived index entries.
 func removeIndex(s []int, val int) []int {
 	for i, v := range s {
 		if v == val {
-			return append(s[:i], s[i+1:]...)
+			s = append(s[:i], s[i+1:]...)
+			// Compact: if length is much smaller than capacity, copy to
+			// a right-sized slice to release the excess backing array.
+			if cap(s) > 64 && len(s) < cap(s)/4 {
+				compacted := make([]int, len(s))
+				copy(compacted, s)
+				return compacted
+			}
+			return s
 		}
 	}
 	return s

--- a/pkg/runtime/manager.go
+++ b/pkg/runtime/manager.go
@@ -20,6 +20,7 @@ type Manager struct {
 	health    *Health
 	startedAt time.Time
 	cancel    context.CancelFunc
+	wg        sync.WaitGroup // tracks background goroutines (auto-pull)
 }
 
 // ManagerConfig configures the Manager's behavior.
@@ -109,7 +110,9 @@ func (m *Manager) cancelHealthLoop() {
 
 func (m *Manager) startAutoPull(ctx context.Context) {
 	if m.autoPull && len(m.models) > 0 {
+		m.wg.Add(1)
 		go func() {
+			defer m.wg.Done()
 			for _, model := range m.models {
 				slog.Info("pulling model", "model", model, "backend", m.rt.Name())
 				if err := m.rt.PullModel(ctx, model, nil); err != nil {
@@ -121,8 +124,10 @@ func (m *Manager) startAutoPull(ctx context.Context) {
 }
 
 // Stop stops health monitoring and shuts down the runtime.
+// It waits for any in-flight auto-pull goroutines to finish.
 func (m *Manager) Stop(ctx context.Context) error {
 	m.cancelHealthLoop()
+	m.wg.Wait() // wait for auto-pull goroutines to finish
 	err := m.rt.Stop(ctx)
 	// Update cached health immediately so GetHealth reflects the stopped state.
 	m.mu.Lock()

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -475,7 +475,7 @@ func (s *Store) GetTrace(ctx context.Context, traceID string) (*storage.Trace, e
 		return nil, fmt.Errorf("getting trace: %w", err)
 	}
 	if len(spans) == 0 {
-		return nil, fmt.Errorf("trace %s not found", traceID)
+		return nil, fmt.Errorf("trace %s: %w", traceID, storage.ErrNotFound)
 	}
 
 	return buildTrace(traceID, spans), nil


### PR DESCRIPTION
## 4 Backend P1 Fixes

### #632 — BigQuery GetTrace returns raw error instead of storage.ErrNotFound
**Before:** `fmt.Errorf("trace %s not found", traceID)` — callers using `errors.Is(err, storage.ErrNotFound)` can't detect not-found
**After:** `fmt.Errorf("trace %s: %w", traceID, storage.ErrNotFound)` — matches SQLite and DuckDB backends

### #662 — BQLogger.writeLoop has no per-insert timeout
**Before:** `l.inserter.Put(context.Background(), row)` — no deadline. Hung BigQuery blocks the entire write loop, fills the 256-entry channel buffer, silently drops all subsequent audit events
**After:** 30-second `context.WithTimeout` per insert

### #663 — WindowCorrelator removeIndex memory leak
**Before:** `append(s[:i], s[i+1:]...)` — shrinks length but underlying array capacity never decreases. Long-lived pod keys with high flow churn cause monotonic memory growth
**After:** Compacts slice (copies to right-sized array) when `len(s) < cap(s)/4 && cap(s) > 64`

### #665 — startAutoPull goroutine has no completion tracking
**Before:** Fire-and-forget `go func()` — `Manager.Stop()` returns while model pulls are still running, causing goroutine leaks in tests and unclean shutdowns
**After:** `sync.WaitGroup` tracks the goroutine; `Stop()` calls `wg.Wait()` before shutting down the runtime

---

**Not included (MEDIUM risk, separate PRs):**
- #637 (OTLP token expiry) — touches Config struct across 3 binaries
- #664 (duplicated RetryConfig) — refactor creating shared package

Closes #632, closes #662, closes #663, closes #665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 30-second timeout for audit event writes, preventing stalled operations.
  * Improved shutdown handling so background processing completes before the runtime stops.
  * Reduced memory usage after removing stored trace indexes.
  * Improved missing-trace errors so they can be identified and handled more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->