### PR TITLE
fix(ci): exit 1 when Firestore emulator fails to start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,10 +171,18 @@ jobs:
             gcloud emulators firestore start \
               --host-port=0.0.0.0:8086 \
               --project=test-project &
+            emulator_ready=false
             for _ in \$(seq 1 30); do
-              curl -sf http://localhost:8086/ && break
+              if curl -sf http://localhost:8086/ > /dev/null 2>&1; then
+                emulator_ready=true
+                break
+              fi
               sleep 2
             done
+            if [ \"\$emulator_ready\" != true ]; then
+              echo '::error::Firestore emulator failed to start after 60 seconds'
+              exit 1
+            fi
           "
 
       - name: Generate proto stubs


### PR DESCRIPTION
## P0 Fix — Firestore Emulator Startup Race (#682)

**Before:** The poll loop tried curl 30 times but silently fell through on exhaustion. Tests proceeded without a Firestore backend → flaky false-positive results.

**After:** Tracks `emulator_ready` flag. If emulator doesn't respond within 60 seconds (30 × 2s), emits a `::error::` annotation and exits 1, failing the job immediately.

```diff
+            emulator_ready=false
             for _ in $(seq 1 30); do
-              curl -sf http://localhost:8086/ && break
+              if curl -sf http://localhost:8086/ > /dev/null 2>&1; then
+                emulator_ready=true
+                break
+              fi
               sleep 2
             done
+            if [ "$emulator_ready" != true ]; then
+              echo '::error::Firestore emulator failed to start after 60 seconds'
+              exit 1
+            fi
```

Closes #682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated test reliability by adding a defined timeout and clearer failure reporting when the Firestore emulator is unavailable.
  * The test workflow now waits up to approximately 60 seconds for the emulator to become ready before stopping with an actionable error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->