### PR TITLE
fix(ci): follow-up — single-quote bash script, curl timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,23 +167,23 @@ jobs:
 
       - name: Start Firestore emulator
         run: |
-          nix develop . --command bash -c "
+          nix develop . --command bash -c '
             gcloud emulators firestore start \
               --host-port=0.0.0.0:8086 \
               --project=test-project &
             emulator_ready=false
-            for _ in \$(seq 1 30); do
-              if curl -sf http://localhost:8086/ > /dev/null 2>&1; then
+            for _ in $(seq 1 30); do
+              if curl -sf --max-time 2 http://localhost:8086/ > /dev/null 2>&1; then
                 emulator_ready=true
                 break
               fi
               sleep 2
             done
-            if [ \"\$emulator_ready\" != true ]; then
-              echo '::error::Firestore emulator failed to start after 60 seconds'
+            if [ "$emulator_ready" != true ]; then
+              echo "::error::Firestore emulator failed to start after 60 seconds"
               exit 1
             fi
-          "
+          '
 
       - name: Generate proto stubs
         run: nix develop . --command buf generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,23 +167,23 @@ jobs:
 
       - name: Start Firestore emulator
         run: |
-          nix develop . --command bash -c '
+          nix develop . --command bash -c "
             gcloud emulators firestore start \
               --host-port=0.0.0.0:8086 \
               --project=test-project &
             emulator_ready=false
-            for _ in $(seq 1 30); do
+            for _ in \$(seq 1 30); do
               if curl -sf --max-time 2 http://localhost:8086/ > /dev/null 2>&1; then
                 emulator_ready=true
                 break
               fi
               sleep 2
             done
-            if [ "$emulator_ready" != true ]; then
-              echo "::error::Firestore emulator failed to start after 60 seconds"
+            if [ \"\$emulator_ready\" != true ]; then
+              echo '::error::Firestore emulator failed to start after 60 seconds'
               exit 1
             fi
-          '
+          "
 
       - name: Generate proto stubs
         run: nix develop . --command buf generate


### PR DESCRIPTION
Follow-up from CodeRabbit review on #745 which was merged before review fixes landed.

**Two fixes:**
1. Single-quote the `bash -c` script — eliminates `\$` / `\"` escape noise
2. Add `--max-time 2` to curl — prevents indefinite hang if emulator binds the port but doesn't respond