### PR TITLE
fix: add OAuth2 token refresh to OTLP exporters

### DIFF
--- a/pkg/storage/otlpexporter/otlpexporter.go
+++ b/pkg/storage/otlpexporter/otlpexporter.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/candelahq/candela/pkg/storage"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"golang.org/x/oauth2"
 )
 
 var _ storage.SpanWriter = (*Writer)(nil)
@@ -17,10 +19,16 @@ var _ storage.SpanWriter = (*Writer)(nil)
 type Config struct {
 	Endpoint    string            `yaml:"endpoint"`    // e.g. "http://localhost:4318"
 	Protocol    string            `yaml:"protocol"`    // "http" (default) or "grpc"
-	Headers     map[string]string `yaml:"headers"`     // optional auth headers
+	Headers     map[string]string `yaml:"headers"`     // optional static headers
 	Insecure    bool              `yaml:"insecure"`    // skip TLS verification
 	Compression string            `yaml:"compression"` // "gzip" (default) or "none"
 	TimeoutSec  int               `yaml:"timeout_sec"` // per-export timeout (default: 30)
+
+	// TokenSource provides auto-refreshing OAuth2 tokens for authentication.
+	// When set, a fresh token is injected via the Authorization header on every
+	// request, replacing any static "Authorization" entry in Headers.
+	// This prevents token expiry (e.g. GCP access tokens expire after ~1 hour).
+	TokenSource oauth2.TokenSource `yaml:"-"`
 }
 
 // Writer exports Candela spans as OTLP traces to any OTel-compatible backend.
@@ -132,5 +140,34 @@ func newHTTPClient(cfg Config) (otlptrace.Client, error) {
 		opts = append(opts, otlptracehttp.WithCompression(otlptracehttp.GzipCompression))
 	}
 
+	// When a TokenSource is provided, inject a custom HTTP client that
+	// refreshes the Authorization header on every request.
+	if cfg.TokenSource != nil {
+		opts = append(opts, otlptracehttp.WithHTTPClient(&http.Client{
+			Transport: &tokenTransport{
+				base:   http.DefaultTransport,
+				source: cfg.TokenSource,
+			},
+		}))
+	}
+
 	return otlptracehttp.NewClient(opts...), nil
+}
+
+// tokenTransport is an http.RoundTripper that injects a fresh OAuth2 token
+// on every outgoing request. This prevents token expiry for long-running
+// exporters (GCP access tokens expire after ~1 hour).
+type tokenTransport struct {
+	base   http.RoundTripper
+	source oauth2.TokenSource
+}
+
+func (t *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := t.source.Token()
+	if err != nil {
+		return nil, fmt.Errorf("otlpexporter: refreshing auth token: %w", err)
+	}
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+	return t.base.RoundTrip(req)
 }

--- a/pkg/storage/otlpexporter/otlpexporter.go
+++ b/pkg/storage/otlpexporter/otlpexporter.go
@@ -146,7 +146,7 @@ func newHTTPClient(cfg Config) (otlptrace.Client, error) {
 		opts = append(opts, otlptracehttp.WithHTTPClient(&http.Client{
 			Transport: &tokenTransport{
 				base:   http.DefaultTransport,
-				source: cfg.TokenSource,
+				source: oauth2.ReuseTokenSource(nil, cfg.TokenSource),
 			},
 		}))
 	}
@@ -168,6 +168,6 @@ func (t *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("otlpexporter: refreshing auth token: %w", err)
 	}
 	req = req.Clone(req.Context())
-	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+	req.Header.Set("Authorization", token.Type()+" "+token.AccessToken)
 	return t.base.RoundTrip(req)
 }

--- a/pkg/tetragonaudit/otel_sink.go
+++ b/pkg/tetragonaudit/otel_sink.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"golang.org/x/oauth2"
 )
 
 var _ Sink = (*OTelSink)(nil)
@@ -22,19 +23,25 @@ type OTelSinkConfig struct {
 	// Endpoint is the OTLP/HTTP endpoint (e.g. "http://localhost:4318").
 	Endpoint string
 
-	// Headers are optional auth/routing headers for the OTLP export.
+	// Headers are optional static auth/routing headers for the OTLP export.
 	Headers map[string]string
 
 	// TimeoutSec is the per-export HTTP timeout in seconds. Default: 10.
 	TimeoutSec int
+
+	// TokenSource provides auto-refreshing OAuth2 tokens for authentication.
+	// When set, a fresh token is injected via the Authorization header on
+	// every request, preventing token expiry (GCP tokens expire after ~1hr).
+	TokenSource oauth2.TokenSource
 }
 
 // OTelSink exports AuditRecords as OTLP log records via HTTP.
 // It implements the Sink interface for the tetragonaudit pipeline.
 type OTelSink struct {
-	endpoint string
-	headers  map[string]string
-	client   *http.Client
+	endpoint    string
+	headers     map[string]string
+	client      *http.Client
+	tokenSource oauth2.TokenSource
 }
 
 // NewOTelSink creates a new OTel log exporter sink.
@@ -47,8 +54,9 @@ func NewOTelSink(cfg OTelSinkConfig) (*OTelSink, error) {
 	}
 
 	return &OTelSink{
-		endpoint: cfg.Endpoint,
-		headers:  cfg.Headers,
+		endpoint:    cfg.Endpoint,
+		headers:     cfg.Headers,
+		tokenSource: cfg.TokenSource,
 		client: &http.Client{
 			Timeout: time.Duration(cfg.TimeoutSec) * time.Second,
 		},
@@ -159,6 +167,15 @@ func (s *OTelSink) exportLogs(ctx context.Context, logs plog.Logs) error {
 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
 	for k, v := range s.headers {
 		httpReq.Header.Set(k, v)
+	}
+
+	// Inject a fresh OAuth2 token if a TokenSource is configured.
+	if s.tokenSource != nil {
+		token, tokenErr := s.tokenSource.Token()
+		if tokenErr != nil {
+			return fmt.Errorf("tetragonaudit: refreshing auth token: %w", tokenErr)
+		}
+		httpReq.Header.Set("Authorization", "Bearer "+token.AccessToken)
 	}
 
 	resp, err := s.client.Do(httpReq)

--- a/pkg/tetragonaudit/otel_sink.go
+++ b/pkg/tetragonaudit/otel_sink.go
@@ -53,10 +53,15 @@ func NewOTelSink(cfg OTelSinkConfig) (*OTelSink, error) {
 		cfg.TimeoutSec = 10
 	}
 
+	tokenSource := cfg.TokenSource
+	if tokenSource != nil {
+		tokenSource = oauth2.ReuseTokenSource(nil, tokenSource)
+	}
+
 	return &OTelSink{
 		endpoint:    cfg.Endpoint,
 		headers:     cfg.Headers,
-		tokenSource: cfg.TokenSource,
+		tokenSource: tokenSource,
 		client: &http.Client{
 			Timeout: time.Duration(cfg.TimeoutSec) * time.Second,
 		},
@@ -175,7 +180,7 @@ func (s *OTelSink) exportLogs(ctx context.Context, logs plog.Logs) error {
 		if tokenErr != nil {
 			return fmt.Errorf("tetragonaudit: refreshing auth token: %w", tokenErr)
 		}
-		httpReq.Header.Set("Authorization", "Bearer "+token.AccessToken)
+		httpReq.Header.Set("Authorization", token.Type()+" "+token.AccessToken)
 	}
 
 	resp, err := s.client.Do(httpReq)


### PR DESCRIPTION
## #637 — OTLP token expires after ~1 hour

**Problem:** OAuth2 tokens (e.g. GCP access tokens) were cached at startup in static headers and never refreshed. After ~1 hour the token expires and all OTLP exports silently fail with 401s.

**Fix:** Add an optional `oauth2.TokenSource` field to both OTLP exporter configs. When set, a fresh token is injected on every request.

### otlpexporter (trace exporter)
- New `tokenTransport` RoundTripper wraps `http.DefaultTransport`
- Calls `TokenSource.Token()` per-request, sets `Authorization: Bearer ...`
- Wired in via `otlptracehttp.WithHTTPClient()`

### tetragonaudit OTelSink (log exporter)
- `TokenSource` added to `OTelSinkConfig`
- `exportLogs()` calls `Token()` before each HTTP request
- Token injected after static headers (so it overrides any stale `Authorization` header)

**Both patterns match** how `pkg/proxy` already handles per-request token refresh for upstream LLM providers.

**Backward compatible:** `TokenSource` is `yaml:"-"` and optional — when nil, behavior is unchanged (static headers only). Callers opt in by passing an `oauth2.TokenSource`.

Closes #637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional OAuth2 authentication for OTLP/HTTP log export.
  * Automatically refreshes access tokens and applies them to outgoing requests.
  * Preserves existing behavior when OAuth2 authentication is not configured.

* **Bug Fixes**
  * Authentication token refresh failures are now surfaced with clear export errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->