### PR TITLE
fix: extract shared grpcretry package, add pre-shutdown readiness flip

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -340,8 +341,15 @@ func main() {
 
 	// Readiness probe: checks that the server can serve traffic.
 	// Used by Cloud Run / Kubernetes for traffic routing decisions.
+	// Returns 503 during graceful shutdown so LBs drain before srv.Shutdown().
+	var shuttingDown atomic.Bool
 	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if shuttingDown.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = fmt.Fprintln(w, `{"status": "shutting_down"}`)
+			return
+		}
 		if err := reader.Ping(r.Context()); err != nil {
 			slog.Error("readyz: storage ping failed", "error", err)
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -1066,6 +1074,11 @@ func main() {
 
 	<-ctx.Done()
 	slog.Info("shutting down...")
+
+	// Flip readiness BEFORE calling Shutdown so LBs stop sending traffic.
+	shuttingDown.Store(true)
+	slog.Info("readyz now returns 503 — draining for 5s")
+	time.Sleep(5 * time.Second)
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -1073,6 +1073,7 @@ func main() {
 	}()
 
 	<-ctx.Done()
+	stop() // Restore default signal handling — a second Ctrl+C force-quits.
 	slog.Info("shutting down...")
 
 	// Flip readiness BEFORE calling Shutdown so LBs stop sending traffic.

--- a/pkg/grpcretry/grpcretry.go
+++ b/pkg/grpcretry/grpcretry.go
@@ -1,0 +1,45 @@
+// Package grpcretry provides shared exponential backoff logic for gRPC
+// reconnection loops. It is used by both hubbleaudit and tetragonaudit
+// to avoid duplicating the backoff computation and configuration.
+package grpcretry
+
+import (
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// Config controls the reconnect backoff behavior.
+type Config struct {
+	// InitialDelay is the first backoff duration (default: 1s).
+	InitialDelay time.Duration
+	// MaxDelay is the backoff ceiling (default: 30s).
+	MaxDelay time.Duration
+	// Multiplier is the backoff factor (default: 2.0).
+	Multiplier float64
+}
+
+// WithDefaults returns a copy of the config with zero-valued fields
+// replaced by sensible defaults.
+func (c Config) WithDefaults() Config {
+	if c.InitialDelay <= 0 {
+		c.InitialDelay = time.Second
+	}
+	if c.MaxDelay <= 0 {
+		c.MaxDelay = 30 * time.Second
+	}
+	if c.Multiplier <= 0 {
+		c.Multiplier = 2.0
+	}
+	return c
+}
+
+// Backoff computes the delay for a given attempt with ±25% jitter.
+func Backoff(attempt int, c Config) time.Duration {
+	d := float64(c.InitialDelay) * math.Pow(c.Multiplier, float64(attempt))
+	if d > float64(c.MaxDelay) {
+		d = float64(c.MaxDelay)
+	}
+	jitter := d * 0.25 * (2*rand.Float64() - 1) //nolint:gosec
+	return time.Duration(d + jitter)
+}

--- a/pkg/grpcretry/grpcretry.go
+++ b/pkg/grpcretry/grpcretry.go
@@ -36,6 +36,12 @@ func (c Config) WithDefaults() Config {
 
 // Backoff computes the delay for a given attempt with ±25% jitter.
 func Backoff(attempt int, c Config) time.Duration {
+	// Guard against overflow: math.Pow(2, 31+) → +Inf.
+	if attempt < 0 {
+		attempt = 0
+	} else if attempt > 30 {
+		attempt = 30
+	}
 	d := float64(c.InitialDelay) * math.Pow(c.Multiplier, float64(attempt))
 	if d > float64(c.MaxDelay) {
 		d = float64(c.MaxDelay)

--- a/pkg/hubbleaudit/grpc_source.go
+++ b/pkg/hubbleaudit/grpc_source.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
-	"math/rand/v2"
 	"sync"
 	"time"
 
+	"github.com/candelahq/candela/pkg/grpcretry"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding"
@@ -236,28 +235,9 @@ func (s *GRPCFlowSource) readLoop(ctx context.Context, stream grpc.ClientStream,
 
 // ── Retry / Health ──
 
-// RetryConfig controls the reconnect backoff behavior.
-type RetryConfig struct {
-	// InitialDelay is the first backoff duration (default: 1s).
-	InitialDelay time.Duration
-	// MaxDelay is the backoff ceiling (default: 30s).
-	MaxDelay time.Duration
-	// Multiplier is the backoff factor (default: 2.0).
-	Multiplier float64
-}
-
-func (rc RetryConfig) withDefaults() RetryConfig {
-	if rc.InitialDelay <= 0 {
-		rc.InitialDelay = time.Second
-	}
-	if rc.MaxDelay <= 0 {
-		rc.MaxDelay = 30 * time.Second
-	}
-	if rc.Multiplier <= 0 {
-		rc.Multiplier = 2.0
-	}
-	return rc
-}
+// RetryConfig is an alias for grpcretry.Config.
+// Kept for backward compatibility with existing callers.
+type RetryConfig = grpcretry.Config
 
 // FlowHandler is called for each flow received from the Hubble stream.
 // Returning an error logs a warning but does not stop the stream.
@@ -267,7 +247,7 @@ type FlowHandler func(ctx context.Context, flow Flow) error
 // exponential backoff. handler is called for each flow. The loop exits
 // when ctx is cancelled.
 func (s *GRPCFlowSource) StreamWithRetry(ctx context.Context, handler FlowHandler, rc RetryConfig) error {
-	rc = rc.withDefaults()
+	rc = rc.WithDefaults()
 	attempt := 0
 
 	for {
@@ -281,7 +261,7 @@ func (s *GRPCFlowSource) StreamWithRetry(ctx context.Context, handler FlowHandle
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			delay := backoff(attempt, rc)
+			delay := grpcretry.Backoff(attempt, rc)
 			slog.Warn("hubbleaudit: gRPC stream creation failed, retrying",
 				"error", err, "attempt", attempt+1, "backoff", delay)
 			attempt++
@@ -313,7 +293,7 @@ func (s *GRPCFlowSource) StreamWithRetry(ctx context.Context, handler FlowHandle
 			}
 		}
 
-		delay := backoff(attempt, rc)
+		delay := grpcretry.Backoff(attempt, rc)
 		slog.Warn("hubbleaudit: gRPC stream error, reconnecting",
 			"error", err, "attempt", attempt+1, "backoff", delay)
 		attempt++
@@ -392,14 +372,4 @@ func (s *GRPCFlowSource) Close() error {
 // Addr returns the configured gRPC address.
 func (s *GRPCFlowSource) Addr() string {
 	return s.cfg.Addr
-}
-
-// backoff computes the delay for a given attempt with ±25% jitter.
-func backoff(attempt int, rc RetryConfig) time.Duration {
-	d := float64(rc.InitialDelay) * math.Pow(rc.Multiplier, float64(attempt))
-	if d > float64(rc.MaxDelay) {
-		d = float64(rc.MaxDelay)
-	}
-	jitter := d * 0.25 * (2*rand.Float64() - 1) //nolint:gosec
-	return time.Duration(d + jitter)
 }

--- a/pkg/hubbleaudit/grpc_source_test.go
+++ b/pkg/hubbleaudit/grpc_source_test.go
@@ -3,6 +3,7 @@ package hubbleaudit
 import (
 	"testing"
 
+	"github.com/candelahq/candela/pkg/grpcretry"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -64,7 +65,7 @@ func TestGRPCFlowSource_SetConnected(t *testing.T) {
 }
 
 func TestRetryConfig_Defaults(t *testing.T) {
-	rc := RetryConfig{}.withDefaults()
+	rc := RetryConfig{}.WithDefaults()
 
 	if rc.InitialDelay != 1_000_000_000 { // 1s
 		t.Errorf("InitialDelay = %v", rc.InitialDelay)
@@ -78,11 +79,11 @@ func TestRetryConfig_Defaults(t *testing.T) {
 }
 
 func TestBackoff_ExponentialGrowth(t *testing.T) {
-	rc := RetryConfig{}.withDefaults()
+	rc := RetryConfig{}.WithDefaults()
 
-	d0 := backoff(0, rc)
-	d1 := backoff(1, rc)
-	d2 := backoff(2, rc)
+	d0 := grpcretry.Backoff(0, rc)
+	d1 := grpcretry.Backoff(1, rc)
+	d2 := grpcretry.Backoff(2, rc)
 
 	// With ±25% jitter, d1 should generally be > d0 and d2 > d1.
 	// We use a generous range to account for jitter.
@@ -98,9 +99,9 @@ func TestBackoff_ExponentialGrowth(t *testing.T) {
 }
 
 func TestBackoff_MaxCap(t *testing.T) {
-	rc := RetryConfig{}.withDefaults()
+	rc := RetryConfig{}.WithDefaults()
 
-	d := backoff(100, rc) // Very high attempt — should be capped.
+	d := grpcretry.Backoff(100, rc) // Very high attempt — should be capped.
 	if d > rc.MaxDelay+rc.MaxDelay/4 {
 		t.Errorf("attempt 100 backoff = %v, exceeds max %v + 25%% jitter", d, rc.MaxDelay)
 	}

--- a/pkg/tetragonaudit/grpc_source.go
+++ b/pkg/tetragonaudit/grpc_source.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
-	"math/rand/v2"
 	"time"
 
+	"github.com/candelahq/candela/pkg/grpcretry"
 	tetragon "github.com/cilium/tetragon/api/v1/tetragon"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -95,28 +94,9 @@ func (s *GRPCSource) Addr() string {
 	return s.addr
 }
 
-// RetryConfig controls the reconnect backoff behavior.
-type RetryConfig struct {
-	// InitialDelay is the first backoff duration (default: 1s).
-	InitialDelay time.Duration
-	// MaxDelay is the backoff ceiling (default: 30s).
-	MaxDelay time.Duration
-	// Multiplier is the backoff factor (default: 2.0).
-	Multiplier float64
-}
-
-func (rc RetryConfig) withDefaults() RetryConfig {
-	if rc.InitialDelay <= 0 {
-		rc.InitialDelay = time.Second
-	}
-	if rc.MaxDelay <= 0 {
-		rc.MaxDelay = 30 * time.Second
-	}
-	if rc.Multiplier <= 0 {
-		rc.Multiplier = 2.0
-	}
-	return rc
-}
+// RetryConfig is an alias for grpcretry.Config.
+// Kept for backward compatibility with existing callers.
+type RetryConfig = grpcretry.Config
 
 // StreamEventsWithRetry streams events from the Tetragon gRPC API with
 // automatic reconnection on failure using exponential backoff.
@@ -127,7 +107,7 @@ func (rc RetryConfig) withDefaults() RetryConfig {
 //
 // The loop exits cleanly when ctx is cancelled (graceful shutdown).
 func (s *GRPCSource) StreamEventsWithRetry(ctx context.Context, pipeline *Pipeline, rc RetryConfig) error {
-	rc = rc.withDefaults()
+	rc = rc.WithDefaults()
 	attempt := 0
 
 	for {
@@ -142,7 +122,7 @@ func (s *GRPCSource) StreamEventsWithRetry(ctx context.Context, pipeline *Pipeli
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			delay := backoff(attempt, rc)
+			delay := grpcretry.Backoff(attempt, rc)
 			slog.Warn("tetragonaudit: gRPC stream creation failed, retrying",
 				"error", err, "attempt", attempt+1, "backoff", delay)
 			attempt++
@@ -175,7 +155,7 @@ func (s *GRPCSource) StreamEventsWithRetry(ctx context.Context, pipeline *Pipeli
 			}
 		}
 
-		delay := backoff(attempt, rc)
+		delay := grpcretry.Backoff(attempt, rc)
 		slog.Warn("tetragonaudit: gRPC stream error, reconnecting",
 			"error", err, "attempt", attempt+1, "backoff", delay)
 		attempt++
@@ -185,17 +165,6 @@ func (s *GRPCSource) StreamEventsWithRetry(ctx context.Context, pipeline *Pipeli
 		case <-time.After(delay):
 		}
 	}
-}
-
-// backoff computes the delay for a given attempt with ±25% jitter.
-func backoff(attempt int, rc RetryConfig) time.Duration {
-	d := float64(rc.InitialDelay) * math.Pow(rc.Multiplier, float64(attempt))
-	if d > float64(rc.MaxDelay) {
-		d = float64(rc.MaxDelay)
-	}
-	// Add ±25% jitter.
-	jitter := d * 0.25 * (2*rand.Float64() - 1) //nolint:gosec
-	return time.Duration(d + jitter)
 }
 
 // Conn returns the underlying gRPC connection for advanced usage

--- a/pkg/tetragonaudit/retry_test.go
+++ b/pkg/tetragonaudit/retry_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/candelahq/candela/pkg/grpcretry"
 )
 
 func TestStreamEventsWithRetry_ReconnectsAfterFailure(t *testing.T) {
@@ -85,7 +87,7 @@ func TestBackoff_ExponentialWithCap(t *testing.T) {
 	for _, tt := range tests {
 		// Run each sub-test multiple times to verify jitter range.
 		for range 20 {
-			d := backoff(tt.attempt, rc)
+			d := grpcretry.Backoff(tt.attempt, rc)
 			if d < tt.minDelay || d > tt.maxDelay {
 				t.Errorf("attempt %d: backoff=%v, want [%v, %v]",
 					tt.attempt, d, tt.minDelay, tt.maxDelay)
@@ -95,7 +97,7 @@ func TestBackoff_ExponentialWithCap(t *testing.T) {
 }
 
 func TestBackoff_DefaultConfig(t *testing.T) {
-	rc := RetryConfig{}.withDefaults()
+	rc := RetryConfig{}.WithDefaults()
 
 	if rc.InitialDelay != time.Second {
 		t.Errorf("InitialDelay=%v, want 1s", rc.InitialDelay)


### PR DESCRIPTION
Batch: #664 + #692

**#664** — Extract duplicated RetryConfig/backoff() from hubbleaudit and tetragonaudit into pkg/grpcretry. Type aliases preserve backward compat.

**#692** — Add atomic.Bool shuttingDown to candela-server. On SIGTERM: /readyz returns 503 immediately, 5s drain, then srv.Shutdown().

Closes #664
Closes #692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Improved gRPC reconnection behavior with consistent exponential backoff and jitter.
  * Added configurable retry delays with sensible defaults and maximum delay limits.
  * Enhanced shutdown handling so readiness checks return a temporary unavailable status while traffic drains safely.
* **Bug Fixes**
  * Improved service behavior during graceful shutdown and transient connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->