### PR TITLE
test: add SearchSpans time-range integration tests

### DIFF
--- a/pkg/connecthandlers/trace_handler_test.go
+++ b/pkg/connecthandlers/trace_handler_test.go
@@ -1,9 +1,15 @@
 package connecthandlers
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	connect "connectrpc.com/connect"
+	typespb "github.com/candelahq/candela/gen/go/candela/types"
+	v1 "github.com/candelahq/candela/gen/go/candela/v1"
 	"github.com/candelahq/candela/pkg/storage"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestTraceUserID(t *testing.T) {
@@ -73,5 +79,164 @@ func TestTraceUserID(t *testing.T) {
 				t.Errorf("traceUserID() = %q, want %q", got, tt.wantID)
 			}
 		})
+	}
+}
+
+// ── Mock SpanReader ─────────────────────────────────────────────────────────
+
+type mockSpanReader struct {
+	spans []storage.Span
+}
+
+func (m *mockSpanReader) GetTrace(ctx context.Context, traceID string) (*storage.Trace, error) {
+	return nil, storage.ErrNotFound
+}
+
+func (m *mockSpanReader) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage.TraceResult, error) {
+	return nil, nil
+}
+
+func (m *mockSpanReader) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.SpanResult, error) {
+	var filtered []storage.Span
+	for _, s := range m.spans {
+		if !q.StartTime.IsZero() && s.StartTime.Before(q.StartTime) {
+			continue
+		}
+		if !q.EndTime.IsZero() && s.EndTime.After(q.EndTime) {
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+
+	total := len(filtered)
+	if q.PageSize > 0 && len(filtered) > q.PageSize {
+		filtered = filtered[:q.PageSize]
+	}
+
+	return &storage.SpanResult{
+		Spans:      filtered,
+		TotalCount: total,
+	}, nil
+}
+
+func (m *mockSpanReader) GetUsageSummary(ctx context.Context, q storage.UsageQuery) (*storage.UsageSummary, error) {
+	return nil, nil
+}
+
+func (m *mockSpanReader) GetModelBreakdown(ctx context.Context, q storage.UsageQuery) ([]storage.ModelUsage, error) {
+	return nil, nil
+}
+
+func (m *mockSpanReader) GetUserLeaderboard(ctx context.Context, q storage.UsageQuery, limit int) ([]storage.UserUsageSummary, error) {
+	return nil, nil
+}
+
+func (m *mockSpanReader) GetTenantLeaderboard(ctx context.Context, q storage.UsageQuery, limit int) ([]storage.TenantUsageSummary, error) {
+	return nil, nil
+}
+
+func (m *mockSpanReader) GetJobLeaderboard(ctx context.Context, q storage.UsageQuery, limit int) ([]storage.JobUsageSummary, error) {
+	return nil, nil
+}
+
+func (m *mockSpanReader) Ping(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockSpanReader) Close() error {
+	return nil
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+func TestSearchSpans_TimeRangeFiltering(t *testing.T) {
+	now := time.Now().UTC()
+	store := &mockSpanReader{
+		spans: []storage.Span{
+			{SpanID: "s1", StartTime: now.Add(-10 * time.Hour), EndTime: now.Add(-9 * time.Hour)},
+			{SpanID: "s2", StartTime: now.Add(-5 * time.Hour), EndTime: now.Add(-4 * time.Hour)},
+			{SpanID: "s3", StartTime: now.Add(-1 * time.Hour), EndTime: now},
+		},
+	}
+	handler := NewTraceHandler(store, nil)
+
+	req := connect.NewRequest(&v1.SearchSpansRequest{
+		ProjectId: "proj1",
+		TimeRange: &typespb.TimeRange{
+			Start: timestamppb.New(now.Add(-6 * time.Hour)),
+			End:   timestamppb.New(now.Add(-2 * time.Hour)),
+		},
+	})
+
+	res, err := handler.SearchSpans(context.Background(), req)
+	if err != nil {
+		t.Fatalf("SearchSpans failed: %v", err)
+	}
+
+	if len(res.Msg.Spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(res.Msg.Spans))
+	}
+	if res.Msg.Spans[0].SpanId != "s2" {
+		t.Errorf("expected span s2, got %s", res.Msg.Spans[0].SpanId)
+	}
+}
+
+func TestSearchSpans_EmptyTimeRange(t *testing.T) {
+	now := time.Now().UTC()
+	store := &mockSpanReader{
+		spans: []storage.Span{
+			{SpanID: "s1", StartTime: now.Add(-10 * time.Hour), EndTime: now.Add(-9 * time.Hour)},
+		},
+	}
+	handler := NewTraceHandler(store, nil)
+
+	req := connect.NewRequest(&v1.SearchSpansRequest{
+		ProjectId: "proj1",
+		TimeRange: &typespb.TimeRange{
+			Start: timestamppb.New(now.Add(-2 * time.Hour)),
+			End:   timestamppb.New(now.Add(-1 * time.Hour)),
+		},
+	})
+
+	res, err := handler.SearchSpans(context.Background(), req)
+	if err != nil {
+		t.Fatalf("SearchSpans failed: %v", err)
+	}
+
+	if len(res.Msg.Spans) != 0 {
+		t.Fatalf("expected 0 spans, got %d", len(res.Msg.Spans))
+	}
+}
+
+func TestSearchSpans_PageSizeLimit(t *testing.T) {
+	now := time.Now().UTC()
+	store := &mockSpanReader{
+		spans: []storage.Span{
+			{SpanID: "s1", StartTime: now.Add(-1 * time.Hour), EndTime: now},
+			{SpanID: "s2", StartTime: now.Add(-1 * time.Hour), EndTime: now},
+			{SpanID: "s3", StartTime: now.Add(-1 * time.Hour), EndTime: now},
+			{SpanID: "s4", StartTime: now.Add(-1 * time.Hour), EndTime: now},
+		},
+	}
+	handler := NewTraceHandler(store, nil)
+
+	req := connect.NewRequest(&v1.SearchSpansRequest{
+		ProjectId: "proj1",
+		Pagination: &typespb.PaginationRequest{
+			PageSize: 2,
+		},
+	})
+
+	res, err := handler.SearchSpans(context.Background(), req)
+	if err != nil {
+		t.Fatalf("SearchSpans failed: %v", err)
+	}
+
+	if len(res.Msg.Spans) != 2 {
+		t.Fatalf("expected 2 spans, got %d", len(res.Msg.Spans))
+	}
+	// The total count should still reflect the total matched spans without page size limit
+	if res.Msg.Pagination.TotalCount != 4 {
+		t.Errorf("expected total count 4, got %d", res.Msg.Pagination.TotalCount)
 	}
 }

--- a/pkg/connecthandlers/trace_handler_test.go
+++ b/pkg/connecthandlers/trace_handler_test.go
@@ -235,6 +235,9 @@ func TestSearchSpans_PageSizeLimit(t *testing.T) {
 	if len(res.Msg.Spans) != 2 {
 		t.Fatalf("expected 2 spans, got %d", len(res.Msg.Spans))
 	}
+	if res.Msg.Spans[0].SpanId != "s1" || res.Msg.Spans[1].SpanId != "s2" {
+		t.Errorf("expected spans [s1, s2], got [%s, %s]", res.Msg.Spans[0].SpanId, res.Msg.Spans[1].SpanId)
+	}
 	// The total count should still reflect the total matched spans without page size limit
 	if res.Msg.Pagination.TotalCount != 4 {
 		t.Errorf("expected total count 4, got %d", res.Msg.Pagination.TotalCount)


### PR DESCRIPTION
Adds 3 integration tests for the SearchSpans RPC in `trace_handler_test.go`:

1. **TimeRangeFiltering** — Inserts spans at different timestamps, verifies only spans within the requested window are returned
2. **EmptyTimeRange** — Verifies empty result when no spans match the window
3. **PageSizeLimit** — Inserts 4 spans, requests page_size=2, verifies exactly 2 returned with total count = 4

These tests cover the exact RPC path that the opencode-candela plugin's `candela_session_cost` tool relies on (`fetchSessionTraces` → `SearchSpans`). Previously only 1 test existed for SearchSpans.