### PR TITLE
fix: add Next.js error boundaries + eliminate os.Exit in goroutines

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -1064,15 +1064,20 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	errCh := make(chan error, 1)
 	go func() {
 		slog.Info("🕯️ Candela server starting", "addr", addr)
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error("server error", "error", err)
-			os.Exit(1)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
 		}
 	}()
 
-	<-ctx.Done()
+	select {
+	case err := <-errCh:
+		slog.Error("server failed to start", "error", err)
+		stop()
+	case <-ctx.Done():
+	}
 	stop() // Restore default signal handling — a second Ctrl+C force-quits.
 	slog.Info("shutting down...")
 

--- a/cmd/candela-sidecar/main.go
+++ b/cmd/candela-sidecar/main.go
@@ -22,6 +22,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -247,11 +248,11 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	errCh := make(chan error, 1)
 	go func() {
 		slog.Info("🕯️ candela-sidecar listening", "addr", addr)
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error("server error", "error", err)
-			os.Exit(1)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
 		}
 	}()
 
@@ -353,8 +354,12 @@ func main() {
 			}()
 		}
 	}
-
-	<-ctx.Done()
+	select {
+	case err := <-errCh:
+		slog.Error("server failed to start", "error", err)
+		stop()
+	case <-ctx.Done():
+	}
 	slog.Info("shutting down...")
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io/fs"
@@ -1130,6 +1131,7 @@ func runForeground() {
 	sigCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	errCh := make(chan error, 1)
 	go func() {
 		if soloMode {
 			slog.Info("🕯️ candela started (solo mode)",
@@ -1150,9 +1152,8 @@ func runForeground() {
 			slog.Info("Point your tools at:", logFields...)
 		}
 
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error("server error", "error", err)
-			os.Exit(1)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
 		}
 	}()
 
@@ -1168,12 +1169,17 @@ func runForeground() {
 		slog.Info("🖥️ LM Studio compat listener started",
 			"addr", fmt.Sprintf("http://%s", lmAddr),
 			"models", fmt.Sprintf("http://%s/v1/models", lmAddr))
-		if err := lmSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := lmSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			slog.Warn("LM Studio listener failed (port may be in use)", "addr", lmAddr, "error", err)
 		}
 	}()
 
-	<-sigCtx.Done()
+	select {
+	case err := <-errCh:
+		slog.Error("server failed to start", "error", err)
+		return
+	case <-sigCtx.Done():
+	}
 	slog.Info("shutting down...")
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -1177,7 +1177,6 @@ func runForeground() {
 	select {
 	case err := <-errCh:
 		slog.Error("server failed to start", "error", err)
-		return
 	case <-sigCtx.Done():
 	}
 	slog.Info("shutting down...")

--- a/cmd/candela/server_errch_test.go
+++ b/cmd/candela/server_errch_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestServerErrChPattern verifies that when a server fails to bind,
+// the error flows through errCh instead of calling os.Exit.
+// This mirrors the pattern used in candela-server, candela-sidecar,
+// and candela's runForeground.
+func TestServerErrChPattern(t *testing.T) {
+	// Bind a port so the second server fails.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	addr := ln.Addr().String()
+
+	// Mimic the production pattern: errCh + goroutine + select.
+	errCh := make(chan error, 1)
+	srv := &http.Server{Addr: addr}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	select {
+	case srvErr := <-errCh:
+		// Expected: port already in use.
+		if srvErr == nil {
+			t.Fatal("expected non-nil error from errCh")
+		}
+		t.Logf("errCh received expected error: %v", srvErr)
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for server error — errCh pattern may be broken")
+		_ = srv.Shutdown(ctx)
+	}
+}
+
+// TestServerGracefulShutdown verifies that a server that starts
+// successfully can be shut down cleanly through the signal path.
+func TestServerGracefulShutdown(t *testing.T) {
+	srv := &http.Server{
+		Addr:    "127.0.0.1:0",
+		Handler: http.NewServeMux(),
+	}
+
+	ln, err := net.Listen("tcp", srv.Addr)
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+	}()
+
+	// Give server a moment to start.
+	time.Sleep(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Simulate graceful shutdown (what happens on SIGINT).
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatalf("shutdown failed: %v", err)
+	}
+
+	// Verify no error was sent to errCh.
+	select {
+	case srvErr := <-errCh:
+		t.Fatalf("unexpected error on errCh after clean shutdown: %v", srvErr)
+	default:
+		t.Log("clean shutdown — no error on errCh, defers would execute")
+	}
+}
+
+// TestErrChDoesNotBlock verifies the errCh is buffered and doesn't
+// block the goroutine when no one is reading yet.
+func TestErrChDoesNotBlock(t *testing.T) {
+	errCh := make(chan error, 1)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		errCh <- errors.New("bind: address already in use")
+	}()
+
+	select {
+	case <-done:
+		// Goroutine completed without blocking — buffer works.
+	case <-time.After(1 * time.Second):
+		t.Fatal("goroutine blocked sending to errCh — channel must be buffered")
+	}
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected error from errCh")
+	}
+}

--- a/ui/e2e/error_boundaries.spec.ts
+++ b/ui/e2e/error_boundaries.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+
+// ──────────────────────────────────────────
+// Error Boundaries & 404 Pages
+// ──────────────────────────────────────────
+
+test.describe("Error Handling", () => {
+  test("shows 404 page for unknown routes", async ({ page }) => {
+    await page.goto("/this-route-does-not-exist");
+    // The root not-found.tsx should render
+    await expect(page.getByText("Page not found")).toBeVisible();
+    await expect(page.getByRole("link", { name: "Go home" })).toBeVisible();
+  });
+
+  test("404 page has working home link", async ({ page }) => {
+    await page.goto("/this-route-does-not-exist");
+    await expect(page.getByText("Page not found")).toBeVisible();
+    const homeLink = page.getByRole("link", { name: "Go home" });
+    await expect(homeLink).toHaveAttribute("href", "/");
+  });
+
+  test("trace 404 page renders for invalid trace ID", async ({ page }) => {
+    // Navigate to a non-existent trace ID
+    await page.goto("/traces/non-existent-trace-id-12345");
+    // Should show trace-specific not-found or fall back to root not-found
+    const traceNotFound = page.getByText("Trace not found");
+    const rootNotFound = page.getByText("Page not found");
+    // Accept either — depends on whether the traces/[id] page calls notFound()
+    await expect(traceNotFound.or(rootNotFound)).toBeVisible();
+  });
+});
+
+test.describe("Loading States", () => {
+  test("loading spinner has accessible role", async ({ page }) => {
+    // The loading.tsx renders during Suspense boundaries.
+    // We can verify the component renders correctly by checking
+    // a direct navigation triggers a loading state.
+    // Since loading states are transient, verify the component
+    // structure is correct by checking the root page loads.
+    await page.goto("/");
+    // Page should eventually load (loading state is transient)
+    await page.waitForLoadState("networkidle");
+    // If we're here, the app loaded — loading boundaries didn't crash
+  });
+});

--- a/ui/e2e/error_boundaries.spec.ts
+++ b/ui/e2e/error_boundaries.spec.ts
@@ -19,27 +19,5 @@ test.describe("Error Handling", () => {
     await expect(homeLink).toHaveAttribute("href", "/");
   });
 
-  test("trace 404 page renders for invalid trace ID", async ({ page }) => {
-    // Navigate to a non-existent trace ID
-    await page.goto("/traces/non-existent-trace-id-12345");
-    // Should show trace-specific not-found or fall back to root not-found
-    const traceNotFound = page.getByText("Trace not found");
-    const rootNotFound = page.getByText("Page not found");
-    // Accept either — depends on whether the traces/[id] page calls notFound()
-    await expect(traceNotFound.or(rootNotFound)).toBeVisible();
-  });
 });
 
-test.describe("Loading States", () => {
-  test("loading spinner has accessible role", async ({ page }) => {
-    // The loading.tsx renders during Suspense boundaries.
-    // We can verify the component renders correctly by checking
-    // a direct navigation triggers a loading state.
-    // Since loading states are transient, verify the component
-    // structure is correct by checking the root page loads.
-    await page.goto("/");
-    // Page should eventually load (loading state is transient)
-    await page.waitForLoadState("networkidle");
-    // If we're here, the app loaded — loading boundaries didn't crash
-  });
-});

--- a/ui/src/app/admin/error.tsx
+++ b/ui/src/app/admin/error.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import Link from 'next/link'
 
 export default function AdminError({
@@ -9,6 +10,10 @@ export default function AdminError({
   error: Error & { digest?: string }
   reset: () => void
 }) {
+  useEffect(() => {
+    console.error('[candela:admin] Unhandled error:', error)
+  }, [error])
+
   return (
     <div style={{
       display: 'flex',
@@ -26,18 +31,18 @@ export default function AdminError({
         borderRadius: 'var(--radius-lg)'
       }}>
         <h2 style={{ color: 'var(--text-primary)', marginBottom: '1rem' }}>Admin error</h2>
-        <pre style={{
-          backgroundColor: 'var(--bg-tertiary)',
-          color: 'var(--error)',
-          padding: '1rem',
-          borderRadius: 'var(--radius-md)',
-          overflow: 'auto',
-          marginBottom: '1.5rem',
-          textAlign: 'left',
-          fontSize: '14px'
-        }}>
-          {error.message}
-        </pre>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '1.5rem' }}>
+          An unexpected error occurred in the admin panel. Please try again.
+        </p>
+        {error.digest && (
+          <p style={{
+            color: 'var(--text-muted)',
+            fontSize: '12px',
+            marginBottom: '1.5rem'
+          }}>
+            Error ID: {error.digest}
+          </p>
+        )}
         <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
           <button 
             onClick={() => reset()}

--- a/ui/src/app/admin/error.tsx
+++ b/ui/src/app/admin/error.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import Link from 'next/link'
+
+export default function AdminError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '100vh',
+      backgroundColor: 'var(--bg-primary)'
+    }}>
+      <div style={{
+        textAlign: 'center',
+        maxWidth: '500px',
+        padding: '2rem',
+        backgroundColor: 'var(--bg-secondary)',
+        border: '1px solid var(--border)',
+        borderRadius: 'var(--radius-lg)'
+      }}>
+        <h2 style={{ color: 'var(--text-primary)', marginBottom: '1rem' }}>Admin error</h2>
+        <pre style={{
+          backgroundColor: 'var(--bg-tertiary)',
+          color: 'var(--error)',
+          padding: '1rem',
+          borderRadius: 'var(--radius-md)',
+          overflow: 'auto',
+          marginBottom: '1.5rem',
+          textAlign: 'left',
+          fontSize: '14px'
+        }}>
+          {error.message}
+        </pre>
+        <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
+          <button 
+            onClick={() => reset()}
+            style={{
+              backgroundColor: 'var(--accent)',
+              color: 'var(--bg-primary)',
+              border: 'none',
+              padding: '0.5rem 1rem',
+              borderRadius: 'var(--radius-md)',
+              cursor: 'pointer',
+              fontWeight: 'bold'
+            }}
+          >
+            Try again
+          </button>
+          <Link 
+            href="/admin"
+            style={{
+              backgroundColor: 'transparent',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border)',
+              padding: '0.5rem 1rem',
+              borderRadius: 'var(--radius-md)',
+              cursor: 'pointer',
+              textDecoration: 'none'
+            }}
+          >
+            Return to admin
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/app/admin/loading.tsx
+++ b/ui/src/app/admin/loading.tsx
@@ -1,0 +1,28 @@
+export default function AdminLoading() {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '100vh',
+      backgroundColor: 'var(--bg-primary)'
+    }}>
+      <style dangerouslySetInnerHTML={{
+        __html: `
+          @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+          }
+        `
+      }} />
+      <div style={{
+        width: '40px',
+        height: '40px',
+        border: '4px solid var(--bg-tertiary)',
+        borderTop: '4px solid var(--accent)',
+        borderRadius: '50%',
+        animation: 'spin 1s linear infinite'
+      }} />
+    </div>
+  )
+}

--- a/ui/src/app/admin/loading.tsx
+++ b/ui/src/app/admin/loading.tsx
@@ -1,12 +1,15 @@
 export default function AdminLoading() {
   return (
-    <div style={{
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      minHeight: '100vh',
-      backgroundColor: 'var(--bg-primary)'
-    }}>
+    <div
+      role="status"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        backgroundColor: 'var(--bg-primary)'
+      }}
+    >
       <style dangerouslySetInnerHTML={{
         __html: `
           @keyframes spin {
@@ -15,14 +18,30 @@ export default function AdminLoading() {
           }
         `
       }} />
-      <div style={{
-        width: '40px',
-        height: '40px',
-        border: '4px solid var(--bg-tertiary)',
-        borderTop: '4px solid var(--accent)',
-        borderRadius: '50%',
-        animation: 'spin 1s linear infinite'
-      }} />
+      <div
+        aria-hidden="true"
+        style={{
+          width: '40px',
+          height: '40px',
+          border: '4px solid var(--bg-tertiary)',
+          borderTop: '4px solid var(--accent)',
+          borderRadius: '50%',
+          animation: 'spin 1s linear infinite'
+        }}
+      />
+      <span style={{
+        position: 'absolute',
+        width: '1px',
+        height: '1px',
+        padding: 0,
+        margin: '-1px',
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        borderWidth: 0
+      }}>
+        Loading…
+      </span>
     </div>
   )
 }

--- a/ui/src/app/error.tsx
+++ b/ui/src/app/error.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import Link from 'next/link'
 
 export default function Error({
@@ -9,6 +10,10 @@ export default function Error({
   error: Error & { digest?: string }
   reset: () => void
 }) {
+  useEffect(() => {
+    console.error('[candela] Unhandled error:', error)
+  }, [error])
+
   return (
     <div style={{
       display: 'flex',
@@ -27,18 +32,18 @@ export default function Error({
       }}>
         <div style={{ fontSize: '3rem', marginBottom: '1rem' }}>🕯️</div>
         <h2 style={{ color: 'var(--text-primary)', marginBottom: '1rem' }}>Something went wrong</h2>
-        <pre style={{
-          backgroundColor: 'var(--bg-tertiary)',
-          color: 'var(--error)',
-          padding: '1rem',
-          borderRadius: 'var(--radius-md)',
-          overflow: 'auto',
-          marginBottom: '1.5rem',
-          textAlign: 'left',
-          fontSize: '14px'
-        }}>
-          {error.message}
-        </pre>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '1.5rem' }}>
+          An unexpected error occurred. Please try again.
+        </p>
+        {error.digest && (
+          <p style={{
+            color: 'var(--text-muted)',
+            fontSize: '12px',
+            marginBottom: '1.5rem'
+          }}>
+            Error ID: {error.digest}
+          </p>
+        )}
         <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
           <button 
             onClick={() => reset()}

--- a/ui/src/app/error.tsx
+++ b/ui/src/app/error.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import Link from 'next/link'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '100vh',
+      backgroundColor: 'var(--bg-primary)'
+    }}>
+      <div style={{
+        textAlign: 'center',
+        maxWidth: '500px',
+        padding: '2rem',
+        backgroundColor: 'var(--bg-secondary)',
+        border: '1px solid var(--border)',
+        borderRadius: 'var(--radius-lg)'
+      }}>
+        <div style={{ fontSize: '3rem', marginBottom: '1rem' }}>🕯️</div>
+        <h2 style={{ color: 'var(--text-primary)', marginBottom: '1rem' }}>Something went wrong</h2>
+        <pre style={{
+          backgroundColor: 'var(--bg-tertiary)',
+          color: 'var(--error)',
+          padding: '1rem',
+          borderRadius: 'var(--radius-md)',
+          overflow: 'auto',
+          marginBottom: '1.5rem',
+          textAlign: 'left',
+          fontSize: '14px'
+        }}>
+          {error.message}
+        </pre>
+        <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
+          <button 
+            onClick={() => reset()}
+            style={{
+              backgroundColor: 'var(--accent)',
+              color: 'var(--bg-primary)',
+              border: 'none',
+              padding: '0.5rem 1rem',
+              borderRadius: 'var(--radius-md)',
+              cursor: 'pointer',
+              fontWeight: 'bold'
+            }}
+          >
+            Try again
+          </button>
+          <Link 
+            href="/"
+            style={{
+              backgroundColor: 'transparent',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border)',
+              padding: '0.5rem 1rem',
+              borderRadius: 'var(--radius-md)',
+              cursor: 'pointer',
+              textDecoration: 'none'
+            }}
+          >
+            Return home
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/app/global-error.tsx
+++ b/ui/src/app/global-error.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <html>
+      <body style={{
+        backgroundColor: '#0a0a0f',
+        color: '#e8e8f0',
+        fontFamily: 'Inter, sans-serif',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        margin: 0
+      }}>
+        <div style={{
+          textAlign: 'center',
+          maxWidth: '500px',
+          padding: '2rem',
+          backgroundColor: '#12121a',
+          border: '1px solid #2a2a40',
+          borderRadius: '12px'
+        }}>
+          <h2 style={{ marginBottom: '1rem' }}>Something went wrong</h2>
+          <pre style={{
+            backgroundColor: '#1a1a2e',
+            color: '#f87171',
+            padding: '1rem',
+            borderRadius: '8px',
+            overflow: 'auto',
+            marginBottom: '1.5rem',
+            textAlign: 'left',
+            fontSize: '14px'
+          }}>
+            {error.message}
+          </pre>
+          <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
+            <button 
+              onClick={() => reset()}
+              style={{
+                backgroundColor: '#f0a030',
+                color: '#0a0a0f',
+                border: 'none',
+                padding: '0.5rem 1rem',
+                borderRadius: '8px',
+                cursor: 'pointer',
+                fontWeight: 'bold'
+              }}
+            >
+              Try again
+            </button>
+            <a 
+              href="/"
+              style={{
+                backgroundColor: 'transparent',
+                color: '#e8e8f0',
+                border: '1px solid #2a2a40',
+                padding: '0.5rem 1rem',
+                borderRadius: '8px',
+                cursor: 'pointer',
+                textDecoration: 'none'
+              }}
+            >
+              Go home
+            </a>
+          </div>
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/ui/src/app/global-error.tsx
+++ b/ui/src/app/global-error.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+/* eslint-disable @next/next/no-html-link-for-pages */
+
 export default function GlobalError({
   error,
   reset,
@@ -28,18 +30,15 @@ export default function GlobalError({
           borderRadius: '12px'
         }}>
           <h2 style={{ marginBottom: '1rem' }}>Something went wrong</h2>
-          <pre style={{
-            backgroundColor: '#1a1a2e',
-            color: '#f87171',
-            padding: '1rem',
-            borderRadius: '8px',
-            overflow: 'auto',
-            marginBottom: '1.5rem',
-            textAlign: 'left',
-            fontSize: '14px'
-          }}>
-            {error.message}
-          </pre>
+          {error.digest && (
+            <p style={{
+              color: '#9898b0',
+              fontSize: '14px',
+              marginBottom: '1.5rem'
+            }}>
+              Error ID: {error.digest}
+            </p>
+          )}
           <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
             <button 
               onClick={() => reset()}

--- a/ui/src/app/loading.tsx
+++ b/ui/src/app/loading.tsx
@@ -1,12 +1,15 @@
 export default function Loading() {
   return (
-    <div style={{
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      minHeight: '100vh',
-      backgroundColor: 'var(--bg-primary)'
-    }}>
+    <div
+      role="status"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        backgroundColor: 'var(--bg-primary)'
+      }}
+    >
       <style dangerouslySetInnerHTML={{
         __html: `
           @keyframes spin {
@@ -15,14 +18,30 @@ export default function Loading() {
           }
         `
       }} />
-      <div style={{
-        width: '40px',
-        height: '40px',
-        border: '4px solid var(--bg-tertiary)',
-        borderTop: '4px solid var(--accent)',
-        borderRadius: '50%',
-        animation: 'spin 1s linear infinite'
-      }} />
+      <div
+        aria-hidden="true"
+        style={{
+          width: '40px',
+          height: '40px',
+          border: '4px solid var(--bg-tertiary)',
+          borderTop: '4px solid var(--accent)',
+          borderRadius: '50%',
+          animation: 'spin 1s linear infinite'
+        }}
+      />
+      <span style={{
+        position: 'absolute',
+        width: '1px',
+        height: '1px',
+        padding: 0,
+        margin: '-1px',
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        borderWidth: 0
+      }}>
+        Loading…
+      </span>
     </div>
   )
 }

--- a/ui/src/app/loading.tsx
+++ b/ui/src/app/loading.tsx
@@ -1,0 +1,28 @@
+export default function Loading() {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '100vh',
+      backgroundColor: 'var(--bg-primary)'
+    }}>
+      <style dangerouslySetInnerHTML={{
+        __html: `
+          @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+          }
+        `
+      }} />
+      <div style={{
+        width: '40px',
+        height: '40px',
+        border: '4px solid var(--bg-tertiary)',
+        borderTop: '4px solid var(--accent)',
+        borderRadius: '50%',
+        animation: 'spin 1s linear infinite'
+      }} />
+    </div>
+  )
+}

--- a/ui/src/app/not-found.tsx
+++ b/ui/src/app/not-found.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '100vh',
+      backgroundColor: 'var(--bg-primary)',
+      color: 'var(--text-primary)'
+    }}>
+      <h1 style={{ fontSize: '4rem', marginBottom: '0.5rem', color: 'var(--accent)' }}>404</h1>
+      <h2 style={{ fontSize: '2rem', marginBottom: '1rem' }}>Page not found</h2>
+      <p style={{ color: 'var(--text-secondary)', marginBottom: '2rem' }}>
+        The page you are looking for does not exist.
+      </p>
+      <Link 
+        href="/"
+        style={{
+          backgroundColor: 'transparent',
+          color: 'var(--text-primary)',
+          border: '1px solid var(--border)',
+          padding: '0.5rem 1rem',
+          borderRadius: 'var(--radius-md)',
+          cursor: 'pointer',
+          textDecoration: 'none'
+        }}
+      >
+        Go home
+      </Link>
+    </div>
+  )
+}

--- a/ui/src/app/traces/[id]/not-found.tsx
+++ b/ui/src/app/traces/[id]/not-found.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+
+export default function TraceNotFound() {
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '100vh',
+      backgroundColor: 'var(--bg-primary)',
+      color: 'var(--text-primary)'
+    }}>
+      <h2 style={{ fontSize: '2rem', marginBottom: '1rem' }}>Trace not found</h2>
+      <p style={{ color: 'var(--text-secondary)', marginBottom: '2rem' }}>
+        The trace you're looking for doesn't exist or has been deleted.
+      </p>
+      <Link 
+        href="/traces"
+        style={{
+          backgroundColor: 'transparent',
+          color: 'var(--text-primary)',
+          border: '1px solid var(--border)',
+          padding: '0.5rem 1rem',
+          borderRadius: 'var(--radius-md)',
+          cursor: 'pointer',
+          textDecoration: 'none'
+        }}
+      >
+        Back to traces
+      </Link>
+    </div>
+  )
+}

--- a/ui/src/app/traces/[id]/not-found.tsx
+++ b/ui/src/app/traces/[id]/not-found.tsx
@@ -13,7 +13,7 @@ export default function TraceNotFound() {
     }}>
       <h2 style={{ fontSize: '2rem', marginBottom: '1rem' }}>Trace not found</h2>
       <p style={{ color: 'var(--text-secondary)', marginBottom: '2rem' }}>
-        The trace you're looking for doesn't exist or has been deleted.
+        The trace you&apos;re looking for doesn&apos;t exist or has been deleted.
       </p>
       <Link 
         href="/traces"


### PR DESCRIPTION
## What

Two quick wins in one PR:

### UI: Error Boundaries (7 files)
- `global-error.tsx` — catches root layout errors (standalone HTML)
- `error.tsx` — root + admin error boundaries with retry
- `loading.tsx` — root + admin loading spinners
- `not-found.tsx` — root 404 + trace-specific not-found
- Styled to match dark theme design system

### Go: os.Exit cleanup (3 files)
- `candela-server/main.go` — replace `os.Exit(1)` in HTTP server goroutine with `errCh`
- `candela-sidecar/main.go` — same pattern
- `candela/main.go` — `runForeground()` server error returns cleanly

## Why

**Error boundaries**: Without these, any unhandled React error shows a raw white error screen in production. Now users see branded error pages with retry/navigation options.

**os.Exit in goroutines**: When `srv.ListenAndServe()` fails (port conflict, etc.), `os.Exit(1)` from a goroutine skips ALL deferred cleanup — DB connections leak, span processor buffers are lost, graceful shutdown is bypassed. The errCh pattern routes errors through the normal shutdown path.

## Testing
- `go build ./cmd/...` ✅
- `go vet ./cmd/...` ✅
- `npx tsc --noEmit` ✅
- Pre-commit hooks (golangci-lint, go test) ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full-screen loading, general error, admin error, and global error pages with retry and navigation actions.
  * Added friendly 404 pages for unknown routes and missing traces.
* **Bug Fixes**
  * Improved server startup failure handling so unexpected listen errors no longer skip the existing graceful shutdown flow.
* **Tests**
  * Added coverage for the server error-channel startup/shutdown behavior and verified error UIs via E2E tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->