### PR TITLE
fix: implement cursor-based pagination for traces

### DIFF
--- a/pkg/connecthandlers/project_handler.go
+++ b/pkg/connecthandlers/project_handler.go
@@ -3,6 +3,7 @@ package connecthandlers
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	connect "connectrpc.com/connect"
 	typespb "github.com/candelahq/candela/gen/go/candela/types"
@@ -63,11 +64,20 @@ func (h *ProjectHandler) ListProjects(
 	ctx context.Context,
 	req *connect.Request[v1.ListProjectsRequest],
 ) (*connect.Response[v1.ListProjectsResponse], error) {
-	limit := 50
-	offset := 0
+	limit, offset := 50, 0
 	if req.Msg.Pagination != nil {
 		if req.Msg.Pagination.PageSize > 0 {
 			limit = int(req.Msg.Pagination.PageSize)
+		}
+		if req.Msg.Pagination.PageToken != "" {
+			const maxOffset = 100_000
+			if parsed, err := strconv.Atoi(req.Msg.Pagination.PageToken); err == nil && parsed > 0 {
+				if parsed > maxOffset {
+					return nil, connect.NewError(connect.CodeInvalidArgument,
+						fmt.Errorf("page_token exceeds maximum offset (%d)", maxOffset))
+				}
+				offset = parsed
+			}
 		}
 	}
 
@@ -82,10 +92,16 @@ func (h *ProjectHandler) ListProjects(
 		pbProjects[i] = projectToProto(&pp)
 	}
 
+	var nextPageToken string
+	if offset+limit < total {
+		nextPageToken = strconv.Itoa(offset + limit)
+	}
+
 	return connect.NewResponse(&v1.ListProjectsResponse{
 		Projects: pbProjects,
 		Pagination: &typespb.PaginationResponse{
-			TotalCount: int32(total),
+			NextPageToken: nextPageToken,
+			TotalCount:    int32(total),
 		},
 	}), nil
 }

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -487,6 +487,11 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		tq.PageSize = 20
 	}
 
+	cursor, err := storage.DecodePageCursor(tq.PageToken)
+	if err != nil {
+		return nil, fmt.Errorf("invalid page token: %w", err)
+	}
+
 	// Build optional WHERE conditions.
 	extraWhere := ""
 	extraHaving := ""
@@ -525,10 +530,21 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		extraWhere += "\n\t\t  AND trace_group = @traceGroup"
 		params = append(params, bigquery.QueryParameter{Name: "traceGroup", Value: tq.TraceGroup})
 	}
+	var havingClauses []string
 	if tq.Status != 0 {
-		extraHaving = "\n\t\tHAVING CASE WHEN MAX(CASE WHEN status = 2 THEN 1 ELSE 0 END) > 0 THEN 2 ELSE 1 END = @statusFilter"
+		havingClauses = append(havingClauses, "CASE WHEN MAX(CASE WHEN status = 2 THEN 1 ELSE 0 END) > 0 THEN 2 ELSE 1 END = @statusFilter")
 		params = append(params, bigquery.QueryParameter{Name: "statusFilter", Value: int(tq.Status)})
 	}
+	if cursor.ID != "" {
+		havingClauses = append(havingClauses, "(MIN(start_time) < @cursorTs OR (MIN(start_time) = @cursorTs AND trace_id < @cursorId))")
+		params = append(params, bigquery.QueryParameter{Name: "cursorTs", Value: cursor.Timestamp}, bigquery.QueryParameter{Name: "cursorId", Value: cursor.ID})
+	}
+	if len(havingClauses) > 0 {
+		extraHaving = "\n\t\tHAVING " + strings.Join(havingClauses, " AND ")
+	}
+
+	// Increment limit to detect if there are more pages
+	params = append(params, bigquery.QueryParameter{Name: "pageSize", Value: tq.PageSize + 1})
 
 	query := fmt.Sprintf(`
 		SELECT trace_id, MIN(start_time) AS earliest
@@ -538,7 +554,7 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		  AND start_time <= @endTime
 		  AND (@userID = '' OR user_id = @userID)%s
 		GROUP BY trace_id%s
-		ORDER BY earliest DESC
+		ORDER BY earliest DESC, trace_id DESC
 		LIMIT @pageSize
 	`, quoteTable(s.tableID), extraWhere, extraHaving)
 
@@ -651,13 +667,47 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		})
 	}
 
-	return &storage.TraceResult{Traces: traces, TotalCount: len(traces)}, nil
+	var nextPageToken string
+	if len(traces) > tq.PageSize {
+		traces = traces[:tq.PageSize]
+		last := traces[len(traces)-1]
+		nextPageToken = storage.EncodePageCursor(storage.PageCursor{
+			Timestamp: last.StartTime,
+			ID:        last.TraceID,
+		})
+	}
+
+	return &storage.TraceResult{Traces: traces, NextPageToken: nextPageToken, TotalCount: len(traces)}, nil
 }
 
 // SearchSpans searches spans with filtering.
 func (s *Store) SearchSpans(ctx context.Context, sq storage.SpanQuery) (*storage.SpanResult, error) {
 	if sq.PageSize == 0 {
 		sq.PageSize = 50
+	}
+
+	cursor, err := storage.DecodePageCursor(sq.PageToken)
+	if err != nil {
+		return nil, fmt.Errorf("invalid page token: %w", err)
+	}
+
+	extraWhere := ""
+	params := []bigquery.QueryParameter{
+		{Name: "projectID", Value: sq.ProjectID},
+		{Name: "startTime", Value: sq.StartTime},
+		{Name: "endTime", Value: sq.EndTime},
+		{Name: "kind", Value: int(sq.Kind)},
+		{Name: "model", Value: sq.Model},
+		{Name: "nameContains", Value: sq.NameContains},
+		{Name: "escapedName", Value: storage.EscapeLike(sq.NameContains)},
+		{Name: "userID", Value: sq.UserID},
+		{Name: "tenantID", Value: sq.TenantID},
+		{Name: "pageSize", Value: sq.PageSize + 1},
+	}
+
+	if cursor.ID != "" {
+		extraWhere = " AND (start_time < @cursorTs OR (start_time = @cursorTs AND span_id < @cursorId))"
+		params = append(params, bigquery.QueryParameter{Name: "cursorTs", Value: cursor.Timestamp}, bigquery.QueryParameter{Name: "cursorId", Value: cursor.ID})
 	}
 
 	query := fmt.Sprintf(`
@@ -669,31 +719,30 @@ func (s *Store) SearchSpans(ctx context.Context, sq storage.SpanQuery) (*storage
 		  AND (@model = '' OR gen_ai_model = @model)
 		  AND (@nameContains = '' OR name LIKE CONCAT('%%', @escapedName, '%%'))
 		  AND (@userID = '' OR user_id = @userID)
-		  AND (@tenantID = '' OR tenant_id = @tenantID)
-		ORDER BY start_time DESC
+		  AND (@tenantID = '' OR tenant_id = @tenantID)%s
+		ORDER BY start_time DESC, span_id DESC
 		LIMIT @pageSize
-	`, quoteTable(s.tableID))
+	`, quoteTable(s.tableID), extraWhere)
 
 	q := s.client.Query(query)
-	q.SetParameters([]bigquery.QueryParameter{
-		{Name: "projectID", Value: sq.ProjectID},
-		{Name: "startTime", Value: sq.StartTime},
-		{Name: "endTime", Value: sq.EndTime},
-		{Name: "kind", Value: int(sq.Kind)},
-		{Name: "model", Value: sq.Model},
-		{Name: "nameContains", Value: sq.NameContains},
-		{Name: "escapedName", Value: storage.EscapeLike(sq.NameContains)},
-		{Name: "userID", Value: sq.UserID},
-		{Name: "tenantID", Value: sq.TenantID},
-		{Name: "pageSize", Value: sq.PageSize},
-	})
+	q.SetParameters(params)
 
 	spans, err := s.querySpans(ctx, q)
 	if err != nil {
 		return nil, fmt.Errorf("searching spans: %w", err)
 	}
 
-	return &storage.SpanResult{Spans: spans, TotalCount: len(spans)}, nil
+	var nextPageToken string
+	if len(spans) > sq.PageSize {
+		spans = spans[:sq.PageSize]
+		last := spans[len(spans)-1]
+		nextPageToken = storage.EncodePageCursor(storage.PageCursor{
+			Timestamp: last.StartTime,
+			ID:        last.SpanID,
+		})
+	}
+
+	return &storage.SpanResult{Spans: spans, NextPageToken: nextPageToken, TotalCount: len(spans)}, nil
 }
 
 // GetUsageSummary returns aggregated usage statistics.

--- a/pkg/storage/duckdb/duckdb.go
+++ b/pkg/storage/duckdb/duckdb.go
@@ -229,6 +229,11 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		q.PageSize = 50
 	}
 
+	cursor, err := storage.DecodePageCursor(q.PageToken)
+	if err != nil {
+		return nil, fmt.Errorf("invalid page token: %w", err)
+	}
+
 	// Allowlisted ORDER BY columns — never interpolate user input directly.
 	// Keys are the proto/API names sent from the frontend.
 	orderCols := map[string]string{
@@ -302,7 +307,25 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		args = append(args, int(q.Status))
 	}
 
-	args = append(args, q.PageSize)
+	// Cursor condition for keyset pagination.
+	if cursor.ID != "" {
+		cursorOp := "<" // DESC: fetch rows earlier than cursor
+		if dir == "ASC" {
+			cursorOp = ">" // ASC: fetch rows later than cursor
+		}
+		cursorHaving := fmt.Sprintf(
+			`(MIN(start_time) %s ? OR (MIN(start_time) = ? AND trace_id %s ?))`,
+			cursorOp, cursorOp,
+		)
+		if having != "" {
+			having += " AND " + cursorHaving
+		} else {
+			having = "HAVING " + cursorHaving
+		}
+		args = append(args, cursor.Timestamp, cursor.Timestamp, cursor.ID)
+	}
+
+	args = append(args, q.PageSize+1)
 
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT
@@ -331,7 +354,7 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		WHERE `+where+`
 		GROUP BY trace_id
 		`+having+`
-		ORDER BY `+orderExpr+` `+dir+`
+		ORDER BY `+orderExpr+` `+dir+`, trace_id `+dir+`
 		LIMIT ?
 	`, args...)
 	if err != nil {
@@ -363,13 +386,51 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		return nil, fmt.Errorf("iterating traces: %w", err)
 	}
 
-	return &storage.TraceResult{Traces: traces, TotalCount: len(traces)}, nil
+	var nextPageToken string
+	if len(traces) > q.PageSize {
+		traces = traces[:q.PageSize]
+		last := traces[len(traces)-1]
+		nextPageToken = storage.EncodePageCursor(storage.PageCursor{
+			Timestamp: last.StartTime,
+			ID:        last.TraceID,
+		})
+	}
+
+	return &storage.TraceResult{Traces: traces, NextPageToken: nextPageToken, TotalCount: len(traces)}, nil
 }
 
 func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.SpanResult, error) {
 	if q.PageSize == 0 {
 		q.PageSize = 50
 	}
+
+	cursor, err := storage.DecodePageCursor(q.PageToken)
+	if err != nil {
+		return nil, fmt.Errorf("invalid page token: %w", err)
+	}
+
+	where := `project_id = ? AND start_time >= ? AND start_time <= ?
+			AND (? = 0 OR kind = ?)
+			AND (? = '' OR gen_ai_model = ?)
+			AND (? = '' OR name LIKE '%' || ? || '%' ESCAPE '\')
+			AND (? = '' OR user_id = ?)
+			AND (? = '' OR tenant_id = ?)`
+
+	args := []any{
+		q.ProjectID, q.StartTime, q.EndTime,
+		int(q.Kind), int(q.Kind),
+		q.Model, q.Model,
+		q.NameContains, storage.EscapeLike(q.NameContains),
+		q.UserID, q.UserID,
+		q.TenantID, q.TenantID,
+	}
+
+	if cursor.ID != "" {
+		where += ` AND (start_time < ? OR (start_time = ? AND span_id < ?))`
+		args = append(args, cursor.Timestamp, cursor.Timestamp, cursor.ID)
+	}
+
+	args = append(args, q.PageSize+1)
 
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT span_id, trace_id, parent_span_id, name, kind, status, status_message,
@@ -378,22 +439,10 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
 			gen_ai_input_content, gen_ai_output_content, attributes, user_id, session_id, tenant_id, job_id
 		FROM spans
-		WHERE project_id = ? AND start_time >= ? AND start_time <= ?
-			AND (? = 0 OR kind = ?)
-			AND (? = '' OR gen_ai_model = ?)
-			AND (? = '' OR name LIKE '%' || ? || '%' ESCAPE '\')
-			AND (? = '' OR user_id = ?)
-			AND (? = '' OR tenant_id = ?)
-		ORDER BY start_time DESC
+		WHERE `+where+`
+		ORDER BY start_time DESC, span_id DESC
 		LIMIT ?
-	`, q.ProjectID, q.StartTime, q.EndTime,
-		int(q.Kind), int(q.Kind),
-		q.Model, q.Model,
-		q.NameContains, storage.EscapeLike(q.NameContains),
-		q.UserID, q.UserID,
-		q.TenantID, q.TenantID,
-		q.PageSize,
-	)
+	`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("searching spans: %w", err)
 	}
@@ -404,7 +453,17 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 		return nil, err
 	}
 
-	return &storage.SpanResult{Spans: spans, TotalCount: len(spans)}, nil
+	var nextPageToken string
+	if len(spans) > q.PageSize {
+		spans = spans[:q.PageSize]
+		last := spans[len(spans)-1]
+		nextPageToken = storage.EncodePageCursor(storage.PageCursor{
+			Timestamp: last.StartTime,
+			ID:        last.SpanID,
+		})
+	}
+
+	return &storage.SpanResult{Spans: spans, NextPageToken: nextPageToken, TotalCount: len(spans)}, nil
 }
 
 func (s *Store) GetUsageSummary(ctx context.Context, q storage.UsageQuery) (*storage.UsageSummary, error) {

--- a/pkg/storage/pagination_test.go
+++ b/pkg/storage/pagination_test.go
@@ -1,0 +1,52 @@
+package storage_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+func TestPageCursor_RoundTrip(t *testing.T) {
+	original := storage.PageCursor{
+		Timestamp: time.Date(2026, 7, 26, 10, 0, 0, 0, time.UTC),
+		ID:        "trace-abc-123",
+	}
+	token := storage.EncodePageCursor(original)
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+
+	decoded, err := storage.DecodePageCursor(token)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if !decoded.Timestamp.Equal(original.Timestamp) {
+		t.Errorf("timestamp mismatch: %v != %v", decoded.Timestamp, original.Timestamp)
+	}
+	if decoded.ID != original.ID {
+		t.Errorf("ID mismatch: %q != %q", decoded.ID, original.ID)
+	}
+}
+
+func TestPageCursor_EmptyToken(t *testing.T) {
+	c, err := storage.DecodePageCursor("")
+	if err != nil {
+		t.Fatalf("empty token should not error: %v", err)
+	}
+	if c.ID != "" {
+		t.Errorf("expected empty ID for empty token, got %q", c.ID)
+	}
+}
+
+func TestPageCursor_InvalidToken(t *testing.T) {
+	_, err := storage.DecodePageCursor("not-valid-base64!!!")
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+
+	_, err = storage.DecodePageCursor("bm90LWpzb24") // base64 of "not-json"
+	if err == nil {
+		t.Fatal("expected error for non-JSON token")
+	}
+}

--- a/pkg/storage/sqlite/pagination_test.go
+++ b/pkg/storage/sqlite/pagination_test.go
@@ -1,0 +1,154 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+func TestQueryTraces_Pagination(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	// Insert 120 traces with distinct timestamps
+	var spans []storage.Span
+	for i := 0; i < 120; i++ {
+		traceID := fmt.Sprintf("trace-%03d", i)
+		ts := now.Add(time.Duration(i) * time.Minute)
+		spans = append(spans, storage.Span{
+			SpanID:    "span-" + traceID,
+			TraceID:   traceID,
+			Name:      "root",
+			Kind:      storage.SpanKindAgent,
+			Status:    storage.SpanStatusOK,
+			StartTime: ts,
+			EndTime:   ts.Add(time.Second),
+			Duration:  time.Second,
+			ProjectID: "proj-1",
+		})
+	}
+	if err := s.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest failed: %v", err)
+	}
+
+	// Page 1
+	res1, err := s.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-1",
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now.Add(240 * time.Minute),
+		PageSize:  50,
+	})
+	if err != nil {
+		t.Fatalf("query page 1 failed: %v", err)
+	}
+	if len(res1.Traces) != 50 {
+		t.Fatalf("page 1 traces = %d, want 50", len(res1.Traces))
+	}
+	if res1.NextPageToken == "" {
+		t.Fatal("page 1 expected non-empty NextPageToken")
+	}
+	// Default sort is DESC, so first trace should be trace-119
+	if res1.Traces[0].TraceID != "trace-119" {
+		t.Errorf("page 1 first trace = %s, want trace-119", res1.Traces[0].TraceID)
+	}
+
+	// Page 2
+	res2, err := s.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-1",
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now.Add(240 * time.Minute),
+		PageSize:  50,
+		PageToken: res1.NextPageToken,
+	})
+	if err != nil {
+		t.Fatalf("query page 2 failed: %v", err)
+	}
+	if len(res2.Traces) != 50 {
+		t.Fatalf("page 2 traces = %d, want 50", len(res2.Traces))
+	}
+	if res2.NextPageToken == "" {
+		t.Fatal("page 2 expected non-empty NextPageToken")
+	}
+
+	// Page 3
+	res3, err := s.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-1",
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now.Add(240 * time.Minute),
+		PageSize:  50,
+		PageToken: res2.NextPageToken,
+	})
+	if err != nil {
+		t.Fatalf("query page 3 failed: %v", err)
+	}
+	if len(res3.Traces) != 20 {
+		t.Fatalf("page 3 traces = %d, want 20", len(res3.Traces))
+	}
+	if res3.NextPageToken != "" {
+		t.Errorf("page 3 expected empty NextPageToken, got %q", res3.NextPageToken)
+	}
+}
+
+func TestQueryTraces_NoDuplicates(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	var spans []storage.Span
+	// Use same timestamp to test tiebreaker
+	ts := now
+	for i := 0; i < 100; i++ {
+		traceID := fmt.Sprintf("trace-%03d", i)
+		spans = append(spans, storage.Span{
+			SpanID:    "span-" + traceID,
+			TraceID:   traceID,
+			Name:      "root",
+			Kind:      storage.SpanKindAgent,
+			Status:    storage.SpanStatusOK,
+			StartTime: ts,
+			EndTime:   ts.Add(time.Second),
+			Duration:  time.Second,
+			ProjectID: "proj-1",
+		})
+	}
+	if err := s.IngestSpans(ctx, spans); err != nil {
+		t.Fatalf("ingest failed: %v", err)
+	}
+
+	// Page 1
+	res1, err := s.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-1",
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now.Add(time.Hour),
+		PageSize:  60,
+	})
+	if err != nil {
+		t.Fatalf("query page 1 failed: %v", err)
+	}
+
+	// Page 2
+	res2, err := s.QueryTraces(ctx, storage.TraceQuery{
+		ProjectID: "proj-1",
+		StartTime: now.Add(-time.Hour),
+		EndTime:   now.Add(time.Hour),
+		PageSize:  60,
+		PageToken: res1.NextPageToken,
+	})
+	if err != nil {
+		t.Fatalf("query page 2 failed: %v", err)
+	}
+
+	seen := make(map[string]bool)
+	for _, tr := range res1.Traces {
+		seen[tr.TraceID] = true
+	}
+	for _, tr := range res2.Traces {
+		if seen[tr.TraceID] {
+			t.Errorf("duplicate trace found across pages: %s", tr.TraceID)
+		}
+	}
+}

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -244,6 +244,11 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		q.PageSize = 50
 	}
 
+	cursor, err := storage.DecodePageCursor(q.PageToken)
+	if err != nil {
+		return nil, fmt.Errorf("invalid page token: %w", err)
+	}
+
 	// Allowlisted ORDER BY columns — never interpolate user input directly.
 	orderCols := map[string]string{
 		"start_time":   "MIN(start_time)",
@@ -320,7 +325,25 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		args = append(args, int(q.Status))
 	}
 
-	args = append(args, q.PageSize)
+	// Cursor condition for keyset pagination.
+	if cursor.ID != "" {
+		cursorOp := "<" // DESC: fetch rows earlier than cursor
+		if dir == "ASC" {
+			cursorOp = ">" // ASC: fetch rows later than cursor
+		}
+		cursorHaving := fmt.Sprintf(
+			`(MIN(start_time) %s ? OR (MIN(start_time) = ? AND trace_id %s ?))`,
+			cursorOp, cursorOp,
+		)
+		if having != "" {
+			having += " AND " + cursorHaving
+		} else {
+			having = "HAVING " + cursorHaving
+		}
+		args = append(args, cursor.Timestamp.Format(time.RFC3339Nano), cursor.Timestamp.Format(time.RFC3339Nano), cursor.ID)
+	}
+
+	args = append(args, q.PageSize+1)
 
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT
@@ -355,7 +378,7 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		WHERE `+where+`
 		GROUP BY trace_id
 		`+having+`
-		ORDER BY `+orderExpr+` `+dir+`
+		ORDER BY `+orderExpr+` `+dir+`, trace_id `+dir+`
 		LIMIT ?
 	`, args...)
 	if err != nil {
@@ -396,13 +419,52 @@ func (s *Store) QueryTraces(ctx context.Context, q storage.TraceQuery) (*storage
 		return nil, fmt.Errorf("iterating traces: %w", err)
 	}
 
-	return &storage.TraceResult{Traces: traces, TotalCount: len(traces)}, nil
+	var nextPageToken string
+	if len(traces) > q.PageSize {
+		traces = traces[:q.PageSize]
+		last := traces[len(traces)-1]
+		nextPageToken = storage.EncodePageCursor(storage.PageCursor{
+			Timestamp: last.StartTime,
+			ID:        last.TraceID,
+		})
+	}
+
+	return &storage.TraceResult{Traces: traces, NextPageToken: nextPageToken, TotalCount: len(traces)}, nil
 }
 
 func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.SpanResult, error) {
 	if q.PageSize == 0 {
 		q.PageSize = 50
 	}
+
+	cursor, err := storage.DecodePageCursor(q.PageToken)
+	if err != nil {
+		return nil, fmt.Errorf("invalid page token: %w", err)
+	}
+
+	where := `(? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
+			AND (? = 0 OR kind = ?)
+			AND (? = '' OR gen_ai_model = ?)
+			AND (? = '' OR name LIKE '%' || ? || '%' ESCAPE '\')
+			AND (? = '' OR user_id = ?)
+			AND (? = '' OR tenant_id = ?)`
+
+	args := []any{
+		q.ProjectID, q.ProjectID,
+		q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
+		int(q.Kind), int(q.Kind),
+		q.Model, q.Model,
+		q.NameContains, storage.EscapeLike(q.NameContains),
+		q.UserID, q.UserID,
+		q.TenantID, q.TenantID,
+	}
+
+	if cursor.ID != "" {
+		where += ` AND (start_time < ? OR (start_time = ? AND span_id < ?))`
+		args = append(args, cursor.Timestamp.Format(time.RFC3339Nano), cursor.Timestamp.Format(time.RFC3339Nano), cursor.ID)
+	}
+
+	args = append(args, q.PageSize+1)
 
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT span_id, trace_id, parent_span_id, name, kind, status, status_message,
@@ -411,23 +473,10 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 			gen_ai_total_tokens, gen_ai_cost_usd, gen_ai_temperature, gen_ai_max_tokens,
 			gen_ai_input_content, gen_ai_output_content, attributes_json, user_id, session_id, tenant_id, job_id
 		FROM spans
-		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
-			AND (? = 0 OR kind = ?)
-			AND (? = '' OR gen_ai_model = ?)
-			AND (? = '' OR name LIKE '%' || ? || '%' ESCAPE '\')
-			AND (? = '' OR user_id = ?)
-			AND (? = '' OR tenant_id = ?)
-		ORDER BY start_time DESC
+		WHERE `+where+`
+		ORDER BY start_time DESC, span_id DESC
 		LIMIT ?
-	`, q.ProjectID, q.ProjectID,
-		q.StartTime.Format(time.RFC3339Nano), q.EndTime.Format(time.RFC3339Nano),
-		int(q.Kind), int(q.Kind),
-		q.Model, q.Model,
-		q.NameContains, storage.EscapeLike(q.NameContains),
-		q.UserID, q.UserID,
-		q.TenantID, q.TenantID,
-		q.PageSize,
-	)
+	`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("searching spans: %w", err)
 	}
@@ -438,7 +487,17 @@ func (s *Store) SearchSpans(ctx context.Context, q storage.SpanQuery) (*storage.
 		return nil, err
 	}
 
-	return &storage.SpanResult{Spans: spans, TotalCount: len(spans)}, nil
+	var nextPageToken string
+	if len(spans) > q.PageSize {
+		spans = spans[:q.PageSize]
+		last := spans[len(spans)-1]
+		nextPageToken = storage.EncodePageCursor(storage.PageCursor{
+			Timestamp: last.StartTime,
+			ID:        last.SpanID,
+		})
+	}
+
+	return &storage.SpanResult{Spans: spans, NextPageToken: nextPageToken, TotalCount: len(spans)}, nil
 }
 
 func (s *Store) GetUsageSummary(ctx context.Context, q storage.UsageQuery) (*storage.UsageSummary, error) {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -5,7 +5,10 @@ package storage
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -185,6 +188,34 @@ type Trace struct {
 	TraceGroup   string        `json:"trace_group,omitempty"`
 }
 
+// PageCursor encodes the keyset position for cursor-based pagination.
+type PageCursor struct {
+	Timestamp time.Time `json:"ts"`
+	ID        string    `json:"id"`
+}
+
+// EncodePageCursor serializes a cursor to a base64 page token.
+func EncodePageCursor(c PageCursor) string {
+	b, _ := json.Marshal(c)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// DecodePageCursor deserializes a base64 page token to a cursor.
+func DecodePageCursor(token string) (PageCursor, error) {
+	if token == "" {
+		return PageCursor{}, nil
+	}
+	b, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return PageCursor{}, fmt.Errorf("invalid page token: %w", err)
+	}
+	var c PageCursor
+	if err := json.Unmarshal(b, &c); err != nil {
+		return PageCursor{}, fmt.Errorf("invalid page token: %w", err)
+	}
+	return c, nil
+}
+
 // TraceQuery defines filters for listing traces.
 type TraceQuery struct {
 	ProjectID   string
@@ -210,7 +241,7 @@ type TraceQuery struct {
 type TraceResult struct {
 	Traces        []TraceSummary
 	NextPageToken string
-	TotalCount    int
+	TotalCount    int // Deprecated: may be zero for cursor-paginated results.
 }
 
 // SpanQuery defines filters for searching individual spans.
@@ -233,7 +264,7 @@ type SpanQuery struct {
 type SpanResult struct {
 	Spans         []Span
 	NextPageToken string
-	TotalCount    int
+	TotalCount    int // Deprecated: may be zero for cursor-paginated results.
 }
 
 // UsageSummary holds aggregated usage metrics.

--- a/ui/e2e/app.spec.ts
+++ b/ui/e2e/app.spec.ts
@@ -205,7 +205,7 @@ test.describe("Traces", () => {
     });
 
     await page.goto("/traces");
-    await expect(page.locator(".table-title")).toHaveText("1 trace");
+    await expect(page.locator(".table-title")).toHaveText("Page 1");
   });
 });
 
@@ -760,7 +760,7 @@ test.describe("Trace Pagination", () => {
     await expect(page.getByRole("button", { name: /previous/i })).toBeDisabled();
   });
 
-  test("disables next when no more pages", async ({ page }) => {
+  test("hides pagination controls when no more pages", async ({ page }) => {
     await mockConnectRPC(page, "/candela.v1.TraceService/ListTraces", {
       traces: [{
         traceId: "trace-1",
@@ -781,6 +781,8 @@ test.describe("Trace Pagination", () => {
     });
 
     await page.goto("/traces");
-    await expect(page.getByRole("button", { name: /next/i })).toBeDisabled();
+    await expect(page.locator(".table-title")).toHaveText("Page 1");
+    // Pagination bar should not render when there's only one page
+    await expect(page.locator(".pagination-controls")).not.toBeVisible();
   });
 });

--- a/ui/e2e/app.spec.ts
+++ b/ui/e2e/app.spec.ts
@@ -729,3 +729,58 @@ test.describe("Responsive sidebar", () => {
     await page.locator(".nav-item").filter({ hasText: "" }).first().click();
   });
 });
+
+// ──────────────────────────────────────────
+// Trace Pagination
+// ──────────────────────────────────────────
+
+test.describe("Trace Pagination", () => {
+  test("shows next button when more traces available", async ({ page }) => {
+    await mockConnectRPC(page, "/candela.v1.TraceService/ListTraces", {
+      traces: Array(50).fill(null).map((_, i) => ({
+        traceId: `trace-${i}`,
+        rootSpanName: `trace-${i}`,
+        startTime: "2024-03-31T00:00:00Z",
+        spanCount: 1,
+        llmCallCount: 1,
+        totalTokens: "100",
+        totalCostUsd: 0.01,
+        primaryModel: "gpt-4",
+        primaryProvider: "openai",
+        status: 1,
+      })),
+      pagination: {
+        nextPageToken: "eyJ0cyI6IjIwMjYtMDctMjZUMDA6MDA6MDBaIiwiaWQiOiJ0cmFjZS00OSJ9",
+        totalCount: 0,
+      },
+    });
+
+    await page.goto("/traces");
+    await expect(page.getByRole("button", { name: /next/i })).toBeEnabled();
+    await expect(page.getByRole("button", { name: /previous/i })).toBeDisabled();
+  });
+
+  test("disables next when no more pages", async ({ page }) => {
+    await mockConnectRPC(page, "/candela.v1.TraceService/ListTraces", {
+      traces: [{
+        traceId: "trace-1",
+        rootSpanName: "single trace",
+        startTime: "2024-03-31T00:00:00Z",
+        spanCount: 1,
+        llmCallCount: 1,
+        totalTokens: "100",
+        totalCostUsd: 0.01,
+        primaryModel: "gpt-4",
+        primaryProvider: "openai",
+        status: 1,
+      }],
+      pagination: {
+        nextPageToken: "",
+        totalCount: 0,
+      },
+    });
+
+    await page.goto("/traces");
+    await expect(page.getByRole("button", { name: /next/i })).toBeDisabled();
+  });
+});

--- a/ui/src/app/traces/page.tsx
+++ b/ui/src/app/traces/page.tsx
@@ -31,6 +31,11 @@ export default function TracesPage() {
     clearFilters,
     refresh,
     fetchInitial,
+    fetchNextPage,
+    fetchPreviousPage,
+    hasNextPage,
+    hasPreviousPage,
+    currentPage,
   } = useTraces();
 
   const [filtersOpen, setFiltersOpen] = useState(false);
@@ -172,7 +177,7 @@ export default function TracesPage() {
             <span className="table-title">
               {loading
                 ? "Loading..."
-                : `${traces.length} trace${traces.length !== 1 ? "s" : ""}`}
+                : `Page ${currentPage}`}
             </span>
             {hasActiveFilters && (
               <span
@@ -270,6 +275,29 @@ export default function TracesPage() {
                 })}
               </tbody>
             </table>
+          )}
+
+          {/* Pagination controls */}
+          {(hasPreviousPage || hasNextPage) && (
+            <div className="pagination-controls" style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "16px 20px", borderTop: "1px solid var(--border-subtle)" }}>
+              <button
+                className="btn btn-sm btn-ghost"
+                onClick={fetchPreviousPage}
+                disabled={!hasPreviousPage}
+              >
+                ← Previous
+              </button>
+              <span className="pagination-info" style={{ fontSize: "13px", color: "var(--text-secondary)" }}>
+                Page {currentPage}
+              </span>
+              <button
+                className="btn btn-sm btn-ghost"
+                onClick={fetchNextPage}
+                disabled={!hasNextPage}
+              >
+                Next →
+              </button>
+            </div>
           )}
         </div>
       </div>

--- a/ui/src/hooks/useTraces.ts
+++ b/ui/src/hooks/useTraces.ts
@@ -12,27 +12,50 @@ type State = {
   loading: boolean;
   error: string | null;
   filters: TraceFilters;
+  nextPageToken: string;
+  currentPageToken: string;
+  pageTokenHistory: string[];
 };
 
 type Action =
-  | { type: "fetch"; filters: TraceFilters }
-  | { type: "success"; traces: TraceSummaryRow[] }
+  | { type: "fetch"; filters: TraceFilters; resetPagination?: boolean }
+  | { type: "success"; traces: TraceSummaryRow[]; nextPageToken: string }
   | { type: "error"; message: string }
   | { type: "set_filters"; filters: TraceFilters }
-  | { type: "clear_filters" };
+  | { type: "clear_filters" }
+  | { type: "set_page_token"; direction: "next" | "prev"; token?: string };
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case "fetch":
+      if (action.resetPagination) {
+        return { ...state, loading: true, error: null, filters: action.filters, currentPageToken: "", pageTokenHistory: [], nextPageToken: "" };
+      }
       return { ...state, loading: true, error: null, filters: action.filters };
     case "success":
-      return { ...state, loading: false, traces: action.traces };
+      return { ...state, loading: false, traces: action.traces, nextPageToken: action.nextPageToken };
     case "error":
       return { ...state, loading: false, error: action.message };
     case "set_filters":
-      return { ...state, filters: action.filters };
+      return { ...state, filters: action.filters, currentPageToken: "", pageTokenHistory: [], nextPageToken: "" };
     case "clear_filters":
-      return { ...state, loading: true, error: null, filters: DEFAULT_FILTERS };
+      return { ...state, loading: true, error: null, filters: DEFAULT_FILTERS, currentPageToken: "", pageTokenHistory: [], nextPageToken: "" };
+    case "set_page_token":
+      if (action.direction === "next") {
+        return {
+          ...state,
+          pageTokenHistory: [...state.pageTokenHistory, state.currentPageToken],
+          currentPageToken: action.token || "",
+        };
+      } else {
+        const prevHistory = [...state.pageTokenHistory];
+        const prevToken = prevHistory.pop() || "";
+        return {
+          ...state,
+          pageTokenHistory: prevHistory,
+          currentPageToken: prevToken,
+        };
+      }
   }
 }
 
@@ -94,6 +117,9 @@ export function useTraces() {
     loading: true,
     error: null,
     filters: DEFAULT_FILTERS,
+    nextPageToken: "",
+    currentPageToken: "",
+    pageTokenHistory: [],
   });
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Track the previous scope mode so we can detect changes
@@ -101,12 +127,13 @@ export function useTraces() {
 
   const fetchRef = useRef<AbortController | null>(null);
 
-  const fetchTraces = useCallback((f: TraceFilters) => {
+  const fetchTraces = useCallback((f: TraceFilters, resetPagination = false) => {
     fetchRef.current?.abort();
     const controller = new AbortController();
     fetchRef.current = controller;
 
-    dispatch({ type: "fetch", filters: f });
+    dispatch({ type: "fetch", filters: f, resetPagination });
+    const pageToken = resetPagination ? "" : state.currentPageToken;
 
     // Build headers — the backend interprets the auth token + this hint
     // to decide whether to filter to the authenticated user's traces.
@@ -117,7 +144,7 @@ export function useTraces() {
     traceClient
       .listTraces({
         projectId: DEFAULT_PROJECT_ID,
-        pagination: { pageSize: 100 },
+        pagination: { pageSize: 100, pageToken },
         search: f.search,
         model: f.model,
         provider: f.provider,
@@ -130,9 +157,11 @@ export function useTraces() {
       })
       .then((res) => {
         if (!controller.signal.aborted) {
+          const nextToken = res.pagination?.nextPageToken ?? "";
           dispatch({
             type: "success",
             traces: (res.traces || []).map(mapTrace),
+            nextPageToken: nextToken,
           });
         }
       })
@@ -141,7 +170,7 @@ export function useTraces() {
           dispatch({ type: "error", message: err.message });
         }
       });
-  }, [isPersonalScope]);
+  }, [isPersonalScope, state.currentPageToken]);
 
   const updateFilters = useCallback(
     (patch: Partial<TraceFilters>) => {
@@ -152,9 +181,9 @@ export function useTraces() {
       if (debounceRef.current) clearTimeout(debounceRef.current);
 
       if (isSearch) {
-        debounceRef.current = setTimeout(() => fetchTraces(next), 300);
+        debounceRef.current = setTimeout(() => fetchTraces(next, true), 300);
       } else {
-        fetchTraces(next);
+        fetchTraces(next, true);
       }
     },
     [state.filters, fetchTraces]
@@ -162,7 +191,7 @@ export function useTraces() {
 
   const clearFilters = useCallback(() => {
     dispatch({ type: "clear_filters" });
-    fetchTraces(DEFAULT_FILTERS);
+    fetchTraces(DEFAULT_FILTERS, true);
   }, [fetchTraces]);
 
   const hasActiveFilters = !!(
@@ -182,9 +211,24 @@ export function useTraces() {
   useEffect(() => {
     if (prevModeRef.current !== mode) {
       prevModeRef.current = mode;
-      fetchTraces(state.filters);
+      fetchTraces(state.filters, true);
     }
   }, [mode, fetchTraces, state.filters]);
+
+  // Re-fetch when currentPageToken changes
+  useEffect(() => {
+    fetchTraces(state.filters);
+  }, [state.currentPageToken, fetchTraces, state.filters]);
+
+  const fetchNextPage = useCallback(() => {
+    if (!state.nextPageToken) return;
+    dispatch({ type: "set_page_token", direction: "next", token: state.nextPageToken });
+  }, [state.nextPageToken]);
+
+  const fetchPreviousPage = useCallback(() => {
+    if (state.pageTokenHistory.length === 0) return;
+    dispatch({ type: "set_page_token", direction: "prev" });
+  }, [state.pageTokenHistory]);
 
   // Abort in-flight request on unmount only. Cleanup must NOT be in the
   // mode/filters effect — fetchTraces already updates fetchRef.current
@@ -203,6 +247,11 @@ export function useTraces() {
     updateFilters,
     clearFilters,
     refresh,
-    fetchInitial: () => fetchTraces(state.filters),
+    fetchInitial: () => fetchTraces(state.filters, true),
+    fetchNextPage,
+    fetchPreviousPage,
+    hasNextPage: !!state.nextPageToken,
+    hasPreviousPage: state.pageTokenHistory.length > 0,
+    currentPage: state.pageTokenHistory.length + 1,
   };
 }


### PR DESCRIPTION
## Problem

Pagination is completely broken across all storage backends:
- `TotalCount` returns `len(traces)` (page size) instead of actual DB count
- No OFFSET or cursor is ever applied — page 2+ always returns page 1
- No `NextPageToken` is ever generated
- Frontend hardcodes `pageSize: 100` and discards pagination response
- Traces page has no Previous/Next buttons

## Solution

**Cursor/keyset pagination** (not OFFSET) using `(timestamp, trace_id)` as the cursor key. This is O(1) regardless of page depth — no scanning discarded rows.

### Storage (SQLite, DuckDB, BigQuery)
- `PageCursor` type with base64 JSON encode/decode
- `LIMIT n+1` trick: fetch `pageSize+1`, if more → `HasMore=true`, trim to `pageSize`, build `NextPageToken` from last row. **Zero extra `COUNT(*)` queries.**
- Keyset `HAVING` clause: `(MIN(start_time), trace_id) < (?, ?)` for DESC order
- `trace_id`/`span_id` tiebreaker in all `ORDER BY` clauses

### Handlers
- `ListProjects`: parse `PageToken` as decimal offset (was hardcoded `offset := 0`) with `maxOffset=100,000` cap

### Frontend
- `useTraces`: cursor history in reducer state, `fetchNextPage/fetchPreviousPage`
- `traces/page.tsx`: Previous/Next pagination controls

### Tests
- PageCursor round-trip + invalid token tests
- SQLite integration: 120 traces across 3 pages, no duplicates
- E2E: Next button enabled/disabled based on `nextPageToken`

## Architecture Decision
Offset pagination was rejected after DE review — it forces the DB to scan+discard rows (`OFFSET 90000` costs the same as reading 90K rows) and `COUNT(DISTINCT)` on every page load is catastrophic for BigQuery billing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination for projects, traces, and spans.
  * Updated the traces UI to show page number plus Previous/Next navigation with correct enabled/disabled states.
* **Bug Fixes**
  * Added validation for pagination tokens and improved handling of invalid/empty tokens.
  * Made trace/span ordering deterministic to prevent duplicates or missed items across pages.
* **Tests**
  * Added and expanded automated tests for cursor tokens, pagination behavior, and trace UI navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->