### PR TITLE
feat: add candela watch for live trace streaming

### DIFF
--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -192,6 +192,12 @@ func main() {
 		cmdStatus()
 	case "doctor":
 		cmdDoctor()
+	case "watch":
+		var watchArgs []string
+		if len(os.Args) > 2 {
+			watchArgs = os.Args[2:]
+		}
+		cmdWatch(watchArgs)
 	case "auth":
 		// Guard: os.Args[2:] is safe (returns [] when len==2), but be explicit.
 		var authArgs []string
@@ -212,6 +218,7 @@ Usage:
   candela status         Show proxy status
   candela doctor         Check for port conflicts
   candela doctor --fix   Kill conflicting processes
+  candela watch [flags]  Stream live traces
   candela run [flags]    Run in foreground
   candela auth login --provider gcp   Login to GCP via browser
   candela auth login --provider aws   Login to AWS
@@ -1047,6 +1054,7 @@ func runForeground() {
 	// Register traces API endpoint (solo mode observability).
 	mux.Handle("/_local/api/traces", newTracesHandler(traceReader))
 	mux.Handle("/_local/api/leaderboard", newLeaderboardHandler(traceReader))
+	mux.Handle("/_local/api/watch", newWatchHandler(spanProc))
 
 	// Register runtime config API — cloudProxy is nil until built below.
 	configAPI := &localAPI{}

--- a/cmd/candela/watch.go
+++ b/cmd/candela/watch.go
@@ -131,15 +131,9 @@ func printTraceRow(t processor.TraceBroadcast) {
 		statusIcon = "❌"
 	}
 
-	name := t.RootSpanName
-	if len(name) > 20 {
-		name = name[:20]
-	}
+	name := truncateRunes(t.RootSpanName, 20)
 
-	model := t.Model
-	if len(model) > 14 {
-		model = model[:14]
-	}
+	model := truncateRunes(t.Model, 14)
 
 	spans := "span"
 	if t.SpanCount != 1 {
@@ -148,4 +142,13 @@ func printTraceRow(t processor.TraceBroadcast) {
 
 	fmt.Printf("%s  %s  %-20s  %-14s  $%.4f  %4dms  %d %s\n",
 		t.Timestamp, statusIcon, name, model, t.CostUSD, t.DurationMs, t.SpanCount, spans)
+}
+
+// truncateRunes truncates s to at most maxRunes Unicode characters.
+func truncateRunes(s string, maxRunes int) string {
+	runes := []rune(s)
+	if len(runes) > maxRunes {
+		return string(runes[:maxRunes])
+	}
+	return s
 }

--- a/cmd/candela/watch.go
+++ b/cmd/candela/watch.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/candelahq/candela/pkg/processor"
+)
+
+func cmdWatch(args []string) {
+	fs := flag.NewFlagSet("watch", flag.ExitOnError)
+	port := fs.Int("port", 0, "server port (default: from config or 8181)")
+	project := fs.String("project", "", "filter by project ID")
+	model := fs.String("model", "", "filter by model")
+	provider := fs.String("provider", "", "filter by provider")
+	jsonOut := fs.Bool("json", false, "output as JSON lines")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "invalid flags: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Resolve port
+	p := *port
+	if p == 0 {
+		cfg := loadConfig("")
+		if cfg != nil && cfg.Port != 0 {
+			p = cfg.Port
+		} else {
+			p = 8181
+		}
+	}
+
+	// Build SSE URL
+	params := url.Values{}
+	if *project != "" {
+		params.Set("project", *project)
+	}
+	if *model != "" {
+		params.Set("model", *model)
+	}
+	if *provider != "" {
+		params.Set("provider", *provider)
+	}
+	sseURL := fmt.Sprintf("http://127.0.0.1:%d/_local/api/watch?%s", p, params.Encode())
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if !*jsonOut {
+		fmt.Println("🕯️  candela watch — streaming traces (Ctrl+C to stop)")
+		fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	}
+
+	var count int
+	start := time.Now()
+
+	// Connect to SSE with retry
+	for {
+		err := streamTraces(ctx, sseURL, *jsonOut, &count)
+		if ctx.Err() != nil {
+			break
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "⚠️  connection lost: %v — retrying in 2s...\n", err)
+			select {
+			case <-time.After(2 * time.Second):
+			case <-ctx.Done():
+			}
+		}
+	}
+
+	if !*jsonOut {
+		fmt.Printf("\n📊 Watched %d traces in %s\n", count, time.Since(start).Round(time.Second))
+	}
+}
+
+func streamTraces(ctx context.Context, sseURL string, jsonOut bool, count *int) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", sseURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := line[6:] // strip "data: "
+
+		*count++
+
+		if jsonOut {
+			fmt.Println(data)
+			continue
+		}
+
+		var t processor.TraceBroadcast
+		if err := json.Unmarshal([]byte(data), &t); err != nil {
+			continue
+		}
+		printTraceRow(t)
+	}
+	return scanner.Err()
+}
+
+func printTraceRow(t processor.TraceBroadcast) {
+	statusIcon := "✅"
+	if t.Status == "error" {
+		statusIcon = "❌"
+	}
+
+	name := t.RootSpanName
+	if len(name) > 20 {
+		name = name[:20]
+	}
+
+	model := t.Model
+	if len(model) > 14 {
+		model = model[:14]
+	}
+
+	spans := "span"
+	if t.SpanCount != 1 {
+		spans = "spans"
+	}
+
+	fmt.Printf("%s  %s  %-20s  %-14s  $%.4f  %4dms  %d %s\n",
+		t.Timestamp, statusIcon, name, model, t.CostUSD, t.DurationMs, t.SpanCount, spans)
+}

--- a/cmd/candela/watch_handler.go
+++ b/cmd/candela/watch_handler.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/candelahq/candela/pkg/processor"
+)
+
+type watchHandler struct {
+	proc *processor.SpanProcessor
+}
+
+func newWatchHandler(proc *processor.SpanProcessor) http.Handler {
+	return &watchHandler{proc: proc}
+}
+
+func (h *watchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	filter := processor.WatchFilter{
+		ProjectID: r.URL.Query().Get("project"),
+		Model:     r.URL.Query().Get("model"),
+		Provider:  r.URL.Query().Get("provider"),
+	}
+
+	ch, cleanup := h.proc.Subscribe(filter)
+	defer cleanup()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	flusher.Flush()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case trace, ok := <-ch:
+			if !ok {
+				return
+			}
+			data, _ := json.Marshal(trace)
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+		}
+	}
+}

--- a/cmd/candela/watch_handler.go
+++ b/cmd/candela/watch_handler.go
@@ -29,13 +29,17 @@ func (h *watchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Provider:  r.URL.Query().Get("provider"),
 	}
 
+	if h.proc == nil {
+		http.Error(w, "trace processing not available", http.StatusServiceUnavailable)
+		return
+	}
+
 	ch, cleanup := h.proc.Subscribe(filter)
 	defer cleanup()
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 	flusher.Flush()
 
 	ctx := r.Context()

--- a/cmd/candela/watch_test.go
+++ b/cmd/candela/watch_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/candelahq/candela/pkg/processor"
+)
+
+func TestFormatTraceRow(t *testing.T) {
+	// Just verify it doesn't panic
+	tb := processor.TraceBroadcast{
+		TraceID:      "abc-123",
+		RootSpanName: "chat/completions",
+		Model:        "gpt-4o",
+		Provider:     "openai",
+		CostUSD:      0.0034,
+		DurationMs:   120,
+		SpanCount:    3,
+		Status:       "ok",
+		Timestamp:    "14:32:05",
+	}
+	printTraceRow(tb)
+}

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -30,6 +30,36 @@ type SpanProcessor struct {
 	done         chan struct{}
 	once         sync.Once
 	droppedSpans atomic.Int64
+
+	subMu       sync.RWMutex
+	subscribers []*subscriber
+}
+
+// TraceBroadcast is the data sent to watch subscribers.
+type TraceBroadcast struct {
+	TraceID      string  `json:"trace_id"`
+	RootSpanName string  `json:"root_name"`
+	Model        string  `json:"model"`
+	Provider     string  `json:"provider"`
+	CostUSD      float64 `json:"cost_usd"`
+	DurationMs   int64   `json:"duration_ms"`
+	SpanCount    int     `json:"span_count"`
+	Status       string  `json:"status"` // "ok" or "error"
+	Timestamp    string  `json:"time"`
+	ProjectID    string  `json:"project_id,omitempty"`
+}
+
+// WatchFilter controls which traces a subscriber receives.
+type WatchFilter struct {
+	ProjectID string
+	Model     string
+	Provider  string
+}
+
+type subscriber struct {
+	ch      chan TraceBroadcast
+	filter  WatchFilter
+	dropped atomic.Int64
 }
 
 // WithAnomalyDetector attaches a Detector to the processor. When set, the
@@ -193,6 +223,8 @@ func (p *SpanProcessor) Run(ctx context.Context) {
 			}(rw, sinkBatch)
 		}
 		wg.Wait()
+		// Broadcast to watch subscribers (best-effort, non-blocking).
+		p.broadcastToWatchers(batch)
 		slog.Debug("flushed spans to storage", "count", len(batch), "sinks", len(p.writers))
 		batch = batch[:0]
 	}
@@ -255,4 +287,92 @@ func (p *SpanProcessor) SinkHealth() []SinkHealth {
 		health[i] = rw.Health()
 	}
 	return health
+}
+
+// Subscribe registers a trace watcher. Returns a read channel and cleanup func.
+// The channel is buffered (cap=100). Slow consumers get dropped events, never blocking ingestion.
+func (p *SpanProcessor) Subscribe(filter WatchFilter) (<-chan TraceBroadcast, func()) {
+	ch := make(chan TraceBroadcast, 100)
+	sub := &subscriber{ch: ch, filter: filter}
+
+	p.subMu.Lock()
+	p.subscribers = append(p.subscribers, sub)
+	p.subMu.Unlock()
+
+	slog.Info("watch subscriber added", "total", len(p.subscribers))
+
+	cleanup := func() {
+		p.subMu.Lock()
+		defer p.subMu.Unlock()
+		for i, s := range p.subscribers {
+			if s == sub {
+				p.subscribers = append(p.subscribers[:i], p.subscribers[i+1:]...)
+				close(ch)
+				slog.Info("watch subscriber removed", "total", len(p.subscribers), "dropped", sub.dropped.Load())
+				break
+			}
+		}
+	}
+	return ch, cleanup
+}
+
+func (p *SpanProcessor) broadcastToWatchers(spans []storage.Span) {
+	p.subMu.RLock()
+	defer p.subMu.RUnlock()
+	if len(p.subscribers) == 0 {
+		return
+	}
+
+	// Group spans by trace to build per-trace summaries.
+	traces := make(map[string]*TraceBroadcast)
+	for _, s := range spans {
+		tb, ok := traces[s.TraceID]
+		if !ok {
+			status := "ok"
+			if s.Status == storage.SpanStatusError {
+				status = "error"
+			}
+			tb = &TraceBroadcast{
+				TraceID:   s.TraceID,
+				Timestamp: s.StartTime.Format("15:04:05"),
+				ProjectID: s.ProjectID,
+				Status:    status,
+			}
+			traces[s.TraceID] = tb
+		}
+		tb.SpanCount++
+		if s.ParentSpanID == "" {
+			tb.RootSpanName = s.Name
+			tb.DurationMs = s.EndTime.Sub(s.StartTime).Milliseconds()
+		}
+		if s.GenAI != nil {
+			tb.CostUSD += s.GenAI.CostUSD
+			if tb.Model == "" {
+				tb.Model = s.GenAI.Model
+				tb.Provider = s.GenAI.Provider
+			}
+		}
+		if s.Status == storage.SpanStatusError {
+			tb.Status = "error"
+		}
+	}
+
+	for _, tb := range traces {
+		for _, sub := range p.subscribers {
+			if sub.filter.ProjectID != "" && sub.filter.ProjectID != tb.ProjectID {
+				continue
+			}
+			if sub.filter.Model != "" && sub.filter.Model != tb.Model {
+				continue
+			}
+			if sub.filter.Provider != "" && sub.filter.Provider != tb.Provider {
+				continue
+			}
+			select {
+			case sub.ch <- *tb:
+			default:
+				sub.dropped.Add(1)
+			}
+		}
+	}
 }

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -297,9 +297,10 @@ func (p *SpanProcessor) Subscribe(filter WatchFilter) (<-chan TraceBroadcast, fu
 
 	p.subMu.Lock()
 	p.subscribers = append(p.subscribers, sub)
+	total := len(p.subscribers)
 	p.subMu.Unlock()
 
-	slog.Info("watch subscriber added", "total", len(p.subscribers))
+	slog.Info("watch subscriber added", "total", total)
 
 	cleanup := func() {
 		p.subMu.Lock()

--- a/pkg/processor/subscribe_test.go
+++ b/pkg/processor/subscribe_test.go
@@ -1,0 +1,126 @@
+package processor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+func TestSubscribe_ReceivesTraces(t *testing.T) {
+	p := newTestProcessor()
+	ch, cleanup := p.Subscribe(WatchFilter{})
+	defer cleanup()
+
+	spans := []storage.Span{
+		testWatchSpan("trace-1", "root-span", "", "gpt-4", "openai"),
+	}
+	p.broadcastToWatchers(spans)
+
+	select {
+	case tb := <-ch:
+		if tb.TraceID != "trace-1" {
+			t.Errorf("expected trace-1, got %s", tb.TraceID)
+		}
+		if tb.Model != "gpt-4" {
+			t.Errorf("expected gpt-4, got %s", tb.Model)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for trace")
+	}
+}
+
+func TestSubscribe_NonBlocking(t *testing.T) {
+	p := newTestProcessor()
+	ch, cleanup := p.Subscribe(WatchFilter{})
+	defer cleanup()
+
+	// Fill the buffer (cap=100)
+	span := testWatchSpan("trace-fill", "root", "", "gpt-4", "openai")
+	for i := 0; i < 150; i++ {
+		p.broadcastToWatchers([]storage.Span{span})
+	}
+
+	// Channel should have 100, rest dropped
+	if len(ch) != 100 {
+		t.Errorf("expected 100 buffered, got %d", len(ch))
+	}
+	// Should not block — this test completing proves it
+}
+
+func TestSubscribe_Cleanup(t *testing.T) {
+	p := newTestProcessor()
+	_, cleanup := p.Subscribe(WatchFilter{})
+	_, cleanup2 := p.Subscribe(WatchFilter{})
+
+	if len(p.subscribers) != 2 {
+		t.Fatalf("expected 2 subscribers, got %d", len(p.subscribers))
+	}
+
+	cleanup()
+	if len(p.subscribers) != 1 {
+		t.Fatalf("expected 1 subscriber after cleanup, got %d", len(p.subscribers))
+	}
+
+	cleanup2()
+	if len(p.subscribers) != 0 {
+		t.Fatalf("expected 0 subscribers after cleanup, got %d", len(p.subscribers))
+	}
+}
+
+func TestSubscribe_FilterMatch(t *testing.T) {
+	p := newTestProcessor()
+	ch, cleanup := p.Subscribe(WatchFilter{Model: "gpt-4"})
+	defer cleanup()
+
+	spans := []storage.Span{
+		testWatchSpan("trace-gpt", "root", "", "gpt-4", "openai"),
+		testWatchSpan("trace-claude", "root", "", "claude-3", "anthropic"),
+	}
+	p.broadcastToWatchers(spans)
+
+	select {
+	case tb := <-ch:
+		if tb.TraceID != "trace-gpt" {
+			t.Errorf("expected trace-gpt, got %s", tb.TraceID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	// claude trace should not have been sent
+	select {
+	case tb := <-ch:
+		t.Errorf("unexpected trace: %s", tb.TraceID)
+	default:
+		// good
+	}
+}
+
+// Test helpers
+func newTestProcessor() *SpanProcessor {
+	return &SpanProcessor{
+		spanCh: make(chan storage.Span, 10),
+		done:   make(chan struct{}),
+	}
+}
+
+func testWatchSpan(traceID, name, parentID, model, provider string) storage.Span {
+	s := storage.Span{
+		TraceID:      traceID,
+		SpanID:       traceID + "-span",
+		ParentSpanID: parentID,
+		Name:         name,
+		StartTime:    time.Now(),
+		EndTime:      time.Now().Add(100 * time.Millisecond),
+		Status:       storage.SpanStatusOK,
+	}
+	if model != "" {
+		s.GenAI = &storage.GenAIAttributes{
+			Model:    model,
+			Provider: provider,
+			CostUSD:  0.0034,
+		}
+	}
+	return s
+}


### PR DESCRIPTION
## What

`candela watch` streams new traces to your terminal in real-time as they are ingested. Zero-latency observability — see every LLM call the moment it completes.

```
🕯️  candela watch — streaming traces (Ctrl+C to stop)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

14:32:05  ✅  chat/completions    gpt-4o         $0.0034   120ms  3 spans
14:32:06  ✅  embeddings          text-embed     $0.0001    45ms  1 span
14:32:08  ❌  chat/completions    claude-3.5     $0.0000   502ms  2 spans
```

## Architecture

**SpanProcessor subscriber system** with non-blocking fan-out:
- `Subscribe()` returns a buffered channel (cap=100) + cleanup func
- `broadcastToWatchers()` runs AFTER sink writes (best-effort, never blocks ingestion)
- Non-blocking sends: `select { case ch <- trace: default: dropped++ }`
- Context-aware cleanup prevents goroutine leaks on disconnect

**SSE endpoint** at `/_local/api/watch`:
- Server-Sent Events stream on the existing local HTTP server
- Query params: `?project=&model=&provider=` for filtering
- Cleanup on client disconnect via `r.Context().Done()`

**CLI** (`candela watch`):
- Connects to local SSE endpoint with auto-retry on disconnect
- `--json` flag for JSONL output (`candela watch --json | jq .model`)
- `--project`, `--model`, `--provider` filters
- Ctrl+C prints summary: total traces watched + duration

## Why SSE instead of Connect streaming RPC?

Protos live in an external BSR module (`buf.build/candelahq/protos`). SSE gives us the same real-time streaming with zero proto changes. When we add `WatchTraces` to the proto, the subscriber system is already built — just wire a Connect handler to `processor.Subscribe()`.

## Tests
- `TestSubscribe_ReceivesTraces`: subscriber gets broadcast traces
- `TestSubscribe_NonBlocking`: full channel never blocks broadcast (critical!)
- `TestSubscribe_Cleanup`: unsubscribe closes channel, removes from list
- `TestSubscribe_FilterMatch`: only matching traces delivered
- `TestFormatTraceRow`: output formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `candela watch` command for streaming live trace activity.
  - Supports filtering by project, model, and provider.
  - Added human-readable and `--json` output modes.
  - Automatically reconnects when the stream is interrupted.
  - Displays trace status, timing, model details, span counts, and costs.

- **Bug Fixes**
  - Added filtering and subscriber handling to ensure relevant trace updates are delivered without blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->