### PR TITLE
feat(ui): span search page + time range filtering on traces

### DIFF
--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -2870,7 +2870,7 @@ tr:hover .model-bar {
   border-radius: 9999px;
   font-size: 11px;
   font-weight: 600;
-  color: #000;
+  color: #fff;
   letter-spacing: 0.02em;
 }
 

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -2836,3 +2836,65 @@ tr:hover .model-bar {
   font-size: 11px;
   color: var(--text-secondary);
 }
+
+/* ── Search Page ─────────────────────────────────────────────── */
+
+.search-hero {
+  margin-bottom: 16px;
+}
+
+.search-hero-input {
+  width: 100%;
+  padding: 14px 20px;
+  font-size: 16px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  color: var(--text-primary);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.search-hero-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(240, 160, 48, 0.15);
+}
+
+.search-hero-input::placeholder {
+  color: var(--text-muted);
+}
+
+.kind-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #000;
+  letter-spacing: 0.02em;
+}
+
+.search-filter-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.search-filter-row .filter-group {
+  min-width: 140px;
+}
+
+.search-shortcut-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}

--- a/ui/src/app/search/page.tsx
+++ b/ui/src/app/search/page.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useSpanSearch } from "@/hooks/useSpanSearch";
+import { ScopeToggle } from "@/components/ScopeToggle";
+import { ErrorBanner } from "@/components/ErrorBanner";
+import { SpanKind } from "@/gen/candela/types/trace_pb";
+
+const kindLabels: Record<number, string> = {
+  [SpanKind.LLM]: "LLM",
+  [SpanKind.AGENT]: "Agent",
+  [SpanKind.TOOL]: "Tool",
+  [SpanKind.RETRIEVAL]: "Retrieval",
+  [SpanKind.EMBEDDING]: "Embedding",
+  [SpanKind.CHAIN]: "Chain",
+  [SpanKind.GENERAL]: "General",
+};
+
+const kindColors: Record<number, string> = {
+  [SpanKind.LLM]: "#f0a030",
+  [SpanKind.AGENT]: "#a78bfa",
+  [SpanKind.TOOL]: "#34d399",
+  [SpanKind.RETRIEVAL]: "#60a5fa",
+  [SpanKind.EMBEDDING]: "#f472b6",
+  [SpanKind.CHAIN]: "#fbbf24",
+  [SpanKind.GENERAL]: "#6b7280",
+};
+
+function kindLabelForSearch(kind: SpanKind) {
+  return kindLabels[kind] || "Unknown";
+}
+
+function kindColorForSearch(kind: SpanKind) {
+  return kindColors[kind] || "var(--text-muted)";
+}
+
+const statusLabel = (s: number) => {
+  if (s === 2) return { text: "error", cls: "badge-error" };
+  return { text: "ok", cls: "badge-success" };
+};
+
+export default function SearchPage() {
+  const router = useRouter();
+  const {
+    spans,
+    loading,
+    error,
+    filters,
+    hasActiveFilters,
+    updateFilters,
+    clearFilters,
+    refresh,
+    fetchInitial,
+    fetchNextPage,
+    fetchPreviousPage,
+    hasNextPage,
+    hasPreviousPage,
+    currentPage,
+  } = useSpanSearch();
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { fetchInitial(); }, []);
+
+  return (
+    <>
+      <header className="main-header">
+        <h1>Search Spans</h1>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          {/* Time range buttons */}
+          <div className="time-range-selector" style={{ display: "flex", gap: "4px" }}>
+            {(["1h", "24h", "7d", "30d"] as const).map((r) => (
+              <button
+                key={r}
+                className={`btn btn-sm ${filters.timeRange === r ? "btn-active" : "btn-ghost"}`}
+                onClick={() => updateFilters({ timeRange: r })}
+                style={{ padding: "4px 8px", fontSize: "12px", borderRadius: "4px" }}
+              >
+                {r}
+              </button>
+            ))}
+          </div>
+          <ScopeToggle />
+          <button className="btn" onClick={refresh}>
+            🔄 Refresh
+          </button>
+        </div>
+      </header>
+
+      <div className="main-body">
+        {/* Search bar - larger, prominent */}
+        <div className="search-hero animate-in">
+          <input
+            type="text"
+            className="search-hero-input"
+            placeholder="Search spans by name, tool, or operation..."
+            value={filters.nameContains}
+            onChange={(e) => updateFilters({ nameContains: e.target.value })}
+          />
+        </div>
+
+        {/* Filter chips row */}
+        <div className="filter-bar animate-in" style={{ display: "flex", gap: "12px", flexWrap: "wrap", marginBottom: "16px" }}>
+          <div className="filter-group" style={{ minWidth: "140px" }}>
+            <select
+              value={filters.kind === null ? "all" : filters.kind.toString()}
+              onChange={(e) =>
+                updateFilters({
+                  kind: e.target.value === "all" ? null : parseInt(e.target.value, 10),
+                })
+              }
+              className="filter-select"
+            >
+              <option value="all">Kind: All</option>
+              <option value={SpanKind.LLM}>LLM</option>
+              <option value={SpanKind.AGENT}>Agent</option>
+              <option value={SpanKind.TOOL}>Tool</option>
+              <option value={SpanKind.RETRIEVAL}>Retrieval</option>
+              <option value={SpanKind.EMBEDDING}>Embedding</option>
+              <option value={SpanKind.CHAIN}>Chain</option>
+              <option value={SpanKind.GENERAL}>General</option>
+            </select>
+          </div>
+          <div className="filter-group">
+            <input
+              type="text"
+              placeholder="Model (e.g. gpt-4o)"
+              value={filters.model}
+              onChange={(e) => updateFilters({ model: e.target.value })}
+              className="filter-input"
+            />
+          </div>
+          <div className="filter-group">
+            <input
+              type="text"
+              placeholder="Job ID"
+              value={filters.jobId}
+              onChange={(e) => updateFilters({ jobId: e.target.value })}
+              className="filter-input"
+            />
+          </div>
+          <div className="filter-group">
+            <input
+              type="text"
+              placeholder="Trace Group"
+              value={filters.traceGroup}
+              onChange={(e) => updateFilters({ traceGroup: e.target.value })}
+              className="filter-input"
+            />
+          </div>
+          {hasActiveFilters && (
+            <button className="btn filter-reset-btn" onClick={clearFilters}>
+              ✕ Clear all
+            </button>
+          )}
+        </div>
+
+        {/* Error banner */}
+        {error && (
+          <ErrorBanner title="Could not load spans">
+            {error}
+          </ErrorBanner>
+        )}
+
+        {/* Results */}
+        <div className="table-container animate-in">
+          <div className="table-header">
+            <span className="table-title">
+              {loading
+                ? "Loading..."
+                : `Page ${currentPage}`}
+            </span>
+            {hasActiveFilters && (
+              <span
+                className="badge badge-info"
+                style={{ fontSize: 11, cursor: "pointer" }}
+                onClick={clearFilters}
+              >
+                Filtered — clear
+              </span>
+            )}
+          </div>
+
+          {spans.length === 0 && !loading ? (
+            <div className="empty-state">
+              <div className="empty-state-icon">🔍</div>
+              <div className="empty-state-title">
+                {hasActiveFilters
+                  ? "No spans match filters"
+                  : "No spans found"}
+              </div>
+              <div className="empty-state-desc">
+                {hasActiveFilters ? (
+                  <>
+                    Try adjusting your filters or{" "}
+                    <button
+                      onClick={clearFilters}
+                      style={{
+                        background: "none",
+                        border: "none",
+                        color: "var(--accent)",
+                        cursor: "pointer",
+                        textDecoration: "underline",
+                        padding: 0,
+                        font: "inherit",
+                      }}
+                    >
+                      clear all filters
+                    </button>
+                    .
+                  </>
+                ) : (
+                  "Spans will appear here once LLM requests flow through the proxy."
+                )}
+              </div>
+            </div>
+          ) : (
+            <table>
+              <thead>
+                <tr>
+                  <th>Span ID</th>
+                  <th>Name</th>
+                  <th>Kind</th>
+                  <th>Model</th>
+                  <th>Tokens</th>
+                  <th>Cost</th>
+                  <th>Latency</th>
+                  <th>Status</th>
+                  <th>Trace</th>
+                  <th>Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {spans.map((s) => {
+                  const st = statusLabel(s.status);
+                  return (
+                    <tr
+                      key={s.spanId}
+                      className="clickable-row"
+                      onClick={() => router.push(`/traces/${s.traceId}`)}
+                    >
+                      <td>
+                        <span className="mono">{s.spanId.slice(0, 12)}…</span>
+                      </td>
+                      <td>{s.name}</td>
+                      <td>
+                        <span className="kind-badge" style={{ background: kindColorForSearch(s.kind) }}>
+                          {kindLabelForSearch(s.kind)}
+                        </span>
+                      </td>
+                      <td>
+                        <span className="mono" style={{ fontSize: 12 }}>
+                          {s.model}
+                        </span>
+                      </td>
+                      <td>{s.totalTokens.toLocaleString()}</td>
+                      <td>${s.costUsd.toFixed(4)}</td>
+                      <td>{s.durationMs.toFixed(0)}ms</td>
+                      <td>
+                        <span className={`badge ${st.cls}`}>{st.text}</span>
+                      </td>
+                      <td>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            router.push(`/traces/${s.traceId}`);
+                          }}
+                          style={{
+                            background: "none",
+                            border: "none",
+                            color: "var(--accent)",
+                            cursor: "pointer",
+                            textDecoration: "underline",
+                            font: "inherit",
+                            padding: 0
+                          }}
+                        >
+                          View Trace
+                        </button>
+                      </td>
+                      <td style={{ color: "var(--text-muted)", fontSize: 12 }}>
+                        {s.startTime}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+
+          {/* Pagination controls */}
+          {(hasPreviousPage || hasNextPage) && (
+            <div className="pagination-controls" style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "16px 20px", borderTop: "1px solid var(--border-subtle)" }}>
+              <button
+                className="btn btn-sm btn-ghost"
+                onClick={fetchPreviousPage}
+                disabled={!hasPreviousPage}
+              >
+                ← Previous
+              </button>
+              <span className="pagination-info" style={{ fontSize: "13px", color: "var(--text-secondary)" }}>
+                Page {currentPage}
+              </span>
+              <button
+                className="btn btn-sm btn-ghost"
+                onClick={fetchNextPage}
+                disabled={!hasNextPage}
+              >
+                Next →
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/ui/src/app/search/page.tsx
+++ b/ui/src/app/search/page.tsx
@@ -237,7 +237,10 @@ export default function SearchPage() {
                     <tr
                       key={s.spanId}
                       className="clickable-row"
+                      tabIndex={0}
+                      role="link"
                       onClick={() => router.push(`/traces/${s.traceId}`)}
+                      onKeyDown={(e) => { if (e.key === "Enter") router.push(`/traces/${s.traceId}`); }}
                     >
                       <td>
                         <span className="mono">{s.spanId.slice(0, 12)}…</span>

--- a/ui/src/app/traces/page.tsx
+++ b/ui/src/app/traces/page.tsx
@@ -279,7 +279,10 @@ export default function TracesPage() {
                     <tr
                       key={t.traceId}
                       className="clickable-row"
+                      tabIndex={0}
+                      role="link"
                       onClick={() => router.push(`/traces/${t.traceId}`)}
+                      onKeyDown={(e) => { if (e.key === "Enter") router.push(`/traces/${t.traceId}`); }}
                     >
                       <td>
                         <span className="mono">{t.traceId.slice(0, 12)}…</span>

--- a/ui/src/app/traces/page.tsx
+++ b/ui/src/app/traces/page.tsx
@@ -47,7 +47,20 @@ export default function TracesPage() {
     <>
       <header className="main-header">
         <h1>Traces</h1>
-        <div style={{ display: "flex", gap: 8 }}>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          {/* Time range buttons */}
+          <div className="time-range-selector" style={{ display: "flex", gap: "4px" }}>
+            {(["1h", "24h", "7d", "30d"] as const).map((r) => (
+              <button
+                key={r}
+                className={`btn btn-sm ${filters.timeRange === r ? "btn-active" : "btn-ghost"}`}
+                onClick={() => updateFilters({ timeRange: r })}
+                style={{ padding: "4px 8px", fontSize: "12px", borderRadius: "4px" }}
+              >
+                {r}
+              </button>
+            ))}
+          </div>
           <ScopeToggle />
           <button className="btn" onClick={refresh}>
             🔄 Refresh
@@ -153,6 +166,26 @@ export default function TracesPage() {
                 placeholder="e.g. experiment-1"
                 value={filters.jobId}
                 onChange={(e) => updateFilters({ jobId: e.target.value })}
+                className="filter-input"
+              />
+            </div>
+            <div className="filter-group">
+              <label className="filter-label">Environment</label>
+              <input
+                type="text"
+                placeholder="e.g. production, staging"
+                value={filters.environment}
+                onChange={(e) => updateFilters({ environment: e.target.value })}
+                className="filter-input"
+              />
+            </div>
+            <div className="filter-group">
+              <label className="filter-label">Trace Group</label>
+              <input
+                type="text"
+                placeholder="e.g. chat, completion"
+                value={filters.traceGroup}
+                onChange={(e) => updateFilters({ traceGroup: e.target.value })}
                 className="filter-input"
               />
             </div>

--- a/ui/src/components/sidebar.tsx
+++ b/ui/src/components/sidebar.tsx
@@ -12,6 +12,7 @@ const navItems = [
       { href: "/today", label: "Today", icon: "🕯️" },
       { href: "/", label: "Dashboard", icon: "📊" },
       { href: "/traces", label: "Traces", icon: "🔍" },
+      { href: "/search", label: "Search", icon: "🔎" },
       { href: "/usage", label: "My Usage", icon: "📈" },
       { href: "/costs", label: "Costs", icon: "💰" },
     ],

--- a/ui/src/hooks/useSpanSearch.ts
+++ b/ui/src/hooks/useSpanSearch.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useReducer, useRef } from "react";
 import { traceClient } from "@/lib/api";
 import { DEFAULT_PROJECT_ID } from "@/lib/constants";
 import { SpanKind } from "@/gen/candela/types/trace_pb";
+import type { Span } from "@/gen/candela/types/trace_pb";
 import { useScope } from "@/components/UserScopeProvider";
 import { create } from "@bufbuild/protobuf";
 import { TimestampSchema } from "@bufbuild/protobuf/wkt";
@@ -72,7 +73,7 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-function mapSpan(span: any): SpanResultRow {
+function mapSpan(span: Span): SpanResultRow {
   const durSeconds = Number(span.duration?.seconds ?? 0);
   const durNanos = Number(span.duration?.nanos ?? 0);
   
@@ -81,11 +82,11 @@ function mapSpan(span: any): SpanResultRow {
     traceId: span.traceId,
     name: span.name || "unknown",
     kind: span.kind ?? SpanKind.UNSPECIFIED,
-    model: span.genai?.model || "—",
-    provider: span.genai?.provider || "—",
+    model: span.genAi?.model || "—",
+    provider: span.genAi?.provider || "—",
     durationMs: durSeconds * 1000 + durNanos / 1e6,
-    totalTokens: Number(span.genai?.totalTokens) || 0,
-    costUsd: span.genai?.costUsd || 0,
+    totalTokens: Number(span.genAi?.totalTokens) || 0,
+    costUsd: span.genAi?.costUsd || 0,
     status: span.status ?? 0,
     startTime: span.startTime
       ? new Date(
@@ -174,6 +175,10 @@ export function useSpanSearch() {
   );
 
   const clearFilters = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
     dispatch({ type: "clear_filters" });
     fetchSpans(DEFAULT_SEARCH_FILTERS, true);
   }, [fetchSpans]);
@@ -183,7 +188,8 @@ export function useSpanSearch() {
     state.filters.kind !== null ||
     state.filters.model ||
     state.filters.jobId ||
-    state.filters.traceGroup
+    state.filters.traceGroup ||
+    state.filters.timeRange !== DEFAULT_SEARCH_FILTERS.timeRange
   );
 
   const refresh = useCallback(
@@ -213,7 +219,10 @@ export function useSpanSearch() {
   }, [state.pageTokenHistory]);
 
   useEffect(() => {
-    return () => fetchRef.current?.abort();
+    return () => {
+      fetchRef.current?.abort();
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
   }, []);
 
   return {

--- a/ui/src/hooks/useSpanSearch.ts
+++ b/ui/src/hooks/useSpanSearch.ts
@@ -3,11 +3,12 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { traceClient } from "@/lib/api";
 import { DEFAULT_PROJECT_ID } from "@/lib/constants";
-import type { TraceSummaryRow, TraceFilters } from "@/types/traces";
-import { DEFAULT_FILTERS } from "@/types/traces";
+import { SpanKind } from "@/gen/candela/types/trace_pb";
 import { useScope } from "@/components/UserScopeProvider";
 import { create } from "@bufbuild/protobuf";
 import { TimestampSchema } from "@bufbuild/protobuf/wkt";
+import type { SpanResultRow, SpanSearchFilters } from "@/types/search";
+import { DEFAULT_SEARCH_FILTERS } from "@/types/search";
 
 function makeTimeRange(range: string) {
   const now = new Date();
@@ -20,20 +21,20 @@ function makeTimeRange(range: string) {
 }
 
 type State = {
-  traces: TraceSummaryRow[];
+  spans: SpanResultRow[];
   loading: boolean;
   error: string | null;
-  filters: TraceFilters;
+  filters: SpanSearchFilters;
   nextPageToken: string;
   currentPageToken: string;
   pageTokenHistory: string[];
 };
 
 type Action =
-  | { type: "fetch"; filters: TraceFilters; resetPagination?: boolean }
-  | { type: "success"; traces: TraceSummaryRow[]; nextPageToken: string }
+  | { type: "fetch"; filters: SpanSearchFilters; resetPagination?: boolean }
+  | { type: "success"; spans: SpanResultRow[]; nextPageToken: string }
   | { type: "error"; message: string }
-  | { type: "set_filters"; filters: TraceFilters }
+  | { type: "set_filters"; filters: SpanSearchFilters }
   | { type: "clear_filters" }
   | { type: "set_page_token"; direction: "next" | "prev"; token?: string };
 
@@ -45,13 +46,13 @@ function reducer(state: State, action: Action): State {
       }
       return { ...state, loading: true, error: null, filters: action.filters };
     case "success":
-      return { ...state, loading: false, traces: action.traces, nextPageToken: action.nextPageToken };
+      return { ...state, loading: false, spans: action.spans, nextPageToken: action.nextPageToken };
     case "error":
       return { ...state, loading: false, error: action.message };
     case "set_filters":
       return { ...state, filters: action.filters, currentPageToken: "", pageTokenHistory: [], nextPageToken: "" };
     case "clear_filters":
-      return { ...state, loading: true, error: null, filters: DEFAULT_FILTERS, currentPageToken: "", pageTokenHistory: [], nextPageToken: "" };
+      return { ...state, loading: true, error: null, filters: DEFAULT_SEARCH_FILTERS, currentPageToken: "", pageTokenHistory: [], nextPageToken: "" };
     case "set_page_token":
       if (action.direction === "next") {
         return {
@@ -71,75 +72,47 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-function mapTrace(t: {
-  traceId: string;
-  rootSpanName: string;
-  primaryModel: string;
-  primaryProvider: string;
-  environment: string;
-  duration?: { seconds: bigint; nanos: number };
-  totalTokens: bigint;
-  totalCostUsd: number;
-  status: number;
-  spanCount: number;
-  llmCallCount: number;
-  startTime?: { seconds: bigint; nanos: number };
-  tenantId?: string;
-  jobId?: string;
-}): TraceSummaryRow {
-  const durSeconds = Number(t.duration?.seconds ?? 0);
-  const durNanos = Number(t.duration?.nanos ?? 0);
+function mapSpan(span: any): SpanResultRow {
+  const durSeconds = Number(span.duration?.seconds ?? 0);
+  const durNanos = Number(span.duration?.nanos ?? 0);
+  
   return {
-    traceId: t.traceId,
-    rootSpanName: t.rootSpanName || "unknown",
-    primaryModel: t.primaryModel || "—",
-    primaryProvider: t.primaryProvider || "—",
-    environment: t.environment || "—",
+    spanId: span.spanId,
+    traceId: span.traceId,
+    name: span.name || "unknown",
+    kind: span.kind ?? SpanKind.UNSPECIFIED,
+    model: span.genai?.model || "—",
+    provider: span.genai?.provider || "—",
     durationMs: durSeconds * 1000 + durNanos / 1e6,
-    totalTokens: Number(t.totalTokens) || 0,
-    totalCostUsd: t.totalCostUsd || 0,
-    status: t.status,
-    spanCount: t.spanCount || 0,
-    llmCallCount: t.llmCallCount || 0,
-    startTime: t.startTime
+    totalTokens: Number(span.genai?.totalTokens) || 0,
+    costUsd: span.genai?.costUsd || 0,
+    status: span.status ?? 0,
+    startTime: span.startTime
       ? new Date(
-          Number(t.startTime.seconds) * 1000 +
-            Math.floor(Number(t.startTime.nanos) / 1e6)
+          Number(span.startTime.seconds) * 1000 +
+            Math.floor(Number(span.startTime.nanos) / 1e6)
         ).toLocaleString()
       : "—",
-    tenantId: t.tenantId,
-    jobId: t.jobId,
   };
 }
 
-/**
- * Hook for fetching and filtering traces.
- * Encapsulates the ListTraces RPC, debounced search, and filter state.
- *
- * Scope-aware: In "personal" mode the backend already scopes by the
- * authenticated user's Firebase token.  We pass `include_budget=true`
- * as a hint header so the backend knows this is a personal-scope request.
- * Re-fetches automatically when the scope mode changes.
- */
-export function useTraces() {
+export function useSpanSearch() {
   const { isPersonalScope, mode } = useScope();
 
   const [state, dispatch] = useReducer(reducer, {
-    traces: [],
+    spans: [],
     loading: true,
     error: null,
-    filters: DEFAULT_FILTERS,
+    filters: DEFAULT_SEARCH_FILTERS,
     nextPageToken: "",
     currentPageToken: "",
     pageTokenHistory: [],
   });
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Track the previous scope mode so we can detect changes
   const prevModeRef = useRef(mode);
-
   const fetchRef = useRef<AbortController | null>(null);
 
-  const fetchTraces = useCallback((f: TraceFilters, resetPagination = false) => {
+  const fetchSpans = useCallback((f: SpanSearchFilters, resetPagination = false) => {
     fetchRef.current?.abort();
     const controller = new AbortController();
     fetchRef.current = controller;
@@ -147,25 +120,21 @@ export function useTraces() {
     dispatch({ type: "fetch", filters: f, resetPagination });
     const pageToken = resetPagination ? "" : state.currentPageToken;
 
-    // Build headers — the backend interprets the auth token + this hint
-    // to decide whether to filter to the authenticated user's traces.
     const headers: Record<string, string> = {};
     if (f.jobId) headers["X-Candela-Job-Id"] = f.jobId;
     if (isPersonalScope) headers["X-Candela-Scope"] = "personal";
 
     traceClient
-      .listTraces({
+      .searchSpans({
         projectId: DEFAULT_PROJECT_ID,
         pagination: { pageSize: 100, pageToken },
-        search: f.search,
+        nameContains: f.nameContains,
+        kind: f.kind === null ? SpanKind.UNSPECIFIED : f.kind,
         model: f.model,
-        provider: f.provider,
-        status: f.status === "ok" ? 1 : f.status === "error" ? 2 : 0,
-        orderBy: f.orderBy,
-        descending: f.descending,
-        timeRange: makeTimeRange(f.timeRange),
-        environment: f.environment,
+        jobId: f.jobId,
         traceGroup: f.traceGroup,
+        timeRange: makeTimeRange(f.timeRange),
+        tenantId: "",
       }, {
         headers,
         signal: controller.signal,
@@ -175,7 +144,7 @@ export function useTraces() {
           const nextToken = res.pagination?.nextPageToken ?? "";
           dispatch({
             type: "success",
-            traces: (res.traces || []).map(mapTrace),
+            spans: (res.spans || []).map(mapSpan),
             nextPageToken: nextToken,
           });
         }
@@ -188,54 +157,50 @@ export function useTraces() {
   }, [isPersonalScope, state.currentPageToken]);
 
   const updateFilters = useCallback(
-    (patch: Partial<TraceFilters>) => {
+    (patch: Partial<SpanSearchFilters>) => {
       const next = { ...state.filters, ...patch };
       dispatch({ type: "set_filters", filters: next });
 
-      const isSearch = "search" in patch;
+      const isSearch = "nameContains" in patch;
       if (debounceRef.current) clearTimeout(debounceRef.current);
 
       if (isSearch) {
-        debounceRef.current = setTimeout(() => fetchTraces(next, true), 300);
+        debounceRef.current = setTimeout(() => fetchSpans(next, true), 300);
       } else {
-        fetchTraces(next, true);
+        fetchSpans(next, true);
       }
     },
-    [state.filters, fetchTraces]
+    [state.filters, fetchSpans]
   );
 
   const clearFilters = useCallback(() => {
     dispatch({ type: "clear_filters" });
-    fetchTraces(DEFAULT_FILTERS, true);
-  }, [fetchTraces]);
+    fetchSpans(DEFAULT_SEARCH_FILTERS, true);
+  }, [fetchSpans]);
 
   const hasActiveFilters = !!(
-    state.filters.search ||
+    state.filters.nameContains ||
+    state.filters.kind !== null ||
     state.filters.model ||
-    state.filters.provider ||
-    state.filters.status ||
     state.filters.jobId ||
-    state.filters.environment ||
     state.filters.traceGroup
   );
 
   const refresh = useCallback(
-    () => fetchTraces(state.filters),
-    [state.filters, fetchTraces]
+    () => fetchSpans(state.filters),
+    [state.filters, fetchSpans]
   );
 
-  // Re-fetch when scope mode changes
   useEffect(() => {
     if (prevModeRef.current !== mode) {
       prevModeRef.current = mode;
-      fetchTraces(state.filters, true);
+      fetchSpans(state.filters, true);
     }
-  }, [mode, fetchTraces, state.filters]);
+  }, [mode, fetchSpans, state.filters]);
 
-  // Re-fetch when currentPageToken changes
   useEffect(() => {
-    fetchTraces(state.filters);
-  }, [state.currentPageToken, fetchTraces, state.filters]);
+    fetchSpans(state.filters);
+  }, [state.currentPageToken, fetchSpans, state.filters]);
 
   const fetchNextPage = useCallback(() => {
     if (!state.nextPageToken) return;
@@ -247,16 +212,12 @@ export function useTraces() {
     dispatch({ type: "set_page_token", direction: "prev" });
   }, [state.pageTokenHistory]);
 
-  // Abort in-flight request on unmount only. Cleanup must NOT be in the
-  // mode/filters effect — fetchTraces already updates fetchRef.current
-  // before React runs the previous effect's cleanup, so that cleanup
-  // would abort the *new* request instead of the old one.
   useEffect(() => {
     return () => fetchRef.current?.abort();
   }, []);
 
   return {
-    traces: state.traces,
+    spans: state.spans,
     loading: state.loading,
     error: state.error,
     filters: state.filters,
@@ -264,7 +225,7 @@ export function useTraces() {
     updateFilters,
     clearFilters,
     refresh,
-    fetchInitial: () => fetchTraces(state.filters, true),
+    fetchInitial: () => fetchSpans(state.filters, true),
     fetchNextPage,
     fetchPreviousPage,
     hasNextPage: !!state.nextPageToken,

--- a/ui/src/hooks/useSpanSearch.ts
+++ b/ui/src/hooks/useSpanSearch.ts
@@ -204,9 +204,16 @@ export function useSpanSearch() {
     }
   }, [mode, fetchSpans, state.filters]);
 
+  // Only fetch on pagination token changes — filter-driven fetches
+  // are handled imperatively by updateFilters/clearFilters.
+  const prevTokenRef = useRef(state.currentPageToken);
   useEffect(() => {
-    fetchSpans(state.filters);
-  }, [state.currentPageToken, fetchSpans, state.filters]);
+    if (prevTokenRef.current !== state.currentPageToken) {
+      prevTokenRef.current = state.currentPageToken;
+      fetchSpans(state.filters);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.currentPageToken]);
 
   const fetchNextPage = useCallback(() => {
     if (!state.nextPageToken) return;

--- a/ui/src/hooks/useTraces.ts
+++ b/ui/src/hooks/useTraces.ts
@@ -216,7 +216,8 @@ export function useTraces() {
     state.filters.status ||
     state.filters.jobId ||
     state.filters.environment ||
-    state.filters.traceGroup
+    state.filters.traceGroup ||
+    state.filters.timeRange !== DEFAULT_FILTERS.timeRange
   );
 
   const refresh = useCallback(

--- a/ui/src/hooks/useTraces.ts
+++ b/ui/src/hooks/useTraces.ts
@@ -233,10 +233,16 @@ export function useTraces() {
     }
   }, [mode, fetchTraces, state.filters]);
 
-  // Re-fetch when currentPageToken changes
+  // Only fetch on pagination token changes — filter-driven fetches
+  // are handled imperatively by updateFilters/clearFilters.
+  const prevTokenRef = useRef(state.currentPageToken);
   useEffect(() => {
-    fetchTraces(state.filters);
-  }, [state.currentPageToken, fetchTraces, state.filters]);
+    if (prevTokenRef.current !== state.currentPageToken) {
+      prevTokenRef.current = state.currentPageToken;
+      fetchTraces(state.filters);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.currentPageToken]);
 
   const fetchNextPage = useCallback(() => {
     if (!state.nextPageToken) return;
@@ -253,7 +259,10 @@ export function useTraces() {
   // before React runs the previous effect's cleanup, so that cleanup
   // would abort the *new* request instead of the old one.
   useEffect(() => {
-    return () => fetchRef.current?.abort();
+    return () => {
+      fetchRef.current?.abort();
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
   }, []);
 
   return {

--- a/ui/src/types/search.ts
+++ b/ui/src/types/search.ts
@@ -1,0 +1,33 @@
+import { SpanKind } from "@/gen/candela/types/trace_pb";
+
+export interface SpanResultRow {
+  spanId: string;
+  traceId: string;
+  name: string;
+  kind: SpanKind;
+  model: string;
+  provider: string;
+  durationMs: number;
+  totalTokens: number;
+  costUsd: number;
+  status: number;
+  startTime: string;
+}
+
+export interface SpanSearchFilters {
+  nameContains: string;
+  kind: SpanKind | null;
+  model: string;
+  jobId: string;
+  traceGroup: string;
+  timeRange: "1h" | "24h" | "7d" | "30d";
+}
+
+export const DEFAULT_SEARCH_FILTERS: SpanSearchFilters = {
+  nameContains: "",
+  kind: null,
+  model: "",
+  jobId: "",
+  traceGroup: "",
+  timeRange: "24h",
+};

--- a/ui/src/types/traces.ts
+++ b/ui/src/types/traces.ts
@@ -26,6 +26,9 @@ export interface TraceFilters {
   descending: boolean;
   tenantId: string;
   jobId: string;
+  timeRange: "1h" | "24h" | "7d" | "30d";
+  environment: string;
+  traceGroup: string;
 }
 
 export const DEFAULT_FILTERS: TraceFilters = {
@@ -37,4 +40,7 @@ export const DEFAULT_FILTERS: TraceFilters = {
   descending: true,
   tenantId: "",
   jobId: "",
+  timeRange: "24h",
+  environment: "",
+  traceGroup: "",
 };


### PR DESCRIPTION
## What

Adds span-level search and enhanced filtering to the web dashboard.

### New: `/search` page
- Uses the existing `SearchSpans` RPC (built in #751, tested in #753, paginated in #755) — **first UI to call it**
- Filter by span kind (LLM/Agent/Tool/Retrieval/Embedding/Chain), model, job ID, trace group
- Color-coded SpanKind badges
- Cursor-based pagination
- Scope-aware (personal vs global)

### Enhanced: `/traces` page
- Time range selector (1h / 24h / 7d / 30d) — was missing, already exists on /models and /costs
- Environment filter
- Trace group filter

### Navigation
- Added Search to sidebar under Observe section

## Files changed
- `ui/src/app/search/page.tsx` [NEW] — search page
- `ui/src/hooks/useSpanSearch.ts` [NEW] — SearchSpans hook
- `ui/src/types/search.ts` [NEW] — span search types
- `ui/src/app/traces/page.tsx` — time range + new filters
- `ui/src/hooks/useTraces.ts` — wire timeRange/environment/traceGroup to RPC
- `ui/src/types/traces.ts` — extended TraceFilters
- `ui/src/components/sidebar.tsx` — nav item
- `ui/src/app/globals.css` — search page styles

## Verification
- `tsc --noEmit` passes with zero errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a span search page with filters for time range, scope, kind, model, job, trace group, and name.
  * Search results include metadata, status, token usage, cost, latency, timestamps, pagination, empty and error states, and trace navigation.
  * Added Search navigation under Observe.
  * Added time-range, environment, and trace-group filters to the traces view.
* **Style**
  * Added responsive search controls, filter styling, badges, focus states, and keyboard shortcut guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->