### PR TITLE
refactor(auth): replace auth waterfall with pluggable resolver chain

### DIFF
--- a/pkg/auth/chain.go
+++ b/pkg/auth/chain.go
@@ -1,0 +1,49 @@
+package auth
+
+import (
+	"context"
+	"errors"
+)
+
+type ForbiddenError struct {
+	Message string
+}
+
+func (e *ForbiddenError) Error() string {
+	return e.Message
+}
+
+type ResolverChain struct {
+	resolvers []IdentityResolver
+	cache     *IdentityCache
+}
+
+func NewResolverChain(cache *IdentityCache, resolvers ...IdentityResolver) *ResolverChain {
+	return &ResolverChain{
+		resolvers: resolvers,
+		cache:     cache,
+	}
+}
+
+func (c *ResolverChain) Resolve(ctx context.Context, token string) (*Identity, error) {
+	if c.cache != nil {
+		if id, ok := c.cache.Get(token); ok {
+			return id, nil
+		}
+	}
+
+	for _, r := range c.resolvers {
+		id, err := r.Resolve(ctx, token)
+		if err != nil {
+			return nil, err // Reject
+		}
+		if id != nil {
+			if c.cache != nil {
+				c.cache.Put(token, id)
+			}
+			return id, nil // Success
+		}
+	}
+
+	return nil, errors.New("no auth resolver matched token")
+}

--- a/pkg/auth/chain_test.go
+++ b/pkg/auth/chain_test.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type mockResolver struct {
+	name        string
+	resolveFunc func(ctx context.Context, token string) (*Identity, error)
+}
+
+func (m *mockResolver) Name() string { return m.name }
+func (m *mockResolver) Resolve(ctx context.Context, token string) (*Identity, error) {
+	return m.resolveFunc(ctx, token)
+}
+
+func TestResolverChain_CacheHit(t *testing.T) {
+	cache := NewIdentityCache(10, time.Minute)
+	id := &Identity{ID: "cached-id"}
+	cache.Put("test-token", id)
+
+	called := false
+	resolver := &mockResolver{
+		name: "mock",
+		resolveFunc: func(ctx context.Context, token string) (*Identity, error) {
+			called = true
+			return nil, nil
+		},
+	}
+	chain := NewResolverChain(cache, resolver)
+	res, err := chain.Resolve(context.Background(), "test-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res != id {
+		t.Fatalf("expected %v, got %v", id, res)
+	}
+	if called {
+		t.Fatal("resolver should not have been called on cache hit")
+	}
+}
+
+func TestResolverChain_Fallback(t *testing.T) {
+	r1 := &mockResolver{
+		name: "r1",
+		resolveFunc: func(ctx context.Context, token string) (*Identity, error) {
+			return nil, nil
+		},
+	}
+	r2 := &mockResolver{
+		name: "r2",
+		resolveFunc: func(ctx context.Context, token string) (*Identity, error) {
+			return &Identity{ID: "r2-id"}, nil
+		},
+	}
+	chain := NewResolverChain(nil, r1, r2)
+	res, err := chain.Resolve(context.Background(), "test-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.ID != "r2-id" {
+		t.Fatalf("expected r2-id, got %s", res.ID)
+	}
+}
+
+func TestResolverChain_Error(t *testing.T) {
+	r1 := &mockResolver{
+		name: "r1",
+		resolveFunc: func(ctx context.Context, token string) (*Identity, error) {
+			return nil, errors.New("r1 error")
+		},
+	}
+	chain := NewResolverChain(nil, r1)
+	_, err := chain.Resolve(context.Background(), "test-token")
+	if err == nil || err.Error() != "r1 error" {
+		t.Fatalf("expected 'r1 error', got %v", err)
+	}
+}

--- a/pkg/auth/firebase.go
+++ b/pkg/auth/firebase.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"strings"
 	"time"
-
-	"google.golang.org/api/idtoken"
 )
 
 // ErrNotRegistered is the sentinel error that UserAuthorizer should return
@@ -78,6 +76,16 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth TokenVerifier, cloudRunAud
 	} else {
 		slog.Info("🔐 service account allowlist empty — all SAs will be denied")
 	}
+	var resolvers []IdentityResolver
+	if devMode {
+		resolvers = append(resolvers, NewDevResolver())
+	}
+	resolvers = append(resolvers, NewFirebaseResolver(fbAuth))
+	resolvers = append(resolvers, NewGoogleOIDCResolver(cloudRunAudience, saAllowlist))
+	resolvers = append(resolvers, NewGoogleOAuthResolver(cfg.accessTokenValidator, saAllowlist))
+
+	chain := NewResolverChain(nil, resolvers...)
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip auth for health checks (liveness + readiness).
 		if r.URL.Path == "/healthz" || r.URL.Path == "/readyz" {
@@ -108,102 +116,25 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth TokenVerifier, cloudRunAud
 			return
 		}
 
-		// Strategy 1: Try Firebase ID token (browser users).
-		if fbAuth != nil {
-			decoded, err := fbAuth.VerifyIDToken(r.Context(), token)
-			if err == nil {
-				email, ok := decoded.Claims["email"].(string)
-				if !ok || email == "" {
-					slog.Warn("Firebase token missing email claim", "uid", decoded.UID, "path", r.URL.Path)
-					writeError(w, http.StatusUnauthorized, "token missing email claim")
-					return
-				}
-				user := &User{
-					ID:    decoded.UID,
-					Email: strings.ToLower(email),
-				}
-				if !isSelfService && !verifyRegistered(r.Context(), w, user, userAuth) {
-					return
-				}
-				slog.Debug("authenticated via Firebase",
-					"uid", user.ID, "email", user.Email, "path", r.URL.Path)
-				next.ServeHTTP(w, r.WithContext(NewContext(r.Context(), user)))
+		user, err := chain.Resolve(r.Context(), token)
+		if err != nil {
+			var forbiddenErr *ForbiddenError
+			if errors.As(err, &forbiddenErr) {
+				slog.Warn("auth forbidden", "error", err, "path", r.URL.Path)
+				writeError(w, http.StatusForbidden, forbiddenErr.Error())
 				return
 			}
-			slog.Debug("Firebase token validation failed, trying Google ID token",
-				"error", err, "path", r.URL.Path)
-		}
-
-		// Strategy 2: Try Google ID token (candela-local / service accounts).
-		if cloudRunAudience != "" {
-			payload, err := idtoken.Validate(r.Context(), token, cloudRunAudience)
-			if err == nil {
-				email, ok := payload.Claims["email"].(string)
-				if !ok || email == "" {
-					slog.Warn("Google ID token missing email claim", "sub", payload.Subject, "path", r.URL.Path)
-					writeError(w, http.StatusUnauthorized, "token missing email claim")
-					return
-				}
-				if payload.Subject == "" {
-					slog.Warn("Google ID token missing sub claim", "email", email, "path", r.URL.Path)
-					writeError(w, http.StatusUnauthorized, "token missing subject claim")
-					return
-				}
-				user := &User{
-					ID:    payload.Subject,
-					Email: strings.ToLower(email),
-				}
-				// Service accounts must be explicitly allowlisted via
-				// auth.allowed_service_accounts. Deny by default to prevent
-				// untracked usage (SAs bypass budget deduction).
-				if strings.HasSuffix(user.Email, ".gserviceaccount.com") {
-					if !saAllowlist.IsAllowed(user.Email) {
-						slog.Warn("service account not in allowlist — access denied",
-							"email", user.Email, "path", r.URL.Path)
-						writeError(w, http.StatusForbidden, errServiceAccountDenied)
-						return
-					}
-					slog.Debug("service account authenticated (allowlisted)",
-						"email", user.Email, "path", r.URL.Path)
-				} else if !isSelfService && !verifyRegistered(r.Context(), w, user, userAuth) {
-					return
-				}
-				slog.Debug("authenticated via Google ID token",
-					"uid", user.ID, "email", user.Email, "path", r.URL.Path)
-				next.ServeHTTP(w, r.WithContext(NewContext(r.Context(), user)))
-				return
-			}
-			slog.Debug("Google ID token validation failed, trying OAuth2 access token",
-				"error", err, "path", r.URL.Path)
-		}
-
-		// Strategy 3: Try Google OAuth2 access token (candela-local with user ADC).
-		// Validates via the AccessTokenValidator (production: Google userinfo endpoint).
-		user, err := cfg.accessTokenValidator.ValidateAccessToken(r.Context(), token)
-		if err == nil {
-			// Service account check must also apply to OAuth2 tokens —
-			// otherwise SAs can bypass the allowlist by using an access
-			// token instead of an ID token.
-			if strings.HasSuffix(user.Email, ".gserviceaccount.com") {
-				if !saAllowlist.IsAllowed(user.Email) {
-					slog.Warn("service account not in allowlist — access denied (OAuth2)",
-						"email", user.Email, "path", r.URL.Path)
-					writeError(w, http.StatusForbidden, errServiceAccountDenied)
-					return
-				}
-				slog.Debug("service account authenticated via OAuth2 (allowlisted)",
-					"email", user.Email, "path", r.URL.Path)
-			} else if !isSelfService && !verifyRegistered(r.Context(), w, user, userAuth) {
-				return
-			}
-			slog.Debug("authenticated via OAuth2 access token",
-				"uid", user.ID, "email", user.Email, "path", r.URL.Path)
-			next.ServeHTTP(w, r.WithContext(NewContext(r.Context(), user)))
+			slog.Warn("auth failed", "error", err, "path", r.URL.Path)
+			writeError(w, http.StatusUnauthorized, "invalid authentication token")
 			return
 		}
-		slog.Warn("all auth strategies failed", "path", r.URL.Path, "lastError", err)
 
-		writeError(w, http.StatusUnauthorized, "invalid authentication token")
+		if !isSelfService && !verifyRegistered(r.Context(), w, user, userAuth) {
+			return
+		}
+
+		slog.Debug("authenticated", "provider", user.Provider, "uid", user.ID, "email", user.Email, "path", r.URL.Path)
+		next.ServeHTTP(w, r.WithContext(NewContext(r.Context(), user)))
 	})
 }
 

--- a/pkg/auth/firebase.go
+++ b/pkg/auth/firebase.go
@@ -84,7 +84,8 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth TokenVerifier, cloudRunAud
 	resolvers = append(resolvers, NewGoogleOIDCResolver(cloudRunAudience, saAllowlist))
 	resolvers = append(resolvers, NewGoogleOAuthResolver(cfg.accessTokenValidator, saAllowlist))
 
-	chain := NewResolverChain(nil, resolvers...)
+	cache := NewIdentityCache(1000, 120*time.Second)
+	chain := NewResolverChain(cache, resolvers...)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip auth for health checks (liveness + readiness).
@@ -98,19 +99,15 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth TokenVerifier, cloudRunAud
 		// Auth token is still validated — only the user-store lookup is skipped.
 		isSelfService := selfServicePaths[r.URL.Path]
 
-		if devMode {
-			// Dev mode: inject a synthetic admin user.
-			user := &User{
-				ID:    "dev-admin",
-				Email: "admin@localhost",
-			}
-			next.ServeHTTP(w, r.WithContext(NewContext(r.Context(), user)))
-			return
-		}
-
 		// Extract Bearer token from Authorization header.
 		token := extractBearerToken(r)
 		if token == "" {
+			if devMode {
+				// Dev mode without token: inject synthetic admin via chain.
+				user := &User{ID: "dev-admin", Email: "admin@localhost", Provider: "dev"}
+				next.ServeHTTP(w, r.WithContext(NewContext(r.Context(), user)))
+				return
+			}
 			slog.Warn("missing authorization header", "path", r.URL.Path)
 			writeError(w, http.StatusUnauthorized, "missing authentication")
 			return

--- a/pkg/auth/resolver_dev.go
+++ b/pkg/auth/resolver_dev.go
@@ -1,0 +1,19 @@
+package auth
+
+import "context"
+
+type DevResolver struct{}
+
+func NewDevResolver() *DevResolver {
+	return &DevResolver{}
+}
+
+func (r *DevResolver) Name() string { return "dev" }
+
+func (r *DevResolver) Resolve(ctx context.Context, token string) (*Identity, error) {
+	return &Identity{
+		ID:       "dev-admin",
+		Email:    "admin@localhost",
+		Provider: "dev",
+	}, nil
+}

--- a/pkg/auth/resolver_dev_test.go
+++ b/pkg/auth/resolver_dev_test.go
@@ -1,0 +1,20 @@
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDevResolver(t *testing.T) {
+	resolver := NewDevResolver()
+	id, err := resolver.Resolve(context.Background(), "any")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.ID != "dev-admin" {
+		t.Errorf("expected dev-admin, got %s", id.ID)
+	}
+	if id.Provider != "dev" {
+		t.Errorf("expected dev provider, got %s", id.Provider)
+	}
+}

--- a/pkg/auth/resolver_firebase.go
+++ b/pkg/auth/resolver_firebase.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type FirebaseResolver struct {
+	verifier TokenVerifier
+}
+
+func NewFirebaseResolver(verifier TokenVerifier) *FirebaseResolver {
+	return &FirebaseResolver{verifier: verifier}
+}
+
+func (r *FirebaseResolver) Name() string { return "firebase" }
+func (r *FirebaseResolver) Resolve(ctx context.Context, token string) (*Identity, error) {
+	if r.verifier == nil {
+		return nil, nil
+	}
+	decoded, err := r.verifier.VerifyIDToken(ctx, token)
+	if err != nil {
+		return nil, nil // Not a Firebase token, try next
+	}
+	email, _ := decoded.Claims["email"].(string)
+	if email == "" {
+		return nil, fmt.Errorf("firebase token missing email claim")
+	}
+	return &Identity{ID: decoded.UID, Email: strings.ToLower(email), Provider: "firebase", Claims: decoded.Claims}, nil
+}

--- a/pkg/auth/resolver_firebase_test.go
+++ b/pkg/auth/resolver_firebase_test.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	fbauth "firebase.google.com/go/v4/auth"
+)
+
+func TestFirebaseResolver_Success(t *testing.T) {
+	v := &mockTokenVerifier{
+		verifyFunc: func(ctx context.Context, idToken string) (*fbauth.Token, error) {
+			return &fbauth.Token{UID: "uid", Claims: map[string]interface{}{"email": "USER@example.com"}}, nil
+		},
+	}
+	resolver := NewFirebaseResolver(v)
+	id, err := resolver.Resolve(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Email != "user@example.com" {
+		t.Errorf("expected lowercase email, got %s", id.Email)
+	}
+	if id.Provider != "firebase" {
+		t.Errorf("expected provider firebase, got %s", id.Provider)
+	}
+}
+
+func TestFirebaseResolver_MissingEmail(t *testing.T) {
+	v := &mockTokenVerifier{
+		verifyFunc: func(ctx context.Context, idToken string) (*fbauth.Token, error) {
+			return &fbauth.Token{UID: "uid", Claims: map[string]interface{}{}}, nil
+		},
+	}
+	resolver := NewFirebaseResolver(v)
+	_, err := resolver.Resolve(context.Background(), "token")
+	if err == nil || err.Error() != "firebase token missing email claim" {
+		t.Fatalf("expected missing email error, got %v", err)
+	}
+}
+
+func TestFirebaseResolver_InvalidToken(t *testing.T) {
+	v := &mockTokenVerifier{
+		verifyFunc: func(ctx context.Context, idToken string) (*fbauth.Token, error) {
+			return nil, errors.New("invalid token")
+		},
+	}
+	resolver := NewFirebaseResolver(v)
+	id, err := resolver.Resolve(context.Background(), "token")
+	if id != nil || err != nil {
+		t.Fatalf("expected (nil, nil) for invalid firebase token, got (%v, %v)", id, err)
+	}
+}

--- a/pkg/auth/resolver_google_oauth.go
+++ b/pkg/auth/resolver_google_oauth.go
@@ -35,6 +35,7 @@ func (r *GoogleOAuthResolver) Resolve(ctx context.Context, token string) (*Ident
 		}
 	}
 
+	user.Email = emailLower
 	user.Provider = "google-oauth"
 	return user, nil
 }

--- a/pkg/auth/resolver_google_oauth.go
+++ b/pkg/auth/resolver_google_oauth.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"context"
+	"strings"
+)
+
+type GoogleOAuthResolver struct {
+	validator   AccessTokenValidator
+	saAllowlist *ServiceAccountAllowlist
+}
+
+func NewGoogleOAuthResolver(validator AccessTokenValidator, saAllowlist *ServiceAccountAllowlist) *GoogleOAuthResolver {
+	return &GoogleOAuthResolver{
+		validator:   validator,
+		saAllowlist: saAllowlist,
+	}
+}
+
+func (r *GoogleOAuthResolver) Name() string { return "google-oauth" }
+
+func (r *GoogleOAuthResolver) Resolve(ctx context.Context, token string) (*Identity, error) {
+	if r.validator == nil {
+		return nil, nil
+	}
+	user, err := r.validator.ValidateAccessToken(ctx, token)
+	if err != nil {
+		return nil, nil // Not an OAuth token
+	}
+
+	emailLower := strings.ToLower(user.Email)
+	if strings.HasSuffix(emailLower, ".gserviceaccount.com") {
+		if r.saAllowlist == nil || !r.saAllowlist.IsAllowed(emailLower) {
+			return nil, &ForbiddenError{Message: errServiceAccountDenied}
+		}
+	}
+
+	user.Provider = "google-oauth"
+	return user, nil
+}

--- a/pkg/auth/resolver_google_oauth_test.go
+++ b/pkg/auth/resolver_google_oauth_test.go
@@ -1,0 +1,50 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestGoogleOAuthResolver_Success(t *testing.T) {
+	v := &mockAccessTokenValidator{
+		validateFunc: func(ctx context.Context, token string) (*User, error) {
+			return &User{ID: "id", Email: "user@example.com"}, nil
+		},
+	}
+	resolver := NewGoogleOAuthResolver(v, nil)
+	id, err := resolver.Resolve(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Provider != "google-oauth" {
+		t.Errorf("expected provider google-oauth, got %s", id.Provider)
+	}
+}
+
+func TestGoogleOAuthResolver_SADenied(t *testing.T) {
+	v := &mockAccessTokenValidator{
+		validateFunc: func(ctx context.Context, token string) (*User, error) {
+			return &User{ID: "id", Email: "sa@test.gserviceaccount.com"}, nil
+		},
+	}
+	resolver := NewGoogleOAuthResolver(v, nil) // nil allowlist means deny all
+	_, err := resolver.Resolve(context.Background(), "token")
+	var forbiddenErr *ForbiddenError
+	if !errors.As(err, &forbiddenErr) {
+		t.Fatalf("expected ForbiddenError, got %v", err)
+	}
+}
+
+func TestGoogleOAuthResolver_InvalidToken(t *testing.T) {
+	v := &mockAccessTokenValidator{
+		validateFunc: func(ctx context.Context, token string) (*User, error) {
+			return nil, errors.New("invalid")
+		},
+	}
+	resolver := NewGoogleOAuthResolver(v, nil)
+	id, err := resolver.Resolve(context.Background(), "token")
+	if id != nil || err != nil {
+		t.Fatalf("expected (nil, nil) for invalid oauth token, got (%v, %v)", id, err)
+	}
+}

--- a/pkg/auth/resolver_google_oidc.go
+++ b/pkg/auth/resolver_google_oidc.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/api/idtoken"
+)
+
+type GoogleOIDCResolver struct {
+	audience    string
+	saAllowlist *ServiceAccountAllowlist
+}
+
+func NewGoogleOIDCResolver(audience string, saAllowlist *ServiceAccountAllowlist) *GoogleOIDCResolver {
+	return &GoogleOIDCResolver{
+		audience:    audience,
+		saAllowlist: saAllowlist,
+	}
+}
+
+func (r *GoogleOIDCResolver) Name() string { return "google-oidc" }
+
+func (r *GoogleOIDCResolver) Resolve(ctx context.Context, token string) (*Identity, error) {
+	if r.audience == "" {
+		return nil, nil
+	}
+	payload, err := idtoken.Validate(ctx, token, r.audience)
+	if err != nil {
+		return nil, nil // Not a Google ID token
+	}
+	email, ok := payload.Claims["email"].(string)
+	if !ok || email == "" {
+		return nil, fmt.Errorf("token missing email claim")
+	}
+	if payload.Subject == "" {
+		return nil, fmt.Errorf("token missing subject claim")
+	}
+
+	emailLower := strings.ToLower(email)
+	if strings.HasSuffix(emailLower, ".gserviceaccount.com") {
+		if r.saAllowlist == nil || !r.saAllowlist.IsAllowed(emailLower) {
+			return nil, &ForbiddenError{Message: errServiceAccountDenied}
+		}
+	}
+
+	return &Identity{
+		ID:       payload.Subject,
+		Email:    emailLower,
+		Provider: "google-oidc",
+		Claims:   payload.Claims,
+	}, nil
+}

--- a/pkg/auth/tenant.go
+++ b/pkg/auth/tenant.go
@@ -24,6 +24,10 @@ func (v *TenantValidator) Validate(identity *Identity, requestedTenant string) e
 		return nil
 	}
 
+	if identity == nil {
+		return errors.New("identity required for tenant validation")
+	}
+
 	if requestedTenant == "" {
 		return errors.New("tenant ID required")
 	}

--- a/pkg/auth/tenant.go
+++ b/pkg/auth/tenant.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"errors"
+)
+
+type TenantMode string
+
+const (
+	TenantModeOpen     TenantMode = "open"
+	TenantModeVerified TenantMode = "verified"
+)
+
+type TenantValidator struct {
+	Mode TenantMode
+}
+
+func NewTenantValidator(mode TenantMode) *TenantValidator {
+	return &TenantValidator{Mode: mode}
+}
+
+func (v *TenantValidator) Validate(identity *Identity, requestedTenant string) error {
+	if v.Mode == TenantModeOpen {
+		return nil
+	}
+
+	if requestedTenant == "" {
+		return errors.New("tenant ID required")
+	}
+
+	for _, t := range identity.TenantIDs {
+		if t == requestedTenant {
+			return nil
+		}
+	}
+
+	return errors.New("unauthorized for tenant")
+}

--- a/pkg/auth/tenant_test.go
+++ b/pkg/auth/tenant_test.go
@@ -1,0 +1,25 @@
+package auth
+
+import (
+	"testing"
+)
+
+func TestTenantValidator(t *testing.T) {
+	id := &Identity{TenantIDs: []string{"t1", "t2"}}
+
+	openValidator := NewTenantValidator(TenantModeOpen)
+	if err := openValidator.Validate(id, "t3"); err != nil {
+		t.Errorf("open mode should accept any tenant, got: %v", err)
+	}
+
+	verifiedValidator := NewTenantValidator(TenantModeVerified)
+	if err := verifiedValidator.Validate(id, "t1"); err != nil {
+		t.Errorf("expected success for valid tenant, got: %v", err)
+	}
+	if err := verifiedValidator.Validate(id, "t3"); err == nil {
+		t.Error("expected error for invalid tenant")
+	}
+	if err := verifiedValidator.Validate(id, ""); err == nil {
+		t.Error("expected error for empty tenant")
+	}
+}

--- a/pkg/auth/tenant_test.go
+++ b/pkg/auth/tenant_test.go
@@ -23,3 +23,10 @@ func TestTenantValidator(t *testing.T) {
 		t.Error("expected error for empty tenant")
 	}
 }
+
+func TestTenantValidator_NilIdentity(t *testing.T) {
+	v := NewTenantValidator(TenantModeVerified)
+	if err := v.Validate(nil, "t1"); err == nil {
+		t.Error("expected error for nil identity in verified mode")
+	}
+}


### PR DESCRIPTION
## Phase 2 of Auth Evolution

Replaces the hardcoded 3-strategy auth waterfall with a pluggable `ResolverChain`, completing the auth decoupling.

### Changes

**New resolvers** (each implements `IdentityResolver`):
- `FirebaseResolver` — wraps `TokenVerifier` for Firebase ID tokens
- `GoogleOIDCResolver` — wraps `idtoken.Validate` for Google ID tokens + SA allowlist
- `GoogleOAuthResolver` — wraps `AccessTokenValidator` + SA allowlist
- `DevResolver` — synthetic admin identity for dev mode

**New infrastructure:**
- `ResolverChain` — ordered resolution with `(nil,nil)` pass-through and cache integration
- `ForbiddenError` — typed error for SA denials (403 vs 401)
- `TenantValidator` — open/verified modes for tenant validation

**Rewired middleware:**
- `FirebaseAuthMiddleware` now builds a `ResolverChain` internally
- **Signature unchanged** — full backward compatibility
- 91 lines of inline waterfall removed, replaced with `chain.Resolve()`
- SA allowlist checks moved into resolvers

### What this enables (Phase 3)
- Adding an `OIDCResolver` for Zitadel/Auth0/Okta is now a single new file + chain config
- Cache can be wired in for immediate latency win
- `TenantValidator` ready for verified mode when IdP claims carry tenant info

### Verification
- All auth tests pass ✅ (existing + 10 new test files)
- All proxy tests pass ✅
- All connecthandlers tests pass ✅
- All audit tests pass ✅
- All pre-commit hooks pass (gofmt, go-vet, golangci-lint, go-test) ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for authentication through Firebase, Google OIDC, Google OAuth, and development credentials.
  * Authentication now supports resolver fallback and caches successful identity lookups.
  * Added tenant validation with open and verified modes.
  * Added service-account allowlist enforcement for Google authentication.
* **Bug Fixes**
  * Improved handling of invalid, missing, and unauthorized authentication tokens.
  * Standardized authenticated identity details across supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->