### PR TITLE
fix(auth): skip direct ID token strategy when iap_service_account is set

### DIFF
--- a/cmd/candela/auth_strategy.go
+++ b/cmd/candela/auth_strategy.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/idtoken"
+)
+
+// authStrategy identifies which authentication strategy was selected.
+type authStrategy int
+
+const (
+	strategyDirectIDToken    authStrategy = iota // Strategy 1: SA credentials → direct OIDC ID token
+	strategyIAPImpersonation                     // Strategy 1.5: IAP impersonation via iap_service_account
+	strategyUserADC                              // Strategy 2: User credentials → OAuth2 access token
+)
+
+func (s authStrategy) String() string {
+	switch s {
+	case strategyDirectIDToken:
+		return "direct-id-token"
+	case strategyIAPImpersonation:
+		return "iap-impersonation"
+	case strategyUserADC:
+		return "user-adc"
+	default:
+		return "unknown"
+	}
+}
+
+// authResult holds the resolved token sources and strategy metadata.
+type authResult struct {
+	// tokenSource provides tokens for Proxy-Authorization (IAP) and
+	// Authorization (server) headers.
+	tokenSource oauth2.TokenSource
+
+	// userTokenSource (optional) provides a separate user identity token
+	// when using dual-token mode (Strategy 1.5). When set, the Director
+	// sends tokenSource → Proxy-Authorization + Authorization, and
+	// userTokenSource → X-Candela-Auth.
+	userTokenSource oauth2.TokenSource
+
+	// strategy records which strategy was selected for diagnostics/testing.
+	strategy authStrategy
+}
+
+// idTokenFactory abstracts idtoken.NewTokenSource for testing.
+// In production, this is idtoken.NewTokenSource.
+type idTokenFactory func(ctx context.Context, audience string, opts ...idtoken.ClientOption) (oauth2.TokenSource, error)
+
+// defaultTokenFactory abstracts google.DefaultTokenSource for testing.
+type defaultTokenFactory func(ctx context.Context, scope ...string) (oauth2.TokenSource, error)
+
+// resolveAuthStrategy selects the authentication strategy based on the
+// available credentials and configuration.
+//
+// When iap_service_account is configured, Strategy 1 (direct ID token) is
+// skipped entirely. This prevents WIF external_account credentials from
+// calling generateIdToken on the caller's own SA — which fails when the
+// SA only has getOpenIdToken on the target IAP SA, not on itself.
+func resolveAuthStrategy(
+	ctx context.Context,
+	cfg *Config,
+	newIDToken idTokenFactory,
+	newDefaultToken defaultTokenFactory,
+) (*authResult, error) {
+
+	// When iap_service_account is configured, skip the direct ID token
+	// strategy. idtoken.NewTokenSource succeeds for WIF external_account
+	// credentials but then calls generateIdToken on the caller's own SA,
+	// which fails if that SA only has getOpenIdToken on the *target* IAP SA
+	// (the typical CI setup). Jump straight to IAP impersonation instead.
+	var ts oauth2.TokenSource
+	var err error
+	if cfg.IAPServiceAccount == "" {
+		ts, err = newIDToken(ctx, cfg.Audience)
+	} else {
+		err = fmt.Errorf("iap_service_account is set, using IAP impersonation")
+	}
+
+	if err == nil {
+		// Strategy 1: Service account credentials → audience-scoped OIDC ID token.
+		result := &authResult{
+			tokenSource: ts,
+			strategy:    strategyDirectIDToken,
+		}
+		slog.Info("resolved auth strategy", "strategy", result.strategy)
+		return result, nil
+	}
+
+	if cfg.IAPServiceAccount != "" {
+		// Strategy 1.5: IAP impersonation → dual token.
+		slog.Debug("using IAP impersonation", "reason", err)
+		baseTSr, err2 := newDefaultToken(ctx, "https://www.googleapis.com/auth/cloud-platform")
+		if err2 != nil {
+			return nil, fmt.Errorf("failed to get credentials: %w", err2)
+		}
+
+		result := &authResult{
+			tokenSource: oauth2.ReuseTokenSource(nil, &iapImpersonatingTokenSource{
+				base:           baseTSr,
+				serviceAccount: cfg.IAPServiceAccount,
+				audience:       cfg.Audience,
+			}),
+			strategy: strategyIAPImpersonation,
+		}
+
+		// Keep the user's ADC token source for server-side identity validation.
+		userTSr, err3 := newDefaultToken(ctx, "openid", "email")
+		if err3 != nil {
+			slog.Warn("failed to get user ADC token source — server auth may fail", "error", err3)
+		} else {
+			result.userTokenSource = userTSr
+		}
+
+		slog.Info("resolved auth strategy", "strategy", result.strategy)
+		return result, nil
+	}
+
+	// Strategy 2: User credentials → OAuth2 access token.
+	slog.Debug("idtoken.NewTokenSource unavailable (user credentials fallback)", "reason", err)
+	ts2, err2 := newDefaultToken(ctx, "openid", "email")
+	if err2 != nil {
+		return nil, fmt.Errorf("failed to get credentials: %w", err2)
+	}
+
+	result := &authResult{
+		tokenSource: ts2,
+		strategy:    strategyUserADC,
+	}
+	slog.Info("resolved auth strategy", "strategy", result.strategy)
+	return result, nil
+}

--- a/cmd/candela/auth_strategy_test.go
+++ b/cmd/candela/auth_strategy_test.go
@@ -1,0 +1,377 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/idtoken"
+)
+
+// ── Test helpers ──
+
+// fakeIDTokenFactory returns a factory that either succeeds (returning a static
+// token source) or fails with a given error. It records whether it was called.
+func fakeIDTokenFactory(succeed bool) (idTokenFactory, *bool) {
+	called := new(bool)
+	return func(_ context.Context, audience string, _ ...idtoken.ClientOption) (oauth2.TokenSource, error) {
+		*called = true
+		if succeed {
+			return &staticTokenSource{accessToken: "direct-id-token-for-" + audience}, nil
+		}
+		return nil, fmt.Errorf("no service account credentials available")
+	}, called
+}
+
+type fakeTokenFactoryContext struct {
+	factory defaultTokenFactory
+	calls   [][]string
+}
+
+// fakeDefaultTokenFactory returns a factory that always succeeds.
+func fakeDefaultTokenFactory() *fakeTokenFactoryContext {
+	ctx := &fakeTokenFactoryContext{}
+	ctx.factory = func(_ context.Context, scope ...string) (oauth2.TokenSource, error) {
+		ctx.calls = append(ctx.calls, scope)
+		return &staticTokenSource{accessToken: "default-token"}, nil
+	}
+	return ctx
+}
+
+// failingDefaultTokenFactory returns a factory that always errors.
+func failingDefaultTokenFactory() defaultTokenFactory {
+	return func(_ context.Context, scope ...string) (oauth2.TokenSource, error) {
+		return nil, fmt.Errorf("no credentials available")
+	}
+}
+
+// ── Strategy selection tests ──
+
+func TestResolveAuthStrategy_DirectIDToken_WhenNoIAPServiceAccount(t *testing.T) {
+	// When iap_service_account is empty and idtoken succeeds → Strategy 1.
+	factory, called := fakeIDTokenFactory(true)
+	cfg := Config{
+		Audience: "test-audience",
+		// IAPServiceAccount is empty
+	}
+
+	result, err := resolveAuthStrategy(context.Background(), &cfg, factory, fakeDefaultTokenFactory().factory)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*called {
+		t.Error("idtoken.NewTokenSource was NOT called — expected it to be called when IAPServiceAccount is empty")
+	}
+	if result.strategy != strategyDirectIDToken {
+		t.Errorf("strategy = %d, want strategyDirectIDToken (%d)", result.strategy, strategyDirectIDToken)
+	}
+	if result.userTokenSource != nil {
+		t.Error("userTokenSource should be nil for Strategy 1")
+	}
+
+	// Verify the token source returns the expected token.
+	tok, err := result.tokenSource.Token()
+	if err != nil {
+		t.Fatalf("Token() error: %v", err)
+	}
+	if tok.AccessToken != "direct-id-token-for-test-audience" {
+		t.Errorf("AccessToken = %q, want %q", tok.AccessToken, "direct-id-token-for-test-audience")
+	}
+}
+
+func TestResolveAuthStrategy_IAPImpersonation_WhenIAPServiceAccountSet(t *testing.T) {
+	// When iap_service_account is set → Strategy 1.5 (skip idtoken entirely).
+	factory, called := fakeIDTokenFactory(true) // would succeed, but shouldn't be called
+	cfg := Config{
+		Audience:          "test-audience",
+		IAPServiceAccount: "candela-server@project.iam.gserviceaccount.com",
+	}
+
+	fdtf := fakeDefaultTokenFactory()
+	result, err := resolveAuthStrategy(context.Background(), &cfg, factory, fdtf.factory)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *called {
+		t.Error("idtoken.NewTokenSource WAS called — expected it to be SKIPPED when IAPServiceAccount is set")
+	}
+	if result.strategy != strategyIAPImpersonation {
+		t.Errorf("strategy = %d, want strategyIAPImpersonation (%d)", result.strategy, strategyIAPImpersonation)
+	}
+	if result.userTokenSource == nil {
+		t.Error("userTokenSource should be set for Strategy 1.5 (dual-token mode)")
+	}
+
+	if len(fdtf.calls) != 2 {
+		t.Fatalf("expected 2 calls to default token factory, got %d", len(fdtf.calls))
+	}
+	if len(fdtf.calls[0]) != 1 || fdtf.calls[0][0] != "https://www.googleapis.com/auth/cloud-platform" {
+		t.Errorf("expected first call to have cloud-platform scope, got %v", fdtf.calls[0])
+	}
+	if len(fdtf.calls[1]) != 2 || fdtf.calls[1][0] != "openid" || fdtf.calls[1][1] != "email" {
+		t.Errorf("expected second call to have openid and email scopes, got %v", fdtf.calls[1])
+	}
+}
+
+func TestResolveAuthStrategy_UserADC_WhenIDTokenFailsAndNoIAPSA(t *testing.T) {
+	// When idtoken fails and iap_service_account is empty → Strategy 2.
+	factory, called := fakeIDTokenFactory(false) // fails
+	cfg := Config{
+		Audience: "test-audience",
+		// IAPServiceAccount is empty
+	}
+
+	result, err := resolveAuthStrategy(context.Background(), &cfg, factory, fakeDefaultTokenFactory().factory)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*called {
+		t.Error("idtoken.NewTokenSource was NOT called")
+	}
+	if result.strategy != strategyUserADC {
+		t.Errorf("strategy = %d, want strategyUserADC (%d)", result.strategy, strategyUserADC)
+	}
+	if result.userTokenSource != nil {
+		t.Error("userTokenSource should be nil for Strategy 2")
+	}
+}
+
+func TestResolveAuthStrategy_IAPImpersonation_FailsWhenNoDefaultCreds(t *testing.T) {
+	// When iap_service_account is set but no default credentials → error.
+	factory, _ := fakeIDTokenFactory(true)
+	cfg := Config{
+		Audience:          "test-audience",
+		IAPServiceAccount: "candela-server@project.iam.gserviceaccount.com",
+	}
+
+	_, err := resolveAuthStrategy(context.Background(), &cfg, factory, failingDefaultTokenFactory())
+	if err == nil {
+		t.Fatal("expected error when default credentials are unavailable")
+	}
+}
+
+func TestResolveAuthStrategy_UserADC_FailsWhenNoDefaultCreds(t *testing.T) {
+	// When idtoken fails, no iap_service_account, AND no default creds → error.
+	factory, _ := fakeIDTokenFactory(false)
+	cfg := Config{
+		Audience: "test-audience",
+	}
+
+	_, err := resolveAuthStrategy(context.Background(), &cfg, factory, failingDefaultTokenFactory())
+	if err == nil {
+		t.Fatal("expected error when default credentials are unavailable")
+	}
+}
+
+// ── iapImpersonatingTokenSource tests ──
+
+func TestIAPImpersonatingTokenSource_Success(t *testing.T) {
+	// Mock the IAM generateIdToken endpoint.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request.
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer base-access-token" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer base-access-token")
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", r.Header.Get("Content-Type"))
+		}
+
+		// Decode and verify the request body.
+		var req struct {
+			Audience     string `json:"audience"`
+			IncludeEmail bool   `json:"includeEmail"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		if req.Audience != "iap-client-id" {
+			t.Errorf("audience = %q, want %q", req.Audience, "iap-client-id")
+		}
+		if !req.IncludeEmail {
+			t.Error("includeEmail should be true")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"token": "generated-iap-id-token",
+		})
+	}))
+	defer server.Close()
+
+	ts := &iapImpersonatingTokenSource{
+		base:           &staticTokenSource{accessToken: "base-access-token"},
+		serviceAccount: "candela-server@project.iam.gserviceaccount.com",
+		audience:       "iap-client-id",
+		// Override the endpoint for testing.
+		endpointURL: server.URL,
+	}
+
+	tok, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token() error: %v", err)
+	}
+	if tok.AccessToken != "generated-iap-id-token" {
+		t.Errorf("AccessToken = %q, want %q", tok.AccessToken, "generated-iap-id-token")
+	}
+	if tok.TokenType != "Bearer" {
+		t.Errorf("TokenType = %q, want %q", tok.TokenType, "Bearer")
+	}
+	if time.Until(tok.Expiry) < 3400*time.Second {
+		t.Errorf("Expiry too soon: %v", tok.Expiry)
+	}
+}
+
+func TestIAPImpersonatingTokenSource_403Permission(t *testing.T) {
+	// Simulate the exact 403 that WIF SAs get.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": map[string]interface{}{
+				"code":    403,
+				"message": "Permission 'iam.serviceAccounts.getOpenIdToken' denied on resource",
+				"status":  "PERMISSION_DENIED",
+			},
+		})
+	}))
+	defer server.Close()
+
+	ts := &iapImpersonatingTokenSource{
+		base:           &staticTokenSource{accessToken: "base-access-token"},
+		serviceAccount: "candela-server@project.iam.gserviceaccount.com",
+		audience:       "iap-client-id",
+		endpointURL:    server.URL,
+	}
+
+	_, err := ts.Token()
+	if err == nil {
+		t.Fatal("expected error on 403 response")
+	}
+	// Should mention the service account for debugging.
+	if got := err.Error(); !strings.Contains(got, "candela-server@project.iam.gserviceaccount.com") {
+		t.Errorf("error should mention the service account, got: %s", got)
+	}
+}
+
+func TestIAPImpersonatingTokenSource_BaseTokenError(t *testing.T) {
+	ts := &iapImpersonatingTokenSource{
+		base:           &failingTokenSource{err: fmt.Errorf("WIF token exchange failed")},
+		serviceAccount: "candela-server@project.iam.gserviceaccount.com",
+		audience:       "iap-client-id",
+	}
+
+	_, err := ts.Token()
+	if err == nil {
+		t.Fatal("expected error when base token source fails")
+	}
+	if got := err.Error(); !strings.Contains(got, "base credentials") {
+		t.Errorf("error should mention base credentials, got: %s", got)
+	}
+}
+
+// ── Additional helpers ──
+
+type failingTokenSource struct {
+	err error
+}
+
+func (f *failingTokenSource) Token() (*oauth2.Token, error) {
+	return nil, f.err
+}
+
+func TestDirector_Headers(t *testing.T) {
+	t.Run("dual-token mode", func(t *testing.T) {
+		var reqHeaders http.Header
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reqHeaders = r.Header
+		}))
+		defer srv.Close()
+
+		tokenSource := &staticTokenSource{accessToken: "iap-token"}
+		userTokenSource := &staticTokenSource{accessToken: "user-token"}
+
+		req, err := http.NewRequest("GET", srv.URL, nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+
+		// Setup Director similarly to main.go lines 770-804
+		director := func(r *http.Request) {
+			tok, _ := tokenSource.Token()
+			r.Header.Set("Proxy-Authorization", "Bearer "+tok.AccessToken)
+			r.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+
+			userTok, _ := userTokenSource.Token()
+			r.Header.Set("X-Candela-Auth", "Bearer "+userTok.AccessToken)
+		}
+
+		director(req)
+
+		// Simulate the reverse proxy sending the request
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("failed to send request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if got := reqHeaders.Get("Proxy-Authorization"); got != "Bearer iap-token" {
+			t.Errorf("Proxy-Authorization = %q, want Bearer iap-token", got)
+		}
+		if got := reqHeaders.Get("Authorization"); got != "Bearer iap-token" {
+			t.Errorf("Authorization = %q, want Bearer iap-token", got)
+		}
+		if got := reqHeaders.Get("X-Candela-Auth"); got != "Bearer user-token" {
+			t.Errorf("X-Candela-Auth = %q, want Bearer user-token", got)
+		}
+	})
+
+	t.Run("single-token mode", func(t *testing.T) {
+		var reqHeaders http.Header
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reqHeaders = r.Header
+		}))
+		defer srv.Close()
+
+		tokenSource := &staticTokenSource{accessToken: "single-token"}
+
+		req, err := http.NewRequest("GET", srv.URL, nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+
+		director := func(r *http.Request) {
+			tok, _ := tokenSource.Token()
+			r.Header.Set("Proxy-Authorization", "Bearer "+tok.AccessToken)
+			r.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+			r.Header.Set("X-Candela-Auth", "Bearer "+tok.AccessToken)
+		}
+
+		director(req)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("failed to send request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if got := reqHeaders.Get("Proxy-Authorization"); got != "Bearer single-token" {
+			t.Errorf("Proxy-Authorization = %q, want Bearer single-token", got)
+		}
+		if got := reqHeaders.Get("Authorization"); got != "Bearer single-token" {
+			t.Errorf("Authorization = %q, want Bearer single-token", got)
+		}
+		if got := reqHeaders.Get("X-Candela-Auth"); got != "Bearer single-token" {
+			t.Errorf("X-Candela-Auth = %q, want Bearer single-token", got)
+		}
+	})
+}

--- a/cmd/candela/iap_token.go
+++ b/cmd/candela/iap_token.go
@@ -21,8 +21,9 @@ import (
 //
 // This token source solves the problem by using the user's access token to call
 // IAM's generateIdToken endpoint, which returns an ID token scoped to the IAP
-// audience. The user needs `roles/iam.serviceAccountTokenCreator` on the target
-// service account (project owners/editors have this by default).
+// audience. The caller needs `roles/iam.serviceAccountTokenCreator` (for local dev) or
+// a custom role with `iam.serviceAccounts.getOpenIdToken` (for CI with WIF) on the target
+// service account.
 //
 // Flow:
 //
@@ -31,6 +32,7 @@ type iapImpersonatingTokenSource struct {
 	base           oauth2.TokenSource
 	serviceAccount string
 	audience       string
+	endpointURL    string // Override IAM endpoint for testing. Empty = production.
 }
 
 func (s *iapImpersonatingTokenSource) Token() (*oauth2.Token, error) {
@@ -41,10 +43,13 @@ func (s *iapImpersonatingTokenSource) Token() (*oauth2.Token, error) {
 	}
 
 	// Call IAM Credentials API to generate an ID token with the IAP audience.
-	url := fmt.Sprintf(
-		"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateIdToken",
-		s.serviceAccount,
-	)
+	endpoint := s.endpointURL
+	if endpoint == "" {
+		endpoint = fmt.Sprintf(
+			"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateIdToken",
+			s.serviceAccount,
+		)
+	}
 	reqPayload := struct {
 		Audience     string `json:"audience"`
 		IncludeEmail bool   `json:"includeEmail"`
@@ -57,7 +62,7 @@ func (s *iapImpersonatingTokenSource) Token() (*oauth2.Token, error) {
 		return nil, fmt.Errorf("IAP: failed to marshal request body: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", url, bytes.NewReader(bodyBytes))
+	req, err := http.NewRequest("POST", endpoint, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("IAP: failed to build request: %w", err)
 	}
@@ -74,7 +79,7 @@ func (s *iapImpersonatingTokenSource) Token() (*oauth2.Token, error) {
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, fmt.Errorf("IAP: generateIdToken returned %d: %s\n"+
-			"Ensure you have roles/iam.serviceAccountTokenCreator on %s",
+			"Ensure you have roles/iam.serviceAccountTokenCreator (local) or a custom role with iam.serviceAccounts.getOpenIdToken (CI) on %s",
 			resp.StatusCode, respBody, s.serviceAccount)
 	}
 

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -758,63 +758,13 @@ func runForeground() {
 		}
 
 		// ── Get auth token source via ADC ──
-		// Strategy 1: idtoken.NewTokenSource (works for service accounts).
-		//   → AccessToken IS the audience-scoped OIDC ID token.
-		// Strategy 2: google.DefaultTokenSource (works for user credentials).
-		//   → AccessToken is an OAuth2 access token. The server validates it
-		//     via the userinfo endpoint (Strategy 3 in FirebaseAuthMiddleware).
-		//
-		// In both cases, token.AccessToken contains the correct bearer token.
-		// Do NOT use token.Extra("id_token") — for user credentials it returns
-		// a generic OIDC token without the required audience claim, which the
-		// server rejects.
-		var tokenSource oauth2.TokenSource
-		var userTokenSource oauth2.TokenSource // User's ADC token for server-side identity validation.
-
-		ts, err := idtoken.NewTokenSource(ctx, cfg.Audience)
-		if err == nil {
-			// Strategy 1: Service account credentials → audience-scoped OIDC ID token.
-			slog.Info("using service account ID token source")
-			tokenSource = ts
-		} else if cfg.IAPServiceAccount != "" {
-			// Strategy 1.5: User credentials + SA impersonation → dual token.
-			// - IAP token: OIDC ID token (via SA impersonation) for Proxy-Authorization
-			// - User token: ADC OAuth2 access token for Authorization (server validates via userinfo)
-			slog.Debug("idtoken.NewTokenSource unavailable, trying IAP impersonation", "reason", err)
-			baseTSr, err2 := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
-			if err2 != nil {
-				slog.Error("failed to get credentials — run 'candela auth login' first",
-					"error", err2)
-				os.Exit(1)
-			}
-			tokenSource = oauth2.ReuseTokenSource(nil, &iapImpersonatingTokenSource{
-				base:           baseTSr,
-				serviceAccount: cfg.IAPServiceAccount,
-				audience:       cfg.Audience,
-			})
-			// Keep the user's ADC token source for server-side auth.
-			// The server validates this via Google's userinfo endpoint.
-			userTSr, err3 := google.DefaultTokenSource(ctx, "openid", "email")
-			if err3 != nil {
-				slog.Warn("failed to get user ADC token source — server auth may fail", "error", err3)
-			} else {
-				userTokenSource = userTSr
-			}
-			slog.Info("using IAP via service account impersonation",
-				"sa", cfg.IAPServiceAccount)
-		} else {
-			// Strategy 2: User credentials → OAuth2 access token.
-			// Works when the server validates via userinfo (no IAP).
-			slog.Debug("idtoken.NewTokenSource unavailable (user credentials fallback)", "reason", err)
-			ts2, err2 := google.DefaultTokenSource(ctx, "openid", "email")
-			if err2 != nil {
-				slog.Error("failed to get credentials — run 'candela auth login' first",
-					"error", err2)
-				os.Exit(1)
-			}
-			slog.Info("using user ADC credentials (OAuth2 access token)")
-			tokenSource = ts2
+		auth, err := resolveAuthStrategy(ctx, cfg, idtoken.NewTokenSource, google.DefaultTokenSource)
+		if err != nil {
+			slog.Error("failed to resolve auth strategy", "error", err)
+			os.Exit(1)
 		}
+		tokenSource := auth.tokenSource
+		userTokenSource := auth.userTokenSource
 
 		// ── Build reverse proxy ──
 		remoteProxy = &httputil.ReverseProxy{


### PR DESCRIPTION
## Problem

When `iap_service_account` is configured (e.g. in CI with WIF), `idtoken.NewTokenSource` succeeds because it detects valid service-account-like credentials (WIF external_account). This causes candela to take **Strategy 1** (direct ID token), which calls `generateIdToken` on the **caller's own SA**.

In CI environments using Workload Identity Federation, the WIF SA (e.g. `cicd-impl-admin-tool@azra-wif`) only has `iam.serviceAccounts.getOpenIdToken` on the **target** IAP SA (`candela-server@...`), not on itself. Result: `403 Permission Denied`.

**Strategy 1.5** (IAP impersonation) is what would actually work — it correctly calls `generateIdToken` on the configured `iap_service_account`. But it's never reached because Strategy 1 doesn't error during init, only at token fetch time.

## Fix

When `iap_service_account` is configured, bypass `idtoken.NewTokenSource` entirely and go straight to IAP impersonation (`iapImpersonatingTokenSource`).

This is a safe change:
- **With `iap_service_account` set**: Was broken (403 on self-impersonation), now works correctly via IAP impersonation
- **Without `iap_service_account`**: No behavior change — Strategy 1 still runs as before

## Context

Discovered while debugging `code-reviewer` CI failures in `implementation-admin-tool` MR !153. The candela-deploy terraform correctly grants IAP token access, but the candela proxy picked the wrong auth strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote authentication when IAP service account configuration is provided by consistently using the IAP impersonation flow.
  * Preserved existing direct ID-token authentication and fallback behavior when no IAP service account is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->