### PR TITLE
fix(ui): wire New Project button + handle auth errors

### DIFF
--- a/ui/src/app/login/page.tsx
+++ b/ui/src/app/login/page.tsx
@@ -5,9 +5,9 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 export default function LoginPage() {
-  const { user, loading, configured, signIn } = useAuth();
+  const { user, loading, configured, signIn, authError, clearAuthError } = useAuth();
   const router = useRouter();
-  const [error, setError] = useState<string | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
   const [signingIn, setSigningIn] = useState(false);
 
   useEffect(() => {
@@ -19,17 +19,17 @@ export default function LoginPage() {
   const handleSignIn = async () => {
     if (!configured) {
       console.error("[Candela] Firebase not configured — NEXT_PUBLIC_FIREBASE_* env vars are missing.");
-      setError("Authentication is currently unavailable. Please contact your administrator.");
+      setLocalError("Authentication is currently unavailable. Please contact your administrator.");
       return;
     }
-    setError(null);
+    setLocalError(null);
+    clearAuthError();
     setSigningIn(true);
     try {
       await signIn();
     } catch (err) {
-      const message = err instanceof Error ? err.message.replace(/^Firebase: /, "") : "Sign-in failed";
+      // AuthProvider already sets authError, but we catch so it doesn't crash
       console.error("Sign-in error:", err);
-      setError(message);
     } finally {
       setSigningIn(false);
     }
@@ -51,8 +51,11 @@ export default function LoginPage() {
         <div className="login-logo">🕯️</div>
         <h1>Candela</h1>
         <p className="login-subtitle">LLM Observability & Proxy</p>
-        {error && (
-          <p className="login-error" role="alert">{error}</p>
+        {localError && (
+          <p className="login-error" role="alert">{localError}</p>
+        )}
+        {authError && (
+          <p className="login-error" role="alert">{authError}</p>
         )}
         <button
           className="login-button"

--- a/ui/src/app/projects/page.tsx
+++ b/ui/src/app/projects/page.tsx
@@ -57,8 +57,8 @@ export default function ProjectsPage() {
         ]);
       }
       handleCloseModal();
-    } catch (err: any) {
-      setCreateError(err.message || "Failed to create project");
+    } catch (err: unknown) {
+      setCreateError(err instanceof Error ? err.message : "Failed to create project");
     } finally {
       setCreating(false);
     }

--- a/ui/src/app/projects/page.tsx
+++ b/ui/src/app/projects/page.tsx
@@ -18,6 +18,52 @@ export default function ProjectsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const [showModal, setShowModal] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newDesc, setNewDesc] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const handleCloseModal = () => {
+    setShowModal(false);
+    setNewName("");
+    setNewDesc("");
+    setCreateError(null);
+  };
+
+  const handleCreateProject = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newName.trim()) return;
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const client = createClient(ProjectService, transport);
+      const res = await client.createProject({
+        name: newName,
+        description: newDesc,
+      });
+      const newP = res.project;
+      if (newP) {
+        setProjects((prev) => [
+          ...prev,
+          {
+            id: newP.id,
+            name: newP.name,
+            description: newP.description,
+            createdAt: newP.createdAt
+              ? new Date(Number(newP.createdAt.seconds) * 1000).toLocaleDateString()
+              : "—",
+          }
+        ]);
+      }
+      handleCloseModal();
+    } catch (err: any) {
+      setCreateError(err.message || "Failed to create project");
+    } finally {
+      setCreating(false);
+    }
+  };
+
   useEffect(() => {
     const client = createClient(ProjectService, transport);
     client
@@ -41,7 +87,7 @@ export default function ProjectsPage() {
     <>
       <header className="main-header">
         <h1>Projects</h1>
-        <button className="btn btn-primary">+ New Project</button>
+        <button className="btn btn-primary" onClick={() => setShowModal(true)}>+ New Project</button>
       </header>
 
       <div className="main-body">
@@ -97,6 +143,46 @@ export default function ProjectsPage() {
           )}
         </div>
       </div>
+
+      {showModal && (
+        <div className="modal-overlay" onClick={handleCloseModal} role="dialog" aria-modal="true" aria-label="New Project">
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-header">
+              <h3>New Project</h3>
+              <button type="button" className="modal-close" onClick={handleCloseModal} aria-label="Close dialog">×</button>
+            </div>
+            <form onSubmit={handleCreateProject} className="modal-body">
+              {createError && <ErrorBanner title="Error">{createError}</ErrorBanner>}
+              <div className="form-group">
+                <label>Name</label>
+                <input
+                  type="text"
+                  required
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="e.g. Production Backend"
+                  autoFocus
+                />
+              </div>
+              <div className="form-group">
+                <label>Description</label>
+                <textarea
+                  value={newDesc}
+                  onChange={(e) => setNewDesc(e.target.value)}
+                  placeholder="Optional context about this project"
+                  rows={3}
+                />
+              </div>
+              <div className="modal-footer">
+                <button type="button" className="btn" onClick={handleCloseModal}>Cancel</button>
+                <button type="submit" className="btn btn-primary" disabled={creating || !newName.trim()}>
+                  {creating ? "Creating..." : "Create Project"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/ui/src/app/projects/page.tsx
+++ b/ui/src/app/projects/page.tsx
@@ -87,7 +87,7 @@ export default function ProjectsPage() {
     <>
       <header className="main-header">
         <h1>Projects</h1>
-        <button className="btn btn-primary" onClick={() => setShowModal(true)}>+ New Project</button>
+        <button className="btn btn-primary" onClick={() => setShowModal(true)} disabled={loading}>+ New Project</button>
       </header>
 
       <div className="main-body">
@@ -154,8 +154,9 @@ export default function ProjectsPage() {
             <form onSubmit={handleCreateProject} className="modal-body">
               {createError && <ErrorBanner title="Error">{createError}</ErrorBanner>}
               <div className="form-group">
-                <label>Name</label>
+                <label htmlFor="project-name">Name</label>
                 <input
+                  id="project-name"
                   type="text"
                   required
                   value={newName}
@@ -165,8 +166,9 @@ export default function ProjectsPage() {
                 />
               </div>
               <div className="form-group">
-                <label>Description</label>
+                <label htmlFor="project-desc">Description</label>
                 <textarea
+                  id="project-desc"
                   value={newDesc}
                   onChange={(e) => setNewDesc(e.target.value)}
                   placeholder="Optional context about this project"

--- a/ui/src/components/AuthProvider.tsx
+++ b/ui/src/components/AuthProvider.tsx
@@ -23,6 +23,8 @@ interface AuthContextType {
   signIn: () => Promise<void>;
   signOut: () => Promise<void>;
   getIdToken: () => Promise<string | null>;
+  authError: string | null;
+  clearAuthError: () => void;
 }
 
 const AuthContext = createContext<AuthContextType>({
@@ -32,6 +34,8 @@ const AuthContext = createContext<AuthContextType>({
   signIn: async () => {},
   signOut: async () => {},
   getIdToken: async () => null,
+  authError: null,
+  clearAuthError: () => {},
 });
 
 export function useAuth() {
@@ -40,6 +44,7 @@ export function useAuth() {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
+  const [authError, setAuthError] = useState<string | null>(null);
   const configured = firebaseAuth !== null;
   // Start as not-loading when Firebase isn't configured (no auth to wait for).
   const [loading, setLoading] = useState(configured);
@@ -53,14 +58,34 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return unsubscribe;
   }, []);
 
+  const clearAuthError = () => setAuthError(null);
+
   const signIn = async () => {
     if (!firebaseAuth) return;
-    await signInWithPopup(firebaseAuth, googleProvider);
+    try {
+      await signInWithPopup(firebaseAuth, googleProvider);
+      setAuthError(null);
+    } catch (err: any) {
+      if (err.code === "auth/popup-blocked") {
+        setAuthError("Sign-in popup was blocked. Please allow popups.");
+      } else if (err.code === "auth/popup-closed-by-user") {
+        // Silently ignore
+      } else {
+        setAuthError(err.message || "Failed to sign in");
+      }
+      throw err;
+    }
   };
 
   const signOut = async () => {
     if (!firebaseAuth) return;
-    await firebaseSignOut(firebaseAuth);
+    try {
+      await firebaseSignOut(firebaseAuth);
+      setAuthError(null);
+    } catch (err: any) {
+      setAuthError(err.message || "Failed to sign out");
+      throw err;
+    }
   };
 
   const getIdToken = async (): Promise<string | null> => {
@@ -70,7 +95,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ user, loading, configured, signIn, signOut, getIdToken }}
+      value={{ user, loading, configured, signIn, signOut, getIdToken, authError, clearAuthError }}
     >
       {children}
     </AuthContext.Provider>

--- a/ui/src/components/AuthProvider.tsx
+++ b/ui/src/components/AuthProvider.tsx
@@ -65,14 +65,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       await signInWithPopup(firebaseAuth, googleProvider);
       setAuthError(null);
-    } catch (err: any) {
-      if (err.code === "auth/popup-closed-by-user") {
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code;
+      if (code === "auth/popup-closed-by-user") {
         return; // User cancelled — not an error
       }
-      if (err.code === "auth/popup-blocked") {
+      if (code === "auth/popup-blocked") {
         setAuthError("Sign-in popup was blocked. Please allow popups.");
       } else {
-        setAuthError(err.message || "Failed to sign in");
+        setAuthError(err instanceof Error ? err.message : "Failed to sign in");
       }
     }
   };
@@ -82,8 +83,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       await firebaseSignOut(firebaseAuth);
       setAuthError(null);
-    } catch (err: any) {
-      setAuthError(err.message || "Failed to sign out");
+    } catch (err: unknown) {
+      setAuthError(err instanceof Error ? err.message : "Failed to sign out");
     }
   };
 

--- a/ui/src/components/AuthProvider.tsx
+++ b/ui/src/components/AuthProvider.tsx
@@ -66,14 +66,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       await signInWithPopup(firebaseAuth, googleProvider);
       setAuthError(null);
     } catch (err: any) {
+      if (err.code === "auth/popup-closed-by-user") {
+        return; // User cancelled — not an error
+      }
       if (err.code === "auth/popup-blocked") {
         setAuthError("Sign-in popup was blocked. Please allow popups.");
-      } else if (err.code === "auth/popup-closed-by-user") {
-        // Silently ignore
       } else {
         setAuthError(err.message || "Failed to sign in");
       }
-      throw err;
     }
   };
 
@@ -84,7 +84,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setAuthError(null);
     } catch (err: any) {
       setAuthError(err.message || "Failed to sign out");
-      throw err;
     }
   };
 


### PR DESCRIPTION
Fixes two P1 bugs in the dashboard.

## #603 — New Project button is a no-op
The primary CTA did literally nothing.

**Fix:** Added a create project modal that calls the existing `CreateProject` RPC. On success, the new project appears in the list immediately.

- Modal with name (required) + description fields
- Uses existing CSS classes (`modal-overlay`, `modal`, `form-group`)
- Error handling in modal
- Loading state during creation

## #610 — AuthProvider silently swallows errors
`signIn` and `signOut` had no try/catch — popup blocks, network errors were invisible.

**Fix:** Both wrapped in try/catch with:
- `auth/popup-blocked` → specific user message
- `auth/popup-closed-by-user` → silently ignored
- Other errors → generic message via `authError` context
- Login page now displays `authError` from the provider

### Verification
- TypeScript compiles clean (`tsc --noEmit` ✅)
- Pre-commit hooks pass ✅

Closes #603, Closes #610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project creation from the Projects page, including name and description fields, validation, progress feedback, and error messages.
  * Newly created projects now appear immediately in the project list.

* **Bug Fixes**
  * Improved authentication error handling by separating provider errors from local configuration errors.
  * Authentication errors are cleared appropriately after successful sign-in or sign-out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->