### PR TITLE
feat(deploy): add Helm chart for candela-server

### DIFF
--- a/deploy/helm/candela-server/Chart.yaml
+++ b/deploy/helm/candela-server/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: candela-server
+description: Candela AI cost observability server with proxy, dashboard, and budget management
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - llm
+  - observability
+  - cost
+  - proxy
+  - budget
+home: https://github.com/candelahq/candela
+sources:
+  - https://github.com/candelahq/candela
+maintainers:
+  - name: candelahq

--- a/deploy/helm/candela-server/templates/_helpers.tpl
+++ b/deploy/helm/candela-server/templates/_helpers.tpl
@@ -1,0 +1,58 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "candela-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "candela-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version for chart label.
+*/}}
+{{- define "candela-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "candela-server.labels" -}}
+helm.sh/chart: {{ include "candela-server.chart" . }}
+{{ include "candela-server.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "candela-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "candela-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service account name.
+*/}}
+{{- define "candela-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "candela-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/candela-server/templates/configmap.yaml
+++ b/deploy/helm/candela-server/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "candela-server.fullname" . }}-config
+  labels:
+    {{- include "candela-server.labels" . | nindent 4 }}
+data:
+  candela.yaml: |
+    port: {{ .Values.server.port }}
+    storage_backend: {{ .Values.storage.backend }}
+    {{- if eq .Values.storage.backend "duckdb" }}
+    duckdb_path: {{ .Values.storage.duckdb.path }}/candela.db
+    {{- end }}
+    {{- if eq .Values.storage.backend "bigquery" }}
+    bigquery_project: {{ .Values.storage.bigquery.projectId }}
+    bigquery_dataset: {{ .Values.storage.bigquery.dataset }}
+    {{- end }}
+    proxy_enabled: {{ .Values.proxy.enabled }}
+    catalog_backend: {{ .Values.catalog.backend }}

--- a/deploy/helm/candela-server/templates/deployment.yaml
+++ b/deploy/helm/candela-server/templates/deployment.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "candela-server.fullname" . }}
+  labels:
+    {{- include "candela-server.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "candela-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "candela-server.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "candela-server.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.server.port }}
+              protocol: TCP
+          env:
+            - name: CANDELA_CONFIG
+              value: /etc/candela/candela.yaml
+            - name: CANDELA_STORAGE_BACKEND
+              value: {{ .Values.storage.backend | quote }}
+            {{- if .Values.auth.devMode }}
+            - name: CANDELA_DEV_MODE
+              value: "true"
+            {{- end }}
+            {{- if .Values.auth.allowedServiceAccounts }}
+            - name: CANDELA_ALLOWED_SERVICE_ACCOUNTS
+              value: {{ .Values.auth.allowedServiceAccounts | quote }}
+            {{- end }}
+            {{- if .Values.budget.timezone }}
+            - name: CANDELA_BUDGET_TIMEZONE
+              value: {{ .Values.budget.timezone | quote }}
+            {{- end }}
+            {{- if .Values.vertex.region }}
+            - name: CANDELA_VERTEX_REGION
+              value: {{ .Values.vertex.region | quote }}
+            {{- end }}
+            {{- if .Values.catalog.backend }}
+            - name: CANDELA_CATALOG_BACKEND
+              value: {{ .Values.catalog.backend | quote }}
+            {{- end }}
+            {{- if .Values.auth.firebase.projectId }}
+            - name: NEXT_PUBLIC_FIREBASE_PROJECT_ID
+              value: {{ .Values.auth.firebase.projectId | quote }}
+            - name: NEXT_PUBLIC_FIREBASE_API_KEY
+              value: {{ .Values.auth.firebase.apiKey | quote }}
+            - name: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+              value: {{ .Values.auth.firebase.authDomain | quote }}
+            - name: NEXT_PUBLIC_FIREBASE_APP_ID
+              value: {{ .Values.auth.firebase.appId | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          volumeMounts:
+            - name: config
+              mountPath: /etc/candela
+              readOnly: true
+            {{- if eq .Values.storage.backend "duckdb" }}
+            - name: data
+              mountPath: {{ .Values.storage.duckdb.path }}
+            {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "candela-server.fullname" . }}-config
+        {{- if eq .Values.storage.backend "duckdb" }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "candela-server.fullname" . }}-data
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/candela-server/templates/hpa.yaml
+++ b/deploy/helm/candela-server/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "candela-server.fullname" . }}
+  labels:
+    {{- include "candela-server.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "candela-server.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/candela-server/templates/ingress.yaml
+++ b/deploy/helm/candela-server/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "candela-server.fullname" . }}
+  labels:
+    {{- include "candela-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "candela-server.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/candela-server/templates/pvc.yaml
+++ b/deploy/helm/candela-server/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.storage.backend "duckdb" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "candela-server.fullname" . }}-data
+  labels:
+    {{- include "candela-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.storage.duckdb.storageClass }}
+  storageClassName: {{ .Values.storage.duckdb.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.duckdb.storageSize }}
+{{- end }}

--- a/deploy/helm/candela-server/templates/service.yaml
+++ b/deploy/helm/candela-server/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "candela-server.fullname" . }}
+  labels:
+    {{- include "candela-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "candela-server.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/candela-server/templates/serviceaccount.yaml
+++ b/deploy/helm/candela-server/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "candela-server.serviceAccountName" . }}
+  labels:
+    {{- include "candela-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/candela-server/values.yaml
+++ b/deploy/helm/candela-server/values.yaml
@@ -1,0 +1,113 @@
+# Candela Server Helm Values
+# Deploy the Candela server with proxy, dashboard, and observability.
+
+image:
+  repository: ghcr.io/candelahq/candela-server
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+# ── Server configuration ──
+server:
+  # Port for the Go backend (ConnectRPC + proxy)
+  port: 8181
+
+# ── Storage backend ──
+# Options: "duckdb", "bigquery", "sqlite"
+storage:
+  backend: duckdb
+  # DuckDB data directory (mounted as PVC)
+  duckdb:
+    path: /data
+    storageSize: 10Gi
+    storageClass: ""
+  # BigQuery settings (when backend: bigquery)
+  bigquery:
+    projectId: ""
+    dataset: "candela"
+
+# ── Proxy ──
+proxy:
+  enabled: true
+
+# ── Auth ──
+auth:
+  # Set to true for local development (bypasses all auth)
+  devMode: false
+  # Comma-separated list of allowed service account emails
+  allowedServiceAccounts: ""
+  # Firebase project ID (for web dashboard auth)
+  firebase:
+    projectId: ""
+    apiKey: ""
+    authDomain: ""
+    appId: ""
+
+# ── Model catalog ──
+catalog:
+  # Options: "embedded", "bigquery"
+  backend: embedded
+
+# ── Budget ──
+budget:
+  # IANA timezone for budget period boundaries
+  timezone: "UTC"
+
+# ── Vertex AI (optional) ──
+vertex:
+  region: ""
+
+# ── Observability export ──
+# Configure where processed spans are sent.
+export:
+  pubsub:
+    topic: ""
+  otlp:
+    endpoint: ""
+
+# ── Ingress ──
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: candela.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# ── Horizontal Pod Autoscaler ──
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+
+# ── Resources ──
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: "2"
+    memory: 1Gi
+
+# ── Service ──
+service:
+  type: ClusterIP
+  port: 8181
+
+# ── Service Account ──
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# ── Pod configuration ──
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podLabels: {}


### PR DESCRIPTION
## Helm Chart for Self-Hosted Candela Server

Unblocks K8s teams that want to self-host Candela. Matches the existing sidecar chart structure.

Closes #724

### Templates
| Resource | File | Conditional |
|:---|:---|:---|
| Deployment | `deployment.yaml` | Always |
| Service | `service.yaml` | Always |
| ServiceAccount | `serviceaccount.yaml` | `serviceAccount.create` |
| ConfigMap | `configmap.yaml` | Always |
| PVC | `pvc.yaml` | `storage.backend == duckdb` |
| HPA | `hpa.yaml` | `autoscaling.enabled` |
| Ingress | `ingress.yaml` | `ingress.enabled` |

### Features
- Health probes: `/healthz` (liveness) + `/readyz` (readiness)
- Config checksum annotation → rolling restarts on config change
- DuckDB PVC with configurable size and storage class
- BigQuery backend (no PVC needed)
- Firebase auth env vars (conditional)
- GKE Workload Identity via SA annotations
- Optional HPA and Ingress with TLS

### Quick Start
```bash
# DuckDB (default, self-contained)
helm install candela deploy/helm/candela-server/ \\
  --set auth.devMode=true

# BigQuery
helm install candela deploy/helm/candela-server/ \\
  --set storage.backend=bigquery \\
  --set storage.bigquery.projectId=my-project
```

### Verification
- `helm lint` ✅
- `helm template` renders correctly ✅
- `check-yaml` hook ✅