### PR TITLE
fix(auth): allowlisted SAs bypass Firestore registration check (#763 regression)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -153,10 +153,13 @@ worker:
 
 auth:
   dev_mode: false
-  # Service accounts allowed to authenticate via Google ID token.
+  # Service accounts allowed to use the proxy via Google ID token or OAuth2.
   # Deny-by-default: if this list is empty (or omitted), ALL service accounts
-  # are rejected with 403. Users must authenticate with personal ADC
-  # (gcloud auth application-default login) instead.
+  # are rejected with 403.
+  #
+  # Allowlisted SAs bypass two gates:
+  #   1. Authentication — the resolver chain permits them (non-listed SAs are rejected)
+  #   2. Registration — they skip the Firestore user-store lookup (no user doc needed)
   #
   # Only add SAs that genuinely need proxy access (e.g. CI runners, shared
   # build agents). SA traffic bypasses per-user budget deduction, so each

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -30,6 +30,7 @@ These are used by the container entrypoint (`deploy/entrypoint.sh`) to generate 
 |----------|---------|-------------|
 | `CANDELA_DEV_MODE` | `false` | Skip auth, inject synthetic admin user. **Never use in production.** |
 | `CLOUD_RUN_URL` | _(empty)_ | Cloud Run service URL. Used as the audience for Google ID token validation (Strategy 2). Set this to enable `candela` Team Mode auth. |
+| `CANDELA_ALLOWED_SERVICE_ACCOUNTS` | _(empty)_ | Comma-separated list of SA emails allowed to use the proxy. Deny-by-default: if empty, all SAs are rejected. Allowlisted SAs bypass Firestore registration. See [Security — SA Allowlist](security.md#sa-allowlist-configuration). |
 
 ### Firestore
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -23,9 +23,9 @@ flowchart TD
     CTX --> HANDLER[ConnectRPC Handler]
 ```
 
-### Strategy Waterfall
+### Strategy Waterfall (Resolver Chain)
 
-The middleware (`pkg/auth/firebase.go`) tries three strategies in sequence. The first successful validation wins:
+The middleware (`pkg/auth/firebase.go`) uses a pluggable `ResolverChain` that tries multiple identity resolvers in sequence. The first successful validation wins:
 
 | # | Strategy | Client | Token Source | Validation Method |
 |---|----------|--------|-------------|-------------------|
@@ -124,7 +124,50 @@ Users with `role = admin` bypass all access tag and tenant checks. Admins always
 
 ### Service Account Behavior
 
-Service accounts (SAs) are treated as **individual users** for access gating purposes. SAs must have the appropriate `access_tags` and belong to an allowed tenant — there is no implicit SA bypass.
+Service accounts (SAs) authenticate via Strategy 2 (Google ID Token) or Strategy 3 (OAuth2 Access Token). SA access is governed by two independent gates:
+
+1. **Authentication** — The SA must be on the `allowed_service_accounts` allowlist (deny-by-default). SAs not on the list are rejected with 403 at the resolver chain level.
+2. **Authorization** — Allowlisted SAs bypass the Firestore user-store registration check (`verifyRegistered`). They do **not** need a Firestore user document. This is because SAs are pre-authorized by the allowlist — requiring a separate user record would be redundant and break CI/CD integrations.
+
+> [!IMPORTANT]
+> SAs on the allowlist bypass **both** the registration gate **and** per-user budget deduction. Each allowlist entry is an unmetered cost vector. Only add SAs that genuinely need proxy access (e.g., CI runners, shared build agents).
+
+#### SA Allowlist Configuration
+
+Configure in `config.yaml` under `auth.allowed_service_accounts`:
+
+```yaml
+auth:
+  allowed_service_accounts:
+    - "candela-ci@my-project.iam.gserviceaccount.com"
+    - "deploy-bot@my-project.iam.gserviceaccount.com"
+```
+
+Behavior:
+- **Deny-by-default**: If the list is empty or omitted, ALL service accounts are rejected with 403.
+- **Case-insensitive**: Lookups are case-insensitive (`Candela-CI@...` matches `candela-ci@...`).
+- **Whitespace-tolerant**: Leading/trailing whitespace is trimmed during construction.
+- **Defense-in-depth**: The bypass only applies to emails ending in `.gserviceaccount.com`, preventing accidental human-user bypasses.
+
+#### SA Auth Flow Diagram
+
+```
+SA Request
+  ↓
+ResolverChain.Resolve(token)
+  ↓
+GoogleOIDCResolver or GoogleOAuthResolver
+  ↓ (extracts email)
+IsAllowed(email)? ──── NO ──→ 403 Forbidden
+  ↓ YES
+verifyRegistered()
+  ↓
+IsAllowed(email) + .gserviceaccount.com? ──── YES ──→ ✅ Skip Firestore
+  ↓ NO
+Firestore lookup ──── not found ──→ 403 "user not registered"
+  ↓ found
+✅ Proceed
+```
 
 ### Fail-Closed on Errors
 

--- a/pkg/auth/firebase.go
+++ b/pkg/auth/firebase.go
@@ -126,7 +126,7 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth TokenVerifier, cloudRunAud
 			return
 		}
 
-		if !isSelfService && !verifyRegistered(r.Context(), w, user, userAuth) {
+		if !isSelfService && !verifyRegistered(r.Context(), w, user, userAuth, saAllowlist) {
 			return
 		}
 
@@ -136,12 +136,22 @@ func FirebaseAuthMiddleware(next http.Handler, fbAuth TokenVerifier, cloudRunAud
 }
 
 // verifyRegistered checks if the authenticated user exists in the user store.
-// Returns true if the user is allowed (registered or no store configured).
+// Returns true if the user is allowed (registered, allowlisted SA, or no store configured).
 // Returns false and writes an error response if the user is not registered (403)
 // or if the lookup fails with a transient error (500).
-func verifyRegistered(ctx context.Context, w http.ResponseWriter, user *User, userAuth UserAuthorizer) bool {
+//
+// Service accounts on the SA allowlist bypass the user-store lookup entirely.
+// They were already authenticated and authorized by the resolver chain;
+// requiring a separate Firestore document is redundant.
+func verifyRegistered(ctx context.Context, w http.ResponseWriter, user *User, userAuth UserAuthorizer, saAllowlist *ServiceAccountAllowlist) bool {
 	if userAuth == nil {
 		return true // no user store — allow all authenticated users
+	}
+	// Allowlisted SAs are pre-authorized — skip the user-store lookup.
+	if saAllowlist != nil && saAllowlist.IsAllowed(user.Email) {
+		slog.Debug("allowlisted SA — skipping registration check",
+			"email", user.Email, "uid", user.ID)
+		return true
 	}
 	if err := userAuth(ctx, user.Email); err != nil {
 		if errors.Is(err, ErrNotRegistered) {

--- a/pkg/auth/firebase.go
+++ b/pkg/auth/firebase.go
@@ -148,7 +148,9 @@ func verifyRegistered(ctx context.Context, w http.ResponseWriter, user *User, us
 		return true // no user store — allow all authenticated users
 	}
 	// Allowlisted SAs are pre-authorized — skip the user-store lookup.
-	if saAllowlist != nil && saAllowlist.IsAllowed(user.Email) {
+	// Defense-in-depth: also verify the email suffix so a human user whose
+	// email coincidentally matches an allowlist entry cannot bypass registration.
+	if saAllowlist != nil && strings.HasSuffix(strings.ToLower(user.Email), ".gserviceaccount.com") && saAllowlist.IsAllowed(user.Email) {
 		slog.Debug("allowlisted SA — skipping registration check",
 			"email", user.Email, "uid", user.ID)
 		return true

--- a/pkg/auth/firebase_test.go
+++ b/pkg/auth/firebase_test.go
@@ -407,6 +407,66 @@ func TestVerifyRegistered_AllowlistedSA_BypassesRegistration(t *testing.T) {
 	})
 }
 
+func TestVerifyRegistered_AllowlistedSA_RequiresSAEmailSuffix(t *testing.T) {
+	// Defense-in-depth: the SA bypass requires BOTH that the email is in the
+	// allowlist AND that it ends with ".gserviceaccount.com". A human email
+	// coincidentally present in the allowlist must NOT bypass registration.
+
+	// Authorizer that rejects everything — simulates "no Firestore doc".
+	authorizer := UserAuthorizer(func(_ context.Context, email string) error {
+		return fmt.Errorf("%w: %s", ErrNotRegistered, email)
+	})
+
+	allowedSA := "cicd-bot@my-project.iam.gserviceaccount.com"
+	humanEmail := "alice@example.com"
+	deniedSA := "rogue-bot@other-project.iam.gserviceaccount.com"
+
+	// Allowlist contains both the real SA and a human email (misconfiguration).
+	saAllowlist := NewServiceAccountAllowlist([]string{allowedSA, humanEmail})
+
+	t.Run("allowlisted SA with correct suffix passes", func(t *testing.T) {
+		user := &User{ID: "sa-good", Email: allowedSA}
+		rr := httptest.NewRecorder()
+
+		ok := verifyRegistered(context.Background(), rr, user, authorizer, saAllowlist)
+		if !ok {
+			t.Fatal("expected allowlisted SA to bypass registration check")
+		}
+		if rr.Body.Len() != 0 {
+			t.Errorf("expected empty body, got %q", rr.Body.String())
+		}
+	})
+
+	t.Run("non-allowlisted SA is blocked", func(t *testing.T) {
+		user := &User{ID: "sa-bad", Email: deniedSA}
+		rr := httptest.NewRecorder()
+
+		ok := verifyRegistered(context.Background(), rr, user, authorizer, saAllowlist)
+		if ok {
+			t.Fatal("expected non-allowlisted SA to be blocked")
+		}
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", rr.Code)
+		}
+	})
+
+	t.Run("human email in allowlist does NOT bypass", func(t *testing.T) {
+		// Even though humanEmail is in the allowlist, it lacks the
+		// .gserviceaccount.com suffix, so the defense-in-depth check
+		// should prevent bypass.
+		user := &User{ID: "human-1", Email: humanEmail}
+		rr := httptest.NewRecorder()
+
+		ok := verifyRegistered(context.Background(), rr, user, authorizer, saAllowlist)
+		if ok {
+			t.Fatal("expected human email to NOT bypass registration even if in allowlist")
+		}
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", rr.Code)
+		}
+	})
+}
+
 // --- ServiceAccountAllowlist tests ---
 
 func TestServiceAccountAllowlist_DenyByDefault(t *testing.T) {

--- a/pkg/auth/firebase_test.go
+++ b/pkg/auth/firebase_test.go
@@ -243,7 +243,7 @@ func TestVerifyRegistered_RegisteredUserAllowed(t *testing.T) {
 	user := &User{ID: "uid-larry", Email: "larry.david@example-corp.com"}
 	rr := httptest.NewRecorder()
 
-	allowed := verifyRegistered(context.Background(), rr, user, authorizer)
+	allowed := verifyRegistered(context.Background(), rr, user, authorizer, nil)
 	if !allowed {
 		t.Fatal("expected registered user to be allowed")
 	}
@@ -262,7 +262,7 @@ func TestVerifyRegistered_UnregisteredUserBlocked(t *testing.T) {
 	user := &User{ID: "uid-rando", Email: "mocha.joe@spite-store.com"}
 	rr := httptest.NewRecorder()
 
-	allowed := verifyRegistered(context.Background(), rr, user, authorizer)
+	allowed := verifyRegistered(context.Background(), rr, user, authorizer, nil)
 	if allowed {
 		t.Fatal("expected unregistered user to be blocked")
 	}
@@ -290,7 +290,7 @@ func TestVerifyRegistered_TransientErrorReturns500(t *testing.T) {
 	user := &User{ID: "uid-jeff", Email: "jeff.greene@example-corp.com"}
 	rr := httptest.NewRecorder()
 
-	allowed := verifyRegistered(context.Background(), rr, user, authorizer)
+	allowed := verifyRegistered(context.Background(), rr, user, authorizer, nil)
 	if allowed {
 		t.Fatal("expected transient error to block the request")
 	}
@@ -314,17 +314,16 @@ func TestVerifyRegistered_NilAuthorizerAllowsAll(t *testing.T) {
 	user := &User{ID: "uid-leon", Email: "leon.black@example-corp.com"}
 	rr := httptest.NewRecorder()
 
-	allowed := verifyRegistered(context.Background(), rr, user, nil)
+	allowed := verifyRegistered(context.Background(), rr, user, nil, nil)
 	if !allowed {
 		t.Fatal("expected nil authorizer to allow all users")
 	}
 }
 
 func TestVerifyRegistered_ServiceAccountBlocked(t *testing.T) {
-	// verifyRegistered itself blocks unknown service accounts when called
-	// directly. In production, the middleware skips verifyRegistered for SAs
-	// authenticated via Google ID token (Strategy 2) — but if a SA were to
-	// reach verifyRegistered through another path, it would still be rejected.
+	// verifyRegistered blocks unknown service accounts that are NOT on the
+	// SA allowlist. Allowlisted SAs bypass this check entirely (see
+	// TestVerifyRegistered_AllowlistedSA_BypassesRegistration).
 	authorizer := UserAuthorizer(func(_ context.Context, email string) error {
 		// Only known team emails pass.
 		known := map[string]bool{
@@ -340,13 +339,72 @@ func TestVerifyRegistered_ServiceAccountBlocked(t *testing.T) {
 	sa := &User{ID: "100000000000000000000", Email: "susie-bot@other-project.iam.gserviceaccount.com"}
 	rr := httptest.NewRecorder()
 
-	allowed := verifyRegistered(context.Background(), rr, sa, authorizer)
+	allowed := verifyRegistered(context.Background(), rr, sa, authorizer, nil)
 	if allowed {
 		t.Fatal("expected external service account to be blocked")
 	}
 	if rr.Code != http.StatusForbidden {
 		t.Errorf("status = %d, want 403", rr.Code)
 	}
+}
+
+func TestVerifyRegistered_AllowlistedSA_BypassesRegistration(t *testing.T) {
+	// Regression test for #763: allowlisted service accounts must bypass the
+	// Firestore user-store lookup. Before the resolver chain refactor, SAs on
+	// the allowlist could use the proxy without a Firestore user document.
+	// The refactor inadvertently broke this by always calling verifyRegistered
+	// without checking the allowlist.
+
+	// Authorizer that rejects everything — simulates "no Firestore doc".
+	authorizer := UserAuthorizer(func(_ context.Context, email string) error {
+		return fmt.Errorf("%w: %s", ErrNotRegistered, email)
+	})
+
+	allowedSA := "cicd-bot@my-project.iam.gserviceaccount.com"
+	deniedSA := "rogue-bot@other-project.iam.gserviceaccount.com"
+	saAllowlist := NewServiceAccountAllowlist([]string{allowedSA})
+
+	// Allowlisted SA should pass even though the authorizer would reject it.
+	t.Run("allowlisted SA passes", func(t *testing.T) {
+		user := &User{ID: "sa-allowed", Email: allowedSA}
+		rr := httptest.NewRecorder()
+
+		ok := verifyRegistered(context.Background(), rr, user, authorizer, saAllowlist)
+		if !ok {
+			t.Fatal("expected allowlisted SA to bypass registration check")
+		}
+		if rr.Body.Len() != 0 {
+			t.Errorf("expected empty body, got %q", rr.Body.String())
+		}
+	})
+
+	// Non-allowlisted SA should still be blocked.
+	t.Run("non-allowlisted SA blocked", func(t *testing.T) {
+		user := &User{ID: "sa-denied", Email: deniedSA}
+		rr := httptest.NewRecorder()
+
+		ok := verifyRegistered(context.Background(), rr, user, authorizer, saAllowlist)
+		if ok {
+			t.Fatal("expected non-allowlisted SA to be blocked")
+		}
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", rr.Code)
+		}
+	})
+
+	// Nil allowlist should not bypass (backward compat).
+	t.Run("nil allowlist does not bypass", func(t *testing.T) {
+		user := &User{ID: "sa-nil", Email: allowedSA}
+		rr := httptest.NewRecorder()
+
+		ok := verifyRegistered(context.Background(), rr, user, authorizer, nil)
+		if ok {
+			t.Fatal("expected nil allowlist to not bypass registration")
+		}
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", rr.Code)
+		}
+	})
 }
 
 // --- ServiceAccountAllowlist tests ---


### PR DESCRIPTION
## Problem

PR #763 (resolver chain refactor) moved SA allowlist checks into the identity resolvers but did not carry the exemption into `verifyRegistered()`. Allowlisted service accounts authenticate successfully but are then blocked with **403 "user not registered"** because they have no Firestore user document.

This broke CI code-review jobs in:
- `implementation-admin-tool` [MR !160](https://gitlab.com/invenero/engineering/implementation-admin-tool/-/merge_requests/160)
- `sqlmesh` [MR !9](https://gitlab.com/invenero/engineering/sqlmesh/-/merge_requests/9)

Both use allowlisted SAs (`cicd-impl-admin-tool@azra-wif`, `sqlmesh-ci@azra-reports-stg`) that were working before Aug 10.

## Root Cause

`verifyRegistered()` always queries Firestore for a user document, even for SAs that already passed the allowlist check in the resolver chain. Before #763, the old auth waterfall handled this differently — allowlisted SAs were not subject to the registration gate.

## Fix

Pass the `saAllowlist` into `verifyRegistered()`. If the authenticated identity is on the allowlist, skip the Firestore lookup entirely.

```go
// Allowlisted SAs are pre-authorized — skip the user-store lookup.
if saAllowlist != nil && saAllowlist.IsAllowed(user.Email) {
    return true
}
```

## Tests

- New: `TestVerifyRegistered_AllowlistedSA_BypassesRegistration` with 3 sub-cases (allowlisted passes, non-allowlisted blocked, nil allowlist backward compat)
- All existing tests updated and passing
- Full pre-commit suite passes (go-vet, golangci-lint, go-test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Allowlisted service accounts can now access the application without being registered in the user store.
  * Service accounts not on the allowlist continue to require registration.

* **Bug Fixes**
  * Preserved existing registration checks and authorization error handling for regular users and non-allowlisted accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->