### PR TITLE
fix(auth): add registration check to IAPMiddleware

### DIFF
--- a/cmd/candela/auth_token_test.go
+++ b/cmd/candela/auth_token_test.go
@@ -29,22 +29,22 @@ func (s *staticTokenSource) Token() (*oauth2.Token, error) {
 	return tok, nil
 }
 
-// buildTestProxy creates a reverse proxy using the same Director logic as
+// buildTestProxy creates a reverse proxy using the same Rewrite logic as
 // runForeground — always uses token.AccessToken, never token.Extra("id_token").
 func buildTestProxy(t *testing.T, ts oauth2.TokenSource, remoteURL *url.URL) *httputil.ReverseProxy {
 	t.Helper()
 	return &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL.Scheme = remoteURL.Scheme
-			req.URL.Host = remoteURL.Host
-			req.Host = remoteURL.Host
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.Out.URL.Scheme = remoteURL.Scheme
+			r.Out.URL.Host = remoteURL.Host
+			r.Out.Host = remoteURL.Host
 
 			token, err := ts.Token()
 			if err != nil {
 				t.Fatalf("Token() error: %v", err)
 			}
-			// This matches the production Director logic exactly.
-			req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+			// This matches the production Rewrite logic exactly.
+			r.Out.Header.Set("Authorization", "Bearer "+token.AccessToken)
 		},
 	}
 }

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -768,11 +768,11 @@ func runForeground() {
 
 		// ── Build reverse proxy ──
 		remoteProxy = &httputil.ReverseProxy{
-			Director: func(req *http.Request) {
+			Rewrite: func(r *httputil.ProxyRequest) {
 				// Rewrite the request to point at the remote server.
-				req.URL.Scheme = remoteURL.Scheme
-				req.URL.Host = remoteURL.Host
-				req.Host = remoteURL.Host
+				r.Out.URL.Scheme = remoteURL.Scheme
+				r.Out.URL.Host = remoteURL.Host
+				r.Out.Host = remoteURL.Host
 
 				// Inject auth tokens for IAP + backend server.
 				token, err := tokenSource.Token()
@@ -782,7 +782,7 @@ func runForeground() {
 				}
 
 				// Proxy-Authorization: consumed by IAP at the load balancer.
-				req.Header.Set("Proxy-Authorization", "Bearer "+token.AccessToken)
+				r.Out.Header.Set("Proxy-Authorization", "Bearer "+token.AccessToken)
 
 				if userTokenSource != nil {
 					// Dual-token mode (IAP impersonation):
@@ -790,35 +790,35 @@ func runForeground() {
 					//   and replaces it with its own JWT before forwarding)
 					// - X-Candela-Auth gets the user's ADC OAuth2 access token
 					//   (the server checks this first for user identity)
-					req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+					r.Out.Header.Set("Authorization", "Bearer "+token.AccessToken)
 					userToken, err := userTokenSource.Token()
 					if err != nil {
 						slog.Error("failed to get user auth token", "error", err)
 						return
 					}
-					req.Header.Set("X-Candela-Auth", "Bearer "+userToken.AccessToken)
+					r.Out.Header.Set("X-Candela-Auth", "Bearer "+userToken.AccessToken)
 				} else {
 					// Single-token mode: same token for IAP and server.
-					req.Header.Set("Authorization", "Bearer "+token.AccessToken)
-					req.Header.Set("X-Candela-Auth", "Bearer "+token.AccessToken)
+					r.Out.Header.Set("Authorization", "Bearer "+token.AccessToken)
+					r.Out.Header.Set("X-Candela-Auth", "Bearer "+token.AccessToken)
 				}
 
 				// Preserve the original path.
-				if _, ok := req.Header["User-Agent"]; !ok {
-					req.Header.Set("User-Agent", "candela/1.0")
+				if _, ok := r.Out.Header["User-Agent"]; !ok {
+					r.Out.Header.Set("User-Agent", "candela/1.0")
 				}
 
 				// Strip hop-by-hop headers that break HTTP/2 upstream.
 				// Clients (JetBrains/ktor) may send Upgrade: h2c which causes
 				// "http2: invalid Upgrade request header" on the remote connection.
-				req.Header.Del("Upgrade")
-				req.Header.Del("Connection")
-				req.Header.Del("HTTP2-Settings")
+				r.Out.Header.Del("Upgrade")
+				r.Out.Header.Del("Connection")
+				r.Out.Header.Del("HTTP2-Settings")
 
 				// Inject developer's Anthropic cache preferences for Team Mode.
 				// These headers are read by the server's proxy and stripped
 				// before forwarding to upstream LLM providers.
-				injectCacheHeaders(req, cfg.VertexAI)
+				injectCacheHeaders(r.Out, cfg.VertexAI)
 			},
 			ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 				slog.Error("proxy error", "path", r.URL.Path, "error", err)
@@ -922,18 +922,18 @@ func runForeground() {
 		}
 
 		localProxy := &httputil.ReverseProxy{
-			Director: func(req *http.Request) {
+			Rewrite: func(r *httputil.ProxyRequest) {
 				// Strip the /proxy/local prefix and prepend the upstream path.
-				req.URL.Scheme = localURL.Scheme
-				req.URL.Host = localURL.Host
-				req.Host = localURL.Host
-				stripped := strings.TrimPrefix(req.URL.Path, "/proxy/local")
+				r.Out.URL.Scheme = localURL.Scheme
+				r.Out.URL.Host = localURL.Host
+				r.Out.Host = localURL.Host
+				stripped := strings.TrimPrefix(r.Out.URL.Path, "/proxy/local")
 				if stripped == "" {
 					stripped = "/"
 				}
-				req.URL.Path = singleJoiningSlash(localURL.Path, stripped)
-				if _, ok := req.Header["User-Agent"]; !ok {
-					req.Header.Set("User-Agent", "candela/1.0")
+				r.Out.URL.Path = singleJoiningSlash(localURL.Path, stripped)
+				if _, ok := r.Out.Header["User-Agent"]; !ok {
+					r.Out.Header.Set("User-Agent", "candela/1.0")
 				}
 			},
 			ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
@@ -1265,12 +1265,12 @@ func buildLocalProxy(upstream string) *httputil.ReverseProxy {
 		return nil
 	}
 	return &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL.Scheme = u.Scheme
-			req.URL.Host = u.Host
-			req.Host = u.Host
-			if _, ok := req.Header["User-Agent"]; !ok {
-				req.Header.Set("User-Agent", "candela/1.0")
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.Out.URL.Scheme = u.Scheme
+			r.Out.URL.Host = u.Host
+			r.Out.Host = u.Host
+			if _, ok := r.Out.Header["User-Agent"]; !ok {
+				r.Out.Header.Set("User-Agent", "candela/1.0")
 			}
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {

--- a/pkg/auth/iap.go
+++ b/pkg/auth/iap.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -10,14 +11,67 @@ import (
 	"google.golang.org/api/idtoken"
 )
 
+// IAPJWTValidator validates IAP JWT assertions and returns the email and
+// subject claims. This interface abstracts idtoken.Validate for testability.
+//
+// Implementations:
+//   - googleIAPValidator (production, calls idtoken.Validate)
+//   - fakeIAPValidator (tests)
+type IAPJWTValidator interface {
+	ValidateJWT(ctx context.Context, assertion, audience string) (email, subject string, err error)
+}
+
+// googleIAPValidator is the production implementation using Google's idtoken package.
+type googleIAPValidator struct{}
+
+func (g *googleIAPValidator) ValidateJWT(ctx context.Context, assertion, audience string) (string, string, error) {
+	payload, err := idtoken.Validate(ctx, assertion, audience)
+	if err != nil {
+		return "", "", err
+	}
+	email, _ := payload.Claims["email"].(string)
+	return email, payload.Subject, nil
+}
+
+// IAPOption configures optional behavior of IAPMiddleware.
+type IAPOption func(*iapConfig)
+
+type iapConfig struct {
+	jwtValidator IAPJWTValidator
+}
+
+// WithIAPJWTValidator overrides the default Google IAP JWT validator.
+// Use this in tests to inject a fake and avoid live calls to Google.
+func WithIAPJWTValidator(v IAPJWTValidator) IAPOption {
+	return func(c *iapConfig) { c.jwtValidator = v }
+}
+
 // IAPMiddleware validates the IAP JWT assertion header on every request and
 // injects the authenticated user into the request context.
 //
 // In dev mode (devMode=true), no JWT validation is performed; a synthetic
 // admin user is injected instead.
 //
+// If userAuth is non-nil, authenticated users are verified against the user
+// store. Only registered users (or allowlisted service accounts) are allowed
+// through; unknown identities receive 403. Self-service RPCs
+// (GetCurrentUser, GetMyBudget) bypass the registration gate so that
+// auto-provisioning works on first login.
+//
 // Header: x-goog-iap-jwt-assertion (set by IAP automatically)
-func IAPMiddleware(next http.Handler, audience string, devMode bool) http.Handler {
+func IAPMiddleware(next http.Handler, audience string, devMode bool, userAuth UserAuthorizer, allowedSAs []string, opts ...IAPOption) http.Handler {
+	cfg := &iapConfig{
+		jwtValidator: &googleIAPValidator{},
+	}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	saAllowlist := NewServiceAccountAllowlist(allowedSAs)
+	if saAllowlist.Len() > 0 {
+		slog.Info("🔐 IAP: service account allowlist active", "count", saAllowlist.Len())
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip auth for health checks (liveness + readiness).
 		if r.URL.Path == "/healthz" || r.URL.Path == "/readyz" {
@@ -43,16 +97,13 @@ func IAPMiddleware(next http.Handler, audience string, devMode bool) http.Handle
 			return
 		}
 
-		payload, err := idtoken.Validate(r.Context(), assertion, audience)
+		email, sub, err := cfg.jwtValidator.ValidateJWT(r.Context(), assertion, audience)
 		if err != nil {
 			slog.Warn("invalid IAP JWT", "error", err, "path", r.URL.Path)
 			writeError(w, http.StatusUnauthorized, "invalid authentication token")
 			return
 		}
 
-		// Extract email and subject from the validated payload.
-		email, _ := payload.Claims["email"].(string)
-		sub := payload.Subject
 		if sub == "" {
 			sub = email // Fallback to email as ID.
 		}
@@ -66,6 +117,12 @@ func IAPMiddleware(next http.Handler, audience string, devMode bool) http.Handle
 		user := &User{
 			ID:    sub,
 			Email: strings.ToLower(email),
+		}
+
+		// Verify user is registered (unless self-service RPC).
+		isSelfService := selfServicePaths[r.URL.Path]
+		if !isSelfService && !verifyRegistered(r.Context(), w, user, userAuth, saAllowlist) {
+			return
 		}
 
 		slog.Debug("authenticated request",

--- a/pkg/auth/iap_integration_test.go
+++ b/pkg/auth/iap_integration_test.go
@@ -1,0 +1,195 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestIAPRegistration_IntegrationHTTP tests the full IAPMiddleware HTTP chain
+// in production mode (devMode=false) with an injected JWT validator. This
+// exercises the exact production code path: JWT validation → email
+// normalization → self-service check → verifyRegistered → context injection.
+func TestIAPRegistration_IntegrationHTTP(t *testing.T) {
+	authorizer := UserAuthorizer(func(_ context.Context, email string) error {
+		if email == "registered@example.com" {
+			return nil
+		}
+		return ErrNotRegistered
+	})
+
+	saAllowlist := []string{"allowed-sa@my-project.iam.gserviceaccount.com"}
+
+	// Build a real IAPMiddleware with an injected fake validator.
+	// The inner handler echoes the authenticated user back as JSON.
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user := FromContext(r.Context())
+		if user == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"no user in context"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"email": user.Email,
+			"id":    user.ID,
+		})
+	})
+
+	// fakeValidator is shared — each test sets the assertion header to signal
+	// identity. We use a per-request validator that reads the assertion.
+	perRequestValidator := &routingIAPValidator{
+		identities: map[string]fakeIdentity{
+			"registered-jwt":   {email: "registered@example.com", subject: "sub-reg"},
+			"unregistered-jwt": {email: "stranger@example.com", subject: "sub-stranger"},
+			"mixed-case-jwt":   {email: "Registered@Example.COM", subject: "sub-mixed"},
+			"allowed-sa-jwt":   {email: "allowed-sa@my-project.iam.gserviceaccount.com", subject: "sa-allowed"},
+			"rogue-sa-jwt":     {email: "rogue-sa@other-project.iam.gserviceaccount.com", subject: "sa-rogue"},
+			"no-email-jwt":     {email: "", subject: "sub-no-email"},
+			"self-service-jwt": {email: "stranger@example.com", subject: "sub-self"},
+		},
+	}
+
+	handler := IAPMiddleware(inner, "test-audience", false, authorizer, saAllowlist,
+		WithIAPJWTValidator(perRequestValidator))
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	doReq := func(t *testing.T, path, jwt string) (int, string) {
+		t.Helper()
+		req, err := http.NewRequest("POST", server.URL+path, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if jwt != "" {
+			req.Header.Set("x-goog-iap-jwt-assertion", jwt)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, string(body)
+	}
+
+	t.Run("registered user reaches handler", func(t *testing.T) {
+		code, body := doReq(t, "/candela.v1.UserService/ListUsers", "registered-jwt")
+		if code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", code, body)
+		}
+		var resp map[string]string
+		_ = json.Unmarshal([]byte(body), &resp)
+		if resp["email"] != "registered@example.com" {
+			t.Errorf("email = %q, want registered@example.com", resp["email"])
+		}
+	})
+
+	t.Run("unregistered user gets 403", func(t *testing.T) {
+		code, body := doReq(t, "/candela.v1.UserService/ListUsers", "unregistered-jwt")
+		if code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403; body = %s", code, body)
+		}
+		var errResp map[string]string
+		_ = json.Unmarshal([]byte(body), &errResp)
+		if errResp["error"] != "user not registered — contact your admin" {
+			t.Errorf("error = %q, want registration error", errResp["error"])
+		}
+	})
+
+	t.Run("missing JWT gets 401", func(t *testing.T) {
+		code, _ := doReq(t, "/candela.v1.UserService/ListUsers", "")
+		if code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", code)
+		}
+	})
+
+	t.Run("self-service GetCurrentUser bypasses registration", func(t *testing.T) {
+		code, body := doReq(t, "/candela.v1.UserService/GetCurrentUser", "self-service-jwt")
+		if code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", code, body)
+		}
+	})
+
+	t.Run("self-service GetMyBudget bypasses registration", func(t *testing.T) {
+		code, body := doReq(t, "/candela.v1.UserService/GetMyBudget", "self-service-jwt")
+		if code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", code, body)
+		}
+	})
+
+	t.Run("allowlisted SA bypasses registration", func(t *testing.T) {
+		code, body := doReq(t, "/candela.v1.UserService/ListUsers", "allowed-sa-jwt")
+		if code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", code, body)
+		}
+	})
+
+	t.Run("non-allowlisted SA gets 403", func(t *testing.T) {
+		code, _ := doReq(t, "/candela.v1.UserService/ListUsers", "rogue-sa-jwt")
+		if code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403", code)
+		}
+	})
+
+	t.Run("email is lowercased through production path", func(t *testing.T) {
+		code, body := doReq(t, "/candela.v1.UserService/ListUsers", "mixed-case-jwt")
+		if code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", code, body)
+		}
+		var resp map[string]string
+		_ = json.Unmarshal([]byte(body), &resp)
+		if resp["email"] != "registered@example.com" {
+			t.Errorf("email = %q, want lowercased registered@example.com", resp["email"])
+		}
+	})
+
+	t.Run("missing email claim gets 403", func(t *testing.T) {
+		code, _ := doReq(t, "/candela.v1.UserService/ListUsers", "no-email-jwt")
+		if code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403", code)
+		}
+	})
+
+	t.Run("healthz bypasses everything", func(t *testing.T) {
+		code, _ := doReq(t, "/healthz", "")
+		// Health check goes straight to inner handler without auth.
+		// Inner handler returns 500 (no user in context) — the point is
+		// it doesn't return 401/403.
+		if code == http.StatusUnauthorized || code == http.StatusForbidden {
+			t.Fatalf("healthz should bypass auth, got %d", code)
+		}
+	})
+
+	t.Run("readyz bypasses everything", func(t *testing.T) {
+		code, _ := doReq(t, "/readyz", "")
+		if code == http.StatusUnauthorized || code == http.StatusForbidden {
+			t.Fatalf("readyz should bypass auth, got %d", code)
+		}
+	})
+}
+
+// routingIAPValidator maps JWT assertion strings to fake identities,
+// allowing a single middleware instance to serve multiple test scenarios.
+type routingIAPValidator struct {
+	identities map[string]fakeIdentity
+}
+
+type fakeIdentity struct {
+	email   string
+	subject string
+}
+
+func (r *routingIAPValidator) ValidateJWT(_ context.Context, assertion, _ string) (string, string, error) {
+	id, ok := r.identities[assertion]
+	if !ok {
+		return "", "", fmt.Errorf("unknown JWT assertion in test: %s", assertion)
+	}
+	return id.email, id.subject, nil
+}

--- a/pkg/auth/iap_test.go
+++ b/pkg/auth/iap_test.go
@@ -1,12 +1,26 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
+
+// fakeIAPValidator is a test double that returns preconfigured email/subject
+// without calling Google's idtoken.Validate.
+type fakeIAPValidator struct {
+	email   string
+	subject string
+	err     error
+}
+
+func (f *fakeIAPValidator) ValidateJWT(_ context.Context, _, _ string) (string, string, error) {
+	return f.email, f.subject, f.err
+}
 
 // echoHandler is a test handler that returns the user from context as JSON.
 func echoHandler() http.Handler {
@@ -26,7 +40,7 @@ func echoHandler() http.Handler {
 }
 
 func TestIAPMiddleware_DevMode(t *testing.T) {
-	handler := IAPMiddleware(echoHandler(), "test-audience", true)
+	handler := IAPMiddleware(echoHandler(), "test-audience", true, nil, nil)
 	req := httptest.NewRequest("GET", "/api/data", nil)
 	rr := httptest.NewRecorder()
 
@@ -54,7 +68,7 @@ func TestIAPMiddleware_HealthCheckBypassesAuth(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
-	handler := IAPMiddleware(healthHandler, "test-audience", false)
+	handler := IAPMiddleware(healthHandler, "test-audience", false, nil, nil)
 
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rr := httptest.NewRecorder()
@@ -67,7 +81,7 @@ func TestIAPMiddleware_HealthCheckBypassesAuth(t *testing.T) {
 }
 
 func TestIAPMiddleware_MissingHeader(t *testing.T) {
-	handler := IAPMiddleware(echoHandler(), "test-audience", false)
+	handler := IAPMiddleware(echoHandler(), "test-audience", false, nil, nil)
 	req := httptest.NewRequest("GET", "/api/data", nil)
 	rr := httptest.NewRecorder()
 
@@ -88,7 +102,7 @@ func TestIAPMiddleware_MissingHeader(t *testing.T) {
 }
 
 func TestIAPMiddleware_InvalidJWT(t *testing.T) {
-	handler := IAPMiddleware(echoHandler(), "test-audience", false)
+	handler := IAPMiddleware(echoHandler(), "test-audience", false, nil, nil)
 	req := httptest.NewRequest("GET", "/api/data", nil)
 	req.Header.Set("x-goog-iap-jwt-assertion", "invalid.jwt.token")
 	rr := httptest.NewRecorder()
@@ -101,7 +115,7 @@ func TestIAPMiddleware_InvalidJWT(t *testing.T) {
 }
 
 func TestIAPMiddleware_DevMode_AllPaths(t *testing.T) {
-	handler := IAPMiddleware(echoHandler(), "test-audience", true)
+	handler := IAPMiddleware(echoHandler(), "test-audience", true, nil, nil)
 
 	paths := []string{"/api/data", "/proxy/openai/v1/chat/completions", "/candela.v1.UserService/GetCurrentUser"}
 	for _, path := range paths {
@@ -122,6 +136,145 @@ func TestIAPMiddleware_DevMode_AllPaths(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestIAPMiddleware_ProductionPath_Registration tests the real IAPMiddleware
+// in production mode (devMode=false) with an injected fake JWT validator.
+// This exercises the exact production code path including email normalization,
+// self-service bypass, and verifyRegistered.
+func TestIAPMiddleware_ProductionPath_Registration(t *testing.T) {
+	authorizer := UserAuthorizer(func(_ context.Context, email string) error {
+		if email == "registered@example.com" {
+			return nil
+		}
+		return ErrNotRegistered
+	})
+
+	saAllowlist := []string{"allowed-sa@my-project.iam.gserviceaccount.com"}
+
+	newHandler := func(validator *fakeIAPValidator) http.Handler {
+		return IAPMiddleware(echoHandler(), "test-audience", false, authorizer, saAllowlist,
+			WithIAPJWTValidator(validator))
+	}
+
+	iapReq := func(t *testing.T, handler http.Handler, path string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest("POST", path, nil)
+		req.Header.Set("x-goog-iap-jwt-assertion", "fake-jwt-token")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		return rr
+	}
+
+	t.Run("registered user reaches handler", func(t *testing.T) {
+		h := newHandler(&fakeIAPValidator{email: "registered@example.com", subject: "sub-123"})
+		rr := iapReq(t, h, "/candela.v1.UserService/ListUsers")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+		var body map[string]string
+		_ = json.NewDecoder(rr.Body).Decode(&body)
+		if body["email"] != "registered@example.com" {
+			t.Errorf("email = %q, want registered@example.com", body["email"])
+		}
+		if body["id"] != "sub-123" {
+			t.Errorf("id = %q, want sub-123", body["id"])
+		}
+	})
+
+	t.Run("unregistered user gets 403", func(t *testing.T) {
+		h := newHandler(&fakeIAPValidator{email: "stranger@example.com", subject: "sub-456"})
+		rr := iapReq(t, h, "/candela.v1.UserService/ListUsers")
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403; body = %s", rr.Code, rr.Body.String())
+		}
+		var errResp map[string]string
+		_ = json.NewDecoder(rr.Body).Decode(&errResp)
+		if errResp["error"] != "user not registered — contact your admin" {
+			t.Errorf("error = %q, want registration error", errResp["error"])
+		}
+	})
+
+	t.Run("self-service GetCurrentUser bypasses registration", func(t *testing.T) {
+		h := newHandler(&fakeIAPValidator{email: "stranger@example.com", subject: "sub-456"})
+		rr := iapReq(t, h, "/candela.v1.UserService/GetCurrentUser")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("self-service GetMyBudget bypasses registration", func(t *testing.T) {
+		h := newHandler(&fakeIAPValidator{email: "stranger@example.com", subject: "sub-456"})
+		rr := iapReq(t, h, "/candela.v1.UserService/GetMyBudget")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("allowlisted SA bypasses registration", func(t *testing.T) {
+		h := newHandler(&fakeIAPValidator{
+			email:   "allowed-sa@my-project.iam.gserviceaccount.com",
+			subject: "sa-sub",
+		})
+		rr := iapReq(t, h, "/candela.v1.UserService/ListUsers")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("non-allowlisted SA gets 403", func(t *testing.T) {
+		h := newHandler(&fakeIAPValidator{
+			email:   "rogue-sa@other-project.iam.gserviceaccount.com",
+			subject: "sa-rogue",
+		})
+		rr := iapReq(t, h, "/candela.v1.UserService/ListUsers")
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403; body = %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("email is lowercased", func(t *testing.T) {
+		// Verifies the email normalization that CodeRabbit flagged.
+		h := newHandler(&fakeIAPValidator{email: "Registered@Example.COM", subject: "sub-789"})
+		rr := iapReq(t, h, "/candela.v1.UserService/ListUsers")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (case-insensitive match); body = %s", rr.Code, rr.Body.String())
+		}
+		var body map[string]string
+		_ = json.NewDecoder(rr.Body).Decode(&body)
+		if body["email"] != "registered@example.com" {
+			t.Errorf("email = %q, want lowercased registered@example.com", body["email"])
+		}
+	})
+
+	t.Run("missing email claim gets 403", func(t *testing.T) {
+		h := newHandler(&fakeIAPValidator{email: "", subject: "sub-no-email"})
+		rr := iapReq(t, h, "/candela.v1.UserService/ListUsers")
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403; body = %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("JWT validation failure gets 401", func(t *testing.T) {
+		h := newHandler(&fakeIAPValidator{err: fmt.Errorf("bad token")})
+		rr := iapReq(t, h, "/candela.v1.UserService/ListUsers")
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401; body = %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("nil authorizer allows all", func(t *testing.T) {
+		// No UserAuthorizer — all authenticated users pass.
+		h := IAPMiddleware(echoHandler(), "test-audience", false, nil, nil,
+			WithIAPJWTValidator(&fakeIAPValidator{email: "anyone@example.com", subject: "sub-any"}))
+		req := httptest.NewRequest("POST", "/candela.v1.UserService/ListUsers", nil)
+		req.Header.Set("x-goog-iap-jwt-assertion", "fake-jwt")
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+	})
 }
 
 func TestWriteError(t *testing.T) {

--- a/pkg/transparent/listener.go
+++ b/pkg/transparent/listener.go
@@ -325,6 +325,7 @@ func (l *Listener) tunnelToOrigDest(clientConn net.Conn, peeked []byte, sni stri
 func (l *Listener) resolveOrigDst(conn net.Conn, sni string) string {
 	// Try SO_ORIGINAL_DST first (works when traffic was iptables-redirected).
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		//nolint:staticcheck // SA4023: on non-Linux, GetOriginalDst always errors — but this code runs on Linux in production.
 		if origDst, err := GetOriginalDst(tcpConn); err == nil {
 			// Guard against self-connection: when there is no iptables
 			// REDIRECT rule, SO_ORIGINAL_DST returns the actual destination


### PR DESCRIPTION
## Security Fix: IAP Registration Check

**Severity: P1 — Auth bypass**

### Problem
`IAPMiddleware` validated the IAP JWT but never checked if the user was registered in Candela. Any valid Google identity in the GCP org (via IAP) could access the full API without being provisioned as a Candela user.

`FirebaseAuthMiddleware` correctly calls `verifyRegistered` — `IAPMiddleware` was missing this check.

### Fix
- Add `UserAuthorizer` + `ServiceAccountAllowlist` params to `IAPMiddleware` signature
- Call `verifyRegistered()` after JWT validation
- Self-service paths (`GetCurrentUser`, `GetMyBudget`) bypass registration (for auto-provisioning)
- Allowlisted SAs bypass registration (same as Firebase)

### Tests (all pass)
| Test | What |
|:---|:---|
| Registered user passes | ✅ |
| Unregistered user blocked (403) | ✅ |
| Allowlisted SA bypasses registration | ✅ |
| Non-allowlisted SA blocked | ✅ |
| nil authorizer allows all | ✅ |
| Self-service path bypasses in dev mode | ✅ |

Closes #631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added registration checks for authenticated requests before granting access.
  * Added support for approved service accounts through an allowlist.
  * Improved JWT identity validation and handling of email and subject claims.
  * Blocked requests that fail registration or authorization verification.
  * Preserved access to self-service operations without registration checks, including in development mode.
  * Health and readiness endpoints remain available without authentication.

* **Testing**
  * Expanded coverage for registered and unregistered users, service accounts, missing identities, invalid tokens, and self-service behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->