### PR TITLE
infra: post-deploy smoke tests + Cloud Run canary deploy & rollback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 # Candela — Deploy to Cloud Run
 #
 # Deploys a container image to Cloud Run using the canary pattern:
-#   1. Deploy new revision with --no-traffic (tagged "canary")
+#   1. Validate inputs and deploy new revision with --no-traffic (tagged "canary")
 #   2. Run smoke tests against the canary revision URL
 #   3. If smoke passes: promote canary to 100% traffic
 #   4. If smoke fails: delete canary revision, keep previous revision live
@@ -9,8 +9,8 @@
 # Creates a GitHub Deployment record for audit trail.
 #
 # Requires:
-#   - Workload Identity Federation or GCP_SA_KEY secret
-#   - GCP_PROJECT_ID, GCP_REGION, CLOUD_RUN_SERVICE secrets/vars
+#   - Workload Identity Federation (WIF_PROVIDER + WIF_SERVICE_ACCOUNT secrets)
+#   - GCP_PROJECT_ID, GCP_REGION, CLOUD_RUN_SERVICE vars
 
 name: Deploy
 
@@ -38,23 +38,30 @@ permissions:
   id-token: write        # Workload Identity Federation
   deployments: write     # GitHub Deployments API
 
-env:
-  IMAGE: ghcr.io/candelahq/candela-server:${{ inputs.image_tag }}
-
 jobs:
-  # ── Gate: staging must pass before production ───────────────────────
-  # Production deploys require a successful staging deploy of the same
-  # image tag. This is enforced via GitHub Environment protection rules.
-
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: ${{ inputs.environment }}
 
+    # Pass workflow inputs via env to avoid shell injection.
+    env:
+      DEPLOY_IMAGE_TAG: ${{ inputs.image_tag }}
+      DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
+
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
+
+      # ── Validate inputs ──────────────────────────────────────────────
+      - name: Validate image tag
+        run: |
+          if [[ ! "$DEPLOY_IMAGE_TAG" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+            echo "❌ Invalid image tag: must be alphanumeric with . _ -"
+            exit 1
+          fi
+          echo "IMAGE=ghcr.io/candelahq/candela-server:${DEPLOY_IMAGE_TAG}" >> "$GITHUB_ENV"
 
       # ── Authenticate to GCP ──────────────────────────────────────────
       - name: Authenticate to Google Cloud
@@ -71,85 +78,107 @@ jobs:
       - name: Create deployment
         id: deployment
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          DEPLOY_IMAGE: ${{ env.IMAGE }}
         with:
           script: |
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.sha,
-              environment: '${{ inputs.environment }}',
-              description: 'Deploy ${{ env.IMAGE }} to ${{ inputs.environment }}',
+              environment: process.env.DEPLOY_ENVIRONMENT,
+              description: `Deploy ${process.env.DEPLOY_IMAGE} to ${process.env.DEPLOY_ENVIRONMENT}`,
               auto_merge: false,
               required_contexts: [],
-              payload: { image: '${{ env.IMAGE }}' },
+              payload: { image: process.env.DEPLOY_IMAGE },
             });
             core.setOutput('id', deployment.data.id);
 
       - name: Set deployment in_progress
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.id }}
         with:
           script: |
             await github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              deployment_id: ${{ steps.deployment.outputs.id }},
+              deployment_id: parseInt(process.env.DEPLOYMENT_ID, 10),
               state: 'in_progress',
               description: 'Deploying canary revision',
             });
+
+      # ── Save current traffic allocation ──────────────────────────────
+      - name: Save current traffic state
+        id: traffic
+        run: |
+          CURRENT=$(gcloud run services describe "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
+            --format='value(status.traffic.revisionName,status.traffic.percent)' \
+            | head -1)
+          echo "previous=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "📊 Current traffic: $CURRENT"
 
       # ── Deploy canary (no traffic) ───────────────────────────────────
       - name: Deploy canary revision
         id: canary
         run: |
-          gcloud run deploy ${{ vars.CLOUD_RUN_SERVICE }} \
-            --project ${{ vars.GCP_PROJECT_ID }} \
-            --region ${{ vars.GCP_REGION }} \
-            --image ${{ env.IMAGE }} \
+          gcloud run deploy "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
+            --image "$IMAGE" \
             --no-traffic \
             --tag canary \
-            --format='value(status.url)' \
             2>&1 | tee /tmp/deploy-output.txt
 
-          # Extract the canary URL from the tagged revision
-          CANARY_URL=$(gcloud run services describe ${{ vars.CLOUD_RUN_SERVICE }} \
-            --project ${{ vars.GCP_PROJECT_ID }} \
-            --region ${{ vars.GCP_REGION }} \
+          # Extract the canary URL and canonical service URL
+          CANARY_URL=$(gcloud run services describe "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
             --format='value(status.traffic[tag=canary].url)')
 
+          SERVICE_URL=$(gcloud run services describe "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
+            --format='value(status.url)')
+
           echo "canary_url=$CANARY_URL" >> "$GITHUB_OUTPUT"
+          echo "service_url=$SERVICE_URL" >> "$GITHUB_OUTPUT"
           echo "🕯️ Canary URL: $CANARY_URL"
 
       # ── Smoke test canary ────────────────────────────────────────────
       - name: Smoke test canary
         id: smoke
+        env:
+          CANARY_URL: ${{ steps.canary.outputs.canary_url }}
+          SERVICE_URL: ${{ steps.canary.outputs.service_url }}
         run: |
           chmod +x scripts/smoke-test.sh
 
-          # Get an identity token for the canary URL
+          # Get an identity token using the canonical service URL as audience
           TOKEN=$(gcloud auth print-identity-token \
-            --audiences=${{ steps.canary.outputs.canary_url }} 2>/dev/null || echo "")
+            --audiences="$SERVICE_URL" 2>/dev/null || echo "")
 
           if [[ -n "$TOKEN" ]]; then
-            ./scripts/smoke-test.sh "${{ steps.canary.outputs.canary_url }}" \
-              --token "$TOKEN" --timeout 90
+            ./scripts/smoke-test.sh "$CANARY_URL" --token "$TOKEN" --timeout 60
           else
-            ./scripts/smoke-test.sh "${{ steps.canary.outputs.canary_url }}" \
-              --timeout 90
+            ./scripts/smoke-test.sh "$CANARY_URL" --timeout 60
           fi
 
       # ── Promote: shift 100% traffic to canary ───────────────────────
       - name: Promote canary to live
         if: success()
         run: |
-          gcloud run services update-traffic ${{ vars.CLOUD_RUN_SERVICE }} \
-            --project ${{ vars.GCP_PROJECT_ID }} \
-            --region ${{ vars.GCP_REGION }} \
+          gcloud run services update-traffic "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
             --to-tags canary=100
 
           # Clean up the canary tag
-          gcloud run services update-traffic ${{ vars.CLOUD_RUN_SERVICE }} \
-            --project ${{ vars.GCP_PROJECT_ID }} \
-            --region ${{ vars.GCP_REGION }} \
+          gcloud run services update-traffic "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
             --clear-tags
 
           echo "✅ Traffic shifted to new revision"
@@ -160,22 +189,34 @@ jobs:
         run: |
           echo "❌ Smoke tests failed — rolling back canary"
 
-          # Remove the canary tag and delete the failed revision
-          CANARY_REVISION=$(gcloud run services describe ${{ vars.CLOUD_RUN_SERVICE }} \
-            --project ${{ vars.GCP_PROJECT_ID }} \
-            --region ${{ vars.GCP_REGION }} \
+          # Identify the canary revision
+          CANARY_REVISION=$(gcloud run services describe "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
             --format='value(status.traffic[tag=canary].revisionName)')
 
-          gcloud run services update-traffic ${{ vars.CLOUD_RUN_SERVICE }} \
-            --project ${{ vars.GCP_PROJECT_ID }} \
-            --region ${{ vars.GCP_REGION }} \
+          # Clear canary tag (removes it from traffic, even if it had 0%)
+          gcloud run services update-traffic "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
             --clear-tags
 
+          # Verify canary is no longer serving before deleting
           if [[ -n "$CANARY_REVISION" ]]; then
-            gcloud run revisions delete "$CANARY_REVISION" \
-              --project ${{ vars.GCP_PROJECT_ID }} \
-              --region ${{ vars.GCP_REGION }} \
-              --quiet || true
+            SERVING=$(gcloud run services describe "${{ vars.CLOUD_RUN_SERVICE }}" \
+              --project "${{ vars.GCP_PROJECT_ID }}" \
+              --region "${{ vars.GCP_REGION }}" \
+              --format='value(status.traffic[revisionName='"$CANARY_REVISION"'].percent)' || echo "0")
+
+            if [[ "${SERVING:-0}" == "0" || -z "$SERVING" ]]; then
+              gcloud run revisions delete "$CANARY_REVISION" \
+                --project "${{ vars.GCP_PROJECT_ID }}" \
+                --region "${{ vars.GCP_REGION }}" \
+                --quiet || true
+              echo "🗑️  Deleted failed canary revision: $CANARY_REVISION"
+            else
+              echo "⚠️  Canary still serving ${SERVING}% — skipping deletion"
+            fi
           fi
 
           echo "🔙 Traffic remains on previous revision"
@@ -184,26 +225,31 @@ jobs:
       - name: Mark deployment success
         if: success()
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.id }}
+          SERVICE_URL: ${{ steps.canary.outputs.service_url }}
         with:
           script: |
             await github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              deployment_id: ${{ steps.deployment.outputs.id }},
+              deployment_id: parseInt(process.env.DEPLOYMENT_ID, 10),
               state: 'success',
               description: 'Deployed and verified',
-              environment_url: '${{ steps.canary.outputs.canary_url }}'.replace('canary---', ''),
+              environment_url: process.env.SERVICE_URL,
             });
 
       - name: Mark deployment failure
         if: failure()
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.id }}
         with:
           script: |
             await github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              deployment_id: ${{ steps.deployment.outputs.id }},
+              deployment_id: parseInt(process.env.DEPLOYMENT_ID, 10),
               state: 'failure',
               description: 'Smoke tests failed — canary rolled back',
             });
@@ -211,9 +257,14 @@ jobs:
       # ── Notify on failure ────────────────────────────────────────────
       - name: Notify on failure
         if: failure() && vars.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ vars.SLACK_WEBHOOK_URL }}
+          SLACK_MESSAGE: |
+            🚨 Candela deploy FAILED (${{ inputs.environment }})
+            Image: `${{ env.IMAGE }}`
+            Triggered by: ${{ github.actor }}
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          curl -s -X POST "${{ vars.SLACK_WEBHOOK_URL }}" \
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
-            -d '{
-              "text": "🚨 Candela deploy FAILED (${{ inputs.environment }})\nImage: `${{ env.IMAGE }}`\nTriggered by: ${{ github.actor }}\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }' || true
+            -d "$(jq -n --arg text "$SLACK_MESSAGE" '{text: $text}')" || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,219 @@
+# Candela — Deploy to Cloud Run
+#
+# Deploys a container image to Cloud Run using the canary pattern:
+#   1. Deploy new revision with --no-traffic (tagged "canary")
+#   2. Run smoke tests against the canary revision URL
+#   3. If smoke passes: promote canary to 100% traffic
+#   4. If smoke fails: delete canary revision, keep previous revision live
+#
+# Creates a GitHub Deployment record for audit trail.
+#
+# Requires:
+#   - Workload Identity Federation or GCP_SA_KEY secret
+#   - GCP_PROJECT_ID, GCP_REGION, CLOUD_RUN_SERVICE secrets/vars
+
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      image_tag:
+        description: "Image tag to deploy (SHA or version, e.g. 'abc1234' or 'v1.2.0')"
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-${{ inputs.environment }}
+  cancel-in-progress: false  # Never cancel an in-flight deploy
+
+permissions:
+  contents: read
+  id-token: write        # Workload Identity Federation
+  deployments: write     # GitHub Deployments API
+
+env:
+  IMAGE: ghcr.io/candelahq/candela-server:${{ inputs.image_tag }}
+
+jobs:
+  # ── Gate: staging must pass before production ───────────────────────
+  # Production deploys require a successful staging deploy of the same
+  # image tag. This is enforced via GitHub Environment protection rules.
+
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      # ── Authenticate to GCP ──────────────────────────────────────────
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2
+
+      # ── Create GitHub Deployment ─────────────────────────────────────
+      - name: Create deployment
+        id: deployment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: '${{ inputs.environment }}',
+              description: 'Deploy ${{ env.IMAGE }} to ${{ inputs.environment }}',
+              auto_merge: false,
+              required_contexts: [],
+              payload: { image: '${{ env.IMAGE }}' },
+            });
+            core.setOutput('id', deployment.data.id);
+
+      - name: Set deployment in_progress
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.id }},
+              state: 'in_progress',
+              description: 'Deploying canary revision',
+            });
+
+      # ── Deploy canary (no traffic) ───────────────────────────────────
+      - name: Deploy canary revision
+        id: canary
+        run: |
+          gcloud run deploy ${{ vars.CLOUD_RUN_SERVICE }} \
+            --project ${{ vars.GCP_PROJECT_ID }} \
+            --region ${{ vars.GCP_REGION }} \
+            --image ${{ env.IMAGE }} \
+            --no-traffic \
+            --tag canary \
+            --format='value(status.url)' \
+            2>&1 | tee /tmp/deploy-output.txt
+
+          # Extract the canary URL from the tagged revision
+          CANARY_URL=$(gcloud run services describe ${{ vars.CLOUD_RUN_SERVICE }} \
+            --project ${{ vars.GCP_PROJECT_ID }} \
+            --region ${{ vars.GCP_REGION }} \
+            --format='value(status.traffic[tag=canary].url)')
+
+          echo "canary_url=$CANARY_URL" >> "$GITHUB_OUTPUT"
+          echo "🕯️ Canary URL: $CANARY_URL"
+
+      # ── Smoke test canary ────────────────────────────────────────────
+      - name: Smoke test canary
+        id: smoke
+        run: |
+          chmod +x scripts/smoke-test.sh
+
+          # Get an identity token for the canary URL
+          TOKEN=$(gcloud auth print-identity-token \
+            --audiences=${{ steps.canary.outputs.canary_url }} 2>/dev/null || echo "")
+
+          if [[ -n "$TOKEN" ]]; then
+            ./scripts/smoke-test.sh "${{ steps.canary.outputs.canary_url }}" \
+              --token "$TOKEN" --timeout 90
+          else
+            ./scripts/smoke-test.sh "${{ steps.canary.outputs.canary_url }}" \
+              --timeout 90
+          fi
+
+      # ── Promote: shift 100% traffic to canary ───────────────────────
+      - name: Promote canary to live
+        if: success()
+        run: |
+          gcloud run services update-traffic ${{ vars.CLOUD_RUN_SERVICE }} \
+            --project ${{ vars.GCP_PROJECT_ID }} \
+            --region ${{ vars.GCP_REGION }} \
+            --to-tags canary=100
+
+          # Clean up the canary tag
+          gcloud run services update-traffic ${{ vars.CLOUD_RUN_SERVICE }} \
+            --project ${{ vars.GCP_PROJECT_ID }} \
+            --region ${{ vars.GCP_REGION }} \
+            --clear-tags
+
+          echo "✅ Traffic shifted to new revision"
+
+      # ── Rollback: smoke failed, remove canary ───────────────────────
+      - name: Rollback canary on failure
+        if: failure() && steps.canary.outcome == 'success'
+        run: |
+          echo "❌ Smoke tests failed — rolling back canary"
+
+          # Remove the canary tag and delete the failed revision
+          CANARY_REVISION=$(gcloud run services describe ${{ vars.CLOUD_RUN_SERVICE }} \
+            --project ${{ vars.GCP_PROJECT_ID }} \
+            --region ${{ vars.GCP_REGION }} \
+            --format='value(status.traffic[tag=canary].revisionName)')
+
+          gcloud run services update-traffic ${{ vars.CLOUD_RUN_SERVICE }} \
+            --project ${{ vars.GCP_PROJECT_ID }} \
+            --region ${{ vars.GCP_REGION }} \
+            --clear-tags
+
+          if [[ -n "$CANARY_REVISION" ]]; then
+            gcloud run revisions delete "$CANARY_REVISION" \
+              --project ${{ vars.GCP_PROJECT_ID }} \
+              --region ${{ vars.GCP_REGION }} \
+              --quiet || true
+          fi
+
+          echo "🔙 Traffic remains on previous revision"
+
+      # ── Deployment status ────────────────────────────────────────────
+      - name: Mark deployment success
+        if: success()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.id }},
+              state: 'success',
+              description: 'Deployed and verified',
+              environment_url: '${{ steps.canary.outputs.canary_url }}'.replace('canary---', ''),
+            });
+
+      - name: Mark deployment failure
+        if: failure()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.id }},
+              state: 'failure',
+              description: 'Smoke tests failed — canary rolled back',
+            });
+
+      # ── Notify on failure ────────────────────────────────────────────
+      - name: Notify on failure
+        if: failure() && vars.SLACK_WEBHOOK_URL != ''
+        run: |
+          curl -s -X POST "${{ vars.SLACK_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "text": "🚨 Candela deploy FAILED (${{ inputs.environment }})\nImage: `${{ env.IMAGE }}`\nTriggered by: ${{ github.actor }}\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }' || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -256,9 +256,9 @@ jobs:
 
       # ── Notify on failure ────────────────────────────────────────────
       - name: Notify on failure
-        if: failure() && vars.SLACK_WEBHOOK_URL != ''
+        if: failure() && secrets.SLACK_WEBHOOK_URL != ''
         env:
-          SLACK_WEBHOOK_URL: ${{ vars.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_MESSAGE: |
             🚨 Candela deploy FAILED (${{ inputs.environment }})
             Image: `${{ env.IMAGE }}`

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,153 @@
+# Candela — Emergency Rollback
+#
+# One-click rollback to a previous Cloud Run revision.
+# Can specify a target revision or auto-select the previous one.
+#
+# Usage:
+#   1. Go to Actions → Rollback → Run workflow
+#   2. Select environment
+#   3. Optionally specify a revision name (from `gcloud run revisions list`)
+#   4. Click "Run workflow"
+
+name: Rollback
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      revision:
+        description: "Revision to rollback to (leave empty for previous)"
+        required: false
+        type: string
+
+concurrency:
+  group: deploy-${{ inputs.environment }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+  deployments: write
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2
+
+      # ── Determine target revision ────────────────────────────────────
+      - name: Resolve rollback target
+        id: target
+        run: |
+          SERVICE="${{ vars.CLOUD_RUN_SERVICE }}"
+          PROJECT="${{ vars.GCP_PROJECT_ID }}"
+          REGION="${{ vars.GCP_REGION }}"
+
+          if [[ -n "${{ inputs.revision }}" ]]; then
+            TARGET="${{ inputs.revision }}"
+            echo "📌 Rolling back to specified revision: $TARGET"
+          else
+            # Get the second-most-recent active revision
+            TARGET=$(gcloud run revisions list \
+              --project "$PROJECT" \
+              --region "$REGION" \
+              --service "$SERVICE" \
+              --sort-by='~metadata.creationTimestamp' \
+              --format='value(metadata.name)' \
+              --limit=2 | tail -1)
+
+            if [[ -z "$TARGET" ]]; then
+              echo "❌ No previous revision found"
+              exit 1
+            fi
+            echo "📌 Rolling back to previous revision: $TARGET"
+          fi
+
+          echo "revision=$TARGET" >> "$GITHUB_OUTPUT"
+
+      # ── Shift traffic ────────────────────────────────────────────────
+      - name: Route traffic to target revision
+        run: |
+          gcloud run services update-traffic ${{ vars.CLOUD_RUN_SERVICE }} \
+            --project ${{ vars.GCP_PROJECT_ID }} \
+            --region ${{ vars.GCP_REGION }} \
+            --to-revisions=${{ steps.target.outputs.revision }}=100 \
+            --clear-tags
+
+          echo "✅ 100% traffic now on: ${{ steps.target.outputs.revision }}"
+
+      # ── Verify rollback ──────────────────────────────────────────────
+      - name: Smoke test after rollback
+        run: |
+          SERVICE_URL=$(gcloud run services describe ${{ vars.CLOUD_RUN_SERVICE }} \
+            --project ${{ vars.GCP_PROJECT_ID }} \
+            --region ${{ vars.GCP_REGION }} \
+            --format='value(status.url)')
+
+          chmod +x scripts/smoke-test.sh
+
+          TOKEN=$(gcloud auth print-identity-token \
+            --audiences="$SERVICE_URL" 2>/dev/null || echo "")
+
+          if [[ -n "$TOKEN" ]]; then
+            ./scripts/smoke-test.sh "$SERVICE_URL" --token "$TOKEN" --timeout 60
+          else
+            ./scripts/smoke-test.sh "$SERVICE_URL" --timeout 60
+          fi
+
+      # ── Audit trail ──────────────────────────────────────────────────
+      - name: Record rollback deployment
+        if: always()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: '${{ inputs.environment }}',
+              description: 'Rollback to ${{ steps.target.outputs.revision }}',
+              auto_merge: false,
+              required_contexts: [],
+              payload: { rollback: true, revision: '${{ steps.target.outputs.revision }}' },
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: '${{ job.status }}' === 'success' ? 'success' : 'failure',
+              description: 'Rollback to ${{ steps.target.outputs.revision }}',
+            });
+
+      # ── Notify ───────────────────────────────────────────────────────
+      - name: Notify
+        if: always() && vars.SLACK_WEBHOOK_URL != ''
+        run: |
+          STATUS="${{ job.status }}"
+          EMOJI=$(if [[ "$STATUS" == "success" ]]; then echo "🔙"; else echo "🚨"; fi)
+
+          curl -s -X POST "${{ vars.SLACK_WEBHOOK_URL }}" \
+            -H 'Content-Type: application/json' \
+            -d "{
+              \"text\": \"${EMOJI} Candela ROLLBACK (${{ inputs.environment }})\nRevision: \`${{ steps.target.outputs.revision }}\`\nStatus: ${STATUS}\nTriggered by: ${{ github.actor }}\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
+            }" || true

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -115,7 +115,57 @@ jobs:
           echo "revision=$TARGET" >> "$GITHUB_OUTPUT"
           echo "✅ Revision $TARGET is ready"
 
-      # ── Shift traffic ────────────────────────────────────────────────
+      # ── Save current traffic and test target via tag ─────────────────
+      - name: Save current traffic state
+        id: current
+        run: |
+          CURRENT_REVISION=$(gcloud run services describe "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
+            --format='value(status.traffic[0].revisionName)')
+          echo "revision=$CURRENT_REVISION" >> "$GITHUB_OUTPUT"
+          echo "📊 Current live revision: $CURRENT_REVISION"
+
+      - name: Tag target revision for testing
+        id: tag
+        run: |
+          # Tag the target revision so we can test it without shifting traffic
+          gcloud run services update-traffic "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
+            --set-tags rollback-test=${{ steps.target.outputs.revision }}
+
+          TAG_URL=$(gcloud run services describe "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
+            --format='value(status.traffic[tag=rollback-test].url)')
+
+          SERVICE_URL=$(gcloud run services describe "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
+            --format='value(status.url)')
+
+          echo "tag_url=$TAG_URL" >> "$GITHUB_OUTPUT"
+          echo "service_url=$SERVICE_URL" >> "$GITHUB_OUTPUT"
+          echo "🏷️ Tag URL: $TAG_URL"
+
+      - name: Smoke test target via tag (before traffic shift)
+        env:
+          TAG_URL: ${{ steps.tag.outputs.tag_url }}
+          SERVICE_URL: ${{ steps.tag.outputs.service_url }}
+        run: |
+          chmod +x scripts/smoke-test.sh
+
+          TOKEN=$(gcloud auth print-identity-token \
+            --audiences="$SERVICE_URL" 2>/dev/null || echo "")
+
+          if [[ -n "$TOKEN" ]]; then
+            ./scripts/smoke-test.sh "$TAG_URL" --token "$TOKEN" --timeout 60
+          else
+            ./scripts/smoke-test.sh "$TAG_URL" --timeout 60
+          fi
+
+      # ── Promote: shift traffic to verified target ──────────────────
       - name: Route traffic to target revision
         run: |
           gcloud run services update-traffic "${{ vars.CLOUD_RUN_SERVICE }}" \
@@ -125,25 +175,6 @@ jobs:
             --clear-tags
 
           echo "✅ 100% traffic now on: ${{ steps.target.outputs.revision }}"
-
-      # ── Verify rollback ──────────────────────────────────────────────
-      - name: Smoke test after rollback
-        run: |
-          SERVICE_URL=$(gcloud run services describe "${{ vars.CLOUD_RUN_SERVICE }}" \
-            --project "${{ vars.GCP_PROJECT_ID }}" \
-            --region "${{ vars.GCP_REGION }}" \
-            --format='value(status.url)')
-
-          chmod +x scripts/smoke-test.sh
-
-          TOKEN=$(gcloud auth print-identity-token \
-            --audiences="$SERVICE_URL" 2>/dev/null || echo "")
-
-          if [[ -n "$TOKEN" ]]; then
-            ./scripts/smoke-test.sh "$SERVICE_URL" --token "$TOKEN" --timeout 60
-          else
-            ./scripts/smoke-test.sh "$SERVICE_URL" --timeout 60
-          fi
 
       # ── Audit trail ──────────────────────────────────────────────────
       - name: Record rollback deployment
@@ -174,9 +205,9 @@ jobs:
 
       # ── Notify ───────────────────────────────────────────────────────
       - name: Notify
-        if: always() && vars.SLACK_WEBHOOK_URL != ''
+        if: always() && secrets.SLACK_WEBHOOK_URL != ''
         env:
-          SLACK_WEBHOOK_URL: ${{ vars.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           TARGET_REVISION: ${{ steps.target.outputs.revision }}
           JOB_STATUS: ${{ job.status }}
         run: |

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -130,10 +130,11 @@ jobs:
         id: tag
         run: |
           # Tag the target revision so we can test it without shifting traffic
+          # Use --update-tags to preserve any existing tags on other revisions
           gcloud run services update-traffic "${{ vars.CLOUD_RUN_SERVICE }}" \
             --project "${{ vars.GCP_PROJECT_ID }}" \
             --region "${{ vars.GCP_REGION }}" \
-            --set-tags rollback-test=${{ steps.target.outputs.revision }}
+            --update-tags rollback-test=${{ steps.target.outputs.revision }}
 
           TAG_URL=$(gcloud run services describe "${{ vars.CLOUD_RUN_SERVICE }}" \
             --project "${{ vars.GCP_PROJECT_ID }}" \
@@ -171,10 +172,18 @@ jobs:
           gcloud run services update-traffic "${{ vars.CLOUD_RUN_SERVICE }}" \
             --project "${{ vars.GCP_PROJECT_ID }}" \
             --region "${{ vars.GCP_REGION }}" \
-            --to-revisions=${{ steps.target.outputs.revision }}=100 \
-            --clear-tags
+            --to-revisions=${{ steps.target.outputs.revision }}=100
 
           echo "✅ 100% traffic now on: ${{ steps.target.outputs.revision }}"
+
+      # ── Clean up test tag (runs on success and failure) ─────────────
+      - name: Remove rollback-test tag
+        if: always() && steps.tag.outcome == 'success'
+        run: |
+          gcloud run services update-traffic "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
+            --remove-tags rollback-test || true
 
       # ── Audit trail ──────────────────────────────────────────────────
       - name: Record rollback deployment

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -2,6 +2,7 @@
 #
 # One-click rollback to a previous Cloud Run revision.
 # Can specify a target revision or auto-select the previous one.
+# Validates the target revision exists and is ready before shifting traffic.
 #
 # Usage:
 #   1. Go to Actions → Rollback → Run workflow
@@ -41,6 +42,11 @@ jobs:
     timeout-minutes: 10
     environment: ${{ inputs.environment }}
 
+    # Pass workflow inputs via env to avoid shell injection.
+    env:
+      ROLLBACK_REVISION: ${{ inputs.revision }}
+      ROLLBACK_ENVIRONMENT: ${{ inputs.environment }}
+
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -55,7 +61,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2
 
-      # ── Determine target revision ────────────────────────────────────
+      # ── Validate and resolve target revision ─────────────────────────
       - name: Resolve rollback target
         id: target
         run: |
@@ -63,8 +69,13 @@ jobs:
           PROJECT="${{ vars.GCP_PROJECT_ID }}"
           REGION="${{ vars.GCP_REGION }}"
 
-          if [[ -n "${{ inputs.revision }}" ]]; then
-            TARGET="${{ inputs.revision }}"
+          if [[ -n "$ROLLBACK_REVISION" ]]; then
+            # Validate revision name format (Cloud Run: service-nnnnn-xxx)
+            if [[ ! "$ROLLBACK_REVISION" =~ ^[a-z0-9-]+$ ]]; then
+              echo "❌ Invalid revision name: must be lowercase alphanumeric with hyphens"
+              exit 1
+            fi
+            TARGET="$ROLLBACK_REVISION"
             echo "📌 Rolling back to specified revision: $TARGET"
           else
             # Get the second-most-recent active revision
@@ -83,14 +94,33 @@ jobs:
             echo "📌 Rolling back to previous revision: $TARGET"
           fi
 
+          # Validate target revision exists and is ready
+          READY=$(gcloud run revisions describe "$TARGET" \
+            --project "$PROJECT" \
+            --region "$REGION" \
+            --format='value(status.conditions[type=Ready].status)' 2>/dev/null || echo "")
+
+          if [[ "$READY" != "True" ]]; then
+            echo "❌ Revision $TARGET is not ready (status: ${READY:-not found})"
+            echo "Available revisions:"
+            gcloud run revisions list \
+              --project "$PROJECT" \
+              --region "$REGION" \
+              --service "$SERVICE" \
+              --format='table(metadata.name, status.conditions[type=Ready].status, metadata.creationTimestamp)' \
+              --limit=5
+            exit 1
+          fi
+
           echo "revision=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "✅ Revision $TARGET is ready"
 
       # ── Shift traffic ────────────────────────────────────────────────
       - name: Route traffic to target revision
         run: |
-          gcloud run services update-traffic ${{ vars.CLOUD_RUN_SERVICE }} \
-            --project ${{ vars.GCP_PROJECT_ID }} \
-            --region ${{ vars.GCP_REGION }} \
+          gcloud run services update-traffic "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
             --to-revisions=${{ steps.target.outputs.revision }}=100 \
             --clear-tags
 
@@ -99,9 +129,9 @@ jobs:
       # ── Verify rollback ──────────────────────────────────────────────
       - name: Smoke test after rollback
         run: |
-          SERVICE_URL=$(gcloud run services describe ${{ vars.CLOUD_RUN_SERVICE }} \
-            --project ${{ vars.GCP_PROJECT_ID }} \
-            --region ${{ vars.GCP_REGION }} \
+          SERVICE_URL=$(gcloud run services describe "${{ vars.CLOUD_RUN_SERVICE }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ vars.GCP_REGION }}" \
             --format='value(status.url)')
 
           chmod +x scripts/smoke-test.sh
@@ -119,35 +149,45 @@ jobs:
       - name: Record rollback deployment
         if: always()
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          TARGET_REVISION: ${{ steps.target.outputs.revision }}
+          JOB_STATUS: ${{ job.status }}
         with:
           script: |
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.sha,
-              environment: '${{ inputs.environment }}',
-              description: 'Rollback to ${{ steps.target.outputs.revision }}',
+              environment: process.env.ROLLBACK_ENVIRONMENT,
+              description: `Rollback to ${process.env.TARGET_REVISION}`,
               auto_merge: false,
               required_contexts: [],
-              payload: { rollback: true, revision: '${{ steps.target.outputs.revision }}' },
+              payload: { rollback: true, revision: process.env.TARGET_REVISION },
             });
             await github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               deployment_id: deployment.data.id,
-              state: '${{ job.status }}' === 'success' ? 'success' : 'failure',
-              description: 'Rollback to ${{ steps.target.outputs.revision }}',
+              state: process.env.JOB_STATUS === 'success' ? 'success' : 'failure',
+              description: `Rollback to ${process.env.TARGET_REVISION}`,
             });
 
       # ── Notify ───────────────────────────────────────────────────────
       - name: Notify
         if: always() && vars.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ vars.SLACK_WEBHOOK_URL }}
+          TARGET_REVISION: ${{ steps.target.outputs.revision }}
+          JOB_STATUS: ${{ job.status }}
         run: |
-          STATUS="${{ job.status }}"
-          EMOJI=$(if [[ "$STATUS" == "success" ]]; then echo "🔙"; else echo "🚨"; fi)
+          if [[ "$JOB_STATUS" == "success" ]]; then EMOJI="🔙"; else EMOJI="🚨"; fi
 
-          curl -s -X POST "${{ vars.SLACK_WEBHOOK_URL }}" \
+          MSG="$EMOJI Candela ROLLBACK ($ROLLBACK_ENVIRONMENT)
+          Revision: \`$TARGET_REVISION\`
+          Status: $JOB_STATUS
+          Triggered by: ${{ github.actor }}
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
-            -d "{
-              \"text\": \"${EMOJI} Candela ROLLBACK (${{ inputs.environment }})\nRevision: \`${{ steps.target.outputs.revision }}\`\nStatus: ${STATUS}\nTriggered by: ${{ github.actor }}\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
-            }" || true
+            -d "$(jq -n --arg text "$MSG" '{text: $text}')" || true

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -4,6 +4,21 @@ This runbook covers day-to-day operations, monitoring, incident response, and ma
 
 ## Deployment
 
+### Automated Deploy (Recommended)
+
+Use the **Deploy** GitHub Actions workflow for zero-downtime canary deployments:
+
+1. Go to **Actions → Deploy → Run workflow**
+2. Select environment (`staging` or `production`)
+3. Enter the image tag (SHA from Publish workflow, e.g. `abc1234`)
+4. The workflow will:
+   - Deploy the new revision with **zero traffic** (canary)
+   - Run smoke tests against the canary URL
+   - **Promote** to 100% traffic if smoke passes
+   - **Rollback** automatically if smoke fails
+
+Deploy audit trail is recorded in the repo's **Environments** tab.
+
 ### Manual Deploy to Cloud Run
 
 ```bash
@@ -27,7 +42,32 @@ gcloud run services update candela \
   --image $REGION-docker.pkg.dev/$PROJECT/candela/candela-server:latest
 ```
 
+### Post-Deploy Verification
+
+Run smoke tests against any Candela deployment:
+
+```bash
+# Local
+./scripts/smoke-test.sh http://localhost:8181
+
+# Staging/Production (with auth)
+./scripts/smoke-test.sh https://candela-xxx.a.run.app \
+  --token "$(gcloud auth print-identity-token)" \
+  --timeout 90
+```
+
+The smoke test verifies liveness (`/healthz`), readiness (`/readyz`), UI serving (`/`), and optionally an authenticated probe (`GetCurrentUser`).
+
 ### Rolling Back
+
+**Automated (recommended):**
+
+1. Go to **Actions → Rollback → Run workflow**
+2. Select environment
+3. Optionally specify a revision name (leave empty for previous revision)
+4. The workflow shifts traffic, runs smoke tests, and records the rollback
+
+**Manual:**
 
 ```bash
 # List revisions

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -85,10 +85,9 @@ check_endpoint() {
     local remaining=$((deadline - SECONDS))
     if [[ $remaining -le 0 ]]; then break; fi
 
-    # Cap curl timeout to remaining budget (min 2s)
+    # Cap curl timeout to remaining budget
     local curl_timeout=$remaining
     if [[ $curl_timeout -gt 15 ]]; then curl_timeout=15; fi
-    if [[ $curl_timeout -lt 2 ]]; then curl_timeout=2; fi
 
     # Build curl args
     local curl_args=(-s -o /dev/null -w "%{http_code}" --connect-timeout "$curl_timeout" --max-time "$curl_timeout")
@@ -101,6 +100,12 @@ check_endpoint() {
     if [[ "$status" == "$expected_status" ]]; then
       # If we need to check body content, fetch the body
       if [[ -n "$body_contains" ]]; then
+        # Recompute remaining budget for body request
+        remaining=$((deadline - SECONDS))
+        if [[ $remaining -le 0 ]]; then break; fi
+        curl_timeout=$remaining
+        if [[ $curl_timeout -gt 15 ]]; then curl_timeout=15; fi
+
         local body_args=(-s --connect-timeout "$curl_timeout" --max-time "$curl_timeout")
         if [[ -n "$TOKEN" ]]; then
           body_args+=(-H "Authorization: Bearer $TOKEN")
@@ -123,7 +128,12 @@ check_endpoint() {
       info "$description — got ${status}, want ${expected_status}, retrying..."
     fi
 
-    sleep "$RETRY_INTERVAL"
+    # Sleep only if time remains; cap sleep to remaining budget
+    remaining=$((deadline - SECONDS))
+    if [[ $remaining -le 0 ]]; then break; fi
+    local sleep_time=$RETRY_INTERVAL
+    if [[ $sleep_time -gt $remaining ]]; then sleep_time=$remaining; fi
+    sleep "$sleep_time"
   done
 
   fail "$description — timed out after ${TIMEOUT}s (last status: ${status})"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# scripts/smoke-test.sh — Post-deploy smoke tests for Candela
+#
+# Verifies a deployed Candela instance is healthy and serving traffic.
+# Portable: works locally, in CI, against Cloud Run, GKE, or any URL.
+#
+# Usage:
+#   ./scripts/smoke-test.sh https://candela.example.com
+#   ./scripts/smoke-test.sh https://candela.example.com --token "$(gcloud auth print-identity-token)"
+#   ./scripts/smoke-test.sh http://localhost:8181 --timeout 30
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — one or more checks failed
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────
+TIMEOUT=90
+TOKEN=""
+RETRY_INTERVAL=5
+
+# ── Parse arguments ───────────────────────────────────────────────────
+usage() {
+  echo "Usage: $0 <url> [--token TOKEN] [--timeout SECONDS]"
+  echo ""
+  echo "Arguments:"
+  echo "  url          Base URL of the Candela instance"
+  echo "  --token      Auth token (Bearer) for authenticated probes"
+  echo "  --timeout    Max seconds to wait for health (default: 90)"
+  exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+BASE_URL="${1%/}"  # Strip trailing slash
+shift
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --token)
+      TOKEN="$2"
+      shift 2
+      ;;
+    --timeout)
+      TIMEOUT="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      usage
+      ;;
+  esac
+done
+
+# ── Helpers ───────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+pass() { echo -e "${GREEN}✓${NC} $1"; }
+fail() { echo -e "${RED}✕${NC} $1"; }
+info() { echo -e "${YELLOW}…${NC} $1"; }
+
+FAILED=0
+
+# check_endpoint URL EXPECTED_STATUS DESCRIPTION [BODY_CONTAINS]
+check_endpoint() {
+  local url="$1"
+  local expected_status="$2"
+  local description="$3"
+  local body_contains="${4:-}"
+
+  local elapsed=0
+  local status=""
+  local body=""
+
+  while [[ $elapsed -lt $TIMEOUT ]]; do
+    # Build curl args
+    local curl_args=(-s -o /dev/null -w "%{http_code}" --connect-timeout 10 --max-time 15)
+    if [[ -n "$TOKEN" ]]; then
+      curl_args+=(-H "Authorization: Bearer $TOKEN")
+    fi
+
+    status=$(curl "${curl_args[@]}" "$url" 2>/dev/null || echo "000")
+
+    if [[ "$status" == "$expected_status" ]]; then
+      # If we need to check body content, fetch the body
+      if [[ -n "$body_contains" ]]; then
+        local body_args=(-s --connect-timeout 10 --max-time 15)
+        if [[ -n "$TOKEN" ]]; then
+          body_args+=(-H "Authorization: Bearer $TOKEN")
+        fi
+        body=$(curl "${body_args[@]}" "$url" 2>/dev/null || echo "")
+
+        if echo "$body" | grep -q "$body_contains"; then
+          pass "$description (${status}, ${elapsed}s)"
+          return 0
+        else
+          info "$description — status OK but body missing '$body_contains', retrying... (${elapsed}s)"
+        fi
+      else
+        pass "$description (${status}, ${elapsed}s)"
+        return 0
+      fi
+    else
+      info "$description — got ${status}, want ${expected_status}, retrying... (${elapsed}s)"
+    fi
+
+    sleep "$RETRY_INTERVAL"
+    elapsed=$((elapsed + RETRY_INTERVAL))
+  done
+
+  fail "$description — timed out after ${TIMEOUT}s (last status: ${status})"
+  FAILED=1
+}
+
+# ── Run checks ────────────────────────────────────────────────────────
+echo ""
+echo "🕯️  Candela Smoke Test"
+echo "   Target:  $BASE_URL"
+echo "   Timeout: ${TIMEOUT}s"
+echo "   Auth:    $(if [[ -n "$TOKEN" ]]; then echo "token provided"; else echo "none"; fi)"
+echo ""
+
+# 1. Liveness — process is alive
+check_endpoint "$BASE_URL/healthz" "200" "Liveness  (/healthz)" '"status":"ok"'
+
+# 2. Readiness — storage backend reachable
+check_endpoint "$BASE_URL/readyz" "200" "Readiness (/readyz)" '"status":"ready"'
+
+# 3. UI serving — HTML page loads
+check_endpoint "$BASE_URL/" "200" "UI served (/)"
+
+# 4. Authenticated probe (if token provided)
+if [[ -n "$TOKEN" ]]; then
+  check_endpoint \
+    "$BASE_URL/candela.v1.UserService/GetCurrentUser" \
+    "200" \
+    "Auth probe (GetCurrentUser)" \
+    '"email"'
+else
+  info "Auth probe — skipped (no --token provided)"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────
+echo ""
+if [[ $FAILED -eq 0 ]]; then
+  echo -e "${GREEN}All smoke tests passed.${NC}"
+  exit 0
+else
+  echo -e "${RED}Smoke tests FAILED.${NC}"
+  exit 1
+fi

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -77,13 +77,21 @@ check_endpoint() {
   local description="$3"
   local body_contains="${4:-}"
 
-  local elapsed=0
   local status=""
   local body=""
+  local deadline=$((SECONDS + TIMEOUT))
 
-  while [[ $elapsed -lt $TIMEOUT ]]; do
+  while [[ $SECONDS -lt $deadline ]]; do
+    local remaining=$((deadline - SECONDS))
+    if [[ $remaining -le 0 ]]; then break; fi
+
+    # Cap curl timeout to remaining budget (min 2s)
+    local curl_timeout=$remaining
+    if [[ $curl_timeout -gt 15 ]]; then curl_timeout=15; fi
+    if [[ $curl_timeout -lt 2 ]]; then curl_timeout=2; fi
+
     # Build curl args
-    local curl_args=(-s -o /dev/null -w "%{http_code}" --connect-timeout 10 --max-time 15)
+    local curl_args=(-s -o /dev/null -w "%{http_code}" --connect-timeout "$curl_timeout" --max-time "$curl_timeout")
     if [[ -n "$TOKEN" ]]; then
       curl_args+=(-H "Authorization: Bearer $TOKEN")
     fi
@@ -93,28 +101,29 @@ check_endpoint() {
     if [[ "$status" == "$expected_status" ]]; then
       # If we need to check body content, fetch the body
       if [[ -n "$body_contains" ]]; then
-        local body_args=(-s --connect-timeout 10 --max-time 15)
+        local body_args=(-s --connect-timeout "$curl_timeout" --max-time "$curl_timeout")
         if [[ -n "$TOKEN" ]]; then
           body_args+=(-H "Authorization: Bearer $TOKEN")
         fi
         body=$(curl "${body_args[@]}" "$url" 2>/dev/null || echo "")
 
         if echo "$body" | grep -q "$body_contains"; then
+          local elapsed=$((TIMEOUT - (deadline - SECONDS)))
           pass "$description (${status}, ${elapsed}s)"
           return 0
         else
-          info "$description — status OK but body missing '$body_contains', retrying... (${elapsed}s)"
+          info "$description — status OK but body missing '$body_contains', retrying..."
         fi
       else
+        local elapsed=$((TIMEOUT - (deadline - SECONDS)))
         pass "$description (${status}, ${elapsed}s)"
         return 0
       fi
     else
-      info "$description — got ${status}, want ${expected_status}, retrying... (${elapsed}s)"
+      info "$description — got ${status}, want ${expected_status}, retrying..."
     fi
 
     sleep "$RETRY_INTERVAL"
-    elapsed=$((elapsed + RETRY_INTERVAL))
   done
 
   fail "$description — timed out after ${TIMEOUT}s (last status: ${status})"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 # ── Defaults ──────────────────────────────────────────────────────────
-TIMEOUT=90
+TIMEOUT=60
 TOKEN=""
 RETRY_INTERVAL=5
 
@@ -130,10 +130,10 @@ echo "   Auth:    $(if [[ -n "$TOKEN" ]]; then echo "token provided"; else echo 
 echo ""
 
 # 1. Liveness — process is alive
-check_endpoint "$BASE_URL/healthz" "200" "Liveness  (/healthz)" '"status":"ok"'
+check_endpoint "$BASE_URL/healthz" "200" "Liveness  (/healthz)" '"status": "ok"'
 
 # 2. Readiness — storage backend reachable
-check_endpoint "$BASE_URL/readyz" "200" "Readiness (/readyz)" '"status":"ready"'
+check_endpoint "$BASE_URL/readyz" "200" "Readiness (/readyz)" '"status": "ready"'
 
 # 3. UI serving — HTML page loads
 check_endpoint "$BASE_URL/" "200" "UI served (/)"

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -30,10 +30,14 @@ const nextConfig: NextConfig = {
           source: "/api/v0/:path*",
           destination: `${backendUrl}/api/v0/:path*`,
         },
-        // Health check
+        // Health checks
         {
           source: "/healthz",
           destination: `${backendUrl}/healthz`,
+        },
+        {
+          source: "/readyz",
+          destination: `${backendUrl}/readyz`,
         },
       ],
     };


### PR DESCRIPTION
## Closes #688 and #689

### What

Zero-downtime deployment pipeline with automated verification and one-click rollback.

### New Files

| File | Purpose |
|:---|:---|
| `scripts/smoke-test.sh` | Portable smoke test script (local, CI, Cloud Run, GKE, Helm) |
| `.github/workflows/deploy.yml` | Canary deploy: `--no-traffic` → smoke → promote or rollback |
| `.github/workflows/rollback.yml` | One-click emergency rollback to previous revision |

### Deploy Flow

```
Publish (GHCR) → Deploy (manual trigger)
                   ├─ Deploy canary (0% traffic)
                   ├─ Smoke test canary URL
                   │   ├─ /healthz → 200
                   │   ├─ /readyz  → 200
                   │   ├─ /        → 200
                   │   └─ GetCurrentUser (if token)
                   ├─ ✅ Pass → promote to 100%
                   └─ ❌ Fail → delete canary, keep previous live
```

### Smoke Test Script

```bash
# Local
./scripts/smoke-test.sh http://localhost:8181

# Production (with auth)
./scripts/smoke-test.sh https://candela.example.com \
  --token "$(gcloud auth print-identity-token)" \
  --timeout 90
```

Features:
- 90s timeout with 5s retry intervals (cold start tolerance)
- Optional authenticated probe (GetCurrentUser)
- Zero CI-specific dependencies — works anywhere

### Bug Fix

Added missing `/readyz` rewrite to `ui/next.config.ts` so readiness checks work through the Next.js ingress.

### Operational Features

- **GitHub Deployments API** audit trail (who deployed what, when)
- **Slack notifications** on deploy failure (optional, via `SLACK_WEBHOOK_URL` var)
- **Staging-first gating** via GitHub Environment protection rules
- **Revision cleanup** — failed canaries are deleted, tags are cleared after promote

### Setup Required

Deployers need to configure:
1. **Workload Identity Federation** — `WIF_PROVIDER` + `WIF_SERVICE_ACCOUNT` secrets
2. **Environment variables** — `GCP_PROJECT_ID`, `GCP_REGION`, `CLOUD_RUN_SERVICE`
3. **GitHub Environments** — `staging` and `production` with optional reviewers
4. **(Optional)** — `SLACK_WEBHOOK_URL` for failure notifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added manually triggered deployment workflows for staging and production with canary releases, smoke tests, promotion, rollback, and deployment tracking.
  - Added a rollback workflow supporting selected or automatically identified previous revisions.
  - Added automated health, readiness, UI, and optional authenticated endpoint checks.

- **Documentation**
  - Expanded operational guidance for deployments, smoke testing, and rollbacks.

- **Bug Fixes**
  - Added support for proxying both health and readiness endpoints through the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->