### PR TITLE
chore: add .editorconfig, .envrc, and align local checks with CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.go]
+indent_style = tab
+
+[*.rs]
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Format check (gofmt)
         shell: bash
         run: |
-          unformatted=$(nix develop . --command gofmt -l . | grep -v "^gen/" | grep -v "^vendor/" || true)
+          unformatted=$(nix develop . --command gofmt -l . 2>/dev/null | grep '\.go$' | grep -v '^gen/' | grep -v '^vendor/' || true)
           if [ -n "$unformatted" ]; then
             echo "::error::Files not gofmt-formatted:"
             echo "$unformatted"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
               - 'go.sum'
               - 'gen/**'
               - 'proto/**'
+              - '.editorconfig'
               - '.github/workflows/ci.yml'
               - 'flake.nix'
               - 'flake.lock'
@@ -125,8 +126,28 @@ jobs:
       - name: Vet
         run: nix develop . --command go vet ./...
 
+      - name: Format check (gofmt)
+        run: |
+          nix develop . --command bash -c '
+            unformatted=$(gofmt -l $(find . -name "*.go" -not -path "./gen/*" -not -path "./vendor/*"))
+            if [ -n "$unformatted" ]; then
+              echo "::error::The following files are not gofmt-formatted:"
+              echo "$unformatted"
+              exit 1
+            fi
+          '
+
+      - name: Verify go.mod/go.sum tidy
+        run: nix develop . --command go mod tidy -diff
+
       - name: Lint
         run: nix develop . --command golangci-lint run --timeout=5m
+
+      - name: Install editorconfig-checker
+        run: nix develop . --command go install github.com/editorconfig-checker/editorconfig-checker/v3/cmd/editorconfig-checker@latest
+
+      - name: Editorconfig check
+        run: nix develop . --command editorconfig-checker
 
   # ── tests — parallel matrix by package group ────────────────────────────────
   go-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,15 +127,7 @@ jobs:
         run: nix develop . --command go vet ./...
 
       - name: Format check (gofmt)
-        run: |
-          nix develop . --command bash -c '
-            unformatted=$(gofmt -l $(find . -name "*.go" -not -path "./gen/*" -not -path "./vendor/*"))
-            if [ -n "$unformatted" ]; then
-              echo "::error::The following files are not gofmt-formatted:"
-              echo "$unformatted"
-              exit 1
-            fi
-          '
+        run: nix develop . --command bash -c "test -z \"$(gofmt -l . | grep -v '^gen/' | grep -v '^vendor/')\" || { echo '::error::Files not gofmt-formatted:'; gofmt -l . | grep -v '^gen/' | grep -v '^vendor/'; exit 1; }"
 
       - name: Verify go.mod/go.sum tidy
         run: nix develop . --command go mod tidy -diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,14 @@ jobs:
         run: nix develop . --command go vet ./...
 
       - name: Format check (gofmt)
-        run: nix develop . --command bash -c "test -z \"$(gofmt -l . | grep -v '^gen/' | grep -v '^vendor/')\" || { echo '::error::Files not gofmt-formatted:'; gofmt -l . | grep -v '^gen/' | grep -v '^vendor/'; exit 1; }"
+        shell: bash
+        run: |
+          unformatted=$(nix develop . --command gofmt -l . | grep -v "^gen/" | grep -v "^vendor/" || true)
+          if [ -n "$unformatted" ]; then
+            echo "::error::Files not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
 
       - name: Verify go.mod/go.sum tidy
         run: nix develop . --command go mod tidy -diff

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -256,7 +256,7 @@ jobs:
 
       # ── Notify on failure ────────────────────────────────────────────
       - name: Notify on failure
-        if: failure() && secrets.SLACK_WEBHOOK_URL != ''
+        if: failure()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_MESSAGE: |

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -214,7 +214,7 @@ jobs:
 
       # ── Notify ───────────────────────────────────────────────────────
       - name: Notify
-        if: always() && secrets.SLACK_WEBHOOK_URL != ''
+        if: always()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           TARGET_REVISION: ${{ steps.target.outputs.revision }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,11 @@ deploy/candela.production.yaml
 !deploy/config.production.example.yaml
 !deploy/candela.production.example.yaml
 
-# Nix
+# Nix / direnv
 result
 result-*
+.direnv/
+.lefthook-remotes/
 
 # Rust
 rust/target/


### PR DESCRIPTION
## What

Align local pre-commit hooks with CI and adopt `.editorconfig` from Azra MR !10.

### New files
- **`.editorconfig`** — Go tabs, Rust 4-space, default 2-space, LF, UTF-8
- **`.envrc`** — `use flake` for direnv

### Modified files
- **`.gitignore`** — add `.direnv/`, `.lefthook-remotes/`
- **`ci.yml`** — add `gofmt`, `go mod tidy -diff`, `editorconfig-checker`, `.editorconfig` to paths-filter

## Why

Two local↔CI gaps: `gofmt` and `go mod tidy` were enforced locally but not in CI. `editorconfig-checker` adds indent style/size, line ending, and charset enforcement.

> **Note for contributors**: Install the [EditorConfig plugin](https://editorconfig.org/#pre-installed) for your editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added consistent project-wide editor settings for formatting, line endings, and whitespace.
  * Improved development environment setup and ignored generated environment files.
  * Enhanced automated checks for formatting, dependency file consistency, and editor configuration.
  * Updated repository ignore rules for development tooling artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->