### PR TITLE
feat(proxy): thread task budget enforcement into request path (#779)

### DIFF
--- a/pkg/proxy/billing_coverage_test.go
+++ b/pkg/proxy/billing_coverage_test.go
@@ -448,7 +448,7 @@ func TestDeductBudget_SkipsZeroCostZeroTokens(t *testing.T) {
 	p.SetUserStore(store)
 
 	// Zero tokens + zero cost → should skip DeductSpend.
-	p.deductBudget(context.Background(), Provider{Name: "local"}, "llama3", "user@test.com", 0, 0, 0)
+	p.deductBudget(context.Background(), Provider{Name: "local"}, "llama3", "user@test.com", "", 0, 0, 0)
 
 	if got := store.deductCount.Load(); got != 0 {
 		t.Errorf("DeductSpend called %d times for zero tokens, want 0", got)
@@ -466,7 +466,7 @@ func TestDeductBudget_CallsForPositiveTokens(t *testing.T) {
 	p.SetUserStore(store)
 
 	// Positive tokens → should call DeductSpend.
-	p.deductBudget(context.Background(), Provider{Name: "anthropic"}, "claude-sonnet-4-20250514", "user@test.com", 100, 50, 0)
+	p.deductBudget(context.Background(), Provider{Name: "anthropic"}, "claude-sonnet-4-20250514", "user@test.com", "", 100, 50, 0)
 
 	if got := store.deductCount.Load(); got != 1 {
 		t.Errorf("DeductSpend called %d times, want 1", got)
@@ -484,7 +484,7 @@ func TestDeductBudget_SkipsServiceAccount(t *testing.T) {
 	p.SetUserStore(store)
 
 	p.deductBudget(context.Background(), Provider{Name: "anthropic"}, "claude-sonnet-4-20250514",
-		"my-sa@project.iam.gserviceaccount.com", 1000, 500, 0)
+		"my-sa@project.iam.gserviceaccount.com", "", 1000, 500, 0)
 
 	if got := store.deductCount.Load(); got != 0 {
 		t.Errorf("DeductSpend called %d times for SA, want 0", got)
@@ -501,7 +501,7 @@ func TestDeductBudget_SkipsEmptyUserID(t *testing.T) {
 	p, _ := New(Config{ProjectID: "test"}, &mockSubmitter{}, calc)
 	p.SetUserStore(store)
 
-	p.deductBudget(context.Background(), Provider{Name: "anthropic"}, "claude-sonnet-4-20250514", "", 1000, 500, 0)
+	p.deductBudget(context.Background(), Provider{Name: "anthropic"}, "claude-sonnet-4-20250514", "", "", 1000, 500, 0)
 
 	if got := store.deductCount.Load(); got != 0 {
 		t.Errorf("DeductSpend called %d times for empty userID, want 0", got)

--- a/pkg/proxy/pending_spend.go
+++ b/pkg/proxy/pending_spend.go
@@ -54,3 +54,20 @@ func (t *pendingSpendTracker) Get(userID string) float64 {
 	defer t.mu.Unlock()
 	return t.pending[userID]
 }
+
+// ReserveIfUnder atomically checks whether (remaining - currentPending - reserveAmount)
+// stays above floor, and if so, records the reservation. Returns true if reserved.
+// This prevents the TOCTOU race between separate Get and Reserve calls.
+func (t *pendingSpendTracker) ReserveIfUnder(id string, remaining, reserveAmount, floor float64) bool {
+	if reserveAmount <= 0 || id == "" {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	effective := remaining - t.pending[id] - reserveAmount
+	if effective < floor {
+		return false
+	}
+	t.pending[id] += reserveAmount
+	return true
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1094,19 +1094,17 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 				"remaining_usd", check.RemainingUSD)
 			return
 		} else {
-			// TOCTOU: check task-level pending spend.
-			effectiveTaskRemaining := check.RemainingUSD - p.taskPendingSpend.Get(jobID)
-			if effectiveTaskRemaining < budgetCheckFloor {
+			// TOCTOU: atomic check-and-reserve for task-level pending spend.
+			taskReserved = reservationFloor
+			if estimatedCost > reservationFloor {
+				taskReserved = estimatedCost
+			}
+			if !p.taskPendingSpend.ReserveIfUnder(jobID, check.RemainingUSD, taskReserved, budgetCheckFloor) {
 				ProxyErrorResponse(w, http.StatusPaymentRequired,
 					"task budget exhausted (concurrent requests in flight)",
 					"task_budget_exhausted")
 				return
 			}
-			taskReserved = reservationFloor
-			if estimatedCost > reservationFloor {
-				taskReserved = estimatedCost
-			}
-			p.taskPendingSpend.Reserve(jobID, taskReserved)
 			defer func() {
 				if taskReserved > 0 {
 					p.taskPendingSpend.Release(jobID, taskReserved)
@@ -1636,6 +1634,16 @@ done:
 	taskRes := taskReserved
 	taskReserved = 0
 
+	// Safety net: release task reservation if handler returns without
+	// clearing it (e.g. read failure, response-size error). The handler
+	// sets *taskReserved=0 after successful deduction, making this a no-op
+	// in the normal path.
+	defer func() {
+		if taskRes > 0 {
+			p.taskPendingSpend.Release(jobID, taskRes)
+		}
+	}()
+
 	if isStreaming && resp.StatusCode == http.StatusOK {
 		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, &reserved, &taskRes)
 	} else {
@@ -2099,11 +2107,26 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 		return
 	}
 
-	// #779: Best-effort task budget deduction (separate Firestore document group).
+	// #779: Task budget deduction (separate Firestore document group).
+	// On failure, enqueue to outbox so the worker retries DeductTaskSpend.
 	if jobID != "" && cost > 0 {
 		if taskErr := p.users.DeductTaskSpend(ctx, jobID, cost); taskErr != nil {
-			slog.Warn("task_deduct_spend: failed (best-effort)",
+			slog.Warn("task_deduct_spend: failed, enqueueing to outbox",
 				"job_id", jobID, "cost_usd", cost, "error", taskErr)
+			if p.spendOutbox != nil {
+				// Enqueue a task-only record (UserID already deducted above).
+				// The worker calls DeductTaskSpend when TaskID is set.
+				if qErr := p.spendOutbox.Enqueue(ctx, spendoutbox.SpendRecord{
+					UserID:  userID,
+					TaskID:  jobID,
+					CostUSD: cost,
+					Tokens:  0, // user spend already recorded; task-only retry
+				}); qErr != nil {
+					slog.Error("task_deduct_spend: CRITICAL — failed to enqueue to outbox",
+						"job_id", jobID, "cost_usd", cost,
+						"enqueue_error", qErr, "original_error", taskErr)
+				}
+			}
 		}
 	}
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -287,6 +287,11 @@ type Proxy struct {
 	// because none have been recorded in Firestore yet.
 	pendingSpend *pendingSpendTracker
 
+	// Task-level TOCTOU mitigation: tracks in-flight spend per jobID
+	// between CheckTaskBudget and DeductTaskSpend. Prevents concurrent
+	// subagents in the same task from blowing through the task budget.
+	taskPendingSpend *pendingSpendTracker
+
 	// HIGH-5: Spans dropped at proxy semaphore (circuit breaker full).
 	droppedSpans atomic.Int64
 
@@ -413,18 +418,19 @@ func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) (*Proxy
 	}
 
 	p := &Proxy{
-		providers:    providers,
-		submitter:    submitter,
-		calc:         calc,
-		projectID:    cfg.ProjectID,
-		config:       cfg,
-		breakers:     breakers,
-		retryConfig:  cfg.Retry,
-		spanSem:      make(chan struct{}, 200), // CRIT-16: cap concurrent span goroutines
-		asyncSem:     make(chan struct{}, 50),  // #333: cap best-effort async goroutines
-		saRL:         newSARateLimiter(0),      // default 120 RPM per SA
-		pendingSpend: newPendingSpendTracker(),
-		client:       newUpstreamHTTPClient(cfg),
+		providers:        providers,
+		submitter:        submitter,
+		calc:             calc,
+		projectID:        cfg.ProjectID,
+		config:           cfg,
+		breakers:         breakers,
+		retryConfig:      cfg.Retry,
+		spanSem:          make(chan struct{}, 200), // CRIT-16: cap concurrent span goroutines
+		asyncSem:         make(chan struct{}, 50),  // #333: cap best-effort async goroutines
+		saRL:             newSARateLimiter(0),      // default 120 RPM per SA
+		pendingSpend:     newPendingSpendTracker(),
+		taskPendingSpend: newPendingSpendTracker(),
+		client:           newUpstreamHTTPClient(cfg),
 	}
 
 	// Initialize fallback resolver if configured.
@@ -1052,6 +1058,63 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// ── Task budget pre-flight (#779) ──────────────────────────────────
+	// Applies when a job ID is present, even for SAs and admins.
+	// Task budgets are explicitly created to cap a specific agent run.
+	// FAIL-CLOSED: if jobID is set, a task budget MUST exist.
+	var taskReserved float64
+	if p.users != nil && jobID != "" {
+		const budgetCheckFloor = 0.001
+		const reservationFloor = 0.05
+		check, err := p.users.CheckTaskBudget(r.Context(), jobID, estimatedCost)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				ProxyErrorResponse(w, http.StatusPaymentRequired,
+					"task budget required — create a budget for job "+jobID,
+					"task_budget_missing")
+				slog.Info("blocked request: no task budget",
+					"job_id", jobID, "user_id", effectiveUserID)
+				return
+			}
+			slog.Error("task budget check failed, blocking request",
+				"job_id", jobID, "error", err)
+			ProxyErrorResponse(w, http.StatusServiceUnavailable,
+				"task budget check unavailable — try again shortly", "service_error")
+			return
+		} else if !check.Allowed {
+			reason := "task_budget_exhausted"
+			if check.Reason != "" {
+				reason = check.Reason
+			}
+			ProxyErrorResponse(w, http.StatusPaymentRequired,
+				fmt.Sprintf("task budget %s — remaining $%.4f of $%.2f",
+					reason, check.RemainingUSD, check.LimitUSD), reason)
+			slog.Info("blocked request: task budget",
+				"job_id", jobID, "reason", reason,
+				"remaining_usd", check.RemainingUSD)
+			return
+		} else {
+			// TOCTOU: check task-level pending spend.
+			effectiveTaskRemaining := check.RemainingUSD - p.taskPendingSpend.Get(jobID)
+			if effectiveTaskRemaining < budgetCheckFloor {
+				ProxyErrorResponse(w, http.StatusPaymentRequired,
+					"task budget exhausted (concurrent requests in flight)",
+					"task_budget_exhausted")
+				return
+			}
+			taskReserved = reservationFloor
+			if estimatedCost > reservationFloor {
+				taskReserved = estimatedCost
+			}
+			p.taskPendingSpend.Reserve(jobID, taskReserved)
+			defer func() {
+				if taskReserved > 0 {
+					p.taskPendingSpend.Release(jobID, taskReserved)
+				}
+			}()
+		}
+	}
+
 	// ── Budget pre-flight with conservative reservation ──
 	// Only applies in team mode (UserStore configured).
 	var budgetReserved float64 // track reservation for Release in deductBudget
@@ -1570,11 +1633,13 @@ done:
 	// Zero out so the deferred release guard (above) becomes a no-op.
 	reserved := budgetReserved
 	budgetReserved = 0
+	taskRes := taskReserved
+	taskReserved = 0
 
 	if isStreaming && resp.StatusCode == http.StatusOK {
-		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, &reserved)
+		p.handleStreamingResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, &reserved, &taskRes)
 	} else {
-		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, &reserved)
+		p.handleStandardResponse(w, r, resp, provider, reqBody, startTime, ttfb, requestID, sessionID, effectiveUserID, tenantID, jobID, cbAllow, traceCtx, proxySpanID, extendedTTL, &reserved, &taskRes)
 	}
 }
 
@@ -1611,6 +1676,7 @@ func (p *Proxy) handleStandardResponse(
 	proxySpanID string,
 	extendedTTL bool, // true = Anthropic 1h TTL (2.0× cache creation rate)
 	budgetReserved *float64, // pending-spend reservation to release after DeductSpend
+	taskReserved *float64, // task-level pending-spend reservation (#779)
 ) {
 	// Read the full response (reject if over 10MB to prevent OOM under concurrent load).
 	// CRIT-15: Previously 50MB — with 100 concurrent requests that's 5GB of heap.
@@ -1680,7 +1746,7 @@ func (p *Proxy) handleStandardResponse(
 		}
 		inputTokens = p.calc.NormalizeCachedInputWithTTL(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens, extendedTTL)
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
-		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens, time.Since(startTime))
+		p.deductBudget(deductCtx, provider, model, effectiveUserID, jobID, inputTokens, outputTokens, time.Since(startTime))
 		deductCancel()
 		// Clear the pending-spend reservation now that DeductSpend has
 		// recorded the actual cost in Firestore. The deferred Release in
@@ -1688,6 +1754,10 @@ func (p *Proxy) handleStandardResponse(
 		if budgetReserved != nil && *budgetReserved > 0 {
 			p.pendingSpend.Release(effectiveUserID, *budgetReserved)
 			*budgetReserved = 0
+		}
+		if taskReserved != nil && *taskReserved > 0 {
+			p.taskPendingSpend.Release(jobID, *taskReserved)
+			*taskReserved = 0
 		}
 	} else if p.spendTracker != nil {
 		// Solo mode: no UserStore but spend tracker is active.
@@ -1744,6 +1814,7 @@ func (p *Proxy) handleStreamingResponse(
 	proxySpanID string,
 	extendedTTL bool, // true = Anthropic 1h TTL (2.0× cache creation rate)
 	budgetReserved *float64, // pending-spend reservation to release after DeductSpend
+	taskReserved *float64, // task-level pending-spend reservation (#779)
 ) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -1847,11 +1918,15 @@ func (p *Proxy) handleStreamingResponse(
 		}
 		inputTokens = p.calc.NormalizeCachedInputWithTTL(provider.Name, model, inputTokens, ct.CacheReadTokens, ct.CacheCreationTokens, extendedTTL)
 		deductCtx, deductCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 15*time.Second)
-		p.deductBudget(deductCtx, provider, model, effectiveUserID, inputTokens, outputTokens, time.Since(startTime))
+		p.deductBudget(deductCtx, provider, model, effectiveUserID, jobID, inputTokens, outputTokens, time.Since(startTime))
 		deductCancel()
 		if budgetReserved != nil && *budgetReserved > 0 {
 			p.pendingSpend.Release(effectiveUserID, *budgetReserved)
 			*budgetReserved = 0
+		}
+		if taskReserved != nil && *taskReserved > 0 {
+			p.taskPendingSpend.Release(jobID, *taskReserved)
+			*taskReserved = 0
 		}
 	} else if p.spendTracker != nil {
 		// Solo mode: record per-model spend for daily limits.
@@ -1922,7 +1997,7 @@ type spanParams struct {
 // written. This MUST run in the request handler goroutine (not async) so that
 // the next request's CheckBudget reads the updated spend from Firestore.
 // Extracted from buildSpan to decouple billing timing from span creation.
-func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, userID string, inputTokens, outputTokens int64, duration time.Duration) {
+func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, userID, jobID string, inputTokens, outputTokens int64, duration time.Duration) {
 	if p.users == nil || userID == "" {
 		return
 	}
@@ -1944,6 +2019,13 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 				"output_tokens", outputTokens,
 				"total_tokens", totalTokens,
 			)
+		}
+		// #779: Even for SAs, deduct from task budget if one exists.
+		if jobID != "" && cost > 0 {
+			if taskErr := p.users.DeductTaskSpend(ctx, jobID, cost); taskErr != nil {
+				slog.Warn("sa_task_deduct: failed (best-effort)",
+					"sa_id", userID, "job_id", jobID, "cost_usd", cost, "error", taskErr)
+			}
 		}
 		return
 	}
@@ -1997,6 +2079,7 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 		if p.spendOutbox != nil {
 			if qErr := p.spendOutbox.Enqueue(ctx, spendoutbox.SpendRecord{
 				UserID:  userID,
+				TaskID:  jobID,
 				CostUSD: cost,
 				Tokens:  totalTokens,
 			}); qErr != nil {
@@ -2014,6 +2097,14 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 				"attempts", maxDeductAttempts, "error", deductErr)
 		}
 		return
+	}
+
+	// #779: Best-effort task budget deduction (separate Firestore document group).
+	if jobID != "" && cost > 0 {
+		if taskErr := p.users.DeductTaskSpend(ctx, jobID, cost); taskErr != nil {
+			slog.Warn("task_deduct_spend: failed (best-effort)",
+				"job_id", jobID, "cost_usd", cost, "error", taskErr)
+		}
 	}
 
 	// Best-effort: update the user's last-active timestamp (proxy usage).

--- a/pkg/proxy/proxy_task_budget_test.go
+++ b/pkg/proxy/proxy_task_budget_test.go
@@ -1,0 +1,438 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/auth"
+	"github.com/candelahq/candela/pkg/costcalc"
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// taskBudgetStore extends budgetUserStore with configurable task budget behavior.
+type taskBudgetStore struct {
+	budgetUserStore
+	taskCheckResult   *storage.TaskBudgetCheckResult
+	taskCheckErr      error
+	taskDeductErr     error
+	taskDeductCount   atomic.Int64
+	taskDeductLastJob string
+}
+
+func (t *taskBudgetStore) CheckTaskBudget(_ context.Context, _ string, _ float64) (*storage.TaskBudgetCheckResult, error) {
+	if t.taskCheckErr != nil {
+		return nil, t.taskCheckErr
+	}
+	return t.taskCheckResult, nil
+}
+
+func (t *taskBudgetStore) DeductTaskSpend(_ context.Context, taskID string, _ float64) error {
+	t.taskDeductCount.Add(1)
+	t.taskDeductLastJob = taskID
+	return t.taskDeductErr
+}
+
+// withTestSAAuth injects a service account identity into the request context.
+func withTestSAAuth(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.NewContext(r.Context(), &auth.User{ID: "sa@project.iam.gserviceaccount.com", Email: "sa@project.iam.gserviceaccount.com"})
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func makeAnthropicRequest(srvURL, jobID string) (*http.Response, error) {
+	req, _ := http.NewRequest("POST",
+		srvURL+"/proxy/anthropic/v1/messages",
+		strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer tok")
+	if jobID != "" {
+		req.Header.Set("X-Candela-Job-Id", jobID)
+	}
+	return http.DefaultClient.Do(req)
+}
+
+func parseErrorType(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	body, _ := io.ReadAll(resp.Body)
+	var errResp struct {
+		Error struct {
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		t.Fatalf("failed to parse error response: %v (body=%s)", err, body)
+	}
+	return errResp.Error.Type
+}
+
+// ── Test: missing task budget → 402 task_budget_missing ──
+
+func TestTaskBudget_MissingBudgetBlocks(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream should NOT be called when task budget is missing")
+		w.WriteHeader(500)
+	}))
+	defer upstream.Close()
+
+	store := &taskBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{Allowed: true, RemainingUSD: 100},
+		},
+		taskCheckErr: storage.ErrNotFound,
+	}
+
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, costcalc.New())
+	p.SetUserStore(store)
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(withTestAuth(mux))
+	defer srv.Close()
+
+	resp, err := makeAnthropicRequest(srv.URL, "task-no-budget")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPaymentRequired {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 402; body = %s", resp.StatusCode, body)
+	}
+	if got := parseErrorType(t, resp); got != "task_budget_missing" {
+		t.Errorf("error type = %q, want 'task_budget_missing'", got)
+	}
+}
+
+// ── Test: exhausted task budget → 402 task_budget_exhausted ──
+
+func TestTaskBudget_ExhaustedBudgetBlocks(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream should NOT be called when task budget is exhausted")
+		w.WriteHeader(500)
+	}))
+	defer upstream.Close()
+
+	store := &taskBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{Allowed: true, RemainingUSD: 100},
+		},
+		taskCheckResult: &storage.TaskBudgetCheckResult{
+			Allowed:      false,
+			RemainingUSD: 0,
+			LimitUSD:     5.0,
+		},
+	}
+
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, costcalc.New())
+	p.SetUserStore(store)
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(withTestAuth(mux))
+	defer srv.Close()
+
+	resp, err := makeAnthropicRequest(srv.URL, "task-exhausted")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPaymentRequired {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 402; body = %s", resp.StatusCode, body)
+	}
+	if got := parseErrorType(t, resp); got != "task_budget_exhausted" {
+		t.Errorf("error type = %q, want 'task_budget_exhausted'", got)
+	}
+}
+
+// ── Test: expired task budget → 402 task_budget_expired ──
+
+func TestTaskBudget_ExpiredBudgetBlocks(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream should NOT be called when task budget is expired")
+		w.WriteHeader(500)
+	}))
+	defer upstream.Close()
+
+	store := &taskBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{Allowed: true, RemainingUSD: 100},
+		},
+		taskCheckResult: &storage.TaskBudgetCheckResult{
+			Allowed: false,
+			Reason:  "task_budget_expired",
+		},
+	}
+
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, costcalc.New())
+	p.SetUserStore(store)
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(withTestAuth(mux))
+	defer srv.Close()
+
+	resp, err := makeAnthropicRequest(srv.URL, "task-expired")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPaymentRequired {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 402; body = %s", resp.StatusCode, body)
+	}
+	if got := parseErrorType(t, resp); got != "task_budget_expired" {
+		t.Errorf("error type = %q, want 'task_budget_expired'", got)
+	}
+}
+
+// ── Test: valid task budget → request proceeds ──
+
+func TestTaskBudget_ValidBudgetAllows(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer upstream.Close()
+
+	store := &taskBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{Allowed: true, RemainingUSD: 100},
+		},
+		taskCheckResult: &storage.TaskBudgetCheckResult{
+			Allowed:      true,
+			RemainingUSD: 5.0,
+			LimitUSD:     10.0,
+		},
+	}
+
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, costcalc.New())
+	p.SetUserStore(store)
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(withTestAuth(mux))
+	defer srv.Close()
+
+	resp, err := makeAnthropicRequest(srv.URL, "task-ok")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body = %s", resp.StatusCode, body)
+	}
+}
+
+// ── Test: no jobID → task budget check skipped ──
+
+func TestTaskBudget_NoJobIDSkipsCheck(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer upstream.Close()
+
+	store := &taskBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{Allowed: true, RemainingUSD: 100},
+		},
+		// If task check is called, it would fail — proving the skip works.
+		taskCheckErr: fmt.Errorf("should not be called"),
+	}
+
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, costcalc.New())
+	p.SetUserStore(store)
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(withTestAuth(mux))
+	defer srv.Close()
+
+	// No X-Candela-Job-Id header.
+	resp, err := makeAnthropicRequest(srv.URL, "")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body = %s", resp.StatusCode, body)
+	}
+}
+
+// ── Test: SA with jobID → task budget enforced ──
+
+func TestTaskBudget_SAWithJobIDEnforced(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream should NOT be called when task budget is missing for SA")
+		w.WriteHeader(500)
+	}))
+	defer upstream.Close()
+
+	store := &taskBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{Allowed: true, RemainingUSD: 100},
+		},
+		taskCheckErr: storage.ErrNotFound,
+	}
+
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, costcalc.New())
+	p.SetUserStore(store)
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(withTestSAAuth(mux))
+	defer srv.Close()
+
+	resp, err := makeAnthropicRequest(srv.URL, "sa-task")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPaymentRequired {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 402; body = %s", resp.StatusCode, body)
+	}
+	if got := parseErrorType(t, resp); got != "task_budget_missing" {
+		t.Errorf("error type = %q, want 'task_budget_missing'", got)
+	}
+}
+
+// ── Test: deductBudget calls DeductTaskSpend with jobID ──
+
+func TestDeductBudget_CallsDeductTaskSpend(t *testing.T) {
+	store := &taskBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{Allowed: true, RemainingUSD: 100},
+		},
+		taskCheckResult: &storage.TaskBudgetCheckResult{Allowed: true, RemainingUSD: 5.0},
+	}
+	calc := costcalc.New()
+	p, _ := New(Config{ProjectID: "test"}, &mockSubmitter{}, calc)
+	p.SetUserStore(store)
+
+	// deductBudget with a jobID and positive tokens → should call DeductTaskSpend.
+	p.deductBudget(context.Background(), Provider{Name: "anthropic"}, "claude-sonnet-4-20250514",
+		"user@test.com", "task-deduct-1", 100, 50, 0)
+
+	if got := store.taskDeductCount.Load(); got != 1 {
+		t.Errorf("DeductTaskSpend called %d times, want 1", got)
+	}
+	if store.taskDeductLastJob != "task-deduct-1" {
+		t.Errorf("DeductTaskSpend jobID = %q, want 'task-deduct-1'", store.taskDeductLastJob)
+	}
+}
+
+// ── Test: deductBudget with empty jobID skips DeductTaskSpend ──
+
+func TestDeductBudget_NoJobIDSkipsTaskDeduct(t *testing.T) {
+	store := &taskBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{Allowed: true, RemainingUSD: 100},
+		},
+	}
+	calc := costcalc.New()
+	p, _ := New(Config{ProjectID: "test"}, &mockSubmitter{}, calc)
+	p.SetUserStore(store)
+
+	p.deductBudget(context.Background(), Provider{Name: "anthropic"}, "claude-sonnet-4-20250514",
+		"user@test.com", "", 100, 50, 0)
+
+	if got := store.taskDeductCount.Load(); got != 0 {
+		t.Errorf("DeductTaskSpend called %d times, want 0", got)
+	}
+}
+
+// ── Test: SA deductBudget still calls DeductTaskSpend ──
+
+func TestDeductBudget_SACallsDeductTaskSpend(t *testing.T) {
+	store := &taskBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{Allowed: true, RemainingUSD: 100},
+		},
+	}
+	calc := costcalc.New()
+	p, _ := New(Config{ProjectID: "test"}, &mockSubmitter{}, calc)
+	p.SetUserStore(store)
+
+	// SA + jobID → should call DeductTaskSpend even though user DeductSpend is skipped.
+	p.deductBudget(context.Background(), Provider{Name: "anthropic"}, "claude-sonnet-4-20250514",
+		"sa@project.iam.gserviceaccount.com", "sa-task-1", 100, 50, 0)
+
+	if got := store.taskDeductCount.Load(); got != 1 {
+		t.Errorf("DeductTaskSpend called %d times for SA, want 1", got)
+	}
+}
+
+// ── Test: task budget check unavailable → 503 ──
+
+func TestTaskBudget_CheckUnavailable(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream should NOT be called when task budget check fails")
+		w.WriteHeader(500)
+	}))
+	defer upstream.Close()
+
+	store := &taskBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{Allowed: true, RemainingUSD: 100},
+		},
+		taskCheckErr: fmt.Errorf("firestore unavailable"),
+	}
+
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "anthropic", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, costcalc.New())
+	p.SetUserStore(store)
+
+	mux := http.NewServeMux()
+	p.RegisterRoutes(mux)
+	srv := httptest.NewServer(withTestAuth(mux))
+	defer srv.Close()
+
+	resp, err := makeAnthropicRequest(srv.URL, "task-err")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 503; body = %s", resp.StatusCode, body)
+	}
+}


### PR DESCRIPTION
## Summary

Thread task budget enforcement into the proxy request path. When a request includes `X-Candela-Job-Id`, the proxy now:

1. **Pre-flight check**: Calls `CheckTaskBudget` before the user budget gate
2. **Fail-closed**: Returns 402 if no task budget exists (`task_budget_missing`)
3. **Blocks exhausted/expired**: Returns 402 with `task_budget_exhausted` or `task_budget_expired`
4. **Deducts spend**: Calls `DeductTaskSpend` after response (best-effort)
5. **SA enforcement**: Task budgets apply even to service accounts and admins
6. **TOCTOU mitigation**: Task-level `pendingSpendTracker` prevents concurrent subagent overdraft
7. **Outbox integration**: `SpendRecord.TaskID` populated for retry worker

## Key design decisions

- **Fail-closed** on missing task budget (few customers, can coordinate)
- Task pre-flight runs **before** user budget gate (task exhaustion blocks even if user has budget)
- `deductBudget` signature gains `jobID` parameter
- SA early-return branch also calls `DeductTaskSpend`

## Files changed

- `pkg/proxy/proxy.go` — pre-flight check, struct field, deductBudget changes
- `pkg/proxy/billing_coverage_test.go` — updated 4 existing test calls for new signature
- `pkg/proxy/proxy_task_budget_test.go` — **10 new tests**

## Tests

| Test | Coverage |
|------|----------|
| MissingBudgetBlocks | 402 `task_budget_missing` |
| ExhaustedBudgetBlocks | 402 `task_budget_exhausted` |
| ExpiredBudgetBlocks | 402 `task_budget_expired` |
| ValidBudgetAllows | Request proceeds (200) |
| NoJobIDSkipsCheck | No task check when header absent |
| SAWithJobIDEnforced | SA + jobID → task budget enforced |
| DeductBudget_CallsDeductTaskSpend | DeductTaskSpend called with correct jobID |
| DeductBudget_NoJobIDSkipsTaskDeduct | No jobID → skip task deduct |
| DeductBudget_SACallsDeductTaskSpend | SA + jobID → DeductTaskSpend called |
| CheckUnavailable | Firestore error → 503 |

Closes #779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task-level budget tracking for requests associated with a job.
  * Requests now reserve estimated spend and release it after processing, including streaming responses.
  * Added task budget enforcement for regular users and service accounts.
  * Spend records now retain the associated task identifier.

* **Bug Fixes**
  * Improved handling of missing, expired, exhausted, or unavailable task budgets.
  * Requests without a job identifier continue without task-budget checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->