### PR TITLE
feat(taskspend): authz, evictor shutdown, REST docs — closes #780, #782, #781

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -528,10 +528,11 @@ func main() {
 		"catalog", catalogPath)
 
 	// ── Task Spend API ──────────────────────────────────────────────────
+	var spendCache *taskspend.Cache
 	if userStore != nil {
-		spendCache := taskspend.New(userStore, taskspend.DefaultTTL)
-		spendCache.StartEvictor(context.Background(), 30*time.Second)
-		mux.HandleFunc("/api/v1/task-spend/", taskspend.Handler(spendCache))
+		spendCache = taskspend.New(userStore, taskspend.DefaultTTL)
+		// NOTE: StartEvictor deferred to after signal.NotifyContext (#782).
+		mux.HandleFunc("/api/v1/task-spend/", taskspend.Handler(spendCache, userStore))
 		slog.Info("task spend API registered", "path", "/api/v1/task-spend/{taskID}")
 	} else {
 		slog.Warn("task spend API disabled: no user store configured")
@@ -1066,6 +1067,11 @@ func main() {
 	// Graceful shutdown.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Start the task spend cache evictor now that we have the signal context (#782).
+	if spendCache != nil {
+		spendCache.StartEvictor(ctx, 30*time.Second)
+	}
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -303,7 +303,7 @@ The `X-Candela-Job-Id` request header connects proxy requests to task budgets fo
 
 **Lifecycle:**
 
-```
+```text
 1. Client sets X-Candela-Job-Id on proxy request
           │
 2. Proxy pre-flight: CheckTaskBudget → enforce limits

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -243,6 +243,94 @@ Controls local LLM runtimes from `candela`. Served via ConnectRPC on the managem
 
 ---
 
+## REST Endpoints (non-Protobuf)
+
+The following endpoints use standard REST conventions and return JSON directly. They do **not** require ConnectRPC framing.
+
+> **Why REST?** The task spend endpoint is designed for lightweight, high-frequency polling (e.g., from CI runners or agent loops). A simple `GET` with no request body is easier to integrate than a ConnectRPC procedure.
+>
+> Task budget _management_ (create, get, delete) uses ConnectRPC via `UserService` (see above).
+
+### `GET /api/v1/task-spend/{taskID}`
+
+Returns the current spend snapshot for a task budget.
+
+**Authentication:** Required (Bearer token via `Authorization` or `X-Candela-Auth` header).
+
+**Authorization:** Owner + admin + service account.
+- The task budget's **owner** can view their own task's spend.
+- **Admins** (`role = "admin"`) can view any task's spend.
+- **Service accounts** (allowlisted `*.iam.gserviceaccount.com`) can view any task's spend.
+- All other callers receive `404 Not Found` (to prevent task ID enumeration).
+
+**Response (200):**
+
+```json
+{
+  "task_id": "task-abc-123",
+  "limit_usd": 10.00,
+  "spent_usd": 3.42,
+  "remaining_usd": 6.58,
+  "expired": false,
+  "cached_at": "2025-01-15T12:00:05.123456789Z"
+}
+```
+
+> **Note:** Responses may be cached for up to 5 seconds. The `cached_at` field indicates when the data was last fetched from Firestore.
+
+**Status Codes:**
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 400 | Missing `taskID` in path |
+| 401 | Authentication required (no valid token) |
+| 404 | Task budget not found, or caller not authorized |
+| 405 | Method not allowed (only GET is supported) |
+| 500 | Internal server error |
+
+**Example:**
+
+```bash
+# Poll task spend (replace TOKEN and TASK_ID)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8181/api/v1/task-spend/$TASK_ID | jq .
+```
+
+### `X-Candela-Job-Id` Header
+
+The `X-Candela-Job-Id` request header connects proxy requests to task budgets for spend tracking.
+
+**Lifecycle:**
+
+```
+1. Client sets X-Candela-Job-Id on proxy request
+          │
+2. Proxy pre-flight: CheckTaskBudget → enforce limits
+          │
+3. Proxy forwards to upstream LLM provider
+          │
+4. Proxy post-response: DeductTaskSpend
+          │
+5. Client polls GET /api/v1/task-spend/{taskID}
+```
+
+- Set this header on LLM proxy requests (e.g., `POST /v1/messages`) to associate spend with a task budget.
+- The task budget must be created _before_ sending requests with its ID.
+- If the header is set but no matching task budget exists, the proxy returns `402 Payment Required` with error type `task_budget_missing` (fail-closed).
+- If the task budget is exhausted or expired, the proxy returns `402` with `task_budget_exhausted` or `task_budget_expired`.
+
+```bash
+# Proxy request with task budget tracking
+curl -X POST http://localhost:8181/v1/messages \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Candela-Job-Id: task-abc-123" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"claude-sonnet-4-20250514","max_tokens":1024,"messages":[{"role":"user","content":"Hello"}]}'
+```
+
+---
+
 ## Interacting with gRPC
 
 Since Candela uses ConnectRPC (which supports both HTTP/JSON and gRPC), you can also use `grpcurl`:

--- a/pkg/taskspend/cache.go
+++ b/pkg/taskspend/cache.go
@@ -66,6 +66,10 @@ type SpendSnapshot struct {
 	RemainingUSD float64 `json:"remaining_usd"`
 	Expired      bool    `json:"expired"`
 	CachedAt     string  `json:"cached_at"`
+
+	// OwnerID is the task budget creator's effective ID.
+	// Used for authorization checks — not included in JSON responses.
+	OwnerID string `json:"-"`
 }
 
 // Get returns the cached spend snapshot for a task, fetching from
@@ -177,5 +181,6 @@ func toSnapshot(e *entry) *SpendSnapshot {
 		RemainingUSD: b.Remaining(),
 		Expired:      b.IsExpired(),
 		CachedAt:     e.fetchedAt.Format(time.RFC3339Nano),
+		OwnerID:      b.UserID,
 	}
 }

--- a/pkg/taskspend/handler.go
+++ b/pkg/taskspend/handler.go
@@ -1,18 +1,28 @@
 package taskspend
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
 
+	"github.com/candelahq/candela/pkg/auth"
 	"github.com/candelahq/candela/pkg/storage"
 )
 
+// UserLookup is the minimal interface for admin role checks.
+type UserLookup interface {
+	GetUser(ctx context.Context, id string) (*storage.UserRecord, error)
+}
+
 // Handler returns an http.HandlerFunc that serves GET /api/v1/task-spend/{taskID}.
 // It reads from the Cache (which read-throughs to Firestore with TTL).
-func Handler(cache *Cache) http.HandlerFunc {
+//
+// Authorization: owner + admin + service account.
+// Unauthenticated → 401. Unauthorized → 404 (prevents task ID enumeration).
+func Handler(cache *Cache, users UserLookup) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -25,6 +35,13 @@ func Handler(cache *Cache) http.HandlerFunc {
 			return
 		}
 
+		// ── Authentication ──
+		caller := auth.FromContext(r.Context())
+		if caller == nil {
+			http.Error(w, `{"error":"authentication required"}`, http.StatusUnauthorized)
+			return
+		}
+
 		snap, err := cache.Get(r.Context(), taskID)
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
@@ -33,6 +50,24 @@ func Handler(cache *Cache) http.HandlerFunc {
 			}
 			slog.Error("taskspend: handler error", "task_id", taskID, "error", err)
 			http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+			return
+		}
+
+		// ── Authorization: owner, admin, or service account ──
+		callerID := caller.EffectiveID()
+		isOwner := snap.OwnerID == callerID
+		isSA := strings.HasSuffix(callerID, ".gserviceaccount.com")
+		isAdmin := false
+
+		if !isOwner && !isSA && users != nil {
+			if record, lookupErr := users.GetUser(r.Context(), callerID); lookupErr == nil && record != nil {
+				isAdmin = record.Role == storage.RoleAdmin
+			}
+		}
+
+		if !isOwner && !isAdmin && !isSA {
+			// Return 404 to prevent task ID enumeration.
+			http.Error(w, `{"error":"task budget not found"}`, http.StatusNotFound)
 			return
 		}
 

--- a/pkg/taskspend/handler.go
+++ b/pkg/taskspend/handler.go
@@ -56,11 +56,15 @@ func Handler(cache *Cache, users UserLookup) http.HandlerFunc {
 		// ── Authorization: owner, admin, or service account ──
 		callerID := caller.EffectiveID()
 		isOwner := snap.OwnerID == callerID
-		isSA := strings.HasSuffix(callerID, ".gserviceaccount.com")
+		isSA := strings.HasSuffix(callerID, ".iam.gserviceaccount.com")
 		isAdmin := false
 
 		if !isOwner && !isSA && users != nil {
-			if record, lookupErr := users.GetUser(r.Context(), callerID); lookupErr == nil && record != nil {
+			record, lookupErr := users.GetUser(r.Context(), callerID)
+			switch {
+			case lookupErr != nil && !errors.Is(lookupErr, storage.ErrNotFound):
+				slog.Error("taskspend: admin lookup failed", "error", lookupErr)
+			case lookupErr == nil && record != nil:
 				isAdmin = record.Role == storage.RoleAdmin
 			}
 		}

--- a/pkg/taskspend/handler_test.go
+++ b/pkg/taskspend/handler_test.go
@@ -1,110 +1,193 @@
 package taskspend
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/candelahq/candela/pkg/auth"
 	"github.com/candelahq/candela/pkg/billing"
 	"github.com/candelahq/candela/pkg/storage"
 )
 
-func TestHandler_HappyPath(t *testing.T) {
-	store := &mockStore{
-		budget: &billing.TaskBudget{
-			TaskID:   "job-http-1",
-			LimitUSD: 10.0,
-			SpentUSD: 2.5,
-		},
+// handlerMockStore implements Store for handler tests.
+type handlerMockStore struct {
+	budget *billing.TaskBudget
+	err    error
+}
+
+func (m *handlerMockStore) GetTaskBudget(_ context.Context, _ string) (*billing.TaskBudget, error) {
+	if m.err != nil {
+		return nil, m.err
 	}
-	cache := New(store, 5*time.Second)
-	handler := Handler(cache)
+	return m.budget, nil
+}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/task-spend/job-http-1", nil)
-	rec := httptest.NewRecorder()
+// mockUserLookup implements UserLookup for testing.
+type mockUserLookup struct {
+	records map[string]*storage.UserRecord
+}
 
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+func (m *mockUserLookup) GetUser(_ context.Context, id string) (*storage.UserRecord, error) {
+	if r, ok := m.records[id]; ok {
+		return r, nil
 	}
-	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
-		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	return nil, storage.ErrNotFound
+}
+
+func testBudget() *billing.TaskBudget {
+	return &billing.TaskBudget{
+		TaskID:    "task-123",
+		UserID:    "owner@example.com",
+		LimitUSD:  10.0,
+		SpentUSD:  3.0,
+		CreatedAt: time.Now().Add(-time.Hour),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+}
+
+func newTestCache(budget *billing.TaskBudget) *Cache {
+	store := &handlerMockStore{budget: budget}
+	return New(store, DefaultTTL)
+}
+
+func doRequest(handler http.HandlerFunc, taskID string, user *auth.User) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("GET", "/api/v1/task-spend/"+taskID, nil)
+	if user != nil {
+		req = req.WithContext(auth.NewContext(req.Context(), user))
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+// ── Test: no auth → 401 ──
+
+func TestHandler_NoAuth_Returns401(t *testing.T) {
+	cache := newTestCache(testBudget())
+	h := Handler(cache, nil)
+
+	rr := doRequest(h, "task-123", nil)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rr.Code)
+	}
+}
+
+// ── Test: owner sees own task → 200 ──
+
+func TestHandler_Owner_Returns200(t *testing.T) {
+	cache := newTestCache(testBudget())
+	h := Handler(cache, nil)
+
+	owner := &auth.User{ID: "owner@example.com", Email: "owner@example.com"}
+	rr := doRequest(h, "task-123", owner)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
 	}
 
 	var snap SpendSnapshot
-	if err := json.NewDecoder(rec.Body).Decode(&snap); err != nil {
+	if err := json.Unmarshal(rr.Body.Bytes(), &snap); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if snap.TaskID != "job-http-1" {
-		t.Errorf("TaskID = %q, want %q", snap.TaskID, "job-http-1")
-	}
-	if snap.RemainingUSD != 7.5 {
-		t.Errorf("RemainingUSD = %v, want 7.5", snap.RemainingUSD)
+	if snap.TaskID != "task-123" {
+		t.Errorf("task_id = %q, want 'task-123'", snap.TaskID)
 	}
 }
 
-func TestHandler_NotFound(t *testing.T) {
-	store := &mockStore{err: storage.ErrNotFound}
-	cache := New(store, 5*time.Second)
-	handler := Handler(cache)
+// ── Test: non-owner, non-admin → 404 ──
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/task-spend/missing", nil)
-	rec := httptest.NewRecorder()
+func TestHandler_NonOwner_Returns404(t *testing.T) {
+	cache := newTestCache(testBudget())
+	users := &mockUserLookup{
+		records: map[string]*storage.UserRecord{
+			"other@example.com": {Role: "member"},
+		},
+	}
+	h := Handler(cache, users)
 
-	handler.ServeHTTP(rec, req)
+	other := &auth.User{ID: "other@example.com", Email: "other@example.com"}
+	rr := doRequest(h, "task-123", other)
 
-	if rec.Code != http.StatusNotFound {
-		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404; body = %s", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandler_MissingTaskID(t *testing.T) {
-	cache := New(&mockStore{}, 5*time.Second)
-	handler := Handler(cache)
+// ── Test: admin sees any task → 200 ──
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/task-spend/", nil)
-	rec := httptest.NewRecorder()
+func TestHandler_Admin_Returns200(t *testing.T) {
+	cache := newTestCache(testBudget())
+	users := &mockUserLookup{
+		records: map[string]*storage.UserRecord{
+			"admin@example.com": {Role: storage.RoleAdmin},
+		},
+	}
+	h := Handler(cache, users)
 
-	handler.ServeHTTP(rec, req)
+	admin := &auth.User{ID: "admin@example.com", Email: "admin@example.com"}
+	rr := doRequest(h, "task-123", admin)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandler_MethodNotAllowed(t *testing.T) {
-	cache := New(&mockStore{}, 5*time.Second)
-	handler := Handler(cache)
+// ── Test: SA sees any task → 200 ──
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/task-spend/job-1", nil)
-	rec := httptest.NewRecorder()
+func TestHandler_SA_Returns200(t *testing.T) {
+	cache := newTestCache(testBudget())
+	h := Handler(cache, nil)
 
-	handler.ServeHTTP(rec, req)
+	sa := &auth.User{
+		ID:    "bot@project.iam.gserviceaccount.com",
+		Email: "bot@project.iam.gserviceaccount.com",
+	}
+	rr := doRequest(h, "task-123", sa)
 
-	if rec.Code != http.StatusMethodNotAllowed {
-		t.Errorf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
 	}
 }
 
-func TestExtractTaskID(t *testing.T) {
-	tests := []struct {
-		path string
-		want string
-	}{
-		{"/api/v1/task-spend/job-123", "job-123"},
-		{"/api/v1/task-spend/job-123/", "job-123"},
-		{"/api/v1/task-spend/", ""},
-		{"/api/v1/task-spend", ""},
-		{"/other/path", ""},
+// ── Test: missing task → 404 ──
+
+func TestHandler_MissingTask_Returns404(t *testing.T) {
+	store := &handlerMockStore{err: storage.ErrNotFound}
+	cache := New(store, DefaultTTL)
+	h := Handler(cache, nil)
+
+	user := &auth.User{ID: "anyone@example.com", Email: "anyone@example.com"}
+	rr := doRequest(h, "no-such-task", user)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rr.Code)
 	}
-	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
-			if got := extractTaskID(tt.path); got != tt.want {
-				t.Errorf("extractTaskID(%q) = %q, want %q", tt.path, got, tt.want)
-			}
-		})
+}
+
+// ── Test: OwnerID not leaked in JSON response ──
+
+func TestHandler_OwnerIDNotInJSON(t *testing.T) {
+	cache := newTestCache(testBudget())
+	h := Handler(cache, nil)
+
+	owner := &auth.User{ID: "owner@example.com", Email: "owner@example.com"}
+	rr := doRequest(h, "task-123", owner)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	// Verify raw JSON doesn't contain owner_id.
+	body := rr.Body.String()
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, exists := raw["owner_id"]; exists {
+		t.Error("owner_id should not appear in JSON response")
 	}
 }

--- a/pkg/taskspend/handler_test.go
+++ b/pkg/taskspend/handler_test.go
@@ -55,13 +55,55 @@ func newTestCache(budget *billing.TaskBudget) *Cache {
 }
 
 func doRequest(handler http.HandlerFunc, taskID string, user *auth.User) *httptest.ResponseRecorder {
-	req := httptest.NewRequest("GET", "/api/v1/task-spend/"+taskID, nil)
+	return doRequestMethod(handler, http.MethodGet, taskID, user)
+}
+
+func doRequestMethod(handler http.HandlerFunc, method, taskID string, user *auth.User) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, "/api/v1/task-spend/"+taskID, nil)
 	if user != nil {
 		req = req.WithContext(auth.NewContext(req.Context(), user))
 	}
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	return rr
+}
+
+// ── Test: non-GET → 405 ──
+
+func TestHandler_NonGET_Returns405(t *testing.T) {
+	h := Handler(newTestCache(testBudget()), nil)
+	owner := &auth.User{ID: "owner@example.com", Email: "owner@example.com"}
+	rr := doRequestMethod(h, http.MethodPost, "task-123", owner)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rr.Code)
+	}
+}
+
+// ── Test: empty task ID → 400 ──
+
+func TestHandler_EmptyTaskID_Returns400(t *testing.T) {
+	h := Handler(newTestCache(testBudget()), nil)
+	owner := &auth.User{ID: "owner@example.com", Email: "owner@example.com"}
+	rr := doRequest(h, "", owner)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rr.Code)
+	}
+}
+
+// ── Test: extractTaskID ──
+
+func TestExtractTaskID(t *testing.T) {
+	cases := map[string]string{
+		"/api/v1/task-spend/task-123":  "task-123",
+		"/api/v1/task-spend/task-123/": "task-123",
+		"/api/v1/task-spend/":          "",
+		"/api/v1/other/task-123":       "",
+	}
+	for path, want := range cases {
+		if got := extractTaskID(path); got != want {
+			t.Errorf("extractTaskID(%q) = %q, want %q", path, got, want)
+		}
+	}
 }
 
 // ── Test: no auth → 401 ──


### PR DESCRIPTION
## Summary

Closes #780, #782. Addresses #781.

### #780 — Authorization for task spend API

Added owner + admin + SA authorization to `GET /api/v1/task-spend/{taskID}`:

| Caller | Access |
|--------|--------|
| **Task owner** (`TaskBudget.UserID`) | ✅ Own task only |
| **Admin** (`role = "admin"`) | ✅ Any task |
| **Service account** (`*.iam.gserviceaccount.com`) | ✅ Any task (infra-level) |
| **Other authenticated user** | ❌ 404 (prevents task ID enumeration) |
| **Unauthenticated** | ❌ 401 |

**Key design decisions:**
- Unauthorized returns **404** (not 403) to prevent task ID enumeration
- `OwnerID` added to `SpendSnapshot` with `json:"-"` tag — used for authz checks only, never leaked in API responses
- SAs are implicitly authorized (consistent with proxy SA bypass)
- Admin check uses existing `GetUser` → `record.Role == RoleAdmin` pattern

**7 new tests** in `handler_test.go`: NoAuth (401), Owner (200), NonOwner (404), Admin (200), SA (200), MissingTask (404), OwnerIDNotInJSON.

### #782 — Wire cache evictor to shutdown context

- Hoisted `spendCache` out of `if` block scope in `main.go`
- Deferred `StartEvictor()` to after `signal.NotifyContext`
- Evictor now cleanly stops on SIGINT/SIGTERM

### #781 — REST API documentation

Added "REST Endpoints (non-Protobuf)" section to `api-reference.md`:
- `GET /api/v1/task-spend/{taskID}` with auth model, status codes, curl example
- `X-Candela-Job-Id` header lifecycle documentation
- Explains why spend is REST while budgets are ConnectRPC

### Files changed

| File | What |
|------|------|
| `pkg/taskspend/handler.go` | Added `UserLookup` interface, owner+admin+SA authz |
| `pkg/taskspend/cache.go` | Added `OwnerID` to `SpendSnapshot` |
| `pkg/taskspend/handler_test.go` | 7 new authorization tests |
| `cmd/candela-server/main.go` | Evictor context fix, pass userStore to Handler |
| `docs/api-reference.md` | REST endpoints section |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the task spend API endpoint documentation, including authentication, authorization, responses, caching, and usage examples.
  - Added support for authenticated task spend access by task owners, administrators, and service accounts.

- **Bug Fixes**
  - Unauthorized requests are rejected, with safeguards against task ID enumeration.
  - Internal owner information is excluded from API responses.
  - Cache eviction now follows the server’s shutdown lifecycle.

- **Tests**
  - Expanded coverage for authentication, authorization, missing tasks, and response privacy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->