### PR TITLE
feat(modellimits): per-user per-model daily budget limits CRUD (#721)

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/candelahq/candela/pkg/catalog"
 	"github.com/candelahq/candela/pkg/connecthandlers"
 	"github.com/candelahq/candela/pkg/costcalc"
+	"github.com/candelahq/candela/pkg/modellimits"
 	"github.com/candelahq/candela/pkg/notify"
 	"github.com/candelahq/candela/pkg/processor"
 	"github.com/candelahq/candela/pkg/proxy"
@@ -534,6 +535,10 @@ func main() {
 		// NOTE: StartEvictor deferred to after signal.NotifyContext (#782).
 		mux.HandleFunc("/api/v1/task-spend/", taskspend.Handler(spendCache, userStore))
 		slog.Info("task spend API registered", "path", "/api/v1/task-spend/{taskID}")
+
+		// ── Model Limits API (#721) ─────────────────────────────────────
+		mux.HandleFunc("/api/v1/users/", modellimits.Handler(userStore, userStore))
+		slog.Info("model limits API registered", "path", "/api/v1/users/{userID}/model-limits")
 	} else {
 		slog.Warn("task spend API disabled: no user store configured")
 	}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -329,6 +329,96 @@ curl -X POST http://localhost:8181/v1/messages \
   -d '{"model":"claude-sonnet-4-20250514","max_tokens":1024,"messages":[{"role":"user","content":"Hello"}]}'
 ```
 
+### Per-Model Daily Spend Limits
+
+Candela supports per-model daily spend ceilings to prevent expensive models from consuming the entire budget. Limits are enforced pre-flight — requests that would exceed the limit are rejected with `402 Payment Required` before reaching the upstream provider.
+
+#### Global Limits (YAML Config)
+
+Set global per-model limits in `config.yaml` that apply to all users:
+
+```yaml
+proxy:
+  daily_limits:
+    - model: "claude-opus-4"
+      max_daily_usd: 50.00
+    - model: "gpt-4o"
+      max_daily_usd: 25.00
+```
+
+- **Model matching:** Uses longest-prefix matching. `"claude-opus-4"` matches `claude-opus-4`, `claude-opus-4-20250514`, etc.
+- **Reset:** Counters reset at UTC midnight.
+- **Scope:** Per-user — each user gets their own daily counter per model.
+- **In-memory:** Counters are tracked in-memory and reset on proxy restart.
+
+#### Per-User Limits (REST API)
+
+Admins can set per-user model limits that override the global YAML config. These are stored in Firestore and persist across restarts.
+
+### `PUT /api/v1/users/{userID}/model-limits/{modelPrefix}`
+
+Create or update a per-user model limit.
+
+**Authentication:** Required. **Authorization:** Admin only.
+
+**Request body:**
+
+```json
+{"max_daily_usd": 10.00}
+```
+
+**Example:**
+
+```bash
+# Cap alice's Claude Opus usage to $10/day
+curl -X PUT -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"max_daily_usd": 10.00}' \
+  http://localhost:8181/api/v1/users/alice/model-limits/claude-opus-4
+```
+
+### `GET /api/v1/users/{userID}/model-limits`
+
+List all per-user model limits.
+
+**Authentication:** Required. **Authorization:** Admin only.
+
+**Response (200):**
+
+```json
+{
+  "user_id": "alice",
+  "limits": [
+    {"user_id": "alice", "model_prefix": "claude-opus-4", "max_daily_usd": 10.00, "created_at": "...", "updated_at": "..."},
+    {"user_id": "alice", "model_prefix": "gpt-4o", "max_daily_usd": 25.00, "created_at": "...", "updated_at": "..."}
+  ]
+}
+```
+
+### `DELETE /api/v1/users/{userID}/model-limits/{modelPrefix}`
+
+Remove a per-user model limit. The global YAML limit (if any) will apply after deletion.
+
+**Authentication:** Required. **Authorization:** Admin only.
+
+```bash
+curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+  http://localhost:8181/api/v1/users/alice/model-limits/claude-opus-4
+```
+
+**Status Codes (all model limit endpoints):**
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 400 | Missing userID, modelPrefix, or invalid body |
+| 401 | Authentication required |
+| 403 | Admin access required |
+| 405 | Method not allowed |
+| 500 | Internal server error |
+
+**Precedence:** Per-user Firestore limit > Global YAML limit > No limit.
+
 ---
 
 ## Interacting with gRPC

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -331,11 +331,11 @@ curl -X POST http://localhost:8181/v1/messages \
 
 ### Per-Model Daily Spend Limits
 
-Candela supports per-model daily spend ceilings to prevent expensive models from consuming the entire budget. Limits are enforced pre-flight — requests that would exceed the limit are rejected with `402 Payment Required` before reaching the upstream provider.
+Candela supports per-model daily spend ceilings to prevent expensive models from consuming the entire budget.
 
 #### Global Limits (YAML Config)
 
-Set global per-model limits in `config.yaml` that apply to all users:
+Global limits are enforced pre-flight via the in-memory `SpendTracker`. Set them in `config.yaml`:
 
 ```yaml
 proxy:
@@ -353,7 +353,10 @@ proxy:
 
 #### Per-User Limits (REST API)
 
-Admins can set per-user model limits that override the global YAML config. These are stored in Firestore and persist across restarts.
+Admins can store per-user model limits in Firestore via the REST API below. These persist across restarts.
+
+> [!NOTE]
+> **Enforcement not yet active.** This API only stores per-user limits. The proxy does not yet consult Firestore limits during the pre-flight gate — that will be wired in a follow-up PR. For now, only the global YAML `daily_limits` are enforced.
 
 ### `PUT /api/v1/users/{userID}/model-limits/{modelPrefix}`
 
@@ -417,7 +420,7 @@ curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 | 405 | Method not allowed |
 | 500 | Internal server error |
 
-**Precedence:** Per-user Firestore limit > Global YAML limit > No limit.
+**Planned precedence (once enforcement is wired):** Per-user Firestore limit > Global YAML limit > No limit.
 
 ---
 

--- a/pkg/billing/types.go
+++ b/pkg/billing/types.go
@@ -78,3 +78,14 @@ type BudgetAlert struct {
 	PeriodKey string    `json:"period_key" firestore:"period_key"`
 	SentAt    time.Time `json:"sent_at" firestore:"sent_at"`
 }
+
+// ModelLimitRecord is a per-user per-model daily spend ceiling.
+// Stored in Firestore at users/{uid}/model_limits/{model_prefix}.
+// When present, overrides any global daily_limits YAML config for that model prefix.
+type ModelLimitRecord struct {
+	UserID      string    `json:"user_id" firestore:"user_id"`
+	ModelPrefix string    `json:"model_prefix" firestore:"model_prefix"` // e.g. "claude-opus-4", "gpt-4o"
+	MaxDailyUSD float64   `json:"max_daily_usd" firestore:"max_daily_usd"`
+	CreatedAt   time.Time `json:"created_at" firestore:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at" firestore:"updated_at"`
+}

--- a/pkg/connecthandlers/integration_test.go
+++ b/pkg/connecthandlers/integration_test.go
@@ -238,6 +238,13 @@ func (s *integrationStore) CheckTaskBudget(_ context.Context, _ string, _ float6
 	return &storage.TaskBudgetCheckResult{Allowed: true}, nil
 }
 func (s *integrationStore) DeductTaskSpend(context.Context, string, float64) error { return nil }
+func (s *integrationStore) SetModelLimit(context.Context, *storage.ModelLimitRecord) error {
+	return nil
+}
+func (s *integrationStore) GetModelLimits(context.Context, string) ([]*storage.ModelLimitRecord, error) {
+	return nil, nil
+}
+func (s *integrationStore) DeleteModelLimit(context.Context, string, string) error { return nil }
 
 // ──────────────────────────────────────────
 // Test server helpers

--- a/pkg/connecthandlers/user_handler_test.go
+++ b/pkg/connecthandlers/user_handler_test.go
@@ -257,6 +257,13 @@ func (m *mockUserStore) CheckTaskBudget(_ context.Context, _ string, _ float64) 
 	return &storage.TaskBudgetCheckResult{Allowed: true}, nil
 }
 func (m *mockUserStore) DeductTaskSpend(context.Context, string, float64) error { return nil }
+func (m *mockUserStore) SetModelLimit(context.Context, *storage.ModelLimitRecord) error {
+	return nil
+}
+func (m *mockUserStore) GetModelLimits(context.Context, string) ([]*storage.ModelLimitRecord, error) {
+	return nil, nil
+}
+func (m *mockUserStore) DeleteModelLimit(context.Context, string, string) error { return nil }
 
 // ──────────────────────────────────────────
 // Tests

--- a/pkg/modellimits/handler.go
+++ b/pkg/modellimits/handler.go
@@ -1,0 +1,193 @@
+// Package modellimits provides a REST API handler for per-user per-model
+// daily spend limits (#721). Admin-only CRUD operations.
+//
+// Endpoints:
+//
+//	PUT    /api/v1/users/{userID}/model-limits/{modelPrefix}  — set/update a limit
+//	GET    /api/v1/users/{userID}/model-limits                — list all limits
+//	DELETE /api/v1/users/{userID}/model-limits/{modelPrefix}  — remove a limit
+package modellimits
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/candelahq/candela/pkg/auth"
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// Store is the minimal interface for model limit persistence.
+type Store interface {
+	SetModelLimit(ctx context.Context, limit *storage.ModelLimitRecord) error
+	GetModelLimits(ctx context.Context, userID string) ([]*storage.ModelLimitRecord, error)
+	DeleteModelLimit(ctx context.Context, userID, modelPrefix string) error
+}
+
+// UserLookup is the minimal interface for admin role checks.
+type UserLookup interface {
+	GetUser(ctx context.Context, id string) (*storage.UserRecord, error)
+}
+
+// setRequest is the JSON body for PUT requests.
+type setRequest struct {
+	MaxDailyUSD float64 `json:"max_daily_usd"`
+}
+
+// Handler returns an http.HandlerFunc that routes model limit CRUD.
+//
+// Authorization: admin only. Unauthenticated → 401. Non-admin → 403.
+func Handler(store Store, users UserLookup) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// ── Authentication ──
+		caller := auth.FromContext(r.Context())
+		if caller == nil {
+			jsonError(w, "authentication required", http.StatusUnauthorized)
+			return
+		}
+
+		// ── Authorization: admin only ──
+		if !isAdmin(r.Context(), caller.EffectiveID(), users) {
+			jsonError(w, "admin access required", http.StatusForbidden)
+			return
+		}
+
+		// Parse path: /api/v1/users/{userID}/model-limits[/{modelPrefix}]
+		userID, modelPrefix := parsePath(r.URL.Path)
+		if userID == "" {
+			jsonError(w, "user_id is required", http.StatusBadRequest)
+			return
+		}
+
+		switch r.Method {
+		case http.MethodPut:
+			handleSet(w, r, store, userID, modelPrefix)
+		case http.MethodGet:
+			handleList(w, r, store, userID)
+		case http.MethodDelete:
+			handleDelete(w, r, store, userID, modelPrefix)
+		default:
+			jsonError(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+func handleSet(w http.ResponseWriter, r *http.Request, store Store, userID, modelPrefix string) {
+	if modelPrefix == "" {
+		jsonError(w, "model_prefix is required in URL path", http.StatusBadRequest)
+		return
+	}
+
+	var req setRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if req.MaxDailyUSD <= 0 {
+		jsonError(w, "max_daily_usd must be > 0", http.StatusBadRequest)
+		return
+	}
+
+	limit := &storage.ModelLimitRecord{
+		UserID:      userID,
+		ModelPrefix: modelPrefix,
+		MaxDailyUSD: req.MaxDailyUSD,
+	}
+	if err := store.SetModelLimit(r.Context(), limit); err != nil {
+		slog.Error("modellimits: set failed", "user_id", userID,
+			"model_prefix", modelPrefix, "error", err)
+		jsonError(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Info("model limit set",
+		"user_id", userID, "model_prefix", modelPrefix,
+		"max_daily_usd", req.MaxDailyUSD,
+		"actor", auth.EmailFromContext(r.Context()))
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(limit)
+}
+
+func handleList(w http.ResponseWriter, r *http.Request, store Store, userID string) {
+	limits, err := store.GetModelLimits(r.Context(), userID)
+	if err != nil {
+		slog.Error("modellimits: list failed", "user_id", userID, "error", err)
+		jsonError(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"user_id": userID,
+		"limits":  limits,
+	})
+}
+
+func handleDelete(w http.ResponseWriter, r *http.Request, store Store, userID, modelPrefix string) {
+	if modelPrefix == "" {
+		jsonError(w, "model_prefix is required in URL path", http.StatusBadRequest)
+		return
+	}
+
+	if err := store.DeleteModelLimit(r.Context(), userID, modelPrefix); err != nil {
+		slog.Error("modellimits: delete failed", "user_id", userID,
+			"model_prefix", modelPrefix, "error", err)
+		jsonError(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Info("model limit deleted",
+		"user_id", userID, "model_prefix", modelPrefix,
+		"actor", auth.EmailFromContext(r.Context()))
+
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = fmt.Fprint(w, `{"ok":true}`)
+}
+
+// parsePath extracts userID and optional modelPrefix from the URL path.
+// Expected: /api/v1/users/{userID}/model-limits[/{modelPrefix}]
+func parsePath(path string) (userID, modelPrefix string) {
+	const prefix = "/api/v1/users/"
+	if !strings.HasPrefix(path, prefix) {
+		return "", ""
+	}
+	rest := strings.TrimPrefix(path, prefix)
+
+	// Split on /model-limits
+	parts := strings.SplitN(rest, "/model-limits", 2)
+	if len(parts) < 2 {
+		return "", ""
+	}
+
+	userID = strings.TrimRight(parts[0], "/")
+	modelPrefix = strings.TrimLeft(parts[1], "/")
+	modelPrefix = strings.TrimRight(modelPrefix, "/")
+
+	return userID, modelPrefix
+}
+
+// isAdmin checks if the caller has admin role.
+func isAdmin(ctx context.Context, callerID string, users UserLookup) bool {
+	if users == nil {
+		return false
+	}
+	record, err := users.GetUser(ctx, callerID)
+	if err != nil {
+		if !errors.Is(err, storage.ErrNotFound) {
+			slog.Error("modellimits: admin lookup failed", "error", err)
+		}
+		return false
+	}
+	return record != nil && record.Role == storage.RoleAdmin
+}
+
+func jsonError(w http.ResponseWriter, msg string, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/pkg/modellimits/handler.go
+++ b/pkg/modellimits/handler.go
@@ -67,6 +67,10 @@ func Handler(store Store, users UserLookup) http.HandlerFunc {
 		case http.MethodPut:
 			handleSet(w, r, store, userID, modelPrefix)
 		case http.MethodGet:
+			if modelPrefix != "" {
+				jsonError(w, "model_prefix not accepted on GET — use GET /api/v1/users/{userID}/model-limits", http.StatusBadRequest)
+				return
+			}
 			handleList(w, r, store, userID)
 		case http.MethodDelete:
 			handleDelete(w, r, store, userID, modelPrefix)
@@ -151,6 +155,8 @@ func handleDelete(w http.ResponseWriter, r *http.Request, store Store, userID, m
 
 // parsePath extracts userID and optional modelPrefix from the URL path.
 // Expected: /api/v1/users/{userID}/model-limits[/{modelPrefix}]
+//
+// Requires "model-limits" as an exact path segment — rejects "model-limits-extra".
 func parsePath(path string) (userID, modelPrefix string) {
 	const prefix = "/api/v1/users/"
 	if !strings.HasPrefix(path, prefix) {
@@ -158,15 +164,21 @@ func parsePath(path string) (userID, modelPrefix string) {
 	}
 	rest := strings.TrimPrefix(path, prefix)
 
-	// Split on /model-limits
-	parts := strings.SplitN(rest, "/model-limits", 2)
-	if len(parts) < 2 {
+	// Split remaining path into segments: [userID, "model-limits", modelPrefix?]
+	segments := strings.Split(strings.Trim(rest, "/"), "/")
+	if len(segments) < 2 {
 		return "", ""
 	}
 
-	userID = strings.TrimRight(parts[0], "/")
-	modelPrefix = strings.TrimLeft(parts[1], "/")
-	modelPrefix = strings.TrimRight(modelPrefix, "/")
+	// segments[0] = userID, segments[1] must be exactly "model-limits"
+	if segments[1] != "model-limits" {
+		return "", ""
+	}
+
+	userID = segments[0]
+	if len(segments) >= 3 && segments[2] != "" {
+		modelPrefix = segments[2]
+	}
 
 	return userID, modelPrefix
 }

--- a/pkg/modellimits/handler_test.go
+++ b/pkg/modellimits/handler_test.go
@@ -286,6 +286,11 @@ func TestParsePath(t *testing.T) {
 		{"/api/v1/users/bob@example.com/model-limits/gemini-2.5-flash", "bob@example.com", "gemini-2.5-flash"},
 		{"/api/v1/other/path", "", ""},
 		{"", "", ""},
+		// CR #2: Exact segment matching — reject "model-limits-extra".
+		{"/api/v1/users/alice/model-limits-extra", "", ""},
+		{"/api/v1/users/alice/model-limitsx/foo", "", ""},
+		// Only users prefix, no model-limits segment.
+		{"/api/v1/users/alice/other-segment", "", ""},
 	}
 
 	for _, tt := range tests {
@@ -294,5 +299,29 @@ func TestParsePath(t *testing.T) {
 			t.Errorf("parsePath(%q) = (%q, %q), want (%q, %q)",
 				tt.path, user, prefix, tt.wantUser, tt.wantPrefix)
 		}
+	}
+}
+
+func TestHandler_GET_RejectsModelPrefix(t *testing.T) {
+	h := Handler(&mockStore{limits: []*storage.ModelLimitRecord{
+		{UserID: "alice", ModelPrefix: "gpt-4o", MaxDailyUSD: 10},
+	}}, &mockUserLookup{role: "admin"})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users/", h)
+	srv := httptest.NewServer(withAuth(mux, "admin-user", "admin@test.com", "admin"))
+	defer srv.Close()
+
+	// GET with model prefix should be rejected.
+	req, _ := http.NewRequest("GET",
+		srv.URL+"/api/v1/users/alice/model-limits/gpt-4o", nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("GET with model prefix: status = %d, want 400", resp.StatusCode)
 	}
 }

--- a/pkg/modellimits/handler_test.go
+++ b/pkg/modellimits/handler_test.go
@@ -1,0 +1,298 @@
+package modellimits
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/auth"
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// mockStore implements Store for testing.
+type mockStore struct {
+	limits     []*storage.ModelLimitRecord
+	setErr     error
+	listErr    error
+	deleteErr  error
+	setCalled  int
+	delCalled  int
+	lastLimit  *storage.ModelLimitRecord
+	lastDelUID string
+	lastDelPfx string
+}
+
+func (m *mockStore) SetModelLimit(_ context.Context, limit *storage.ModelLimitRecord) error {
+	m.setCalled++
+	m.lastLimit = limit
+	if m.setErr != nil {
+		return m.setErr
+	}
+	m.limits = append(m.limits, limit)
+	return nil
+}
+
+func (m *mockStore) GetModelLimits(_ context.Context, _ string) ([]*storage.ModelLimitRecord, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.limits, nil
+}
+
+func (m *mockStore) DeleteModelLimit(_ context.Context, userID, modelPrefix string) error {
+	m.delCalled++
+	m.lastDelUID = userID
+	m.lastDelPfx = modelPrefix
+	return m.deleteErr
+}
+
+// mockUserLookup implements UserLookup for testing.
+type mockUserLookup struct {
+	role string
+}
+
+func (m *mockUserLookup) GetUser(_ context.Context, _ string) (*storage.UserRecord, error) {
+	return &storage.UserRecord{Role: m.role}, nil
+}
+
+func withAuth(h http.Handler, userID, email, role string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.NewContext(r.Context(), &auth.User{ID: userID, Email: email})
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func TestHandler_Unauthenticated(t *testing.T) {
+	h := Handler(&mockStore{}, &mockUserLookup{role: "admin"})
+	req := httptest.NewRequest("GET", "/api/v1/users/alice/model-limits", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandler_NonAdmin(t *testing.T) {
+	h := Handler(&mockStore{}, &mockUserLookup{role: "developer"})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users/", h)
+	srv := httptest.NewServer(withAuth(mux, "dev-user", "dev@test.com", "developer"))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api/v1/users/alice/model-limits", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestHandler_SetModelLimit(t *testing.T) {
+	store := &mockStore{}
+	h := Handler(store, &mockUserLookup{role: "admin"})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users/", h)
+	srv := httptest.NewServer(withAuth(mux, "admin-user", "admin@test.com", "admin"))
+	defer srv.Close()
+
+	body := `{"max_daily_usd": 25.00}`
+	req, _ := http.NewRequest("PUT",
+		srv.URL+"/api/v1/users/alice/model-limits/claude-opus-4",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if store.setCalled != 1 {
+		t.Errorf("SetModelLimit called %d times, want 1", store.setCalled)
+	}
+	if store.lastLimit.UserID != "alice" {
+		t.Errorf("UserID = %q, want 'alice'", store.lastLimit.UserID)
+	}
+	if store.lastLimit.ModelPrefix != "claude-opus-4" {
+		t.Errorf("ModelPrefix = %q, want 'claude-opus-4'", store.lastLimit.ModelPrefix)
+	}
+	if store.lastLimit.MaxDailyUSD != 25.00 {
+		t.Errorf("MaxDailyUSD = %f, want 25.00", store.lastLimit.MaxDailyUSD)
+	}
+}
+
+func TestHandler_SetModelLimit_InvalidAmount(t *testing.T) {
+	store := &mockStore{}
+	h := Handler(store, &mockUserLookup{role: "admin"})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users/", h)
+	srv := httptest.NewServer(withAuth(mux, "admin-user", "admin@test.com", "admin"))
+	defer srv.Close()
+
+	body := `{"max_daily_usd": -5.00}`
+	req, _ := http.NewRequest("PUT",
+		srv.URL+"/api/v1/users/alice/model-limits/claude-opus-4",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	if store.setCalled != 0 {
+		t.Errorf("SetModelLimit should not be called for invalid amount")
+	}
+}
+
+func TestHandler_ListModelLimits(t *testing.T) {
+	store := &mockStore{
+		limits: []*storage.ModelLimitRecord{
+			{UserID: "alice", ModelPrefix: "claude-opus-4", MaxDailyUSD: 50.00},
+			{UserID: "alice", ModelPrefix: "gpt-4o", MaxDailyUSD: 25.00},
+		},
+	}
+	h := Handler(store, &mockUserLookup{role: "admin"})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users/", h)
+	srv := httptest.NewServer(withAuth(mux, "admin-user", "admin@test.com", "admin"))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET",
+		srv.URL+"/api/v1/users/alice/model-limits", nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var result struct {
+		UserID string                      `json:"user_id"`
+		Limits []*storage.ModelLimitRecord `json:"limits"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result.Limits) != 2 {
+		t.Errorf("got %d limits, want 2", len(result.Limits))
+	}
+}
+
+func TestHandler_DeleteModelLimit(t *testing.T) {
+	store := &mockStore{}
+	h := Handler(store, &mockUserLookup{role: "admin"})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users/", h)
+	srv := httptest.NewServer(withAuth(mux, "admin-user", "admin@test.com", "admin"))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("DELETE",
+		srv.URL+"/api/v1/users/alice/model-limits/claude-opus-4", nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if store.delCalled != 1 {
+		t.Errorf("DeleteModelLimit called %d times, want 1", store.delCalled)
+	}
+	if store.lastDelUID != "alice" {
+		t.Errorf("userID = %q, want 'alice'", store.lastDelUID)
+	}
+	if store.lastDelPfx != "claude-opus-4" {
+		t.Errorf("modelPrefix = %q, want 'claude-opus-4'", store.lastDelPfx)
+	}
+}
+
+func TestHandler_SetMissingModelPrefix(t *testing.T) {
+	h := Handler(&mockStore{}, &mockUserLookup{role: "admin"})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users/", h)
+	srv := httptest.NewServer(withAuth(mux, "admin-user", "admin@test.com", "admin"))
+	defer srv.Close()
+
+	body := `{"max_daily_usd": 25.00}`
+	req, _ := http.NewRequest("PUT",
+		srv.URL+"/api/v1/users/alice/model-limits",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestHandler_MethodNotAllowed(t *testing.T) {
+	h := Handler(&mockStore{}, &mockUserLookup{role: "admin"})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users/", h)
+	srv := httptest.NewServer(withAuth(mux, "admin-user", "admin@test.com", "admin"))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("PATCH",
+		srv.URL+"/api/v1/users/alice/model-limits/claude-opus-4", nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestParsePath(t *testing.T) {
+	tests := []struct {
+		path       string
+		wantUser   string
+		wantPrefix string
+	}{
+		{"/api/v1/users/alice/model-limits", "alice", ""},
+		{"/api/v1/users/alice/model-limits/claude-opus-4", "alice", "claude-opus-4"},
+		{"/api/v1/users/alice/model-limits/gpt-4o/", "alice", "gpt-4o"},
+		{"/api/v1/users/bob@example.com/model-limits/gemini-2.5-flash", "bob@example.com", "gemini-2.5-flash"},
+		{"/api/v1/other/path", "", ""},
+		{"", "", ""},
+	}
+
+	for _, tt := range tests {
+		user, prefix := parsePath(tt.path)
+		if user != tt.wantUser || prefix != tt.wantPrefix {
+			t.Errorf("parsePath(%q) = (%q, %q), want (%q, %q)",
+				tt.path, user, prefix, tt.wantUser, tt.wantPrefix)
+		}
+	}
+}

--- a/pkg/proxy/budget_gate_test.go
+++ b/pkg/proxy/budget_gate_test.go
@@ -88,6 +88,13 @@ func (b *budgetUserStore) CheckTaskBudget(_ context.Context, _ string, _ float64
 	return &storage.TaskBudgetCheckResult{Allowed: true}, nil
 }
 func (b *budgetUserStore) DeductTaskSpend(context.Context, string, float64) error { return nil }
+func (b *budgetUserStore) SetModelLimit(context.Context, *storage.ModelLimitRecord) error {
+	return nil
+}
+func (b *budgetUserStore) GetModelLimits(context.Context, string) ([]*storage.ModelLimitRecord, error) {
+	return nil, nil
+}
+func (b *budgetUserStore) DeleteModelLimit(context.Context, string, string) error { return nil }
 
 // ====================================================================
 // Pre-flight Budget Gate

--- a/pkg/storage/firestoredb/firestoredb.go
+++ b/pkg/storage/firestoredb/firestoredb.go
@@ -853,6 +853,79 @@ func (s *Store) GetGrant(ctx context.Context, userID, grantID string) (*storage.
 }
 
 // ──────────────────────────────────────────
+// Model Limits (#721)
+// ──────────────────────────────────────────
+
+const modelLimitsCol = "model_limits"
+
+// SetModelLimit creates or updates a per-user per-model daily spend limit.
+// Uses the sanitized model prefix as the document ID for upsert semantics.
+func (s *Store) SetModelLimit(ctx context.Context, limit *storage.ModelLimitRecord) error {
+	if limit.UserID == "" || limit.ModelPrefix == "" {
+		return fmt.Errorf("firestoredb: SetModelLimit: user_id and model_prefix are required")
+	}
+	if limit.MaxDailyUSD <= 0 {
+		return fmt.Errorf("firestoredb: SetModelLimit: max_daily_usd must be > 0")
+	}
+	now := time.Now().UTC()
+	if limit.CreatedAt.IsZero() {
+		limit.CreatedAt = now
+	}
+	limit.UpdatedAt = now
+
+	userID := sanitizeID(limit.UserID)
+	docID := sanitizeID(limit.ModelPrefix)
+	ref := s.client.Collection(usersCol).Doc(userID).
+		Collection(modelLimitsCol).Doc(docID)
+	_, err := ref.Set(ctx, map[string]interface{}{
+		"user_id":       limit.UserID,
+		"model_prefix":  limit.ModelPrefix,
+		"max_daily_usd": limit.MaxDailyUSD,
+		"created_at":    limit.CreatedAt,
+		"updated_at":    limit.UpdatedAt,
+	})
+	if err != nil {
+		return fmt.Errorf("firestoredb: setting model limit: %w", err)
+	}
+	return nil
+}
+
+// GetModelLimits returns all per-model daily limits for a user.
+func (s *Store) GetModelLimits(ctx context.Context, userID string) ([]*storage.ModelLimitRecord, error) {
+	userID = sanitizeID(userID)
+	snaps, err := s.client.Collection(usersCol).Doc(userID).
+		Collection(modelLimitsCol).Documents(ctx).GetAll()
+	if err != nil {
+		return nil, fmt.Errorf("firestoredb: listing model limits: %w", err)
+	}
+
+	limits := make([]*storage.ModelLimitRecord, 0, len(snaps))
+	for _, snap := range snaps {
+		var rec storage.ModelLimitRecord
+		if err := snap.DataTo(&rec); err != nil {
+			slog.Warn("firestoredb: skipping malformed model limit",
+				"doc_id", snap.Ref.ID, "error", err)
+			continue
+		}
+		limits = append(limits, &rec)
+	}
+	return limits, nil
+}
+
+// DeleteModelLimit removes a per-user model limit by model prefix.
+func (s *Store) DeleteModelLimit(ctx context.Context, userID, modelPrefix string) error {
+	userID = sanitizeID(userID)
+	docID := sanitizeID(modelPrefix)
+	ref := s.client.Collection(usersCol).Doc(userID).
+		Collection(modelLimitsCol).Doc(docID)
+	_, err := ref.Delete(ctx)
+	if err != nil {
+		return fmt.Errorf("firestoredb: deleting model limit: %w", err)
+	}
+	return nil
+}
+
+// ──────────────────────────────────────────
 // Budget Enforcement
 // ──────────────────────────────────────────
 

--- a/pkg/storage/firestoredb/firestoredb.go
+++ b/pkg/storage/firestoredb/firestoredb.go
@@ -14,6 +14,8 @@ package firestoredb
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -858,8 +860,16 @@ func (s *Store) GetGrant(ctx context.Context, userID, grantID string) (*storage.
 
 const modelLimitsCol = "model_limits"
 
+// modelLimitDocID returns a collision-resistant document ID for a model prefix.
+// We use SHA-256 hex digest instead of sanitizeID because sanitizeID maps
+// distinct prefixes (e.g. "foo/bar" and "foo_bar") to the same key.
+func modelLimitDocID(modelPrefix string) string {
+	h := sha256.Sum256([]byte(modelPrefix))
+	return hex.EncodeToString(h[:])
+}
+
 // SetModelLimit creates or updates a per-user per-model daily spend limit.
-// Uses the sanitized model prefix as the document ID for upsert semantics.
+// Uses a Firestore transaction to preserve CreatedAt on updates.
 func (s *Store) SetModelLimit(ctx context.Context, limit *storage.ModelLimitRecord) error {
 	if limit.UserID == "" || limit.ModelPrefix == "" {
 		return fmt.Errorf("firestoredb: SetModelLimit: user_id and model_prefix are required")
@@ -867,26 +877,39 @@ func (s *Store) SetModelLimit(ctx context.Context, limit *storage.ModelLimitReco
 	if limit.MaxDailyUSD <= 0 {
 		return fmt.Errorf("firestoredb: SetModelLimit: max_daily_usd must be > 0")
 	}
-	now := time.Now().UTC()
-	if limit.CreatedAt.IsZero() {
-		limit.CreatedAt = now
-	}
-	limit.UpdatedAt = now
 
 	userID := sanitizeID(limit.UserID)
-	docID := sanitizeID(limit.ModelPrefix)
+	docID := modelLimitDocID(limit.ModelPrefix)
 	ref := s.client.Collection(usersCol).Doc(userID).
 		Collection(modelLimitsCol).Doc(docID)
-	_, err := ref.Set(ctx, map[string]interface{}{
-		"user_id":       limit.UserID,
-		"model_prefix":  limit.ModelPrefix,
-		"max_daily_usd": limit.MaxDailyUSD,
-		"created_at":    limit.CreatedAt,
-		"updated_at":    limit.UpdatedAt,
+
+	now := time.Now().UTC()
+
+	err := s.client.RunTransaction(ctx, func(_ context.Context, tx *firestore.Transaction) error {
+		// Read existing doc to preserve CreatedAt if it exists.
+		snap, err := tx.Get(ref)
+		createdAt := now
+		if err == nil {
+			// Existing doc — preserve its CreatedAt.
+			if t, ok := snap.Data()["created_at"].(time.Time); ok {
+				createdAt = t
+			}
+		}
+		// If the doc doesn't exist (status.Code == codes.NotFound), createdAt stays as now.
+
+		return tx.Set(ref, map[string]interface{}{
+			"user_id":       limit.UserID,
+			"model_prefix":  limit.ModelPrefix,
+			"max_daily_usd": limit.MaxDailyUSD,
+			"created_at":    createdAt,
+			"updated_at":    now,
+		})
 	})
 	if err != nil {
 		return fmt.Errorf("firestoredb: setting model limit: %w", err)
 	}
+
+	limit.UpdatedAt = now
 	return nil
 }
 
@@ -915,7 +938,7 @@ func (s *Store) GetModelLimits(ctx context.Context, userID string) ([]*storage.M
 // DeleteModelLimit removes a per-user model limit by model prefix.
 func (s *Store) DeleteModelLimit(ctx context.Context, userID, modelPrefix string) error {
 	userID = sanitizeID(userID)
-	docID := sanitizeID(modelPrefix)
+	docID := modelLimitDocID(modelPrefix)
 	ref := s.client.Collection(usersCol).Doc(userID).
 		Collection(modelLimitsCol).Doc(docID)
 	_, err := ref.Delete(ctx)

--- a/pkg/storage/firestoredb/firestoredb.go
+++ b/pkg/storage/firestoredb/firestoredb.go
@@ -884,18 +884,22 @@ func (s *Store) SetModelLimit(ctx context.Context, limit *storage.ModelLimitReco
 		Collection(modelLimitsCol).Doc(docID)
 
 	now := time.Now().UTC()
+	var createdAt time.Time
 
 	err := s.client.RunTransaction(ctx, func(_ context.Context, tx *firestore.Transaction) error {
 		// Read existing doc to preserve CreatedAt if it exists.
 		snap, err := tx.Get(ref)
-		createdAt := now
+		createdAt = now
 		if err == nil {
 			// Existing doc — preserve its CreatedAt.
 			if t, ok := snap.Data()["created_at"].(time.Time); ok {
 				createdAt = t
 			}
+		} else if status.Code(err) != codes.NotFound {
+			// Real read error — abort the transaction.
+			return err
 		}
-		// If the doc doesn't exist (status.Code == codes.NotFound), createdAt stays as now.
+		// If NotFound, createdAt stays as now (new record).
 
 		return tx.Set(ref, map[string]interface{}{
 			"user_id":       limit.UserID,
@@ -909,6 +913,7 @@ func (s *Store) SetModelLimit(ctx context.Context, limit *storage.ModelLimitReco
 		return fmt.Errorf("firestoredb: setting model limit: %w", err)
 	}
 
+	limit.CreatedAt = createdAt
 	limit.UpdatedAt = now
 	return nil
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -556,6 +556,9 @@ type AuditRecord struct {
 // BudgetCheckResult is a type alias for billing.BudgetCheckResult.
 type BudgetCheckResult = billing.BudgetCheckResult
 
+// ModelLimitRecord is a type alias for billing.ModelLimitRecord.
+type ModelLimitRecord = billing.ModelLimitRecord
+
 // UserStore manages users, budgets, grants, audit, and rate limits.
 // Implemented by firestoredb for production.
 type UserStore interface {
@@ -612,6 +615,17 @@ type UserStore interface {
 
 	// GetGrant returns a specific grant by ID.
 	GetGrant(ctx context.Context, userID, grantID string) (*GrantRecord, error)
+
+	// ── Model Limits (#721) ──
+
+	// SetModelLimit creates or updates a per-user per-model daily spend limit.
+	SetModelLimit(ctx context.Context, limit *ModelLimitRecord) error
+
+	// GetModelLimits returns all model limits for a user.
+	GetModelLimits(ctx context.Context, userID string) ([]*ModelLimitRecord, error)
+
+	// DeleteModelLimit removes a per-user model limit.
+	DeleteModelLimit(ctx context.Context, userID, modelPrefix string) error
 
 	// ── Budget Enforcement ──
 


### PR DESCRIPTION
## Summary

PR 1 of 3 for #721 — Per-model budget limits.

Adds REST API for admins to manage per-user per-model daily spend limits, plus documents the existing `daily_limits` YAML config.

## Changes

### New: `pkg/modellimits` package
- REST handler: `PUT/GET/DELETE /api/v1/users/{userID}/model-limits/{modelPrefix}`
- Admin-only auth (403 for non-admin, 401 for unauthenticated)
- 9 handler tests (auth, CRUD, validation, path parsing)

### Storage layer
- `ModelLimitRecord` type in `pkg/billing/types.go`
- `SetModelLimit`, `GetModelLimits`, `DeleteModelLimit` on `UserStore` interface
- Firestore implementation: `users/{uid}/model_limits/{model_prefix}` subcollection

### Server wiring
- Registered in `cmd/candela-server/main.go` alongside task-spend API

### Documentation
- Documented existing `daily_limits` YAML config in api-reference.md
- Documented new REST API endpoints with curl examples
- Documented precedence: per-user Firestore > global YAML > no limit

## Next PRs
- **PR 2:** Proxy merges Firestore + YAML limits in pre-flight gate
- **PR 3:** Dashboard: per-model spend vs limit display

Closes #721 (partially)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin-only REST APIs to create, view, and delete per-user daily spending limits for specific models.
  * Added persistent storage with validation and model-prefix matching.
  * Integrated the model-limit API into the server when user storage is configured.

* **Documentation**
  * Documented configuration, authorization, endpoints, reset behavior, precedence rules, and current enforcement limitations.

* **Tests**
  * Added coverage for authentication, authorization, validation, listing, deletion, unsupported methods, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->