### PR TITLE
feat(proxy): enforce per-user model limits from Firestore (#721)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -353,10 +353,10 @@ proxy:
 
 #### Per-User Limits (REST API)
 
-Admins can store per-user model limits in Firestore via the REST API below. These persist across restarts.
+Admins can set per-user model limits that override the global YAML config. These are stored in Firestore and persist across restarts. The proxy merges per-user limits with YAML defaults at request time.
 
-> [!NOTE]
-> **Enforcement not yet active.** This API only stores per-user limits. The proxy does not yet consult Firestore limits during the pre-flight gate — that will be wired in a follow-up PR. For now, only the global YAML `daily_limits` are enforced.
+> [!TIP]
+> Per-user limits are cached for 60 seconds. Changes made via the REST API may take up to 60 seconds to take effect in the proxy.
 
 ### `PUT /api/v1/users/{userID}/model-limits/{modelPrefix}`
 
@@ -420,7 +420,7 @@ curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 | 405 | Method not allowed |
 | 500 | Internal server error |
 
-**Planned precedence (once enforcement is wired):** Per-user Firestore limit > Global YAML limit > No limit.
+**Precedence:** Per-user Firestore limit > Global YAML limit > No limit.
 
 ---
 

--- a/pkg/proxy/model_limit_cache.go
+++ b/pkg/proxy/model_limit_cache.go
@@ -1,0 +1,133 @@
+// Package proxy — model_limit_cache.go provides a per-user model limit cache
+// that loads limits from Firestore and merges them with global YAML defaults.
+// Used by the proxy pre-flight gate to enforce per-user per-model daily spend
+// limits (#721, PR 2).
+//
+// Cache behavior:
+//   - 60s TTL with lazy expiry (checked on read, no background evictor)
+//   - Per-Proxy-instance: in a multi-replica deployment, each replica has its
+//     own cache. Admin changes propagate within ≤60s per replica.
+//   - Fail-open: if Firestore is unreachable, falls back to YAML-only limits.
+package proxy
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// modelLimitStore is the minimal interface for loading per-user model limits.
+type modelLimitStore interface {
+	GetModelLimits(ctx context.Context, userID string) ([]*storage.ModelLimitRecord, error)
+}
+
+// mlCacheEntry holds cached per-user model limits with a fetch timestamp.
+type mlCacheEntry struct {
+	limits    []SpendLimitConfig
+	fetchedAt time.Time
+}
+
+// modelLimitCache is a TTL cache for per-user model limits loaded from Firestore.
+// Thread-safe for concurrent reads/writes from proxy request handlers.
+type modelLimitCache struct {
+	mu      sync.RWMutex
+	entries map[string]*mlCacheEntry
+	ttl     time.Duration
+	store   modelLimitStore
+}
+
+// newModelLimitCache creates a cache with the given TTL and backing store.
+func newModelLimitCache(store modelLimitStore, ttl time.Duration) *modelLimitCache {
+	return &modelLimitCache{
+		entries: make(map[string]*mlCacheEntry),
+		ttl:     ttl,
+		store:   store,
+	}
+}
+
+// getUserLimits returns the cached per-user limits, refreshing from the store
+// if the entry is missing or expired. Returns nil on store errors (fail-open).
+func (c *modelLimitCache) getUserLimits(ctx context.Context, userID string) []SpendLimitConfig {
+	// Fast path: check cache under read lock.
+	c.mu.RLock()
+	entry, ok := c.entries[userID]
+	if ok && time.Since(entry.fetchedAt) < c.ttl {
+		limits := entry.limits
+		c.mu.RUnlock()
+		return limits
+	}
+	c.mu.RUnlock()
+
+	// Slow path: fetch from store under write lock.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check after acquiring write lock (another goroutine may have refreshed).
+	entry, ok = c.entries[userID]
+	if ok && time.Since(entry.fetchedAt) < c.ttl {
+		return entry.limits
+	}
+
+	records, err := c.store.GetModelLimits(ctx, userID)
+	if err != nil {
+		slog.Warn("model limit cache: failed to load user limits, falling back to YAML",
+			"user_id", userID, "error", err)
+		// Fail-open: return nil so mergedLimits falls back to YAML-only.
+		return nil
+	}
+
+	limits := recordsToLimits(records)
+	c.entries[userID] = &mlCacheEntry{
+		limits:    limits,
+		fetchedAt: time.Now(),
+	}
+	return limits
+}
+
+// mergedLimits returns the effective limits for a user by merging their
+// Firestore limits with the global YAML defaults. User limits override YAML
+// for the same model prefix; YAML-only and user-only limits are both included.
+func (c *modelLimitCache) mergedLimits(ctx context.Context, userID string, yamlLimits []SpendLimitConfig) []SpendLimitConfig {
+	userLimits := c.getUserLimits(ctx, userID)
+	if len(userLimits) == 0 {
+		return yamlLimits
+	}
+	if len(yamlLimits) == 0 {
+		return userLimits
+	}
+
+	// Build a set of user-overridden model prefixes (lowercased).
+	userPrefixes := make(map[string]struct{}, len(userLimits))
+	for _, ul := range userLimits {
+		userPrefixes[strings.ToLower(ul.Model)] = struct{}{}
+	}
+
+	// Start with user limits, then append YAML limits that aren't overridden.
+	merged := make([]SpendLimitConfig, 0, len(userLimits)+len(yamlLimits))
+	merged = append(merged, userLimits...)
+	for _, yl := range yamlLimits {
+		if _, overridden := userPrefixes[strings.ToLower(yl.Model)]; !overridden {
+			merged = append(merged, yl)
+		}
+	}
+	return merged
+}
+
+// recordsToLimits converts storage records to SpendLimitConfig slice.
+func recordsToLimits(records []*storage.ModelLimitRecord) []SpendLimitConfig {
+	if len(records) == 0 {
+		return nil
+	}
+	limits := make([]SpendLimitConfig, len(records))
+	for i, r := range records {
+		limits[i] = SpendLimitConfig{
+			Model:       r.ModelPrefix,
+			MaxDailyUSD: r.MaxDailyUSD,
+		}
+	}
+	return limits
+}

--- a/pkg/proxy/model_limit_cache_test.go
+++ b/pkg/proxy/model_limit_cache_test.go
@@ -1,0 +1,228 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// mockModelLimitStore implements modelLimitStore for testing.
+type mockModelLimitStore struct {
+	limits map[string][]*storage.ModelLimitRecord
+	err    error
+	calls  int
+}
+
+func (m *mockModelLimitStore) GetModelLimits(_ context.Context, userID string) ([]*storage.ModelLimitRecord, error) {
+	m.calls++
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.limits[userID], nil
+}
+
+func TestModelLimitCache_HitWithinTTL(t *testing.T) {
+	store := &mockModelLimitStore{
+		limits: map[string][]*storage.ModelLimitRecord{
+			"alice": {
+				{UserID: "alice", ModelPrefix: "claude-opus-4", MaxDailyUSD: 10},
+			},
+		},
+	}
+	cache := newModelLimitCache(store, 60*time.Second)
+
+	// First call — cache miss, fetches from store.
+	limits := cache.getUserLimits(context.Background(), "alice")
+	if len(limits) != 1 || limits[0].MaxDailyUSD != 10 {
+		t.Fatalf("first call: got %+v, want [{claude-opus-4, 10}]", limits)
+	}
+	if store.calls != 1 {
+		t.Fatalf("first call: store.calls = %d, want 1", store.calls)
+	}
+
+	// Second call — cache hit, no additional store call.
+	limits = cache.getUserLimits(context.Background(), "alice")
+	if len(limits) != 1 {
+		t.Fatalf("second call: got %d limits, want 1", len(limits))
+	}
+	if store.calls != 1 {
+		t.Fatalf("second call: store.calls = %d, want 1 (cached)", store.calls)
+	}
+}
+
+func TestModelLimitCache_ExpiredTTL(t *testing.T) {
+	store := &mockModelLimitStore{
+		limits: map[string][]*storage.ModelLimitRecord{
+			"alice": {
+				{UserID: "alice", ModelPrefix: "gpt-4o", MaxDailyUSD: 5},
+			},
+		},
+	}
+	// Use a very short TTL so it expires immediately.
+	cache := newModelLimitCache(store, 1*time.Nanosecond)
+
+	_ = cache.getUserLimits(context.Background(), "alice")
+	if store.calls != 1 {
+		t.Fatalf("first call: store.calls = %d, want 1", store.calls)
+	}
+
+	// Wait for TTL to expire.
+	time.Sleep(10 * time.Millisecond)
+
+	_ = cache.getUserLimits(context.Background(), "alice")
+	if store.calls != 2 {
+		t.Fatalf("after TTL: store.calls = %d, want 2", store.calls)
+	}
+}
+
+func TestModelLimitCache_StoreError_FailOpen(t *testing.T) {
+	store := &mockModelLimitStore{
+		err: errors.New("firestore unavailable"),
+	}
+	cache := newModelLimitCache(store, 60*time.Second)
+
+	// Fail-open: should return nil (no user limits), not error.
+	limits := cache.getUserLimits(context.Background(), "alice")
+	if limits != nil {
+		t.Fatalf("on store error: got %+v, want nil", limits)
+	}
+}
+
+func TestMergedLimits_UserOverridesYAML(t *testing.T) {
+	store := &mockModelLimitStore{
+		limits: map[string][]*storage.ModelLimitRecord{
+			"alice": {
+				{UserID: "alice", ModelPrefix: "claude-opus-4", MaxDailyUSD: 10},
+			},
+		},
+	}
+	cache := newModelLimitCache(store, 60*time.Second)
+
+	yamlLimits := []SpendLimitConfig{
+		{Model: "claude-opus-4", MaxDailyUSD: 50},
+		{Model: "gpt-4o", MaxDailyUSD: 25},
+	}
+
+	merged := cache.mergedLimits(context.Background(), "alice", yamlLimits)
+
+	// Should have 2 entries: alice's claude-opus-4 ($10) + YAML gpt-4o ($25).
+	if len(merged) != 2 {
+		t.Fatalf("merged: got %d limits, want 2", len(merged))
+	}
+
+	// First entry should be alice's override (user limits come first).
+	if merged[0].Model != "claude-opus-4" || merged[0].MaxDailyUSD != 10 {
+		t.Errorf("merged[0] = {%s, %.2f}, want {claude-opus-4, 10.00}", merged[0].Model, merged[0].MaxDailyUSD)
+	}
+
+	// Second entry should be the YAML-only limit (not overridden).
+	if merged[1].Model != "gpt-4o" || merged[1].MaxDailyUSD != 25 {
+		t.Errorf("merged[1] = {%s, %.2f}, want {gpt-4o, 25.00}", merged[1].Model, merged[1].MaxDailyUSD)
+	}
+}
+
+func TestMergedLimits_UserOnlyLimits(t *testing.T) {
+	store := &mockModelLimitStore{
+		limits: map[string][]*storage.ModelLimitRecord{
+			"bob": {
+				{UserID: "bob", ModelPrefix: "gemini-2.5-flash", MaxDailyUSD: 3},
+			},
+		},
+	}
+	cache := newModelLimitCache(store, 60*time.Second)
+
+	// No YAML limits at all.
+	merged := cache.mergedLimits(context.Background(), "bob", nil)
+
+	if len(merged) != 1 || merged[0].Model != "gemini-2.5-flash" {
+		t.Fatalf("user-only: got %+v, want [{gemini-2.5-flash, 3}]", merged)
+	}
+}
+
+func TestMergedLimits_NoUserLimits_ReturnsYAML(t *testing.T) {
+	store := &mockModelLimitStore{
+		limits: map[string][]*storage.ModelLimitRecord{},
+	}
+	cache := newModelLimitCache(store, 60*time.Second)
+
+	yamlLimits := []SpendLimitConfig{
+		{Model: "claude-opus-4", MaxDailyUSD: 50},
+	}
+
+	merged := cache.mergedLimits(context.Background(), "alice", yamlLimits)
+
+	// Should return YAML limits unchanged.
+	if len(merged) != 1 || merged[0].MaxDailyUSD != 50 {
+		t.Fatalf("no user limits: got %+v, want YAML", merged)
+	}
+}
+
+func TestMergedLimits_StoreError_FallsBackToYAML(t *testing.T) {
+	store := &mockModelLimitStore{
+		err: errors.New("firestore down"),
+	}
+	cache := newModelLimitCache(store, 60*time.Second)
+
+	yamlLimits := []SpendLimitConfig{
+		{Model: "gpt-4o", MaxDailyUSD: 25},
+	}
+
+	merged := cache.mergedLimits(context.Background(), "alice", yamlLimits)
+
+	// Fail-open: should return YAML limits.
+	if len(merged) != 1 || merged[0].MaxDailyUSD != 25 {
+		t.Fatalf("store error: got %+v, want YAML fallback", merged)
+	}
+}
+
+func TestMergedLimits_CaseInsensitiveOverride(t *testing.T) {
+	store := &mockModelLimitStore{
+		limits: map[string][]*storage.ModelLimitRecord{
+			"alice": {
+				{UserID: "alice", ModelPrefix: "Claude-Opus-4", MaxDailyUSD: 10},
+			},
+		},
+	}
+	cache := newModelLimitCache(store, 60*time.Second)
+
+	yamlLimits := []SpendLimitConfig{
+		{Model: "claude-opus-4", MaxDailyUSD: 50},
+	}
+
+	merged := cache.mergedLimits(context.Background(), "alice", yamlLimits)
+
+	// User limit (case-different) should override YAML.
+	if len(merged) != 1 {
+		t.Fatalf("case-insensitive: got %d limits, want 1", len(merged))
+	}
+	if merged[0].MaxDailyUSD != 10 {
+		t.Errorf("case-insensitive: limit = %.2f, want 10.00", merged[0].MaxDailyUSD)
+	}
+}
+
+func TestRecordsToLimits(t *testing.T) {
+	records := []*storage.ModelLimitRecord{
+		{ModelPrefix: "claude-opus-4", MaxDailyUSD: 10},
+		{ModelPrefix: "gpt-4o", MaxDailyUSD: 25},
+	}
+
+	limits := recordsToLimits(records)
+	if len(limits) != 2 {
+		t.Fatalf("got %d limits, want 2", len(limits))
+	}
+	if limits[0].Model != "claude-opus-4" || limits[0].MaxDailyUSD != 10 {
+		t.Errorf("limits[0] = %+v", limits[0])
+	}
+	if limits[1].Model != "gpt-4o" || limits[1].MaxDailyUSD != 25 {
+		t.Errorf("limits[1] = %+v", limits[1])
+	}
+}
+
+func TestRecordsToLimits_Nil(t *testing.T) {
+	if got := recordsToLimits(nil); got != nil {
+		t.Errorf("nil records: got %+v, want nil", got)
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -272,6 +272,10 @@ type Proxy struct {
 	config       Config        // retained for limit config access
 	spendTracker *SpendTracker // per-user per-model daily spend tracker (nil if no limits)
 
+	// #721: Per-user model limit cache — merges Firestore limits with YAML
+	// defaults. Nil in solo mode (no UserStore). 60s TTL, fail-open.
+	modelLimits *modelLimitCache
+
 	// #207: Model allowlist policy gate.
 	policy *ModelPolicy
 
@@ -463,8 +467,18 @@ func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) (*Proxy
 }
 
 // SetUserStore sets the optional UserStore for budget deduction.
+// Also initializes the per-user model limit cache (#721) so the proxy
+// can merge Firestore limits with YAML defaults in the pre-flight gate.
 func (p *Proxy) SetUserStore(users storage.UserStore) {
 	p.users = users
+	if users != nil {
+		p.modelLimits = newModelLimitCache(users, 60*time.Second)
+		// Ensure spendTracker exists — user-specific limits need it
+		// even if no global YAML daily_limits are configured.
+		if p.spendTracker == nil {
+			p.spendTracker = NewSpendTracker()
+		}
+	}
 }
 
 // SetBudgetChecker sets the optional BudgetChecker for threshold notifications.
@@ -480,6 +494,17 @@ func (p *Proxy) SetCatalog(c catalog.ModelCatalogStore) {
 // SetSpendOutbox sets the optional spend outbox for durable DeductSpend retries (CRIT-3).
 func (p *Proxy) SetSpendOutbox(o *spendoutbox.Outbox) {
 	p.spendOutbox = o
+}
+
+// effectiveLimits returns the merged per-model daily spend limits for a user.
+// If a model limit cache is available (team mode), user-specific Firestore
+// limits override global YAML defaults. Falls back to YAML-only if the cache
+// is nil (solo mode) or on Firestore errors (fail-open).
+func (p *Proxy) effectiveLimits(ctx context.Context, userID string) []SpendLimitConfig {
+	if p.modelLimits == nil {
+		return p.config.DailyLimits
+	}
+	return p.modelLimits.mergedLimits(ctx, userID, p.config.DailyLimits)
 }
 
 // DroppedSpans returns the total number of spans dropped at the proxy semaphore (HIGH-5).
@@ -1191,21 +1216,36 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// ── Per-model daily spend limit (#278) ──
-	// Checks in-memory per-user per-model daily spend against configured limits.
+	// ── Per-model daily spend limit (#278, #721) ──
+	// Checks in-memory per-user per-model daily spend against merged limits
+	// (per-user Firestore overrides > global YAML defaults).
 	// Uses "local" fallback for solo mode where effectiveUserID is empty.
 	if p.spendTracker != nil && requestModel != "" {
 		limitUser := effectiveUserID
 		if limitUser == "" {
 			limitUser = "local"
 		}
-		allowed, spent, limit := p.spendTracker.Check(limitUser, requestModel, p.config.DailyLimits, estimatedCost)
+		limits := p.effectiveLimits(r.Context(), limitUser)
+		allowed, spent, limit := p.spendTracker.Check(limitUser, requestModel, limits, estimatedCost)
 		if !allowed {
+			// Determine limit source for operator debugging.
+			limitSource := "yaml"
+			if p.modelLimits != nil {
+				if ul := p.modelLimits.getUserLimits(r.Context(), limitUser); len(ul) > 0 {
+					for _, u := range ul {
+						if strings.EqualFold(u.Model, requestModel) || strings.HasPrefix(strings.ToLower(requestModel), strings.ToLower(u.Model)) {
+							limitSource = "firestore"
+							break
+						}
+					}
+				}
+			}
 			ProxyErrorResponse(w, http.StatusPaymentRequired, fmt.Sprintf("daily spend limit for %s reached ($%.2f/$%.2f)",
 				requestModel, spent, limit), "daily_limit_exceeded")
 			slog.Info("blocked request: daily model spend limit exceeded",
 				"user_id", limitUser, "model", requestModel,
-				"spent_usd", spent, "limit_usd", limit)
+				"spent_usd", spent, "limit_usd", limit,
+				"limit_source", limitSource)
 			return
 		}
 	}
@@ -1789,7 +1829,7 @@ func (p *Proxy) handleStandardResponse(
 		if limitUser == "" {
 			limitUser = "local"
 		}
-		p.spendTracker.Record(limitUser, model, cost, p.config.DailyLimits)
+		p.spendTracker.Record(limitUser, model, cost, p.effectiveLimits(r.Context(), limitUser))
 	}
 
 	// Create observability span (async — don't block the handler).
@@ -1957,7 +1997,7 @@ func (p *Proxy) handleStreamingResponse(
 		if limitUser == "" {
 			limitUser = "local"
 		}
-		p.spendTracker.Record(limitUser, model, cost, p.config.DailyLimits)
+		p.spendTracker.Record(limitUser, model, cost, p.effectiveLimits(r.Context(), limitUser))
 	}
 
 	// Create observability span (async — don't block the handler).
@@ -2045,7 +2085,7 @@ func (p *Proxy) deductBudget(ctx context.Context, provider Provider, model, user
 	// This must happen even if DeductSpend fails, since the upstream
 	// response was already forwarded (spend happened, we're tracking it).
 	if p.spendTracker != nil && cost > 0 {
-		p.spendTracker.Record(userID, model, cost, p.config.DailyLimits)
+		p.spendTracker.Record(userID, model, cost, p.effectiveLimits(ctx, userID))
 	}
 
 	// #10: DeductSpend is called when CostUSD>0 OR TotalTokens>0.


### PR DESCRIPTION
## PR 2 of 3 for #721 — Per-Model Budget Limits

Wires Firestore-stored per-user model limits into the proxy pre-flight gate so they're actually enforced.

### Changes
- **New `modelLimitCache`** (60s TTL, fail-open, lazy expiry) — loads user limits from Firestore and merges with global YAML defaults
- **Pre-flight gate** now uses `effectiveLimits()` — per-user Firestore limits override YAML for matching model prefixes
- **All 3 `Record()` call sites** updated to track against merged limits
- **Block log** includes `limit_source` (firestore vs yaml) for operator debugging
- **`SpendTracker` auto-initialized** when UserStore set — supports user-only limits with no YAML `daily_limits`
- **Docs updated**: enforcement now active, 60s cache TTL note, precedence line restored

### Design Decisions
- **Fail-open**: If Firestore is unreachable when cache expires, falls back to YAML-only limits
- **60s TTL**: Admin limit changes propagate within ≤60s per proxy replica
- **Per-replica cache**: Each proxy instance has its own cache (documented in code)

### Tests
10 new tests in `model_limit_cache_test.go`:
- Cache TTL hit/miss
- Merge precedence (user overrides YAML)
- Fail-open on store errors
- Case-insensitive override
- User-only and YAML-only limit scenarios

Closes the core enforcement loop for #721. Dashboard (PR 3) is a follow-up.