### PR TITLE
feat: per-SA daily budget cap with auto-provisioning (#608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to Candela are documented here, organized by development pha
 - `TaskID` field on `BudgetAlert` for task-scoped notification context
 - Spend outbox extended with `TaskID` for durable task deduction retry
 - Fast task spend API: `GET /api/v1/task-spend/{taskID}` with in-memory cache (5s TTL)
+- **⚠️ BREAKING**: Service account daily budget enforcement (#608) — SAs without a configured budget are auto-provisioned with a `$10/day` daily limit. SAs that previously ran with unbounded spend will now be capped. Set `CANDELA_SA_DAILY_BUDGET_USD` to adjust or set to `0` to disable auto-provisioning.
+- `service_accounts.default_daily_budget_usd` config option (default: 10.0)
+- `CANDELA_SA_DAILY_BUDGET_USD` environment variable override
+- Fail-open auto-provisioning: if Firestore is unavailable during first SA request, the request is allowed through
+- SA startup log warning when budget enforcement is active
 
 ## v0.10.1 — 2026-07-07
 

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -1208,6 +1208,7 @@ func loadConfig() (*Config, error) {
 	}
 
 	var cfg Config
+	cfg.ServiceAccounts.DefaultDailyBudgetUSD = 10.0 // #608: default before YAML so explicit 0 disables
 
 	data, err := os.ReadFile(cfgPath)
 	if err != nil {
@@ -1261,12 +1262,9 @@ func loadConfig() (*Config, error) {
 	}
 
 	// Service account default daily budget — env var override.
-	// Default: $10/day (conservative, easy to raise per-SA).
-	if cfg.ServiceAccounts.DefaultDailyBudgetUSD == 0 {
-		cfg.ServiceAccounts.DefaultDailyBudgetUSD = 10.0
-	}
+	// Default $10/day is set before YAML unmarshal; explicit YAML 0 or env 0 disables.
 	if env := os.Getenv("CANDELA_SA_DAILY_BUDGET_USD"); env != "" {
-		if val, err := strconv.ParseFloat(env, 64); err == nil && val > 0 {
+		if val, err := strconv.ParseFloat(env, 64); err == nil && val >= 0 {
 			cfg.ServiceAccounts.DefaultDailyBudgetUSD = val
 		}
 	}

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -131,6 +131,9 @@ type Config struct {
 	Users   struct {
 		DefaultDailyBudgetUSD float64 `yaml:"default_daily_budget_usd"` // auto-assigned to new users (0 = no default)
 	} `yaml:"users"`
+	ServiceAccounts struct {
+		DefaultDailyBudgetUSD float64 `yaml:"default_daily_budget_usd"` // auto-assigned to SAs without a budget (default: 10.0)
+	} `yaml:"service_accounts"`
 	Sinks struct {
 		OTLP struct {
 			Enabled     bool              `yaml:"enabled"`
@@ -880,6 +883,18 @@ func main() {
 				}
 
 				slog.Info("🔔 Budget deduction + notifications wired into proxy")
+
+				// #608: Wire SA default budget for auto-provisioning.
+				if cfg.ServiceAccounts.DefaultDailyBudgetUSD > 0 {
+					llmProxy.SetSADefaultBudget(cfg.ServiceAccounts.DefaultDailyBudgetUSD)
+					if len(cfg.Auth.AllowedServiceAccounts) > 0 {
+						slog.Warn("⚠️  SA budget enforcement active — service accounts without a configured budget "+
+							"will be auto-provisioned at the default daily limit. "+
+							"Use SetBudget RPC or CANDELA_SA_DAILY_BUDGET_USD to adjust.",
+							"default_daily_usd", cfg.ServiceAccounts.DefaultDailyBudgetUSD,
+							"allowed_sa_count", len(cfg.Auth.AllowedServiceAccounts))
+					}
+				}
 			}
 
 			llmProxy.RegisterRoutes(mux)
@@ -1243,6 +1258,17 @@ func loadConfig() (*Config, error) {
 			}
 		}
 		cfg.Auth.AllowedServiceAccounts = append(cfg.Auth.AllowedServiceAccounts, sas...)
+	}
+
+	// Service account default daily budget — env var override.
+	// Default: $10/day (conservative, easy to raise per-SA).
+	if cfg.ServiceAccounts.DefaultDailyBudgetUSD == 0 {
+		cfg.ServiceAccounts.DefaultDailyBudgetUSD = 10.0
+	}
+	if env := os.Getenv("CANDELA_SA_DAILY_BUDGET_USD"); env != "" {
+		if val, err := strconv.ParseFloat(env, 64); err == nil && val > 0 {
+			cfg.ServiceAccounts.DefaultDailyBudgetUSD = val
+		}
 	}
 
 	// Auth: dev mode — env var override.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -157,15 +157,17 @@ auth:
   # Deny-by-default: if this list is empty (or omitted), ALL service accounts
   # are rejected with 403.
   #
-  # Allowlisted SAs bypass two gates:
-  #   1. Authentication — the resolver chain permits them (non-listed SAs are rejected)
-  #   2. Registration — they skip the Firestore user-store lookup (no user doc needed)
-  #
-  # Only add SAs that genuinely need proxy access (e.g. CI runners, shared
-  # build agents). SA traffic bypasses per-user budget deduction, so each
-  # entry here is an unmetered cost vector.
+  # Allowlisted SAs are subject to budget enforcement (#608). SAs without a
+  # configured budget are auto-provisioned with the default daily limit
+  # (see service_accounts.default_daily_budget_usd below).
   # allowed_service_accounts:
   #   - "candela-ci@my-project.iam.gserviceaccount.com"
+
+# Service account budget defaults (#608).
+# SAs without an explicit budget are auto-provisioned with this daily limit.
+# Set to 0 to disable auto-provisioning (SAs without a budget will be blocked).
+# service_accounts:
+#   default_daily_budget_usd: 10.0
 
 # Optional export sinks — fan-out to external systems alongside primary storage.
 # These are write-only; the primary storage backend handles reads.

--- a/docs/service-account-budgets.md
+++ b/docs/service-account-budgets.md
@@ -1,0 +1,99 @@
+# Service Account Budget Enforcement
+
+> **⚠️ BREAKING CHANGE (v0.XX)**: Service account budget enforcement is now enabled
+> by default. SAs without a configured budget are auto-provisioned with a $10/day
+> daily limit. Set `CANDELA_SA_DAILY_BUDGET_USD` to adjust, or set it to `0` to
+> disable auto-provisioning (SAs without a budget will be blocked).
+
+## Overview
+
+Service accounts (SAs) are now subject to the same budget enforcement as human
+users. When an SA makes its first proxy request and has no budget configured,
+Candela automatically provisions a default daily budget. This prevents a
+compromised SA from accumulating unbounded LLM costs.
+
+## How It Works
+
+1. **First request**: SA calls the proxy with no budget in Firestore
+2. **Auto-provision**: Candela creates a `$10/day` daily budget for the SA
+3. **Normal enforcement**: All subsequent requests go through the standard
+   budget pipeline — CheckBudget → pending spend reservation → DeductSpend →
+   threshold alerts → auto-disable at 100%
+
+### What SAs Get for Free
+
+Because SAs use the same budget infrastructure as users:
+
+| Capability | Works for SAs |
+|:---|:---|
+| Daily budget with timezone-aware rollover | ✅ |
+| 80% / 90% / 100% threshold alerts (Slack, webhook) | ✅ |
+| Auto-disable (`soft_blocked`) when budget exhausted | ✅ |
+| Pending spend TOCTOU protection | ✅ |
+| Durable outbox retry on Firestore failure | ✅ |
+| Grant waterfall (SAs can receive grants) | ✅ |
+| Per-model daily limits (#721) | ✅ |
+| Dashboard visibility | ✅ |
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|:---|:---|:---|
+| `CANDELA_SA_DAILY_BUDGET_USD` | `10.0` | Default daily budget for SAs without an explicit budget |
+
+### Config File (`config.yaml`)
+
+```yaml
+service_accounts:
+  default_daily_budget_usd: 10.0  # $10/day default
+```
+
+### Per-SA Budget Override
+
+Admins can set a custom budget for any SA using the `SetBudget` RPC:
+
+```bash
+# Via grpcurl or the dashboard admin panel
+candela admin set-budget \
+  --user "candela-ci@my-project.iam.gserviceaccount.com" \
+  --limit 100.0 \
+  --period daily
+```
+
+Or via the dashboard: **Admin → Users → (select SA) → Set Budget**.
+
+## Fail-Open Behavior
+
+If auto-provisioning fails (e.g., Firestore is temporarily unavailable), the
+request is **allowed through** and the error is logged. This preserves
+availability — budget enforcement is a financial control, not a security gate.
+
+The next request will retry auto-provisioning.
+
+## Startup Warning
+
+When SA budget enforcement is active, you'll see this log at startup:
+
+```
+⚠️  SA budget enforcement active — service accounts without a configured budget
+will be auto-provisioned at the default daily limit.
+Use SetBudget RPC or CANDELA_SA_DAILY_BUDGET_USD to adjust.
+```
+
+## Disabling Auto-Provisioning
+
+To disable auto-provisioning (SAs without a budget will be blocked with 402):
+
+```yaml
+service_accounts:
+  default_daily_budget_usd: 0
+```
+
+Or: `CANDELA_SA_DAILY_BUDGET_USD=0`
+
+> **Note**: This does NOT disable SA budget enforcement — SAs are always subject
+> to budget checks when a UserStore is configured (#736). Setting the default to 0
+> only disables auto-provisioning. SAs can still be manually given budgets via
+> `SetBudget`.

--- a/docs/service-account-budgets.md
+++ b/docs/service-account-budgets.md
@@ -76,7 +76,7 @@ The next request will retry auto-provisioning.
 
 When SA budget enforcement is active, you'll see this log at startup:
 
-```
+```text
 ⚠️  SA budget enforcement active — service accounts without a configured budget
 will be auto-provisioned at the default daily limit.
 Use SetBudget RPC or CANDELA_SA_DAILY_BUDGET_USD to adjust.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/candelahq/candela/pkg/attribution"
 	"github.com/candelahq/candela/pkg/auth"
+	"github.com/candelahq/candela/pkg/billing"
 	"github.com/candelahq/candela/pkg/catalog"
 	"github.com/candelahq/candela/pkg/cloudauth"
 	"github.com/candelahq/candela/pkg/costcalc"
@@ -283,8 +284,12 @@ type Proxy struct {
 	saSpendMicroUSD atomic.Int64
 
 	// Per-service-account in-process rate limiter.
-	// SAs bypass user budget/rate-limit checks, so this is their only throttle.
 	saRL *saRateLimiter
+
+	// #608: Default daily budget for SAs without an explicit budget.
+	// When > 0, SAs hitting ReasonNoBudget are auto-provisioned with this limit.
+	saDefaultBudgetUSD float64
+	saProvisioned      sync.Map // tracks which SA IDs have been auto-provisioned this process
 
 	// TOCTOU mitigation: tracks in-flight spend between CheckBudget and
 	// DeductSpend. Without this, concurrent requests all pass CheckBudget
@@ -494,6 +499,13 @@ func (p *Proxy) SetCatalog(c catalog.ModelCatalogStore) {
 // SetSpendOutbox sets the optional spend outbox for durable DeductSpend retries (CRIT-3).
 func (p *Proxy) SetSpendOutbox(o *spendoutbox.Outbox) {
 	p.spendOutbox = o
+}
+
+// SetSADefaultBudget sets the default daily budget for service accounts
+// that don't have an explicit budget. When > 0, SAs hitting the budget gate
+// with no budget will be auto-provisioned with this daily limit (#608).
+func (p *Proxy) SetSADefaultBudget(usd float64) {
+	p.saDefaultBudgetUSD = usd
 }
 
 // effectiveLimits returns the merged per-model daily spend limits for a user.
@@ -1140,7 +1152,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// ── Budget pre-flight with conservative reservation ──
 	// Only applies in team mode (UserStore configured).
 	// Service accounts are included (#736) — SAs without a budget/grant
-	// record are blocked (fail-closed). Admins opt SAs in via CreateBudget.
+	// record are auto-provisioned with a default daily limit (#608).
 	var budgetReserved float64 // track reservation for Release in deductBudget
 	if p.users != nil && effectiveUserID != "" && !isAdmin {
 		// Check whether the user can afford this request. Use the estimated
@@ -1162,7 +1174,42 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 				"user_id", effectiveUserID)
 			ProxyErrorResponse(w, http.StatusServiceUnavailable, "budget check failed — try again shortly", "service_error")
 			return
-		} else if !check.Allowed {
+		}
+
+		// #608: Auto-provision default budget for SAs with no budget.
+		// Uses sync.Map to ensure we only write to Firestore once per SA per process.
+		// Fail-open: if auto-provision fails, allow the request (availability > precision).
+		if !check.Allowed && check.Reason == billing.ReasonNoBudget &&
+			isServiceAccount && p.saDefaultBudgetUSD > 0 {
+			if _, alreadyDone := p.saProvisioned.LoadOrStore(effectiveUserID, true); !alreadyDone {
+				provErr := p.users.SetBudget(r.Context(), &billing.BudgetRecord{
+					UserID:     effectiveUserID,
+					LimitUSD:   p.saDefaultBudgetUSD,
+					PeriodType: "daily",
+				})
+				if provErr != nil {
+					// Fail-open: allow this request, log the error.
+					slog.Error("sa_budget: auto-provision failed, allowing request",
+						"sa_id", effectiveUserID,
+						"default_daily_usd", p.saDefaultBudgetUSD,
+						"error", provErr)
+					p.saProvisioned.Delete(effectiveUserID) // allow retry next request
+					goto skipBudget
+				}
+				slog.Info("sa_budget: auto-provisioned default daily budget",
+					"sa_id", effectiveUserID,
+					"daily_limit_usd", p.saDefaultBudgetUSD)
+			}
+			// Re-check budget now that it's provisioned.
+			check, err = p.users.CheckBudget(r.Context(), effectiveUserID, checkAmount)
+			if err != nil || check == nil {
+				slog.Error("sa_budget: re-check failed after provision, allowing request",
+					"sa_id", effectiveUserID, "error", err)
+				goto skipBudget
+			}
+		}
+
+		if !check.Allowed {
 			msg := "budget exhausted — contact your admin for a grant or budget increase"
 			if checkAmount > budgetCheckFloor && check.RemainingUSD > 0 {
 				msg = fmt.Sprintf("estimated cost $%.4f exceeds remaining budget $%.4f — contact your admin", checkAmount, check.RemainingUSD)
@@ -1200,7 +1247,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 			}
 		}()
 	}
-
+skipBudget:
 	// ── Per-request cost cap (#277) ──
 	// Estimates the request cost from body size and rejects if it exceeds
 	// the configured maximum. Runs for all users (solo + team mode).

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/candelahq/candela/pkg/attribution"
 	"github.com/candelahq/candela/pkg/auth"
@@ -289,7 +290,8 @@ type Proxy struct {
 	// #608: Default daily budget for SAs without an explicit budget.
 	// When > 0, SAs hitting ReasonNoBudget are auto-provisioned with this limit.
 	saDefaultBudgetUSD float64
-	saProvisioned      sync.Map // tracks which SA IDs have been auto-provisioned this process
+	saProvisionFlight  singleflight.Group // coalesces concurrent first-request provisions
+	saProvisioned      sync.Map           // tracks which SA IDs have been successfully provisioned
 
 	// TOCTOU mitigation: tracks in-flight spend between CheckBudget and
 	// DeductSpend. Without this, concurrent requests all pass CheckBudget
@@ -1154,7 +1156,7 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// Service accounts are included (#736) — SAs without a budget/grant
 	// record are auto-provisioned with a default daily limit (#608).
 	var budgetReserved float64 // track reservation for Release in deductBudget
-	if p.users != nil && effectiveUserID != "" && !isAdmin {
+	if p.users != nil && effectiveUserID != "" && (!isAdmin || isServiceAccount) {
 		// Check whether the user can afford this request. Use the estimated
 		// cost when available; fall back to a minimal floor for requests
 		// where the model/cost is unknown ($0.001 is below any cloud model).
@@ -1177,15 +1179,33 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// #608: Auto-provision default budget for SAs with no budget.
-		// Uses sync.Map to ensure we only write to Firestore once per SA per process.
-		// Fail-open: if auto-provision fails, allow the request (availability > precision).
+		// Uses singleflight to coalesce concurrent first requests into one
+		// SetBudget call. Fail-open: if provision fails, allow the request.
 		if !check.Allowed && check.Reason == billing.ReasonNoBudget &&
 			isServiceAccount && p.saDefaultBudgetUSD > 0 {
-			if _, alreadyDone := p.saProvisioned.LoadOrStore(effectiveUserID, true); !alreadyDone {
-				provErr := p.users.SetBudget(r.Context(), &billing.BudgetRecord{
-					UserID:     effectiveUserID,
-					LimitUSD:   p.saDefaultBudgetUSD,
-					PeriodType: "daily",
+			if _, ok := p.saProvisioned.Load(effectiveUserID); !ok {
+				// singleflight.Do coalesces concurrent calls — only the
+				// first goroutine executes SetBudget; others block and
+				// receive the same result.
+				_, provErr, _ := p.saProvisionFlight.Do(effectiveUserID, func() (interface{}, error) {
+					// Double-check: another request may have succeeded
+					// between our CheckBudget and this Do call.
+					if _, done := p.saProvisioned.Load(effectiveUserID); done {
+						return nil, nil
+					}
+					err := p.users.SetBudget(r.Context(), &billing.BudgetRecord{
+						UserID:     effectiveUserID,
+						LimitUSD:   p.saDefaultBudgetUSD,
+						PeriodType: "daily",
+					})
+					if err != nil {
+						return nil, err
+					}
+					p.saProvisioned.Store(effectiveUserID, true)
+					slog.Info("sa_budget: auto-provisioned default daily budget",
+						"sa_id", effectiveUserID,
+						"daily_limit_usd", p.saDefaultBudgetUSD)
+					return nil, nil
 				})
 				if provErr != nil {
 					// Fail-open: allow this request, log the error.
@@ -1193,12 +1213,8 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 						"sa_id", effectiveUserID,
 						"default_daily_usd", p.saDefaultBudgetUSD,
 						"error", provErr)
-					p.saProvisioned.Delete(effectiveUserID) // allow retry next request
 					goto skipBudget
 				}
-				slog.Info("sa_budget: auto-provisioned default daily budget",
-					"sa_id", effectiveUserID,
-					"daily_limit_usd", p.saDefaultBudgetUSD)
 			}
 			// Re-check budget now that it's provisioned.
 			check, err = p.users.CheckBudget(r.Context(), effectiveUserID, checkAmount)

--- a/pkg/proxy/sa_budget_test.go
+++ b/pkg/proxy/sa_budget_test.go
@@ -1,0 +1,370 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/auth"
+	"github.com/candelahq/candela/pkg/billing"
+	"github.com/candelahq/candela/pkg/costcalc"
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// saBudgetStore extends budgetUserStore to track SetBudget calls for SA tests.
+type saBudgetStore struct {
+	budgetUserStore
+	setBudgetCalls    []storage.BudgetRecord
+	setBudgetErr      error
+	provisioned       bool
+	provisionedResult *storage.BudgetCheckResult
+}
+
+func (s *saBudgetStore) SetBudget(_ context.Context, b *storage.BudgetRecord) error {
+	s.setBudgetCalls = append(s.setBudgetCalls, *b)
+	if s.setBudgetErr != nil {
+		return s.setBudgetErr
+	}
+	s.provisioned = true
+	return nil
+}
+
+func (s *saBudgetStore) CheckBudget(_ context.Context, _ string, _ float64) (*storage.BudgetCheckResult, error) {
+	if s.provisioned && s.provisionedResult != nil {
+		return s.provisionedResult, nil
+	}
+	return s.checkResult, s.checkErr
+}
+
+// withSABudgetTestAuth injects a service account identity into the request context.
+func withSABudgetTestAuth(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := auth.NewContext(r.Context(), &auth.User{
+			ID:    "candela-ci@my-project.iam.gserviceaccount.com",
+			Email: "candela-ci@my-project.iam.gserviceaccount.com",
+		})
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// ====================================================================
+// SA Auto-Provisioning Tests (#608)
+// ====================================================================
+
+func TestSABudget_AutoProvisionOnNoBudget(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"hello"}}],"usage":{"prompt_tokens":10,"completion_tokens":5}}`))
+	}))
+	defer upstream.Close()
+
+	store := &saBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{
+				Allowed: false,
+				Reason:  billing.ReasonNoBudget,
+			},
+		},
+		provisionedResult: &storage.BudgetCheckResult{
+			Allowed:      true,
+			Reason:       billing.ReasonAllowed,
+			RemainingUSD: 10.0,
+			BudgetUSD:    10.0,
+		},
+	}
+
+	calc := costcalc.New()
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, calc)
+	p.SetUserStore(store)
+	p.SetSADefaultBudget(10.0)
+
+	handler := withSABudgetTestAuth(p)
+	req := httptest.NewRequest("POST", "/proxy/openai/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		body, _ := io.ReadAll(rec.Result().Body)
+		t.Fatalf("expected 200, got %d: %s", rec.Code, body)
+	}
+
+	if len(store.setBudgetCalls) != 1 {
+		t.Fatalf("expected 1 SetBudget call, got %d", len(store.setBudgetCalls))
+	}
+	budget := store.setBudgetCalls[0]
+	if budget.LimitUSD != 10.0 {
+		t.Errorf("expected limit 10.0, got %f", budget.LimitUSD)
+	}
+	if budget.PeriodType != "daily" {
+		t.Errorf("expected period_type daily, got %s", budget.PeriodType)
+	}
+	if !strings.HasSuffix(budget.UserID, ".iam.gserviceaccount.com") {
+		t.Errorf("expected SA ID, got %s", budget.UserID)
+	}
+}
+
+func TestSABudget_SkipsAutoProvisionForHumanUsers(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream should NOT be called when budget is exhausted for human user")
+		w.WriteHeader(500)
+	}))
+	defer upstream.Close()
+
+	store := &saBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{
+				Allowed: false,
+				Reason:  billing.ReasonNoBudget,
+			},
+		},
+	}
+
+	calc := costcalc.New()
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, calc)
+	p.SetUserStore(store)
+	p.SetSADefaultBudget(10.0)
+
+	handler := withTestAuth(p) // human user
+	req := httptest.NewRequest("POST", "/proxy/openai/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d", rec.Code)
+	}
+	if len(store.setBudgetCalls) != 0 {
+		t.Fatalf("expected 0 SetBudget calls for human user, got %d", len(store.setBudgetCalls))
+	}
+}
+
+func TestSABudget_FailOpenOnProvisionError(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"hello"}}],"usage":{"prompt_tokens":10,"completion_tokens":5}}`))
+	}))
+	defer upstream.Close()
+
+	store := &saBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{
+				Allowed: false,
+				Reason:  billing.ReasonNoBudget,
+			},
+		},
+		setBudgetErr: fmt.Errorf("firestore unavailable"),
+	}
+
+	calc := costcalc.New()
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, calc)
+	p.SetUserStore(store)
+	p.SetSADefaultBudget(10.0)
+
+	handler := withSABudgetTestAuth(p)
+	req := httptest.NewRequest("POST", "/proxy/openai/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		body, _ := io.ReadAll(rec.Result().Body)
+		t.Fatalf("expected 200 (fail-open), got %d: %s", rec.Code, body)
+	}
+}
+
+func TestSABudget_BlocksExhaustedSA(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream should NOT be called when SA budget is exhausted")
+		w.WriteHeader(500)
+	}))
+	defer upstream.Close()
+
+	store := &saBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{
+				Allowed:      false,
+				Reason:       billing.ReasonBudgetExhausted,
+				RemainingUSD: 0,
+			},
+		},
+	}
+
+	calc := costcalc.New()
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, calc)
+	p.SetUserStore(store)
+	p.SetSADefaultBudget(10.0)
+
+	handler := withSABudgetTestAuth(p)
+	req := httptest.NewRequest("POST", "/proxy/openai/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPaymentRequired {
+		body, _ := io.ReadAll(rec.Result().Body)
+		t.Fatalf("expected 402 for exhausted SA budget, got %d: %s", rec.Code, body)
+	}
+	if len(store.setBudgetCalls) != 0 {
+		t.Fatalf("expected 0 SetBudget calls for exhausted SA, got %d", len(store.setBudgetCalls))
+	}
+}
+
+func TestSABudget_NoAutoProvisionWhenDisabled(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream should NOT be called")
+		w.WriteHeader(500)
+	}))
+	defer upstream.Close()
+
+	store := &saBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{
+				Allowed: false,
+				Reason:  billing.ReasonNoBudget,
+			},
+		},
+	}
+
+	calc := costcalc.New()
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, calc)
+	p.SetUserStore(store)
+	// saDefaultBudgetUSD is 0 (default) — auto-provision disabled
+
+	handler := withSABudgetTestAuth(p)
+	req := httptest.NewRequest("POST", "/proxy/openai/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402 when auto-provision disabled, got %d", rec.Code)
+	}
+	if len(store.setBudgetCalls) != 0 {
+		t.Fatalf("expected 0 SetBudget calls when disabled, got %d", len(store.setBudgetCalls))
+	}
+}
+
+func TestSABudget_OnlyProvisionedOnce(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"hello"}}],"usage":{"prompt_tokens":10,"completion_tokens":5}}`))
+	}))
+	defer upstream.Close()
+
+	store := &saBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{
+				Allowed: false,
+				Reason:  billing.ReasonNoBudget,
+			},
+		},
+		provisionedResult: &storage.BudgetCheckResult{
+			Allowed:      true,
+			Reason:       billing.ReasonAllowed,
+			RemainingUSD: 10.0,
+			BudgetUSD:    10.0,
+		},
+	}
+
+	calc := costcalc.New()
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, calc)
+	p.SetUserStore(store)
+	p.SetSADefaultBudget(10.0)
+
+	handler := withSABudgetTestAuth(p)
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest("POST", "/proxy/openai/v1/chat/completions",
+			strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			body, _ := io.ReadAll(rec.Result().Body)
+			t.Fatalf("request %d: expected 200, got %d: %s", i, rec.Code, body)
+		}
+	}
+
+	if len(store.setBudgetCalls) != 1 {
+		t.Fatalf("expected 1 SetBudget call (cached), got %d", len(store.setBudgetCalls))
+	}
+}
+
+func TestSABudget_ResponseContainsBudgetExhaustedError(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream should NOT be called")
+		w.WriteHeader(500)
+	}))
+	defer upstream.Close()
+
+	store := &saBudgetStore{
+		budgetUserStore: budgetUserStore{
+			checkResult: &storage.BudgetCheckResult{
+				Allowed:      false,
+				Reason:       billing.ReasonBudgetExhausted,
+				RemainingUSD: 0,
+			},
+		},
+	}
+
+	calc := costcalc.New()
+	p, _ := New(Config{
+		Providers: []Provider{{Name: "openai", UpstreamURL: upstream.URL}},
+		ProjectID: "test",
+	}, &mockSubmitter{}, calc)
+	p.SetUserStore(store)
+	p.SetSADefaultBudget(10.0)
+
+	handler := withSABudgetTestAuth(p)
+	req := httptest.NewRequest("POST", "/proxy/openai/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d", rec.Code)
+	}
+
+	var errResp struct {
+		Error struct {
+			Type string `json:"type"`
+		} `json:"error"`
+	}
+	body, _ := io.ReadAll(rec.Result().Body)
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		t.Fatalf("failed to parse error response: %v", err)
+	}
+	if errResp.Error.Type != "insufficient_budget" {
+		t.Errorf("expected error type 'insufficient_budget', got %q", errResp.Error.Type)
+	}
+}


### PR DESCRIPTION
## Summary

Adds configurable daily budget enforcement for service accounts. SAs without an explicit budget are auto-provisioned with a default daily limit ($10/day).

**⚠️ BREAKING**: SAs that previously ran with unbounded spend will now be capped.

## What Changed

| File | Change |
|:---|:---|
| `cmd/candela-server/main.go` | `service_accounts.default_daily_budget_usd` config + `CANDELA_SA_DAILY_BUDGET_USD` env var + startup warning |
| `pkg/proxy/proxy.go` | Auto-provision SA budget on first request (fail-open), sync.Map dedup |
| `pkg/proxy/sa_budget_test.go` | 7 new tests |
| `docs/service-account-budgets.md` | New docs page |
| `config.example.yaml` | Updated SA comments, added `service_accounts` section |
| `CHANGELOG.md` | Breaking change notice |

## How It Works

1. SA hits proxy → `CheckBudget` returns `ReasonNoBudget`
2. Proxy detects SA + `saDefaultBudgetUSD > 0` → calls `SetBudget` (once per SA per process via `sync.Map`)
3. Re-checks budget → proceeds through normal enforcement path
4. If `SetBudget` fails → **fail-open** (allow request, log error, retry next request)

## Test Coverage

- `TestSABudget_AutoProvisionOnNoBudget` — auto-provisions and succeeds
- `TestSABudget_SkipsAutoProvisionForHumanUsers` — human users are NOT auto-provisioned
- `TestSABudget_FailOpenOnProvisionError` — Firestore failure → allow request
- `TestSABudget_BlocksExhaustedSA` — SA with exhausted budget gets 402
- `TestSABudget_NoAutoProvisionWhenDisabled` — `saDefaultBudgetUSD=0` → no auto-provision
- `TestSABudget_OnlyProvisionedOnce` — 3 requests → 1 SetBudget call
- `TestSABudget_ResponseContainsBudgetExhaustedError` — error format check

Closes #608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily budget enforcement for service accounts.
  * Service accounts without an assigned budget can be automatically provisioned with a configurable default.
  * Added configuration and environment-variable options, including the ability to disable automatic provisioning.
  * Budget-exhausted service accounts receive a clear error response.

* **Bug Fixes**
  * Provisioning failures now fail open, allowing requests to continue and retry later.

* **Documentation**
  * Added guidance covering configuration, overrides, enforcement, provisioning behavior, and startup warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->