### PR TITLE
feat: config-driven OIDC resolver chain (#764)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to Candela are documented here, organized by development pha
 - `CANDELA_SA_DAILY_BUDGET_USD` environment variable override
 - Fail-open auto-provisioning: if Firestore is unavailable during first SA request, the request is allowed through
 - SA startup log warning when budget enforcement is active
+- **Generic OIDC authentication** (#764) — config-driven resolver chain supporting any OIDC provider (Zitadel, Auth0, Okta, Keycloak, Cognito). Add `auth.resolvers` to `config.yaml` with issuer/audience. Zero config change required for existing Firebase deployments.
+- `auth.resolvers` config: ordered list of identity resolvers (`oidc`, `firebase`, `google_oidc`, `google_oauth`)
+- `ChainAuthMiddleware`: clean auth middleware decoupled from Firebase SDK
+- `BuildResolverChain`: config-driven resolver chain construction with validation
+- Configurable OIDC claim mapping (subject, email, roles, tenants) with sensible defaults
+- New docs page: `docs/generic-oidc.md` with provider-specific quickstarts
 
 ## v0.10.1 — 2026-07-07
 

--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -119,8 +119,9 @@ type Config struct {
 		FlushInterval string `yaml:"flush_interval"`
 	} `yaml:"worker"`
 	Auth struct {
-		DevMode                bool     `yaml:"dev_mode"`                 // If true, skip auth validation
-		AllowedServiceAccounts []string `yaml:"allowed_service_accounts"` // SAs allowed to proxy — deny all if empty
+		DevMode                bool                 `yaml:"dev_mode"`                 // If true, skip auth validation
+		AllowedServiceAccounts []string             `yaml:"allowed_service_accounts"` // SAs allowed to proxy — deny all if empty
+		Resolvers              []auth.ResolverEntry `yaml:"resolvers"`                // Config-driven resolver chain (#764)
 	} `yaml:"auth"`
 	Firestore struct {
 		Enabled    bool   `yaml:"enabled"`
@@ -1024,6 +1025,7 @@ func main() {
 	}
 
 	// Initialize Firebase Admin SDK for token verification.
+	// Needed for both legacy and config-driven paths when "firebase" resolver is used.
 	var tokenVerifier auth.TokenVerifier
 	if !devMode {
 		fbApp, err := firebase.NewApp(context.Background(), nil)
@@ -1058,14 +1060,40 @@ func main() {
 		}
 	}
 
-	authedMux := auth.FirebaseAuthMiddleware(
-		corsMiddleware(mux, cfg.CORS.AllowedOrigins),
-		tokenVerifier,
-		cloudRunURL,
-		userAuth,
-		devMode,
-		cfg.Auth.AllowedServiceAccounts,
-	)
+	saAllowlist := auth.NewServiceAccountAllowlist(cfg.Auth.AllowedServiceAccounts)
+
+	var authedMux http.Handler
+	if len(cfg.Auth.Resolvers) > 0 {
+		// #764: Config-driven resolver chain — supports OIDC, Firebase, Google, etc.
+		chain, err := auth.BuildResolverChain(context.Background(), cfg.Auth.Resolvers, auth.BuildOptions{
+			FirebaseVerifier: tokenVerifier,
+			CloudRunAudience: cloudRunURL,
+			SAAllowlist:      saAllowlist,
+			DevMode:          devMode,
+		})
+		if err != nil {
+			slog.Error("FATAL: failed to build auth resolver chain", "error", err)
+			os.Exit(1)
+		}
+		slog.Info("🔐 Config-driven resolver chain active", "resolver_count", len(cfg.Auth.Resolvers))
+		authedMux = auth.ChainAuthMiddleware(
+			corsMiddleware(mux, cfg.CORS.AllowedOrigins),
+			chain,
+			userAuth,
+			saAllowlist,
+			devMode,
+		)
+	} else {
+		// Legacy path: hardcoded Firebase → Google OIDC → Google OAuth chain.
+		authedMux = auth.FirebaseAuthMiddleware(
+			corsMiddleware(mux, cfg.CORS.AllowedOrigins),
+			tokenVerifier,
+			cloudRunURL,
+			userAuth,
+			devMode,
+			cfg.Auth.AllowedServiceAccounts,
+		)
+	}
 	if devMode {
 		slog.Info("🔓 Running in dev mode — auth disabled")
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -153,6 +153,19 @@ worker:
 
 auth:
   dev_mode: false
+
+  # Config-driven resolver chain (#764). When set, replaces the default
+  # Firebase-only chain. Resolvers are tried in order — first match wins.
+  # Omit this section entirely to use the legacy Firebase chain.
+  #
+  # resolvers:
+  #   - type: oidc                    # Generic OIDC — works with any provider
+  #     issuer: https://zitadel.example.com
+  #     audience: candela-server
+  #     claim_mapping:                # Optional — defaults work for most providers
+  #       tenants: "urn:zitadel:iam:org:project:roles"
+  #   - type: firebase                # Firebase Auth (browser sessions)
+  #   - type: google_oauth            # Google OAuth2 (CLI: candela auth login)
   # Service accounts allowed to use the proxy via Google ID token or OAuth2.
   # Deny-by-default: if this list is empty (or omitted), ALL service accounts
   # are rejected with 403.

--- a/docs/generic-oidc.md
+++ b/docs/generic-oidc.md
@@ -1,0 +1,164 @@
+# Generic OIDC Authentication
+
+Candela supports any OIDC-compliant identity provider through config-driven
+resolver chains. This replaces the need for Firebase Auth as the sole identity
+backend, enabling enterprises using Zitadel, Auth0, Okta, Keycloak, or Cognito
+to adopt Candela without changing their existing identity infrastructure.
+
+## Quick Start
+
+Add your OIDC provider to `config.yaml`:
+
+```yaml
+auth:
+  resolvers:
+    - type: oidc
+      issuer: https://your-idp.example.com
+      audience: candela-server
+```
+
+That's it. Candela auto-discovers the JWKS endpoint from your issuer's
+`.well-known/openid-configuration` and validates tokens at request time.
+
+## How It Works
+
+1. Client sends `Authorization: Bearer <id_token>` with a token from your OIDC provider
+2. Candela's resolver chain tries each configured resolver in order
+3. The OIDC resolver verifies the token signature via JWKS, checks audience and expiry
+4. On success, the `sub` and `email` claims become the user's identity
+5. Normal budget enforcement, RBAC, and tenant validation apply
+
+## Provider-Specific Configs
+
+### Zitadel
+
+```yaml
+auth:
+  resolvers:
+    - type: oidc
+      issuer: https://your-instance.zitadel.cloud
+      audience: your-project-id
+      claim_mapping:
+        tenants: "urn:zitadel:iam:org:project:roles"
+```
+
+### Auth0
+
+```yaml
+auth:
+  resolvers:
+    - type: oidc
+      issuer: https://your-tenant.auth0.com
+      audience: https://candela-api
+```
+
+### Okta
+
+```yaml
+auth:
+  resolvers:
+    - type: oidc
+      issuer: https://your-org.okta.com/oauth2/default
+      audience: candela
+```
+
+### Keycloak
+
+```yaml
+auth:
+  resolvers:
+    - type: oidc
+      issuer: https://keycloak.example.com/realms/your-realm
+      audience: candela-server
+```
+
+### AWS Cognito
+
+```yaml
+auth:
+  resolvers:
+    - type: oidc
+      issuer: https://cognito-idp.us-east-1.amazonaws.com/us-east-1_XXXXXXXXX
+      audience: your-cognito-client-id
+```
+
+## Migration from Firebase
+
+Add the OIDC resolver **before** Firebase to prioritize new tokens while
+maintaining backward compatibility for existing Firebase sessions:
+
+```yaml
+auth:
+  resolvers:
+    - type: oidc
+      issuer: https://your-idp.example.com
+      audience: candela-server
+    - type: firebase        # fallback for existing browser sessions
+    - type: google_oauth    # fallback for CLI users (candela auth login)
+```
+
+The resolver chain tries each resolver in order. The first resolver that
+recognizes the token wins. Unrecognized tokens fall through to the next resolver.
+
+## Claim Mapping
+
+By default, Candela maps these standard OIDC claims:
+
+| Claim | Default | Maps to |
+|:---|:---|:---|
+| `sub` | Subject | `Identity.ID` |
+| `email` | Email | `Identity.Email` |
+| `roles` | Roles | (future: RBAC) |
+| `candela.tenants` | Tenant IDs | `Identity.TenantIDs` |
+
+Override any claim name with `claim_mapping`:
+
+```yaml
+auth:
+  resolvers:
+    - type: oidc
+      issuer: https://your-idp.example.com
+      audience: candela-server
+      claim_mapping:
+        subject: "sub"
+        email: "email"
+        roles: "custom:roles"
+        tenants: "custom:tenant_ids"
+```
+
+Most providers use standard claims — you only need `claim_mapping` if your
+provider uses custom claim names for tenant or role information.
+
+## Resolver Types
+
+| Type | Description | When to Use |
+|:---|:---|:---|
+| `oidc` | Generic OIDC with auto-discovery | Any OIDC provider |
+| `firebase` | Firebase Auth ID tokens | Browser UI with Firebase Auth SDK |
+| `google_oidc` | Google ID tokens (Cloud Run) | `candela-local` behind Cloud Run |
+| `google_oauth` | Google OAuth2 access tokens | `candela auth login --provider gcp` |
+
+## Tenant Validation
+
+When using OIDC with multi-tenancy, switch to verified tenant mode:
+
+```yaml
+auth:
+  tenant_mode: verified
+  resolvers:
+    - type: oidc
+      issuer: https://your-idp.example.com
+      audience: candela-server
+      claim_mapping:
+        tenants: "candela.tenants"
+```
+
+In `verified` mode, the `X-Candela-Tenant-Id` header is validated against the
+tenant IDs in the signed JWT claims. Requests for unauthorized tenants are
+rejected with 403.
+
+## Backward Compatibility
+
+If `auth.resolvers` is not set in your config, Candela uses the legacy
+Firebase-based chain (Firebase → Google OIDC → Google OAuth). **Existing
+deployments require zero config changes.**

--- a/pkg/auth/builder.go
+++ b/pkg/auth/builder.go
@@ -1,0 +1,126 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// ResolverEntry describes a single resolver in the config-driven chain.
+// The Type field selects which resolver to instantiate; remaining fields
+// are type-specific.
+type ResolverEntry struct {
+	Type         string         `yaml:"type"`          // "oidc", "firebase", "google_oauth", "google_oidc"
+	Issuer       string         `yaml:"issuer"`        // OIDC: issuer URL (required)
+	Audience     string         `yaml:"audience"`      // OIDC: expected "aud" claim (required)
+	ClaimMapping *ClaimMapEntry `yaml:"claim_mapping"` // OIDC: optional claim overrides
+}
+
+// ClaimMapEntry configures how OIDC token claims map to Identity fields.
+// All fields are optional — defaults are used when empty.
+type ClaimMapEntry struct {
+	Subject string `yaml:"subject"` // default: "sub"
+	Email   string `yaml:"email"`   // default: "email"
+	Roles   string `yaml:"roles"`   // default: "roles"
+	Tenants string `yaml:"tenants"` // default: "candela.tenants"
+}
+
+// BuildOptions provides dependencies needed by individual resolvers.
+type BuildOptions struct {
+	// Firebase
+	FirebaseVerifier TokenVerifier
+
+	// Google OIDC (Cloud Run audience for candela-local tokens)
+	CloudRunAudience string
+
+	// Service account allowlist (shared across Google resolvers)
+	SAAllowlist *ServiceAccountAllowlist
+
+	// Dev mode: prepends a DevResolver to the chain
+	DevMode bool
+
+	// Cache settings
+	CacheMaxSize int
+	CacheTTL     time.Duration
+}
+
+// BuildResolverChain constructs a ResolverChain from config entries.
+// Each entry's Type determines which resolver is instantiated.
+// Returns an error if a required field is missing or OIDC discovery fails.
+func BuildResolverChain(ctx context.Context, configs []ResolverEntry, opts BuildOptions) (*ResolverChain, error) {
+	var resolvers []IdentityResolver
+
+	if opts.DevMode {
+		resolvers = append(resolvers, NewDevResolver())
+		slog.Info("🔐 resolver chain: dev resolver added")
+	}
+
+	for i, cfg := range configs {
+		r, err := buildResolver(ctx, cfg, opts)
+		if err != nil {
+			return nil, fmt.Errorf("resolver[%d] (%s): %w", i, cfg.Type, err)
+		}
+		resolvers = append(resolvers, r)
+		slog.Info("🔐 resolver chain: added resolver", "type", cfg.Type, "name", r.Name())
+	}
+
+	if len(resolvers) == 0 {
+		return nil, fmt.Errorf("no resolvers configured (and dev_mode is off)")
+	}
+
+	maxSize := opts.CacheMaxSize
+	if maxSize <= 0 {
+		maxSize = 1000
+	}
+	ttl := opts.CacheTTL
+	if ttl <= 0 {
+		ttl = 120 * time.Second
+	}
+	cache := NewIdentityCache(maxSize, ttl)
+
+	return NewResolverChain(cache, resolvers...), nil
+}
+
+func buildResolver(ctx context.Context, cfg ResolverEntry, opts BuildOptions) (IdentityResolver, error) {
+	switch cfg.Type {
+	case "oidc":
+		if cfg.Issuer == "" {
+			return nil, fmt.Errorf("issuer is required for OIDC resolver")
+		}
+		if cfg.Audience == "" {
+			return nil, fmt.Errorf("audience is required for OIDC resolver")
+		}
+		claimMap := DefaultOIDCClaimMapping()
+		if cfg.ClaimMapping != nil {
+			if cfg.ClaimMapping.Subject != "" {
+				claimMap.Subject = cfg.ClaimMapping.Subject
+			}
+			if cfg.ClaimMapping.Email != "" {
+				claimMap.Email = cfg.ClaimMapping.Email
+			}
+			if cfg.ClaimMapping.Roles != "" {
+				claimMap.Roles = cfg.ClaimMapping.Roles
+			}
+			if cfg.ClaimMapping.Tenants != "" {
+				claimMap.Tenants = cfg.ClaimMapping.Tenants
+			}
+		}
+		return NewOIDCResolver(ctx, cfg.Issuer, cfg.Audience, claimMap)
+
+	case "firebase":
+		if opts.FirebaseVerifier == nil {
+			return nil, fmt.Errorf("firebase resolver requires Firebase Admin SDK (is dev_mode on?)")
+		}
+		return NewFirebaseResolver(opts.FirebaseVerifier), nil
+
+	case "google_oidc":
+		return NewGoogleOIDCResolver(opts.CloudRunAudience, opts.SAAllowlist), nil
+
+	case "google_oauth":
+		return NewGoogleOAuthResolver(DefaultAccessTokenValidator(), opts.SAAllowlist), nil
+
+	default:
+		return nil, fmt.Errorf("unknown resolver type: %q (supported: oidc, firebase, google_oidc, google_oauth)", cfg.Type)
+	}
+}

--- a/pkg/auth/builder_test.go
+++ b/pkg/auth/builder_test.go
@@ -1,0 +1,119 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	fbauth "firebase.google.com/go/v4/auth"
+)
+
+func TestBuildResolverChain_Empty(t *testing.T) {
+	_, err := BuildResolverChain(context.Background(), nil, BuildOptions{})
+	if err == nil {
+		t.Fatal("expected error for empty resolvers with dev_mode off")
+	}
+}
+
+func TestBuildResolverChain_DevModeOnly(t *testing.T) {
+	chain, err := BuildResolverChain(context.Background(), nil, BuildOptions{DevMode: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	id, err := chain.Resolve(context.Background(), "anything")
+	if err != nil {
+		t.Fatalf("dev resolver should accept any token: %v", err)
+	}
+	if id.Provider != "dev" {
+		t.Errorf("expected provider=dev, got %q", id.Provider)
+	}
+}
+
+func TestBuildResolverChain_UnknownType(t *testing.T) {
+	entries := []ResolverEntry{{Type: "magic"}}
+	_, err := BuildResolverChain(context.Background(), entries, BuildOptions{})
+	if err == nil {
+		t.Fatal("expected error for unknown resolver type")
+	}
+}
+
+func TestBuildResolverChain_OIDCMissingIssuer(t *testing.T) {
+	entries := []ResolverEntry{{Type: "oidc", Audience: "my-app"}}
+	_, err := BuildResolverChain(context.Background(), entries, BuildOptions{})
+	if err == nil {
+		t.Fatal("expected error for OIDC without issuer")
+	}
+}
+
+func TestBuildResolverChain_OIDCMissingAudience(t *testing.T) {
+	entries := []ResolverEntry{{Type: "oidc", Issuer: "https://example.com"}}
+	_, err := BuildResolverChain(context.Background(), entries, BuildOptions{})
+	if err == nil {
+		t.Fatal("expected error for OIDC without audience")
+	}
+}
+
+func TestBuildResolverChain_FirebaseWithoutVerifier(t *testing.T) {
+	entries := []ResolverEntry{{Type: "firebase"}}
+	_, err := BuildResolverChain(context.Background(), entries, BuildOptions{})
+	if err == nil {
+		t.Fatal("expected error for firebase without verifier")
+	}
+}
+
+func TestBuildResolverChain_FirebaseWithVerifier(t *testing.T) {
+	entries := []ResolverEntry{{Type: "firebase"}}
+	chain, err := BuildResolverChain(context.Background(), entries, BuildOptions{
+		FirebaseVerifier: &mockTokenVerifier{
+			verifyFunc: func(ctx context.Context, idToken string) (*fbauth.Token, error) {
+				return &fbauth.Token{UID: "uid", Claims: map[string]interface{}{"email": "test@example.com"}}, nil
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if chain == nil {
+		t.Fatal("expected non-nil chain")
+	}
+}
+
+func TestBuildResolverChain_GoogleOAuth(t *testing.T) {
+	entries := []ResolverEntry{{Type: "google_oauth"}}
+	chain, err := BuildResolverChain(context.Background(), entries, BuildOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if chain == nil {
+		t.Fatal("expected non-nil chain")
+	}
+}
+
+func TestBuildResolverChain_GoogleOIDC(t *testing.T) {
+	entries := []ResolverEntry{{Type: "google_oidc"}}
+	chain, err := BuildResolverChain(context.Background(), entries, BuildOptions{
+		CloudRunAudience: "https://candela.run.app",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if chain == nil {
+		t.Fatal("expected non-nil chain")
+	}
+}
+
+func TestBuildResolverChain_MultipleResolvers(t *testing.T) {
+	entries := []ResolverEntry{
+		{Type: "google_oidc"},
+		{Type: "google_oauth"},
+	}
+	chain, err := BuildResolverChain(context.Background(), entries, BuildOptions{
+		DevMode: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should have 3 resolvers: dev + google_oidc + google_oauth
+	if chain == nil {
+		t.Fatal("expected non-nil chain")
+	}
+}

--- a/pkg/auth/middleware_chain.go
+++ b/pkg/auth/middleware_chain.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+)
+
+// ChainAuthMiddleware validates bearer tokens using a pre-built ResolverChain.
+// This is the config-driven alternative to FirebaseAuthMiddleware — it works
+// with any combination of resolvers (OIDC, Firebase, Google, etc.).
+//
+// The middleware:
+//  1. Skips health-check paths (/healthz, /readyz)
+//  2. Extracts the bearer token from Authorization or X-Candela-Auth headers
+//  3. Resolves the token through the chain (first match wins)
+//  4. Verifies the user is registered (unless self-service path)
+//  5. Injects the Identity into the request context
+func ChainAuthMiddleware(next http.Handler, chain *ResolverChain, userAuth UserAuthorizer, saAllowlist *ServiceAccountAllowlist, devMode bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Skip auth for health checks (liveness + readiness).
+		if r.URL.Path == "/healthz" || r.URL.Path == "/readyz" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		isSelfService := selfServicePaths[r.URL.Path]
+
+		token := extractBearerToken(r)
+		if token == "" {
+			if devMode {
+				user := &User{ID: "dev-admin", Email: "admin@localhost", Provider: "dev"}
+				next.ServeHTTP(w, r.WithContext(NewContext(r.Context(), user)))
+				return
+			}
+			slog.Warn("missing authorization header", "path", r.URL.Path)
+			writeError(w, http.StatusUnauthorized, "missing authentication")
+			return
+		}
+
+		user, err := chain.Resolve(r.Context(), token)
+		if err != nil {
+			var forbiddenErr *ForbiddenError
+			if errors.As(err, &forbiddenErr) {
+				slog.Warn("auth forbidden", "error", err, "path", r.URL.Path)
+				writeError(w, http.StatusForbidden, forbiddenErr.Error())
+				return
+			}
+			slog.Warn("auth failed", "error", err, "path", r.URL.Path)
+			writeError(w, http.StatusUnauthorized, "invalid authentication token")
+			return
+		}
+
+		if !isSelfService && !verifyRegistered(r.Context(), w, user, userAuth, saAllowlist) {
+			return
+		}
+
+		slog.Debug("authenticated", "provider", user.Provider, "uid", user.ID, "email", user.Email, "path", r.URL.Path)
+		next.ServeHTTP(w, r.WithContext(NewContext(r.Context(), user)))
+	})
+}


### PR DESCRIPTION
## Summary

Adds `auth.resolvers` config for pluggable identity provider chains. Enterprises using Zitadel, Auth0, Okta, Keycloak, or Cognito can now authenticate without Firebase.

**Zero breaking change**: omit `auth.resolvers` to keep the existing Firebase chain.

## What Changed

| File | Change |
|:---|:---|
| `pkg/auth/builder.go` | `BuildResolverChain` — maps YAML resolver entries to `IdentityResolver` instances |
| `pkg/auth/middleware_chain.go` | `ChainAuthMiddleware` — clean middleware decoupled from Firebase SDK init |
| `pkg/auth/builder_test.go` | 9 tests: validation, error cases, multi-resolver construction |
| `cmd/candela-server/main.go` | Config-driven path when `auth.resolvers` is present; legacy fallback otherwise |
| `config.example.yaml` | OIDC resolver config examples |
| `docs/generic-oidc.md` | Provider-specific quickstarts (Zitadel, Auth0, Okta, Keycloak, Cognito) |
| `CHANGELOG.md` | Feature entry |

## How It Works

```yaml
auth:
  resolvers:
    - type: oidc
      issuer: https://zitadel.example.com
      audience: candela-server
    - type: firebase      # fallback for browser sessions
    - type: google_oauth  # fallback for CLI
```

1. Resolvers are tried in config order (first match wins)
2. OIDC resolver auto-discovers JWKS from issuer's `.well-known/openid-configuration`
3. Configurable claim mapping (defaults work for 90% of providers)
4. Failed token = try next resolver. Invalid token = reject immediately.

## Design Decisions

- **Config order = priority** (no priority field, no magic)
- **YAML only** — no env var for issuer/audience (architectural, not operational)
- **Zero claim_mapping required** — defaults (`sub`, `email`, `roles`, `candela.tenants`) cover most providers

## Test Coverage

- `TestBuildResolverChain_Empty` — error without resolvers
- `TestBuildResolverChain_DevModeOnly` — dev resolver accepts any token
- `TestBuildResolverChain_UnknownType` — rejects unknown types
- `TestBuildResolverChain_OIDCMissing{Issuer,Audience}` — validation
- `TestBuildResolverChain_Firebase{Without,With}Verifier` — dependency check
- `TestBuildResolverChain_Google{OAuth,OIDC}` — construction
- `TestBuildResolverChain_MultipleResolvers` — multi-resolver chain
- Full auth + proxy test suites pass

Closes #764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added generic OIDC authentication support with configurable issuer, audience, and claim mapping.
  - Added ordered authentication resolver chains supporting OIDC, Firebase, Google OIDC, and Google OAuth.
  - Added configurable development-mode authentication and improved authentication error handling.
  - Added service-account allowlist support for authenticated requests.

- **Documentation**
  - Added provider configuration examples, migration guidance, and authentication flow documentation.
  - Existing Firebase authentication remains supported when no resolver chain is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->