### PR TITLE
fix: address CodeRabbit review on #764 OIDC resolver chain

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -1025,9 +1025,18 @@ func main() {
 	}
 
 	// Initialize Firebase Admin SDK for token verification.
-	// Needed for both legacy and config-driven paths when "firebase" resolver is used.
+	// Only needed for legacy path (no resolvers configured) or when a
+	// "firebase" resolver is explicitly listed. OIDC-only deployments
+	// skip this entirely — no GCP ADC required.
+	needsFirebase := len(cfg.Auth.Resolvers) == 0 // legacy path always uses Firebase
+	for _, r := range cfg.Auth.Resolvers {
+		if r.Type == "firebase" {
+			needsFirebase = true
+			break
+		}
+	}
 	var tokenVerifier auth.TokenVerifier
-	if !devMode {
+	if !devMode && needsFirebase {
 		fbApp, err := firebase.NewApp(context.Background(), nil)
 		if err != nil {
 			slog.Error("failed to initialize Firebase Admin SDK", "error", err)

--- a/docs/generic-oidc.md
+++ b/docs/generic-oidc.md
@@ -138,24 +138,16 @@ provider uses custom claim names for tenant or role information.
 | `google_oidc` | Google ID tokens (Cloud Run) | `candela-local` behind Cloud Run |
 | `google_oauth` | Google OAuth2 access tokens | `candela auth login --provider gcp` |
 
-## Tenant Validation
+## Tenant Validation (Planned)
 
-When using OIDC with multi-tenancy, switch to verified tenant mode:
+> **Note**: The `TenantValidator` infrastructure exists internally but is not yet
+> exposed as a config option. When wired, you'll be able to switch to `verified`
+> tenant mode so that `X-Candela-Tenant-Id` headers are validated against signed
+> JWT claims.
 
-```yaml
-auth:
-  tenant_mode: verified
-  resolvers:
-    - type: oidc
-      issuer: https://your-idp.example.com
-      audience: candela-server
-      claim_mapping:
-        tenants: "candela.tenants"
-```
-
-In `verified` mode, the `X-Candela-Tenant-Id` header is validated against the
-tenant IDs in the signed JWT claims. Requests for unauthorized tenants are
-rejected with 403.
+For now, configure `claim_mapping.tenants` to extract tenant IDs from your OIDC
+tokens. The tenant IDs are populated on `Identity.TenantIDs` and available for
+application-level validation.
 
 ## Backward Compatibility
 

--- a/pkg/auth/builder.go
+++ b/pkg/auth/builder.go
@@ -110,6 +110,11 @@ func buildResolver(ctx context.Context, cfg ResolverEntry, opts BuildOptions) (I
 
 	case "firebase":
 		if opts.FirebaseVerifier == nil {
+			if opts.DevMode {
+				// In dev mode, DevResolver handles all tokens before Firebase
+				// is reached. Return a no-op Firebase resolver for chain integrity.
+				return NewFirebaseResolver(nil), nil
+			}
 			return nil, fmt.Errorf("firebase resolver requires Firebase Admin SDK (is dev_mode on?)")
 		}
 		return NewFirebaseResolver(opts.FirebaseVerifier), nil

--- a/pkg/auth/builder_test.go
+++ b/pkg/auth/builder_test.go
@@ -60,6 +60,24 @@ func TestBuildResolverChain_FirebaseWithoutVerifier(t *testing.T) {
 	}
 }
 
+func TestBuildResolverChain_FirebaseDevModeNoVerifier(t *testing.T) {
+	// In dev mode, DevResolver handles all tokens — firebase resolver
+	// can be configured without a verifier for config portability.
+	entries := []ResolverEntry{{Type: "firebase"}}
+	chain, err := BuildResolverChain(context.Background(), entries, BuildOptions{DevMode: true})
+	if err != nil {
+		t.Fatalf("dev mode should allow firebase without verifier: %v", err)
+	}
+	// DevResolver is prepended, so any token resolves via dev
+	id, err := chain.Resolve(context.Background(), "any-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Provider != "dev" {
+		t.Errorf("expected dev provider in dev mode, got %q", id.Provider)
+	}
+}
+
 func TestBuildResolverChain_FirebaseWithVerifier(t *testing.T) {
 	entries := []ResolverEntry{{Type: "firebase"}}
 	chain, err := BuildResolverChain(context.Background(), entries, BuildOptions{


### PR DESCRIPTION
## Summary

Follow-up fixes for #791 (merged) addressing 3 CodeRabbit review findings.

## Fixes

| # | Issue | Fix |
|:---|:---|:---|
| 1 | Firebase SDK initialized unconditionally — OIDC-only deploys without GCP ADC crash at startup | Only init Firebase when `type: firebase` is in `auth.resolvers` or using legacy path |
| 2 | `dev_mode: true` + `firebase` resolver → nil verifier → startup crash | Allow nil verifier when `DevMode` is true (DevResolver catches all tokens first) |
| 3 | `auth.tenant_mode` documented in `docs/generic-oidc.md` but not wired in config | Replaced with "Planned" note — `TenantValidator` exists internally but not yet a YAML option |

## Files Changed

- `cmd/candela-server/main.go`: Conditional Firebase init (`needsFirebase` flag)
- `pkg/auth/builder.go`: Dev mode nil-verifier bypass for firebase resolver
- `pkg/auth/builder_test.go`: New `TestBuildResolverChain_FirebaseDevModeNoVerifier`
- `docs/generic-oidc.md`: Tenant validation section → "Planned"

## Testing

- All 10 builder tests pass (including new dev mode test)
- Full `pkg/auth/` test suite passes
- `go build ./cmd/candela-server/` succeeds

Ref #791, #764