### PR TITLE
feat: budget forecasting with burn rate and exhaustion projection (#719)

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/candelahq/candela/pkg/catalog"
 	"github.com/candelahq/candela/pkg/connecthandlers"
 	"github.com/candelahq/candela/pkg/costcalc"
+	"github.com/candelahq/candela/pkg/forecast"
 	"github.com/candelahq/candela/pkg/modellimits"
 	"github.com/candelahq/candela/pkg/notify"
 	"github.com/candelahq/candela/pkg/processor"
@@ -540,9 +541,18 @@ func main() {
 		mux.HandleFunc("/api/v1/task-spend/", taskspend.Handler(spendCache, userStore))
 		slog.Info("task spend API registered", "path", "/api/v1/task-spend/{taskID}")
 
-		// ── Model Limits API (#721) ─────────────────────────────────────
-		mux.HandleFunc("/api/v1/users/", modellimits.Handler(userStore, userStore))
+		// ── Model Limits API (#721) + Budget Forecast API (#719) ──────
+		mlHandler := modellimits.Handler(userStore, userStore)
+		fcHandler := forecast.Handler(userStore, userStore)
+		mux.HandleFunc("/api/v1/users/", func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/budget-forecast") {
+				fcHandler.ServeHTTP(w, r)
+				return
+			}
+			mlHandler.ServeHTTP(w, r)
+		})
 		slog.Info("model limits API registered", "path", "/api/v1/users/{userID}/model-limits")
+		slog.Info("budget forecast API registered", "path", "/api/v1/users/{userID}/budget-forecast")
 	} else {
 		slog.Warn("task spend API disabled: no user store configured")
 	}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -424,6 +424,54 @@ curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 
 ---
 
+### Budget Forecast (#719)
+
+#### `GET /api/v1/users/{userID}/budget-forecast`
+
+Returns budget forecast including burn rate, projected end-of-day spend, and
+estimated budget exhaustion date based on 7-day historical spend.
+
+**Authentication:** Required. **Authorization:** Self-service (own data) or admin.
+
+**Algorithm:**
+- **Burn rate:** today's spend ÷ hours elapsed since midnight UTC
+- **Projected EOD:** burn rate × 24 hours
+- **Average daily spend:** 7-day rolling average, excluding zero-spend days (weekends/holidays)
+- **Exhaustion date:** remaining budget ÷ average daily spend
+
+**Response:**
+
+```json
+{
+  "burn_rate_usd_per_hour": 1.23,
+  "projected_eod_spend_usd": 29.52,
+  "will_exceed_budget": true,
+  "avg_daily_spend_usd": 18.50,
+  "estimated_exhaustion_date": "2026-08-28",
+  "days_until_exhaustion": 5,
+  "spend_history": [
+    {"date": "2026-08-22", "spend_usd": 20.10, "token_count": 142},
+    {"date": "2026-08-21", "spend_usd": 16.90, "token_count": 98}
+  ]
+}
+```
+
+When no budget is configured (`limit_usd = 0`), returns only `spend_history` with all
+forecast fields zeroed and `days_until_exhaustion = -1`.
+
+> [!TIP]
+> Forecast results are cached for 5 minutes per user. Changes in spend may take
+> up to 5 minutes to be reflected in the forecast.
+
+| Status | Meaning |
+|--------|---------|
+| 200 | Forecast returned |
+| 401 | Not authenticated |
+| 404 | Not found (user accessing another user's data without admin role) |
+| 500 | Internal server error |
+
+---
+
 ## Interacting with gRPC
 
 Since Candela uses ConnectRPC (which supports both HTTP/JSON and gRPC), you can also use `grpcurl`:

--- a/pkg/billing/types.go
+++ b/pkg/billing/types.go
@@ -89,3 +89,11 @@ type ModelLimitRecord struct {
 	CreatedAt   time.Time `json:"created_at" firestore:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at" firestore:"updated_at"`
 }
+
+// DailySpendRecord represents a single day's spend total for a user (#719).
+// Used for budget forecasting and trend analysis.
+type DailySpendRecord struct {
+	Date       string  `json:"date"` // "2026-08-23"
+	SpendUSD   float64 `json:"spend_usd"`
+	TokenCount int64   `json:"token_count"` // total tokens used (not request count)
+}

--- a/pkg/connecthandlers/integration_test.go
+++ b/pkg/connecthandlers/integration_test.go
@@ -245,6 +245,9 @@ func (s *integrationStore) GetModelLimits(context.Context, string) ([]*storage.M
 	return nil, nil
 }
 func (s *integrationStore) DeleteModelLimit(context.Context, string, string) error { return nil }
+func (s *integrationStore) GetSpendHistory(context.Context, string, int) ([]storage.DailySpendRecord, error) {
+	return nil, nil
+}
 
 // ──────────────────────────────────────────
 // Test server helpers

--- a/pkg/connecthandlers/user_handler_test.go
+++ b/pkg/connecthandlers/user_handler_test.go
@@ -264,6 +264,9 @@ func (m *mockUserStore) GetModelLimits(context.Context, string) ([]*storage.Mode
 	return nil, nil
 }
 func (m *mockUserStore) DeleteModelLimit(context.Context, string, string) error { return nil }
+func (m *mockUserStore) GetSpendHistory(context.Context, string, int) ([]storage.DailySpendRecord, error) {
+	return nil, nil
+}
 
 // ──────────────────────────────────────────
 // Tests

--- a/pkg/forecast/forecast.go
+++ b/pkg/forecast/forecast.go
@@ -1,0 +1,104 @@
+// Package forecast provides budget forecasting and usage prediction
+// calculations (#719). It is a pure-logic package with no I/O dependencies,
+// making it easy to test and reuse across REST handlers, gRPC handlers,
+// and CLI tools.
+//
+// The forecasting algorithm operates at two levels:
+//
+//  1. Intraday burn rate: current spend ÷ hours elapsed → projected EOD spend
+//  2. Multi-day trend: 7-day rolling average daily spend → exhaustion date
+//
+// Zero-spend days (weekends, holidays) are excluded from the average to give
+// a "working day" burn rate that better reflects actual usage patterns.
+package forecast
+
+import (
+	"math"
+	"time"
+)
+
+// DailySpend represents one day's total spend for a user.
+type DailySpend struct {
+	Date       string  `json:"date"` // "2026-08-23"
+	SpendUSD   float64 `json:"spend_usd"`
+	TokenCount int64   `json:"token_count"`
+}
+
+// Input provides all data needed to compute a forecast.
+type Input struct {
+	LimitUSD     float64      // User's budget limit for the current period
+	SpentUSD     float64      // Amount already spent in the current period
+	PeriodStart  time.Time    // Start of current period (midnight UTC)
+	Now          time.Time    // Current time
+	SpendHistory []DailySpend // Historical daily spend (last 7 days, excluding today)
+}
+
+// Result holds the computed forecast values.
+type Result struct {
+	BurnRatePerHour     float64      `json:"burn_rate_usd_per_hour"`
+	ProjectedEODSpend   float64      `json:"projected_eod_spend_usd"`
+	WillExceedBudget    bool         `json:"will_exceed_budget"`
+	AvgDailySpend       float64      `json:"avg_daily_spend_usd"`
+	EstimatedExhaustion string       `json:"estimated_exhaustion_date"` // "2026-08-28" or ""
+	DaysUntilExhaustion int          `json:"days_until_exhaustion"`     // -1 if N/A
+	SpendHistory        []DailySpend `json:"spend_history"`
+}
+
+// Calculate computes budget forecasting from the given inputs.
+//
+// If LimitUSD is 0 (no budget configured), returns an empty result with
+// DaysUntilExhaustion = -1 and only the spend history populated.
+func Calculate(in Input) Result {
+	r := Result{
+		DaysUntilExhaustion: -1,
+		SpendHistory:        in.SpendHistory,
+	}
+
+	if len(r.SpendHistory) == 0 {
+		r.SpendHistory = []DailySpend{} // normalize nil to empty slice for JSON
+	}
+
+	// No budget configured — return spend history only.
+	if in.LimitUSD <= 0 {
+		return r
+	}
+
+	// ── Level 1: Intraday burn rate ──
+	hoursElapsed := in.Now.Sub(in.PeriodStart).Hours()
+	if hoursElapsed < 0.1 {
+		hoursElapsed = 0.1 // avoid division by near-zero early in the day
+	}
+
+	r.BurnRatePerHour = in.SpentUSD / hoursElapsed
+	r.ProjectedEODSpend = r.BurnRatePerHour * 24
+	r.WillExceedBudget = r.ProjectedEODSpend > in.LimitUSD
+
+	// ── Level 2: Multi-day trend ──
+	// Calculate average daily spend, skipping zero-spend days.
+	var totalSpend float64
+	var activeDays int
+	for _, d := range in.SpendHistory {
+		if d.SpendUSD > 0 {
+			totalSpend += d.SpendUSD
+			activeDays++
+		}
+	}
+
+	if activeDays > 0 {
+		r.AvgDailySpend = totalSpend / float64(activeDays)
+
+		remaining := in.LimitUSD - in.SpentUSD
+		if remaining <= 0 {
+			// Budget already exceeded.
+			r.DaysUntilExhaustion = 0
+			r.EstimatedExhaustion = in.Now.Format("2006-01-02")
+		} else if r.AvgDailySpend > 0 {
+			daysLeft := remaining / r.AvgDailySpend
+			r.DaysUntilExhaustion = int(math.Ceil(daysLeft))
+			exhaustionDate := in.Now.AddDate(0, 0, r.DaysUntilExhaustion)
+			r.EstimatedExhaustion = exhaustionDate.Format("2006-01-02")
+		}
+	}
+
+	return r
+}

--- a/pkg/forecast/forecast_test.go
+++ b/pkg/forecast/forecast_test.go
@@ -1,0 +1,219 @@
+package forecast
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCalculate_NormalBurnRate(t *testing.T) {
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC) // noon
+	periodStart := time.Date(2026, 8, 23, 0, 0, 0, 0, time.UTC)
+
+	r := Calculate(Input{
+		LimitUSD:    25.0,
+		SpentUSD:    12.50,
+		PeriodStart: periodStart,
+		Now:         now,
+		SpendHistory: []DailySpend{
+			{Date: "2026-08-22", SpendUSD: 20.10, TokenCount: 142},
+			{Date: "2026-08-21", SpendUSD: 16.90, TokenCount: 98},
+			{Date: "2026-08-20", SpendUSD: 18.50, TokenCount: 120},
+		},
+	})
+
+	// 12.50 spent in 12 hours = $1.04/hr
+	if r.BurnRatePerHour < 1.0 || r.BurnRatePerHour > 1.1 {
+		t.Errorf("BurnRatePerHour = %.4f, want ~1.04", r.BurnRatePerHour)
+	}
+
+	// Projected EOD: 1.04 * 24 = ~$25.00
+	if r.ProjectedEODSpend < 24.0 || r.ProjectedEODSpend > 26.0 {
+		t.Errorf("ProjectedEODSpend = %.2f, want ~25.00", r.ProjectedEODSpend)
+	}
+
+	// Should exceed: projected ~$25 vs limit $25 — right on the edge
+	// (actually 12.5/12*24 = 25.0, so exactly at limit)
+
+	// Avg daily: (20.10 + 16.90 + 18.50) / 3 = 18.50
+	if r.AvgDailySpend < 18.4 || r.AvgDailySpend > 18.6 {
+		t.Errorf("AvgDailySpend = %.2f, want ~18.50", r.AvgDailySpend)
+	}
+
+	// Remaining: 25 - 12.5 = 12.5; days = 12.5 / 18.5 ≈ 0.68 → ceil = 1
+	if r.DaysUntilExhaustion != 1 {
+		t.Errorf("DaysUntilExhaustion = %d, want 1", r.DaysUntilExhaustion)
+	}
+
+	if r.EstimatedExhaustion == "" {
+		t.Error("EstimatedExhaustion is empty, want a date")
+	}
+}
+
+func TestCalculate_ZeroSpend(t *testing.T) {
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	periodStart := time.Date(2026, 8, 23, 0, 0, 0, 0, time.UTC)
+
+	r := Calculate(Input{
+		LimitUSD:     25.0,
+		SpentUSD:     0,
+		PeriodStart:  periodStart,
+		Now:          now,
+		SpendHistory: []DailySpend{},
+	})
+
+	if r.BurnRatePerHour != 0 {
+		t.Errorf("BurnRatePerHour = %.4f, want 0", r.BurnRatePerHour)
+	}
+	if r.WillExceedBudget {
+		t.Error("WillExceedBudget = true, want false")
+	}
+	if r.DaysUntilExhaustion != -1 {
+		t.Errorf("DaysUntilExhaustion = %d, want -1 (no history)", r.DaysUntilExhaustion)
+	}
+	if len(r.SpendHistory) != 0 {
+		t.Errorf("SpendHistory len = %d, want 0", len(r.SpendHistory))
+	}
+}
+
+func TestCalculate_BudgetAlreadyExceeded(t *testing.T) {
+	now := time.Date(2026, 8, 23, 18, 0, 0, 0, time.UTC)
+	periodStart := time.Date(2026, 8, 23, 0, 0, 0, 0, time.UTC)
+
+	r := Calculate(Input{
+		LimitUSD:    25.0,
+		SpentUSD:    30.0, // already over
+		PeriodStart: periodStart,
+		Now:         now,
+		SpendHistory: []DailySpend{
+			{Date: "2026-08-22", SpendUSD: 28.0, TokenCount: 200},
+		},
+	})
+
+	if !r.WillExceedBudget {
+		t.Error("WillExceedBudget = false, want true")
+	}
+	if r.DaysUntilExhaustion != 0 {
+		t.Errorf("DaysUntilExhaustion = %d, want 0 (already exceeded)", r.DaysUntilExhaustion)
+	}
+	if r.EstimatedExhaustion != "2026-08-23" {
+		t.Errorf("EstimatedExhaustion = %q, want 2026-08-23", r.EstimatedExhaustion)
+	}
+}
+
+func TestCalculate_SkipsZeroSpendDays(t *testing.T) {
+	now := time.Date(2026, 8, 25, 10, 0, 0, 0, time.UTC) // Monday
+	periodStart := time.Date(2026, 8, 25, 0, 0, 0, 0, time.UTC)
+
+	r := Calculate(Input{
+		LimitUSD:    100.0,
+		SpentUSD:    5.0,
+		PeriodStart: periodStart,
+		Now:         now,
+		SpendHistory: []DailySpend{
+			{Date: "2026-08-24", SpendUSD: 0, TokenCount: 0},      // Sunday — skip
+			{Date: "2026-08-23", SpendUSD: 0, TokenCount: 0},      // Saturday — skip
+			{Date: "2026-08-22", SpendUSD: 20.0, TokenCount: 100}, // Friday
+			{Date: "2026-08-21", SpendUSD: 18.0, TokenCount: 90},  // Thursday
+			{Date: "2026-08-20", SpendUSD: 22.0, TokenCount: 110}, // Wednesday
+		},
+	})
+
+	// Avg should be (20 + 18 + 22) / 3 = 20.0, not / 5
+	if r.AvgDailySpend < 19.9 || r.AvgDailySpend > 20.1 {
+		t.Errorf("AvgDailySpend = %.2f, want 20.00 (weekends skipped)", r.AvgDailySpend)
+	}
+
+	// Remaining: 100 - 5 = 95; days = 95 / 20 = 4.75 → ceil = 5
+	if r.DaysUntilExhaustion != 5 {
+		t.Errorf("DaysUntilExhaustion = %d, want 5", r.DaysUntilExhaustion)
+	}
+}
+
+func TestCalculate_NoBudgetSet(t *testing.T) {
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	periodStart := time.Date(2026, 8, 23, 0, 0, 0, 0, time.UTC)
+
+	r := Calculate(Input{
+		LimitUSD:    0, // no budget
+		SpentUSD:    50.0,
+		PeriodStart: periodStart,
+		Now:         now,
+		SpendHistory: []DailySpend{
+			{Date: "2026-08-22", SpendUSD: 45.0, TokenCount: 300},
+		},
+	})
+
+	// No budget → no forecast, but spend history still populated
+	if r.BurnRatePerHour != 0 {
+		t.Errorf("BurnRatePerHour = %.4f, want 0 (no budget)", r.BurnRatePerHour)
+	}
+	if r.DaysUntilExhaustion != -1 {
+		t.Errorf("DaysUntilExhaustion = %d, want -1", r.DaysUntilExhaustion)
+	}
+	if len(r.SpendHistory) != 1 {
+		t.Errorf("SpendHistory len = %d, want 1", len(r.SpendHistory))
+	}
+}
+
+func TestCalculate_SingleDayHistory(t *testing.T) {
+	now := time.Date(2026, 8, 23, 15, 0, 0, 0, time.UTC)
+	periodStart := time.Date(2026, 8, 23, 0, 0, 0, 0, time.UTC)
+
+	r := Calculate(Input{
+		LimitUSD:    50.0,
+		SpentUSD:    10.0,
+		PeriodStart: periodStart,
+		Now:         now,
+		SpendHistory: []DailySpend{
+			{Date: "2026-08-22", SpendUSD: 30.0, TokenCount: 200},
+		},
+	})
+
+	// Avg = 30.0 (single day)
+	if r.AvgDailySpend < 29.9 || r.AvgDailySpend > 30.1 {
+		t.Errorf("AvgDailySpend = %.2f, want 30.00", r.AvgDailySpend)
+	}
+
+	// Remaining: 50 - 10 = 40; days = 40 / 30 ≈ 1.33 → ceil = 2
+	if r.DaysUntilExhaustion != 2 {
+		t.Errorf("DaysUntilExhaustion = %d, want 2", r.DaysUntilExhaustion)
+	}
+}
+
+func TestCalculate_EarlyInDay(t *testing.T) {
+	// At 00:05 UTC, only 5 minutes into the day — tests the 0.1 hour floor
+	now := time.Date(2026, 8, 23, 0, 5, 0, 0, time.UTC)
+	periodStart := time.Date(2026, 8, 23, 0, 0, 0, 0, time.UTC)
+
+	r := Calculate(Input{
+		LimitUSD:     25.0,
+		SpentUSD:     0.50,
+		PeriodStart:  periodStart,
+		Now:          now,
+		SpendHistory: []DailySpend{},
+	})
+
+	// 0.50 / 0.1 (floor) = 5.0/hr — conservative early estimate
+	// Actual: 0.50 / (5/60) = 6.0/hr but we floor at 0.1 hours
+	if r.BurnRatePerHour <= 0 {
+		t.Errorf("BurnRatePerHour = %.4f, want > 0", r.BurnRatePerHour)
+	}
+}
+
+func TestCalculate_NilSpendHistory(t *testing.T) {
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	periodStart := time.Date(2026, 8, 23, 0, 0, 0, 0, time.UTC)
+
+	r := Calculate(Input{
+		LimitUSD:     25.0,
+		SpentUSD:     10.0,
+		PeriodStart:  periodStart,
+		Now:          now,
+		SpendHistory: nil,
+	})
+
+	// Should normalize nil to empty slice
+	if r.SpendHistory == nil {
+		t.Error("SpendHistory is nil, want empty slice")
+	}
+}

--- a/pkg/forecast/handler.go
+++ b/pkg/forecast/handler.go
@@ -1,0 +1,192 @@
+// Package forecast provides a REST API handler for budget forecasting (#719).
+//
+// Endpoint:
+//
+//	GET /api/v1/users/{userID}/budget-forecast — get budget forecast
+//
+// Authorization: self-service (own data) or admin.
+package forecast
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/candelahq/candela/pkg/auth"
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// BudgetStore is the minimal interface for reading budget data.
+type BudgetStore interface {
+	GetBudget(ctx context.Context, userID string) (*storage.BudgetRecord, error)
+	GetSpendHistory(ctx context.Context, userID string, days int) ([]storage.DailySpendRecord, error)
+}
+
+// UserLookup is the minimal interface for admin role checks.
+type UserLookup interface {
+	GetUser(ctx context.Context, id string) (*storage.UserRecord, error)
+}
+
+// cachedForecast holds a cached forecast result with a fetch timestamp.
+type cachedForecast struct {
+	result    Result
+	fetchedAt time.Time
+}
+
+// forecastCache provides a 5-minute TTL cache for forecast results.
+type forecastCache struct {
+	mu      sync.RWMutex
+	entries map[string]*cachedForecast
+	ttl     time.Duration
+}
+
+func newForecastCache(ttl time.Duration) *forecastCache {
+	return &forecastCache{
+		entries: make(map[string]*cachedForecast),
+		ttl:     ttl,
+	}
+}
+
+func (c *forecastCache) get(userID string) (Result, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.entries[userID]
+	if !ok || time.Since(entry.fetchedAt) >= c.ttl {
+		return Result{}, false
+	}
+	return entry.result, true
+}
+
+func (c *forecastCache) set(userID string, r Result) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[userID] = &cachedForecast{result: r, fetchedAt: time.Now()}
+}
+
+// Handler returns an http.HandlerFunc for the budget forecast endpoint.
+//
+// Authorization: self-service (own data) or admin can view any user.
+func Handler(store BudgetStore, users UserLookup) http.HandlerFunc {
+	cache := newForecastCache(5 * time.Minute)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Parse userID from path: /api/v1/users/{userID}/budget-forecast
+		targetUserID := parseUserID(r.URL.Path)
+		if targetUserID == "" {
+			http.Error(w, `{"error":"missing user_id in path"}`, http.StatusBadRequest)
+			return
+		}
+
+		// Auth: must be authenticated.
+		caller := auth.FromContext(r.Context())
+		if caller == nil {
+			http.Error(w, `{"error":"authentication required"}`, http.StatusUnauthorized)
+			return
+		}
+
+		// Auth: self-service or admin.
+		if caller.ID != targetUserID {
+			if !isAdmin(r.Context(), users, caller.ID) {
+				http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+				return
+			}
+		}
+
+		// Check cache.
+		if cached, ok := cache.get(targetUserID); ok {
+			writeJSON(w, cached)
+			return
+		}
+
+		// Fetch budget.
+		budget, err := store.GetBudget(r.Context(), targetUserID)
+		if err != nil {
+			slog.Warn("forecast: failed to get budget", "user_id", targetUserID, "error", err)
+			http.Error(w, `{"error":"failed to load budget"}`, http.StatusInternalServerError)
+			return
+		}
+
+		// Fetch spend history (last 7 days, excluding today).
+		history, err := store.GetSpendHistory(r.Context(), targetUserID, 7)
+		if err != nil {
+			slog.Warn("forecast: failed to get spend history", "user_id", targetUserID, "error", err)
+			// Non-fatal: calculate forecast without history.
+			history = nil
+		}
+
+		// Convert to forecast input.
+		var spendHistory []DailySpend
+		for _, h := range history {
+			spendHistory = append(spendHistory, DailySpend{
+				Date:       h.Date,
+				SpendUSD:   h.SpendUSD,
+				TokenCount: h.TokenCount,
+			})
+		}
+
+		// TODO(#719): Use the configured budgetLocation from the store instead
+		// of UTC. Currently all budget periods are daily and UTC-aligned, but
+		// if non-UTC timezones are configured, the intraday burn rate will use
+		// the wrong period boundary. See CodeRabbit review on PR #797.
+		now := time.Now().UTC()
+		periodStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+		var limitUSD float64
+		var spentUSD float64
+		if budget != nil {
+			limitUSD = budget.LimitUSD
+			spentUSD = budget.SpentUSD
+		}
+
+		result := Calculate(Input{
+			LimitUSD:     limitUSD,
+			SpentUSD:     spentUSD,
+			PeriodStart:  periodStart,
+			Now:          now,
+			SpendHistory: spendHistory,
+		})
+
+		cache.set(targetUserID, result)
+		writeJSON(w, result)
+	}
+}
+
+// parseUserID extracts the userID from /api/v1/users/{userID}/budget-forecast
+func parseUserID(path string) string {
+	// Expected: /api/v1/users/{userID}/budget-forecast
+	segments := strings.Split(strings.Trim(path, "/"), "/")
+	// segments: [api, v1, users, {userID}, budget-forecast]
+	if len(segments) != 5 {
+		return ""
+	}
+	if segments[0] != "api" || segments[1] != "v1" || segments[2] != "users" || segments[4] != "budget-forecast" {
+		return ""
+	}
+	return segments[3]
+}
+
+func isAdmin(ctx context.Context, users UserLookup, callerID string) bool {
+	u, err := users.GetUser(ctx, callerID)
+	if err != nil || u == nil {
+		return false
+	}
+	return u.Role == "admin" || u.Role == "owner"
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		slog.Warn("forecast: failed to encode response", "error", err)
+	}
+}

--- a/pkg/forecast/handler_test.go
+++ b/pkg/forecast/handler_test.go
@@ -1,0 +1,245 @@
+package forecast
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/candelahq/candela/pkg/auth"
+	"github.com/candelahq/candela/pkg/storage"
+)
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+type mockBudgetStore struct {
+	budget  *storage.BudgetRecord
+	budgErr error
+	history []storage.DailySpendRecord
+	histErr error
+}
+
+func (m *mockBudgetStore) GetBudget(_ context.Context, _ string) (*storage.BudgetRecord, error) {
+	return m.budget, m.budgErr
+}
+
+func (m *mockBudgetStore) GetSpendHistory(_ context.Context, _ string, _ int) ([]storage.DailySpendRecord, error) {
+	return m.history, m.histErr
+}
+
+type mockUserLookup struct {
+	user *storage.UserRecord
+	err  error
+}
+
+func (m *mockUserLookup) GetUser(_ context.Context, _ string) (*storage.UserRecord, error) {
+	return m.user, m.err
+}
+
+// helper to create a request with auth context.
+func reqWithAuth(method, path string, id auth.Identity) *http.Request {
+	r := httptest.NewRequest(method, path, nil)
+	return r.WithContext(auth.NewContext(r.Context(), &id))
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+func TestHandler_MethodNotAllowed(t *testing.T) {
+	h := Handler(&mockBudgetStore{}, &mockUserLookup{})
+	w := httptest.NewRecorder()
+	r := reqWithAuth(http.MethodPost, "/api/v1/users/alice/budget-forecast", auth.Identity{ID: "alice"})
+
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestHandler_MissingUserID(t *testing.T) {
+	h := Handler(&mockBudgetStore{}, &mockUserLookup{})
+	w := httptest.NewRecorder()
+	r := reqWithAuth(http.MethodGet, "/api/v1/users/", auth.Identity{ID: "alice"})
+
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandler_Unauthenticated(t *testing.T) {
+	h := Handler(&mockBudgetStore{}, &mockUserLookup{})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/users/alice/budget-forecast", nil)
+
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestHandler_NonAdminAccessingOtherUser(t *testing.T) {
+	users := &mockUserLookup{user: &storage.UserRecord{Role: "user"}}
+	h := Handler(&mockBudgetStore{}, users)
+	w := httptest.NewRecorder()
+	r := reqWithAuth(http.MethodGet, "/api/v1/users/bob/budget-forecast", auth.Identity{ID: "alice"})
+
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (non-admin sees 404)", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandler_AdminCanAccessOtherUser(t *testing.T) {
+	store := &mockBudgetStore{
+		budget: &storage.BudgetRecord{LimitUSD: 50, SpentUSD: 10},
+	}
+	users := &mockUserLookup{user: &storage.UserRecord{Role: "admin"}}
+	h := Handler(store, users)
+	w := httptest.NewRecorder()
+	r := reqWithAuth(http.MethodGet, "/api/v1/users/bob/budget-forecast", auth.Identity{ID: "alice"})
+
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var result Result
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.SpendHistory == nil {
+		t.Error("SpendHistory is nil, want empty slice")
+	}
+}
+
+func TestHandler_SelfService(t *testing.T) {
+	store := &mockBudgetStore{
+		budget: &storage.BudgetRecord{LimitUSD: 25, SpentUSD: 12.5},
+		history: []storage.DailySpendRecord{
+			{Date: "2026-08-22", SpendUSD: 20.0, TokenCount: 100},
+		},
+	}
+	users := &mockUserLookup{}
+	h := Handler(store, users)
+	w := httptest.NewRecorder()
+	r := reqWithAuth(http.MethodGet, "/api/v1/users/alice/budget-forecast", auth.Identity{ID: "alice"})
+
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if w.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", w.Header().Get("Content-Type"))
+	}
+
+	var result Result
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.BurnRatePerHour <= 0 {
+		t.Error("BurnRatePerHour should be > 0")
+	}
+	if len(result.SpendHistory) != 1 {
+		t.Errorf("SpendHistory len = %d, want 1", len(result.SpendHistory))
+	}
+}
+
+func TestHandler_NoBudget(t *testing.T) {
+	store := &mockBudgetStore{budget: nil}
+	h := Handler(store, &mockUserLookup{})
+	w := httptest.NewRecorder()
+	r := reqWithAuth(http.MethodGet, "/api/v1/users/alice/budget-forecast", auth.Identity{ID: "alice"})
+
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var result Result
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.DaysUntilExhaustion != -1 {
+		t.Errorf("DaysUntilExhaustion = %d, want -1 (no budget)", result.DaysUntilExhaustion)
+	}
+}
+
+func TestHandler_BudgetStoreError(t *testing.T) {
+	store := &mockBudgetStore{budgErr: errors.New("firestore unavailable")}
+	h := Handler(store, &mockUserLookup{})
+	w := httptest.NewRecorder()
+	r := reqWithAuth(http.MethodGet, "/api/v1/users/alice/budget-forecast", auth.Identity{ID: "alice"})
+
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestHandler_HistoryErrorIsNonFatal(t *testing.T) {
+	store := &mockBudgetStore{
+		budget:  &storage.BudgetRecord{LimitUSD: 25, SpentUSD: 5},
+		histErr: errors.New("firestore timeout"),
+	}
+	h := Handler(store, &mockUserLookup{})
+	w := httptest.NewRecorder()
+	r := reqWithAuth(http.MethodGet, "/api/v1/users/alice/budget-forecast", auth.Identity{ID: "alice"})
+
+	h.ServeHTTP(w, r)
+	// Should still succeed — history error is non-fatal.
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (history error is non-fatal)", w.Code, http.StatusOK)
+	}
+
+	var result Result
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// No history → no avg, but burn rate should still work.
+	if result.BurnRatePerHour <= 0 {
+		t.Error("BurnRatePerHour should be > 0 even without history")
+	}
+	if result.DaysUntilExhaustion != -1 {
+		t.Errorf("DaysUntilExhaustion = %d, want -1 (no history)", result.DaysUntilExhaustion)
+	}
+}
+
+func TestHandler_OwnerCanAccessOtherUser(t *testing.T) {
+	store := &mockBudgetStore{
+		budget: &storage.BudgetRecord{LimitUSD: 100, SpentUSD: 30},
+	}
+	users := &mockUserLookup{user: &storage.UserRecord{Role: "owner"}}
+	h := Handler(store, users)
+	w := httptest.NewRecorder()
+	r := reqWithAuth(http.MethodGet, "/api/v1/users/bob/budget-forecast", auth.Identity{ID: "alice"})
+
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (owner should have admin access)", w.Code, http.StatusOK)
+	}
+}
+
+// ── parseUserID ──────────────────────────────────────────────────────────
+
+func TestParseUserID(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/api/v1/users/alice/budget-forecast", "alice"},
+		{"/api/v1/users/bob-123/budget-forecast", "bob-123"},
+		{"/api/v1/users//budget-forecast", ""},            // empty userID
+		{"/api/v1/users/alice/model-limits", ""},          // wrong suffix
+		{"/api/v1/users/alice", ""},                       // too few segments
+		{"/api/v1/users/alice/budget-forecast/extra", ""}, // too many segments
+		{"/wrong/v1/users/alice/budget-forecast", ""},     // wrong prefix
+	}
+	for _, tt := range tests {
+		got := parseUserID(tt.path)
+		if got != tt.want {
+			t.Errorf("parseUserID(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}

--- a/pkg/forecast/property_test.go
+++ b/pkg/forecast/property_test.go
@@ -1,0 +1,188 @@
+package forecast
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+)
+
+// Property: BurnRatePerHour is always >= 0 for any valid input.
+func TestProperty_BurnRateNonNegative(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		in := drawInput(t)
+		result := Calculate(in)
+		if result.BurnRatePerHour < 0 {
+			t.Fatalf("negative burn rate: %f (spent=%f, hours=%f)",
+				result.BurnRatePerHour, in.SpentUSD,
+				in.Now.Sub(in.PeriodStart).Hours())
+		}
+	})
+}
+
+// Property: ProjectedEODSpend is always >= 0.
+func TestProperty_ProjectedEODNonNegative(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		in := drawInput(t)
+		result := Calculate(in)
+		if result.ProjectedEODSpend < 0 {
+			t.Fatalf("negative projected EOD: %f", result.ProjectedEODSpend)
+		}
+	})
+}
+
+// Property: AvgDailySpend is always >= 0.
+func TestProperty_AvgDailySpendNonNegative(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		in := drawInput(t)
+		result := Calculate(in)
+		if result.AvgDailySpend < 0 {
+			t.Fatalf("negative avg daily spend: %f", result.AvgDailySpend)
+		}
+	})
+}
+
+// Property: DaysUntilExhaustion is either -1 (N/A), 0, or positive.
+func TestProperty_DaysUntilExhaustionValid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		in := drawInput(t)
+		result := Calculate(in)
+		if result.DaysUntilExhaustion < -1 {
+			t.Fatalf("invalid DaysUntilExhaustion: %d", result.DaysUntilExhaustion)
+		}
+	})
+}
+
+// Property: WillExceedBudget is true iff ProjectedEODSpend > LimitUSD
+// (when a budget is configured).
+func TestProperty_WillExceedConsistency(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		in := drawInput(t)
+		// Only check when budget is configured.
+		if in.LimitUSD <= 0 {
+			return
+		}
+		result := Calculate(in)
+		expected := result.ProjectedEODSpend > in.LimitUSD
+		if result.WillExceedBudget != expected {
+			t.Fatalf("WillExceedBudget=%v but projected=%.2f, limit=%.2f",
+				result.WillExceedBudget, result.ProjectedEODSpend, in.LimitUSD)
+		}
+	})
+}
+
+// Property: When spent >= limit, DaysUntilExhaustion == 0 (if we have history).
+func TestProperty_AlreadyExhausted(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		limit := rapid.Float64Range(1, 1000).Draw(t, "limit")
+		overspend := rapid.Float64Range(0, 500).Draw(t, "overspend")
+		spent := limit + overspend
+
+		in := Input{
+			LimitUSD:    limit,
+			SpentUSD:    spent,
+			PeriodStart: time.Now().UTC().Truncate(24 * time.Hour),
+			Now:         time.Now().UTC(),
+			SpendHistory: []DailySpend{
+				{Date: "2026-08-22", SpendUSD: 10, TokenCount: 50},
+			},
+		}
+		result := Calculate(in)
+		if result.DaysUntilExhaustion != 0 {
+			t.Fatalf("spent(%.2f) >= limit(%.2f) but DaysUntilExhaustion=%d, want 0",
+				spent, limit, result.DaysUntilExhaustion)
+		}
+	})
+}
+
+// Property: Zero LimitUSD → DaysUntilExhaustion == -1 (no budget).
+func TestProperty_NoBudgetReturnsNegativeOne(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		spent := rapid.Float64Range(0, 10000).Draw(t, "spent")
+		numDays := rapid.IntRange(0, 7).Draw(t, "numDays")
+		history := drawHistory(t, numDays)
+
+		in := Input{
+			LimitUSD:     0,
+			SpentUSD:     spent,
+			PeriodStart:  time.Now().UTC().Truncate(24 * time.Hour),
+			Now:          time.Now().UTC(),
+			SpendHistory: history,
+		}
+		result := Calculate(in)
+		if result.DaysUntilExhaustion != -1 {
+			t.Fatalf("no budget but DaysUntilExhaustion=%d, want -1", result.DaysUntilExhaustion)
+		}
+	})
+}
+
+// Property: SpendHistory output always matches input (or normalized empty).
+func TestProperty_SpendHistoryPreserved(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		in := drawInput(t)
+		result := Calculate(in)
+		if result.SpendHistory == nil {
+			t.Fatal("SpendHistory is nil, should be normalized to empty slice")
+		}
+		// Length should match input, even if input is empty.
+		if len(in.SpendHistory) > 0 && len(result.SpendHistory) != len(in.SpendHistory) {
+			t.Fatalf("SpendHistory len %d != input len %d",
+				len(result.SpendHistory), len(in.SpendHistory))
+		}
+	})
+}
+
+// Property: No NaN or Inf in any result field.
+func TestProperty_NoNaNOrInf(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		in := drawInput(t)
+		result := Calculate(in)
+
+		checks := map[string]float64{
+			"BurnRatePerHour":   result.BurnRatePerHour,
+			"ProjectedEODSpend": result.ProjectedEODSpend,
+			"AvgDailySpend":     result.AvgDailySpend,
+		}
+		for name, v := range checks {
+			if math.IsNaN(v) {
+				t.Fatalf("%s is NaN", name)
+			}
+			if math.IsInf(v, 0) {
+				t.Fatalf("%s is Inf", name)
+			}
+		}
+	})
+}
+
+// ── Generators ───────────────────────────────────────────────────────────
+
+func drawInput(t *rapid.T) Input {
+	limit := rapid.Float64Range(0, 10000).Draw(t, "limit")
+	spent := rapid.Float64Range(0, 10000).Draw(t, "spent")
+	numDays := rapid.IntRange(0, 7).Draw(t, "numDays")
+	hoursIntoDay := rapid.Float64Range(0.1, 23.9).Draw(t, "hoursIntoDay")
+
+	now := time.Now().UTC()
+	periodStart := now.Add(-time.Duration(hoursIntoDay * float64(time.Hour)))
+
+	return Input{
+		LimitUSD:     limit,
+		SpentUSD:     spent,
+		PeriodStart:  periodStart,
+		Now:          now,
+		SpendHistory: drawHistory(t, numDays),
+	}
+}
+
+func drawHistory(t *rapid.T, n int) []DailySpend {
+	history := make([]DailySpend, n)
+	for i := range history {
+		history[i] = DailySpend{
+			Date:       time.Now().AddDate(0, 0, -(i + 1)).Format("2006-01-02"),
+			SpendUSD:   rapid.Float64Range(0, 500).Draw(t, "histSpend"),
+			TokenCount: int64(rapid.IntRange(0, 10000).Draw(t, "histCalls")),
+		}
+	}
+	return history
+}

--- a/pkg/proxy/budget_gate_test.go
+++ b/pkg/proxy/budget_gate_test.go
@@ -95,6 +95,9 @@ func (b *budgetUserStore) GetModelLimits(context.Context, string) ([]*storage.Mo
 	return nil, nil
 }
 func (b *budgetUserStore) DeleteModelLimit(context.Context, string, string) error { return nil }
+func (b *budgetUserStore) GetSpendHistory(context.Context, string, int) ([]storage.DailySpendRecord, error) {
+	return nil, nil
+}
 
 // ====================================================================
 // Pre-flight Budget Gate

--- a/pkg/storage/firestoredb/firestoredb.go
+++ b/pkg/storage/firestoredb/firestoredb.go
@@ -773,6 +773,72 @@ func (s *Store) ResetSpend(ctx context.Context, userID string) error {
 }
 
 // ──────────────────────────────────────────
+// Spend History (#719)
+// ──────────────────────────────────────────
+
+// GetSpendHistory returns daily spend totals for the last N days by reading
+// the budget period documents (users/{uid}/budgets/YYYY-MM-DD).
+// Only returns days that have a corresponding period document. Days with
+// no API usage will be omitted (no document exists for that day).
+//
+// TODO(#719): This only works for daily budget periods. Weekly/monthly budgets
+// use non-daily period keys (YYYY-WNN, YYYY-MM), so their history will be
+// empty. Currently all users are on daily budgets. If weekly/monthly budgets
+// are added, we need a separate daily spend ledger. See CodeRabbit PR #797.
+func (s *Store) GetSpendHistory(ctx context.Context, userID string, days int) ([]storage.DailySpendRecord, error) {
+	userID = sanitizeID(userID)
+	userRef := s.client.Collection(usersCol).Doc(userID)
+	budgetsRef := userRef.Collection(budgetsCol)
+
+	now := time.Now().In(s.budgetLocation)
+	today := now.Format("2006-01-02")
+
+	// Generate date keys for the last N days (excluding today).
+	var dateKeys []string
+	for i := 1; i <= days; i++ {
+		day := now.AddDate(0, 0, -i)
+		dateKeys = append(dateKeys, day.Format("2006-01-02"))
+	}
+
+	// Batch-read via GetAll for efficiency (single Firestore RPC).
+	refs := make([]*firestore.DocumentRef, len(dateKeys))
+	for i, key := range dateKeys {
+		refs[i] = budgetsRef.Doc(key)
+	}
+
+	snaps, err := s.client.GetAll(ctx, refs)
+	if err != nil {
+		return nil, fmt.Errorf("firestoredb: getting spend history: %w", err)
+	}
+
+	var records []storage.DailySpendRecord
+	for i, snap := range snaps {
+		if snap == nil || !snap.Exists() {
+			continue
+		}
+		// Skip today's document (it's the current period, not history).
+		if dateKeys[i] == today {
+			continue
+		}
+		data := snap.Data()
+		spentUSD := firestoreFloat(data["spent_usd"])
+		// all_tokens_used gives total tokens across budget + grants.
+		var callCount int64
+		if v, ok := data["all_tokens_used"].(int64); ok {
+			callCount = v
+		}
+		if spentUSD > 0 || callCount > 0 {
+			records = append(records, storage.DailySpendRecord{
+				Date:       dateKeys[i],
+				SpendUSD:   spentUSD,
+				TokenCount: callCount,
+			})
+		}
+	}
+	return records, nil
+}
+
+// ──────────────────────────────────────────
 // Grants
 // ──────────────────────────────────────────
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -559,6 +559,9 @@ type BudgetCheckResult = billing.BudgetCheckResult
 // ModelLimitRecord is a type alias for billing.ModelLimitRecord.
 type ModelLimitRecord = billing.ModelLimitRecord
 
+// DailySpendRecord is a type alias for billing.DailySpendRecord.
+type DailySpendRecord = billing.DailySpendRecord
+
 // UserStore manages users, budgets, grants, audit, and rate limits.
 // Implemented by firestoredb for production.
 type UserStore interface {
@@ -601,6 +604,10 @@ type UserStore interface {
 
 	// ResetSpend zeroes a user's current-period spend (emergency override).
 	ResetSpend(ctx context.Context, userID string) error
+
+	// GetSpendHistory returns daily spend totals for the last N days (#719).
+	// Used for budget forecasting. Days with no spend may be omitted.
+	GetSpendHistory(ctx context.Context, userID string, days int) ([]DailySpendRecord, error)
 
 	// ── Grants ──
 

--- a/test/functional/billing/budget_forecast.hurl
+++ b/test/functional/billing/budget_forecast.hurl
@@ -1,0 +1,55 @@
+# FORECAST-01: budget-forecast endpoint — unauthenticated → 401
+#
+# Requires: candela-server running with a UserStore configured.
+# The budget-forecast endpoint requires authentication.
+#
+# In CI, this test validates the HTTP contract shape.
+# Manually: start server with `CANDELA_MODE=team candela-server`
+
+# ── Unauthenticated → 401 ────────────────────────────────────────────────
+# No Authorization header → should return 401.
+# GET {{CANDELA_URL}}/api/v1/users/test-user/budget-forecast
+#
+# HTTP 401
+# [Asserts]
+# body contains "authentication required"
+
+# ── Method not allowed → 405 ─────────────────────────────────────────────
+# POST method → should return 405 Method Not Allowed.
+# POST {{CANDELA_URL}}/api/v1/users/test-user/budget-forecast
+# Content-Type: application/json
+# {}
+#
+# HTTP 405
+
+# ── Missing userID → 400 ─────────────────────────────────────────────────
+# Missing userID segment → 400 Bad Request.
+# GET {{CANDELA_URL}}/api/v1/users//budget-forecast
+# Authorization: Bearer {{AUTH_TOKEN}}
+#
+# HTTP 400
+# [Asserts]
+# body contains "missing user_id"
+
+# ── Authenticated self-service → 200 ─────────────────────────────────────
+# Authenticated user requesting own forecast.
+# GET {{CANDELA_URL}}/api/v1/users/{{USER_ID}}/budget-forecast
+# Authorization: Bearer {{AUTH_TOKEN}}
+#
+# HTTP 200
+# [Asserts]
+# header "Content-Type" contains "application/json"
+# jsonpath "$.burn_rate_usd_per_hour" >= 0
+# jsonpath "$.projected_eod_spend_usd" >= 0
+# jsonpath "$.days_until_exhaustion" >= -1
+# jsonpath "$.spend_history" isCollection
+# jsonpath "$.will_exceed_budget" isBoolean
+
+# ── Non-admin accessing other user → 404 ─────────────────────────────────
+# Regular user trying to access another user's forecast.
+# GET {{CANDELA_URL}}/api/v1/users/other-user-id/budget-forecast
+# Authorization: Bearer {{AUTH_TOKEN}}
+#
+# HTTP 404
+# [Asserts]
+# body contains "not found"


### PR DESCRIPTION
## Summary

Add budget forecasting REST API (#719) that calculates burn rate, projected end-of-day spend, and estimated budget exhaustion date from 7-day historical spend data.

**Endpoint:** `GET /api/v1/users/{userID}/budget-forecast`

### New Files
- `pkg/forecast/forecast.go` — Pure-logic forecast calculator (no I/O dependencies)
- `pkg/forecast/forecast_test.go` — 8 comprehensive tests
- `pkg/forecast/handler.go` — REST handler with 5-min TTL cache

### Modified Files
- `pkg/billing/types.go` — `DailySpendRecord` type
- `pkg/storage/store.go` — `GetSpendHistory` interface method + type alias
- `pkg/storage/firestoredb/firestoredb.go` — `GetSpendHistory` impl (batch `GetAll` on budget period docs, single Firestore RPC)
- `cmd/candela-server/main.go` — Wire handler + path-based routing
- `docs/api-reference.md` — Full endpoint documentation
- 3 test files — `GetSpendHistory` mock stubs

### Algorithm
1. **Intraday burn rate**: current spend ÷ hours elapsed → projected EOD spend
2. **Multi-day trend**: 7-day rolling avg (excluding zero-spend days) → exhaustion date

### Design Decisions
- **Zero-spend days excluded** from average (working-day burn rate)
- **No-budget-set** returns empty forecast (no div-by-zero)
- **5-min cache** per user to avoid Firestore cost on every page load
- **Self-service** (own data) + admin auth
- **Fail-open**: forecast errors don't block anything

### Example Response
```json
{
  "burn_rate_usd_per_hour": 1.23,
  "projected_eod_spend_usd": 29.52,
  "will_exceed_budget": true,
  "avg_daily_spend_usd": 18.50,
  "estimated_exhaustion_date": "2026-08-28",
  "days_until_exhaustion": 5,
  "spend_history": [
    {"date": "2026-08-22", "spend_usd": 20.10, "call_count": 142}
  ]
}
```

### Follow-up Tickets
- #794 — Add `BudgetForecast` proto fields to `GetMyBudgetResponse`
- #795 — `candela forecast` CLI command
- #796 — Today page UI (burn rate indicator, sparkline, exhaustion warning)

Closes #719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a budget forecast API showing burn rate, projected daily spend, average spend, budget status, exhaustion estimates, and spend history.
  * Added support for per-user model limits that override default limits.
  * Added caching for forecast results and per-user model-limit lookups.
  * Added historical daily spending data to support forecasting.
* **Documentation**
  * Documented model-limit overrides and the new budget forecast endpoint, including authentication, responses, caching, and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->