### PR TITLE
fix: BQ duplicate pageSize param + correlated subquery — dashboard/traces broken

### DIFF
--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -500,7 +500,6 @@ func (s *Store) QueryTraces(ctx context.Context, tq storage.TraceQuery) (*storag
 		{Name: "startTime", Value: tq.StartTime},
 		{Name: "endTime", Value: tq.EndTime},
 		{Name: "userID", Value: tq.UserID},
-		{Name: "pageSize", Value: tq.PageSize},
 	}
 	if tq.Environment != "" {
 		extraWhere += "\n\t\t  AND environment = @environment"
@@ -1192,31 +1191,34 @@ func (s *Store) GetTenantLeaderboard(ctx context.Context, uq storage.UsageQuery,
 }
 
 func (s *Store) GetJobLeaderboard(ctx context.Context, uq storage.UsageQuery, limit int) ([]storage.JobUsageSummary, error) {
-	query := fmt.Sprintf(`SELECT job_id, COUNT(DISTINCT trace_id) AS call_count,
-		COALESCE(SUM(gen_ai_total_tokens),0) AS total_tokens,
-		COALESCE(SUM(gen_ai_cost_usd),0) AS total_cost_usd,
+	query := fmt.Sprintf(`WITH top_models AS (
+		SELECT job_id, gen_ai_model,
+			SUM(gen_ai_cost_usd) AS model_cost,
+			ROW_NUMBER() OVER (PARTITION BY job_id ORDER BY SUM(gen_ai_cost_usd) DESC) AS rn
+		FROM %s
+		WHERE (@projectID = '' OR project_id = @projectID)
+			AND start_time >= @startTime
+			AND start_time <= @endTime
+			AND gen_ai_model IS NOT NULL AND gen_ai_model != ''
+			AND job_id IS NOT NULL AND job_id != ''
+		GROUP BY job_id, gen_ai_model
+	)
+	SELECT spans.job_id, COUNT(DISTINCT spans.trace_id) AS call_count,
+		COALESCE(SUM(spans.gen_ai_total_tokens),0) AS total_tokens,
+		COALESCE(SUM(spans.gen_ai_cost_usd),0) AS total_cost_usd,
 		COALESCE(
-			AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
-			AVG(CASE WHEN kind = @llmKind THEN duration_ns ELSE NULL END),
+			AVG(CASE WHEN spans.parent_span_id = '' THEN spans.duration_ns ELSE NULL END),
+			AVG(CASE WHEN spans.kind = @llmKind THEN spans.duration_ns ELSE NULL END),
 			0
 		) AS avg_duration_ns,
-		COALESCE((
-			SELECT s2.gen_ai_model FROM %s s2
-			WHERE s2.job_id = spans.job_id
-				AND (@projectID = '' OR s2.project_id = @projectID)
-				AND s2.start_time >= @startTime
-				AND s2.start_time <= @endTime
-				AND s2.gen_ai_model IS NOT NULL AND s2.gen_ai_model != ''
-			GROUP BY s2.gen_ai_model
-			ORDER BY SUM(s2.gen_ai_cost_usd) DESC
-			LIMIT 1
-		), '') AS top_model
+		COALESCE(tm.gen_ai_model, '') AS top_model
 	FROM %s spans
-	WHERE (@projectID = '' OR project_id = @projectID)
-		AND start_time >= @startTime
-		AND start_time <= @endTime
-		AND job_id IS NOT NULL AND job_id != ''
-	GROUP BY job_id
+	LEFT JOIN top_models tm ON tm.job_id = spans.job_id AND tm.rn = 1
+	WHERE (@projectID = '' OR spans.project_id = @projectID)
+		AND spans.start_time >= @startTime
+		AND spans.start_time <= @endTime
+		AND spans.job_id IS NOT NULL AND spans.job_id != ''
+	GROUP BY spans.job_id, tm.gen_ai_model
 	ORDER BY total_cost_usd DESC
 	LIMIT @limit`, quoteTable(s.tableID), quoteTable(s.tableID))
 	q := s.client.Query(query)

--- a/pkg/storage/bigquery/query_test.go
+++ b/pkg/storage/bigquery/query_test.go
@@ -419,3 +419,111 @@ func TestPing_ReturnsError(t *testing.T) {
 		t.Errorf("error = %v, want to contain 'connection refused'", err)
 	}
 }
+
+// ── Regression: duplicate parameter names (#799) ─────────────────────
+
+// assertNoDuplicateParams fails if any parameter name appears more than once.
+// BQ rejects duplicate named params with "Error 400: Duplicate query parameters".
+func assertNoDuplicateParams(t *testing.T, params []bq.QueryParameter) {
+	t.Helper()
+	seen := make(map[string]int)
+	for _, p := range params {
+		seen[p.Name]++
+	}
+	for name, count := range seen {
+		if count > 1 {
+			t.Errorf("duplicate query parameter %q (appears %d times)", name, count)
+		}
+	}
+}
+
+func TestQueryTraces_NoDuplicateParams(t *testing.T) {
+	client := newMockBQClient()
+
+	capturedQuery := &mockBQQuery{
+		iter: &mockBQRowIterator{
+			nextFunc: func(dst interface{}) error {
+				return iterator.Done
+			},
+		},
+	}
+	client.enqueueQuery(capturedQuery)
+
+	s := testStore(client)
+	_, _ = s.QueryTraces(context.Background(), storage.TraceQuery{
+		ProjectID:   "proj",
+		StartTime:   time.Now().Add(-1 * time.Hour),
+		EndTime:     time.Now(),
+		PageSize:    50,
+		Environment: "prod",
+		Model:       "gpt-4",
+		Provider:    "openai",
+		Search:      "hello",
+		JobID:       "job-1",
+		TraceGroup:  "group-1",
+		TenantID:    "tenant-1",
+	})
+
+	assertNoDuplicateParams(t, capturedQuery.params)
+}
+
+func TestSearchSpans_NoDuplicateParams(t *testing.T) {
+	client := newMockBQClient()
+
+	capturedQuery := &mockBQQuery{
+		iter: &mockBQRowIterator{
+			nextFunc: func(dst interface{}) error {
+				return iterator.Done
+			},
+		},
+	}
+	client.enqueueQuery(capturedQuery)
+
+	s := testStore(client)
+	_, _ = s.SearchSpans(context.Background(), storage.SpanQuery{
+		ProjectID: "proj",
+		StartTime: time.Now().Add(-1 * time.Hour),
+		EndTime:   time.Now(),
+		PageSize:  50,
+		UserID:    "user@test.com",
+		TenantID:  "tenant-1",
+	})
+
+	assertNoDuplicateParams(t, capturedQuery.params)
+}
+
+// ── Regression: correlated subquery in job leaderboard (#799) ────────
+
+func TestGetJobLeaderboard_UsesCTENotCorrelatedSubquery(t *testing.T) {
+	client := newMockBQClient()
+
+	capturedQuery := &mockBQQuery{
+		iter: &mockBQRowIterator{
+			nextFunc: func(dst interface{}) error {
+				return iterator.Done
+			},
+		},
+	}
+	client.enqueueQuery(capturedQuery)
+
+	s := testStore(client)
+	_, _ = s.GetJobLeaderboard(context.Background(), storage.UsageQuery{
+		ProjectID: "proj",
+		StartTime: time.Now().Add(-1 * time.Hour),
+		EndTime:   time.Now(),
+	}, 10)
+
+	sql := capturedQuery.sql
+
+	// Must use CTE pattern, not correlated subquery.
+	assertContains(t, sql, "WITH top_models AS")
+	assertContains(t, sql, "LEFT JOIN top_models")
+	assertContains(t, sql, "ROW_NUMBER()")
+
+	// Must NOT contain correlated subquery pattern.
+	if strings.Contains(sql, "s2.job_id = spans.job_id") {
+		t.Error("SQL still contains correlated subquery pattern 's2.job_id = spans.job_id'")
+	}
+
+	assertNoDuplicateParams(t, capturedQuery.params)
+}

--- a/pkg/storage/bigquery/query_test.go
+++ b/pkg/storage/bigquery/query_test.go
@@ -181,13 +181,13 @@ func TestQueryTraces_DefaultPageSize(t *testing.T) {
 		PageSize:  0, // should default to 20
 	})
 
-	// Check that pageSize parameter was set to 20.
+	// Check that pageSize parameter was set to 21 (default 20 + 1 for has-more-pages detection).
 	for _, p := range capturedQuery.params {
 		if p.Name == "pageSize" {
-			if v, ok := p.Value.(int); ok && v == 20 {
-				return // correct default
+			if v, ok := p.Value.(int); ok && v == 21 {
+				return // correct: default 20 + 1
 			}
-			t.Errorf("pageSize = %v, want 20", p.Value)
+			t.Errorf("pageSize = %v, want 21", p.Value)
 			return
 		}
 	}


### PR DESCRIPTION
## 🚨 Production Hotfix

Dashboard and Traces pages are returning `[internal] internal error` on both staging and production.

## Root Cause

Diagnosed from Cloud Run logs (`gcloud logging read`):

### Bug 1: Duplicate `pageSize` query parameter
```
querying traces: googleapi: Error 400: Duplicate query parameters named pageSize, invalid
```

`QueryTraces` added `pageSize` twice:
- Line 503: `{Name: "pageSize", Value: tq.PageSize}` (initial params)
- Line 547: `{Name: "pageSize", Value: tq.PageSize + 1}` (for LIMIT n+1 has-more-pages trick)

BQ started rejecting duplicate named parameters. **Fix**: removed the first one — the `+1` version at line 547 is the one actually used by the LIMIT clause.

### Bug 2: Correlated subquery in job leaderboard
```
querying job leaderboard: googleapi: Error 400: Correlated subqueries that reference other tables are not supported unless they can be de-correlated
```

`GetJobLeaderboard` used `WHERE s2.job_id = spans.job_id` inside a scalar subquery. BQ doesn't support correlated subqueries referencing other tables. **Fix**: rewrote using a CTE with `ROW_NUMBER() OVER (PARTITION BY job_id)` + `LEFT JOIN`.

## Changes

| File | Change |
|:---|:---|
| `pkg/storage/bigquery/bigquery.go` | Remove duplicate pageSize param, rewrite job leaderboard CTE |
| `pkg/storage/bigquery/query_test.go` | Update expected pageSize from 20 → 21 (accounts for +1) |

## Introduced By

- Duplicate pageSize: [#755](https://github.com/candelahq/candela/pull/755) (cursor-based pagination)
- Correlated subquery: unclear — may have worked in an older BQ API version

Closes the dashboard/traces production outage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved trace list pagination so results correctly include an additional item for detecting whether more pages are available.
  - Improved job leaderboard results by consistently identifying and displaying the highest-cost model associated with each job.
  - Updated pagination behavior to provide more reliable navigation when browsing trace results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->