### PR TITLE
security: fail closed on /debug/metrics when userStore is nil (CWE-862)

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -398,7 +398,14 @@ func main() {
 	// Requires admin role — exposes dropped span counts and spend data (#706).
 	mux.HandleFunc("/debug/metrics", func(w http.ResponseWriter, r *http.Request) {
 		// Admin-only guard: look up caller role from userStore.
-		if userStore != nil {
+		// Fail closed: if userStore is nil (Firestore disabled) and not in
+		// dev mode, deny access entirely (#706, CWE-862).
+		if userStore == nil {
+			if !cfg.Auth.DevMode {
+				http.Error(w, "admin access required (user store not configured)", http.StatusForbidden)
+				return
+			}
+		} else {
 			caller := auth.FromContext(r.Context())
 			if caller == nil {
 				http.Error(w, "authentication required", http.StatusUnauthorized)


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review feedback from [PR #801](https://github.com/candelahq/candela/pull/801#pullrequestreview-5047961679).

### Problem

When Firestore is disabled (`userStore == nil`) in non-dev mode, the `/debug/metrics` admin guard was completely skipped — any authenticated user could access sensitive metrics (dropped span counts, SA spend data). This is CWE-862: Missing Authorization.

### Fix

Fail closed:

| Condition | Result |
|:---|:---|
| `userStore == nil` + dev mode | ✅ Allow (solo developer) |
| `userStore == nil` + prod mode | ❌ 403 Forbidden |
| `userStore` set + admin role | ✅ Allow |
| `userStore` set + non-admin | ❌ 403 Forbidden |
| `userStore` set + storage error | ❌ 500 Internal Server Error |

### Audit of similar patterns

Scanned all `userStore != nil` guards in `main.go` (lines 533, 561, 864, 1090). The other four are **feature wiring** (audit interceptors, task spend API, proxy user store, user authorizer) — they enable optional features when Firestore is available but don't gate security-sensitive endpoints. No other authorization bypass found.

## Type of Change
- [x] Security fix

## Testing
- `go build ./cmd/candela-server/` — compiles clean
- `go test ./cmd/candela-server/ -count=1` — all pass
- Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved access protection for the `/debug/metrics` endpoint.
  - Requests are now denied by default when authorization is unavailable, while development mode continues to allow access for testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->