### PR TITLE
fix: 7 security and correctness fixes (#661 #659 #658 #660 #716 #657 #655)

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -1428,7 +1428,12 @@ func corsMiddleware(next http.Handler, origins []string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
 
-		if allowAll {
+		if allowAll && origin != "" {
+			// Reflect the request origin instead of "*" because the CORS spec
+			// forbids wildcard when credentials (Authorization) are in play (#659).
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Add("Vary", "Origin")
+		} else if allowAll {
 			w.Header().Set("Access-Control-Allow-Origin", "*")
 		} else if allowed[origin] {
 			w.Header().Set("Access-Control-Allow-Origin", origin)

--- a/cmd/candela-sidecar/main.go
+++ b/cmd/candela-sidecar/main.go
@@ -421,7 +421,12 @@ func corsMiddleware(next http.Handler, origins []string) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
-		if allowAll {
+		if allowAll && origin != "" {
+			// Reflect the request origin instead of "*" because the CORS spec
+			// forbids wildcard when credentials (Authorization) are in play (#659).
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Add("Vary", "Origin")
+		} else if allowAll {
 			w.Header().Set("Access-Control-Allow-Origin", "*")
 		} else if allowed[origin] {
 			w.Header().Set("Access-Control-Allow-Origin", origin)

--- a/cmd/candela-sidecar/sidecar_integration_test.go
+++ b/cmd/candela-sidecar/sidecar_integration_test.go
@@ -92,6 +92,11 @@ func TestSidecar_CORSHeaders(t *testing.T) {
 	if allowOrigin != "http://example.com" {
 		t.Errorf("Access-Control-Allow-Origin = %q, want %q", allowOrigin, "http://example.com")
 	}
+
+	// Reflected origins must include Vary: Origin for correct cache behavior.
+	if vary := resp.Header.Get("Vary"); !strings.Contains(vary, "Origin") {
+		t.Errorf("Vary header = %q, want it to contain 'Origin'", vary)
+	}
 }
 
 // TestSidecar_ProviderFiltering verifies that the parseHeaders and envOr

--- a/cmd/candela-sidecar/sidecar_integration_test.go
+++ b/cmd/candela-sidecar/sidecar_integration_test.go
@@ -87,8 +87,10 @@ func TestSidecar_CORSHeaders(t *testing.T) {
 	}
 
 	allowOrigin := resp.Header.Get("Access-Control-Allow-Origin")
-	if allowOrigin != "*" {
-		t.Errorf("Access-Control-Allow-Origin = %q, want *", allowOrigin)
+	// When wildcard is configured and Origin is present, we reflect the origin
+	// instead of "*" to comply with the CORS spec for credentialed requests (#659).
+	if allowOrigin != "http://example.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", allowOrigin, "http://example.com")
 	}
 }
 

--- a/pkg/connecthandlers/dashboard_handler.go
+++ b/pkg/connecthandlers/dashboard_handler.go
@@ -85,6 +85,14 @@ func (h *DashboardHandler) GetModelBreakdown(
 			q.EndTime = msg.TimeRange.End.AsTime()
 		}
 	}
+	// Default to last 24 hours if no time range specified (#655).
+	// Prevents full-table scans on BigQuery and empty results on DuckDB/SQLite.
+	if q.StartTime.IsZero() {
+		q.StartTime = time.Now().Add(-24 * time.Hour)
+	}
+	if q.EndTime.IsZero() {
+		q.EndTime = time.Now()
+	}
 
 	models, err := h.store.GetModelBreakdown(ctx, q)
 	if err != nil {

--- a/pkg/connecthandlers/usercache.go
+++ b/pkg/connecthandlers/usercache.go
@@ -29,9 +29,10 @@ import (
 // #B: Negative entries (user not found) are cached with a 5-second TTL to
 // prevent a thundering herd of Firestore reads when a user is not yet provisioned.
 type userIDCache struct {
-	mu      sync.RWMutex
-	entries map[string]userIDEntry
-	stop    chan struct{}
+	mu        sync.RWMutex
+	entries   map[string]userIDEntry
+	stop      chan struct{}
+	closeOnce sync.Once
 }
 
 type userIDEntry struct {
@@ -69,14 +70,9 @@ var globalUserIDCache = func() *userIDCache {
 }()
 
 // Close stops the background eviction goroutine (#657).
-// Safe to call multiple times.
+// Safe to call multiple times and concurrently.
 func (c *userIDCache) Close() {
-	select {
-	case <-c.stop:
-		// Already closed.
-	default:
-		close(c.stop)
-	}
+	c.closeOnce.Do(func() { close(c.stop) })
 }
 
 // evictExpired removes all entries whose TTL has elapsed. Called by the

--- a/pkg/connecthandlers/usercache.go
+++ b/pkg/connecthandlers/usercache.go
@@ -31,6 +31,7 @@ import (
 type userIDCache struct {
 	mu      sync.RWMutex
 	entries map[string]userIDEntry
+	stop    chan struct{}
 }
 
 type userIDEntry struct {
@@ -48,18 +49,35 @@ const (
 var globalUserIDCache = func() *userIDCache {
 	c := &userIDCache{
 		entries: make(map[string]userIDEntry),
+		stop:    make(chan struct{}),
 	}
 	// Background goroutine: sweep expired entries every 30 seconds.
 	// This keeps write-path critical sections O(1) — no per-write map scan.
 	go func() {
 		ticker := time.NewTicker(userIDCacheSweepPeriod)
 		defer ticker.Stop()
-		for range ticker.C {
-			c.evictExpired()
+		for {
+			select {
+			case <-ticker.C:
+				c.evictExpired()
+			case <-c.stop:
+				return
+			}
 		}
 	}()
 	return c
 }()
+
+// Close stops the background eviction goroutine (#657).
+// Safe to call multiple times.
+func (c *userIDCache) Close() {
+	select {
+	case <-c.stop:
+		// Already closed.
+	default:
+		close(c.stop)
+	}
+}
 
 // evictExpired removes all entries whose TTL has elapsed. Called by the
 // background sweep goroutine; must not be called while already holding the lock.

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -816,8 +816,8 @@ func (c *Calculator) loadDefaults() {
 		if m.Provider == "" || m.Model == "" {
 			panic(fmt.Sprintf("costcalc: pricing.yaml entry %d: provider and model are required", i))
 		}
-		if m.InputPerMillion <= 0 || m.OutputPerMillion <= 0 {
-			panic(fmt.Sprintf("costcalc: pricing.yaml entry %d (%s/%s): prices must be > 0", i, m.Provider, m.Model))
+		if m.InputPerMillion <= 0 || m.OutputPerMillion < 0 {
+			panic(fmt.Sprintf("costcalc: pricing.yaml entry %d (%s/%s): input price must be > 0, output price must be >= 0", i, m.Provider, m.Model))
 		}
 	}
 	for _, m := range pf.Models {

--- a/pkg/costcalc/drift_test.go
+++ b/pkg/costcalc/drift_test.go
@@ -120,8 +120,8 @@ func TestPricingYAMLValid(t *testing.T) {
 		if m.InputPerMillion <= 0 {
 			t.Errorf("entry %d (%s/%s): input_per_million must be > 0", i, m.Provider, m.Model)
 		}
-		if m.OutputPerMillion <= 0 {
-			t.Errorf("entry %d (%s/%s): output_per_million must be > 0", i, m.Provider, m.Model)
+		if m.OutputPerMillion < 0 {
+			t.Errorf("entry %d (%s/%s): output_per_million must be >= 0", i, m.Provider, m.Model)
 		}
 	}
 }

--- a/pkg/costcalc/pricing.yaml
+++ b/pkg/costcalc/pricing.yaml
@@ -234,3 +234,48 @@ models:
     model: grok-4.20-non-reasoning
     input_per_million: 1.25
     output_per_million: 2.50
+
+  # ── Embedding Models (#716) ───────────────────────────────
+  # Embedding models produce vectors, not tokens — output price is 0.
+  - provider: openai
+    model: text-embedding-3-small
+    input_per_million: 0.02
+    output_per_million: 0.02
+
+  - provider: openai
+    model: text-embedding-3-large
+    input_per_million: 0.13
+    output_per_million: 0.13
+
+  - provider: openai
+    model: text-embedding-ada-002
+    input_per_million: 0.10
+    output_per_million: 0.10
+
+  - provider: google
+    model: text-embedding-004
+    input_per_million: 0.025
+    output_per_million: 0.025
+
+  - provider: google
+    model: text-embedding-005
+    input_per_million: 0.025
+    output_per_million: 0.025
+
+  # ── Image Generation Models (#716) ────────────────────────
+  # Image models are priced per-image, but we track via input tokens.
+  # These prices approximate the per-1K-token equivalent of per-image pricing.
+  - provider: openai
+    model: dall-e-3
+    input_per_million: 40.00
+    output_per_million: 40.00
+
+  - provider: openai
+    model: dall-e-2
+    input_per_million: 20.00
+    output_per_million: 20.00
+
+  - provider: google
+    model: imagen-3.0-generate-002
+    input_per_million: 25.00
+    output_per_million: 25.00

--- a/pkg/costcalc/pricing.yaml
+++ b/pkg/costcalc/pricing.yaml
@@ -240,27 +240,27 @@ models:
   - provider: openai
     model: text-embedding-3-small
     input_per_million: 0.02
-    output_per_million: 0.02
+    output_per_million: 0
 
   - provider: openai
     model: text-embedding-3-large
     input_per_million: 0.13
-    output_per_million: 0.13
+    output_per_million: 0
 
   - provider: openai
     model: text-embedding-ada-002
     input_per_million: 0.10
-    output_per_million: 0.10
+    output_per_million: 0
 
   - provider: google
     model: text-embedding-004
     input_per_million: 0.025
-    output_per_million: 0.025
+    output_per_million: 0
 
   - provider: google
     model: text-embedding-005
     input_per_million: 0.025
-    output_per_million: 0.025
+    output_per_million: 0
 
   # ── Image Generation Models (#716) ────────────────────────
   # Image models are priced per-image, but we track via input tokens.

--- a/pkg/costcalc/testdata/pricing_snapshot.json
+++ b/pkg/costcalc/testdata/pricing_snapshot.json
@@ -132,6 +132,24 @@
     "output_per_million": 7.5
   },
   {
+    "model": "imagen-3.0-generate-002",
+    "provider": "google",
+    "input_per_million": 25,
+    "output_per_million": 25
+  },
+  {
+    "model": "text-embedding-004",
+    "provider": "google",
+    "input_per_million": 0.025,
+    "output_per_million": 0.025
+  },
+  {
+    "model": "text-embedding-005",
+    "provider": "google",
+    "input_per_million": 0.025,
+    "output_per_million": 0.025
+  },
+  {
     "model": "llama-4-maverick-17b-128e-instruct-maas",
     "provider": "meta",
     "input_per_million": 0.2,
@@ -160,6 +178,18 @@
     "provider": "mistral",
     "input_per_million": 0.1,
     "output_per_million": 0.3
+  },
+  {
+    "model": "dall-e-2",
+    "provider": "openai",
+    "input_per_million": 20,
+    "output_per_million": 20
+  },
+  {
+    "model": "dall-e-3",
+    "provider": "openai",
+    "input_per_million": 40,
+    "output_per_million": 40
   },
   {
     "model": "gpt-4.1",
@@ -202,6 +232,24 @@
     "provider": "openai",
     "input_per_million": 1.1,
     "output_per_million": 4.4
+  },
+  {
+    "model": "text-embedding-3-large",
+    "provider": "openai",
+    "input_per_million": 0.13,
+    "output_per_million": 0.13
+  },
+  {
+    "model": "text-embedding-3-small",
+    "provider": "openai",
+    "input_per_million": 0.02,
+    "output_per_million": 0.02
+  },
+  {
+    "model": "text-embedding-ada-002",
+    "provider": "openai",
+    "input_per_million": 0.1,
+    "output_per_million": 0.1
   },
   {
     "model": "qwen3-235b-a22b-instruct-2507-maas",

--- a/pkg/costcalc/testdata/pricing_snapshot.json
+++ b/pkg/costcalc/testdata/pricing_snapshot.json
@@ -141,13 +141,13 @@
     "model": "text-embedding-004",
     "provider": "google",
     "input_per_million": 0.025,
-    "output_per_million": 0.025
+    "output_per_million": 0
   },
   {
     "model": "text-embedding-005",
     "provider": "google",
     "input_per_million": 0.025,
-    "output_per_million": 0.025
+    "output_per_million": 0
   },
   {
     "model": "llama-4-maverick-17b-128e-instruct-maas",
@@ -237,19 +237,19 @@
     "model": "text-embedding-3-large",
     "provider": "openai",
     "input_per_million": 0.13,
-    "output_per_million": 0.13
+    "output_per_million": 0
   },
   {
     "model": "text-embedding-3-small",
     "provider": "openai",
     "input_per_million": 0.02,
-    "output_per_million": 0.02
+    "output_per_million": 0
   },
   {
     "model": "text-embedding-ada-002",
     "provider": "openai",
     "input_per_million": 0.1,
-    "output_per_million": 0.1
+    "output_per_million": 0
   },
   {
     "model": "qwen3-235b-a22b-instruct-2507-maas",

--- a/pkg/runtime/ollama/ollama.go
+++ b/pkg/runtime/ollama/ollama.go
@@ -88,6 +88,7 @@ func (r *Runtime) Stop(ctx context.Context) error {
 	}
 
 	// Wait for the process to exit, with a grace period.
+	// Also honor caller context cancellation.
 	done := make(chan error, 1)
 	go func() { done <- r.cmd.Wait() }()
 
@@ -95,6 +96,10 @@ func (r *Runtime) Stop(ctx context.Context) error {
 	select {
 	case <-done:
 		// Exited cleanly.
+	case <-ctx.Done():
+		// Caller cancelled — force kill immediately.
+		_ = r.cmd.Process.Kill()
+		<-done
 	case <-time.After(gracePeriod):
 		// Grace period expired — force kill.
 		_ = r.cmd.Process.Kill()

--- a/pkg/runtime/ollama/ollama.go
+++ b/pkg/runtime/ollama/ollama.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/candelahq/candela/pkg/runtime"
@@ -69,16 +70,37 @@ func (r *Runtime) Start(ctx context.Context) error {
 	return runtime.WaitHealthy(ctx, r.baseURL(), 500*time.Millisecond, 30*time.Second)
 }
 
-// Stop terminates the Ollama process.
+// Stop terminates the Ollama process gracefully (#661).
+// Sends SIGTERM first, waits up to 5 seconds for clean shutdown
+// (GPU memory release, inference drain), then falls back to SIGKILL.
 func (r *Runtime) Stop(ctx context.Context) error {
 	if r.cmd == nil || r.cmd.Process == nil {
 		return nil
 	}
-	if err := r.cmd.Process.Kill(); err != nil {
-		return fmt.Errorf("ollama: stop: %w", err)
+
+	// Try graceful shutdown first.
+	if err := r.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		// Process may already be dead — try Kill as fallback.
+		_ = r.cmd.Process.Kill()
+		_ = r.cmd.Wait()
+		r.cmd = nil
+		return nil
 	}
-	// Wait to avoid zombie processes.
-	_ = r.cmd.Wait()
+
+	// Wait for the process to exit, with a grace period.
+	done := make(chan error, 1)
+	go func() { done <- r.cmd.Wait() }()
+
+	const gracePeriod = 5 * time.Second
+	select {
+	case <-done:
+		// Exited cleanly.
+	case <-time.After(gracePeriod):
+		// Grace period expired — force kill.
+		_ = r.cmd.Process.Kill()
+		<-done
+	}
+
 	r.cmd = nil
 	return nil
 }

--- a/pkg/runtime/vllm/vllm.go
+++ b/pkg/runtime/vllm/vllm.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os/exec"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/candelahq/candela/pkg/runtime"
@@ -93,17 +94,38 @@ func (r *Runtime) Start(ctx context.Context) error {
 	return runtime.WaitHealthy(ctx, r.baseURL()+"/health/ready", 2*time.Second, 5*time.Minute)
 }
 
-// Stop terminates the vLLM process.
+// Stop terminates the vLLM process gracefully (#661).
+// Sends SIGTERM first, waits up to 5 seconds for clean shutdown
+// (GPU memory release, inference drain), then falls back to SIGKILL.
 func (r *Runtime) Stop(ctx context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.cmd == nil || r.cmd.Process == nil {
 		return nil
 	}
-	if err := r.cmd.Process.Kill(); err != nil {
-		return fmt.Errorf("vllm: stop: %w", err)
+
+	// Try graceful shutdown first.
+	if err := r.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		_ = r.cmd.Process.Kill()
+		_ = r.cmd.Wait()
+		r.cmd = nil
+		return nil
 	}
-	_ = r.cmd.Wait()
+
+	// Wait for the process to exit, with a grace period.
+	done := make(chan error, 1)
+	go func() { done <- r.cmd.Wait() }()
+
+	const gracePeriod = 5 * time.Second
+	select {
+	case <-done:
+		// Exited cleanly.
+	case <-time.After(gracePeriod):
+		// Grace period expired — force kill.
+		_ = r.cmd.Process.Kill()
+		<-done
+	}
+
 	r.cmd = nil
 	return nil
 }

--- a/pkg/runtime/vllm/vllm.go
+++ b/pkg/runtime/vllm/vllm.go
@@ -113,6 +113,7 @@ func (r *Runtime) Stop(ctx context.Context) error {
 	}
 
 	// Wait for the process to exit, with a grace period.
+	// Also honor caller context cancellation.
 	done := make(chan error, 1)
 	go func() { done <- r.cmd.Wait() }()
 
@@ -120,6 +121,10 @@ func (r *Runtime) Stop(ctx context.Context) error {
 	select {
 	case <-done:
 		// Exited cleanly.
+	case <-ctx.Done():
+		// Caller cancelled — force kill immediately.
+		_ = r.cmd.Process.Kill()
+		<-done
 	case <-time.After(gracePeriod):
 		// Grace period expired — force kill.
 		_ = r.cmd.Process.Kill()

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -1316,7 +1316,12 @@ func buildTrace(traceID string, spans []storage.Span) *storage.Trace {
 }
 
 // quoteTable wraps a fully-qualified table ID in backticks for BigQuery SQL.
-// Escapes any embedded backticks to prevent SQL injection via config values.
+// Strips any embedded backticks to prevent SQL injection via config values —
+// BigQuery does not support escaping backticks within quoted identifiers.
 func quoteTable(tableID string) string {
-	return "`" + strings.ReplaceAll(tableID, "`", "\\`") + "`"
+	cleaned := strings.ReplaceAll(tableID, "`", "")
+	if cleaned == "" {
+		return "``" // will produce a clear SQL error rather than silent injection
+	}
+	return "`" + cleaned + "`"
 }

--- a/pkg/storage/bigquery/bigquery_test.go
+++ b/pkg/storage/bigquery/bigquery_test.go
@@ -15,7 +15,7 @@ func TestQuoteTable(t *testing.T) {
 	}{
 		{"simple", "project.dataset.table", "`project.dataset.table`"},
 		{"already safe", "my_project.spans.traces", "`my_project.spans.traces`"},
-		{"embedded backtick", "proj`.evil", "`proj\\`.evil`"},
+		{"embedded backtick stripped", "proj`.evil", "`proj.evil`"},
 		{"empty", "", "``"},
 	}
 	for _, tt := range tests {

--- a/pkg/storage/duckdb/duckdb.go
+++ b/pkg/storage/duckdb/duckdb.go
@@ -516,9 +516,10 @@ func (s *Store) GetModelBreakdown(ctx context.Context, q storage.UsageQuery) ([]
 		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
 			AND gen_ai_model != ''
 			AND (? = '' OR user_id = ?)
+			AND (? = '' OR tenant_id = ?)
 		GROUP BY gen_ai_model, gen_ai_provider
 		ORDER BY SUM(gen_ai_cost_usd) DESC
-	`, q.ProjectID, q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID)
+	`, q.ProjectID, q.ProjectID, q.StartTime, q.EndTime, q.UserID, q.UserID, q.TenantID, q.TenantID)
 	if err != nil {
 		return nil, fmt.Errorf("querying model breakdown: %w", err)
 	}
@@ -568,11 +569,13 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, q storage.UsageQuery, li
 		FROM spans
 		WHERE (? = '' OR project_id = ?) AND start_time >= ? AND start_time <= ?
 			AND user_id != ''
+			AND (? = '' OR tenant_id = ?)
 		GROUP BY user_id
 		ORDER BY SUM(gen_ai_cost_usd) DESC
 		LIMIT ?
 	`, int(storage.SpanKindLLM), q.ProjectID, q.ProjectID, q.StartTime, q.EndTime,
-		q.ProjectID, q.ProjectID, q.StartTime, q.EndTime, limit)
+		q.ProjectID, q.ProjectID, q.StartTime, q.EndTime,
+		q.TenantID, q.TenantID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying user leaderboard: %w", err)
 	}


### PR DESCRIPTION
## Summary

Seven security and correctness fixes — 1 P0, 6 P2.

### 🔴 #661 (P0) — Graceful shutdown for Ollama/vLLM runtimes

`Stop()` was sending `SIGKILL` immediately, which can corrupt GPU state and leak VRAM. Now sends `SIGTERM` first, waits up to 5 seconds for clean shutdown, then falls back to `SIGKILL`.

**Files:** `pkg/runtime/ollama/ollama.go`, `pkg/runtime/vllm/vllm.go`

### 🔴 #659 (P2) — CORS wildcard with auth headers

When wildcard `*` is configured and an `Origin` header is present, the middleware now reflects the request origin instead of literal `*`. The CORS spec forbids `Access-Control-Allow-Origin: *` when credentials (`Authorization`) are in play — browsers reject such responses.

**Files:** `cmd/candela-server/main.go`, `cmd/candela-sidecar/main.go`

### 🔴 #658 (P2) — DuckDB missing tenant filter

`GetModelBreakdown` and `GetUserLeaderboard` in DuckDB were missing `AND (? = '' OR tenant_id = ?)` filters. Multi-tenant self-hosters could see other tenants' model usage and leaderboard data.

**File:** `pkg/storage/duckdb/duckdb.go`

### 🔴 #660 (P2) — BigQuery backtick escape incorrect

`quoteTable()` used `\\`` to escape backticks, but BigQuery SQL doesn't support backslash escaping in identifiers. Now strips backticks entirely to prevent injection.

**File:** `pkg/storage/bigquery/bigquery.go`

### 🟡 #716 (P2) — Embedding and image model pricing

Added 8 models to `pricing.yaml`:
- OpenAI: text-embedding-3-small, text-embedding-3-large, ada-002, dall-e-3, dall-e-2
- Google: text-embedding-004, text-embedding-005, imagen-3.0-generate-002

### 🟡 #657 (P2) — userIDCache goroutine leak

Background sweep goroutine had no stop mechanism. Added `stop` channel and `Close()` method so the goroutine terminates on shutdown.

**File:** `pkg/connecthandlers/usercache.go`

### 🟡 #655 (P2) — GetModelBreakdown full-table scan

When `TimeRange` is nil, `StartTime`/`EndTime` defaulted to zero values, causing full-table scans on BigQuery (expensive) or empty results on DuckDB/SQLite. Now defaults to last 24 hours.

**File:** `pkg/connecthandlers/dashboard_handler.go`

## Testing
- All 8 affected packages pass: ollama, vllm, duckdb, bigquery, costcalc, connecthandlers, candela-server, candela-sidecar
- Pre-commit hooks pass (gofmt, go-vet, go-mod-tidy, check-yaml, check-json)
- Pricing snapshot updated for new models

Closes #661, closes #659, closes #658, closes #660, closes #716, closes #657, closes #655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pricing coverage for embedding and image-generation models.
  - Dashboard model breakdowns now default to the most recent 24 hours when no range is selected.
  - Added support for models with no output-token charges.

- **Bug Fixes**
  - Improved CORS handling for credentialed requests by reflecting request origins correctly.
  - Ensured usage aggregations remain scoped to the selected tenant.
  - Improved protection for invalid table identifiers.
  - Runtime services now shut down gracefully, with a forced stop only if needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->