### PR TITLE
fix: 7 backend correctness fixes (#652 #651 #649 #654 #650 #653 #648)

### DIFF
--- a/cmd/candela-server/main.go
+++ b/cmd/candela-server/main.go
@@ -1458,8 +1458,27 @@ func corsMiddleware(next http.Handler, origins []string) http.Handler {
 // validateAuthConfig checks that the auth configuration is safe for the runtime environment.
 // Returns an error if the configuration would be insecure.
 func validateAuthConfig(devMode bool, kService, cloudRunURL string) error {
-	if devMode && kService != "" {
-		return fmt.Errorf("auth.dev_mode=true is not allowed on Cloud Run (K_SERVICE=%s)", kService)
+	if devMode {
+		// Detect production environments beyond Cloud Run (#648).
+		// Any of these env vars indicate the server is running in a managed
+		// production environment where dev_mode must not be enabled.
+		prodIndicators := []struct {
+			env  string
+			desc string
+		}{
+			{"K_SERVICE", "Cloud Run"},
+			{"K_REVISION", "Cloud Run / Knative"},
+			{"KUBERNETES_SERVICE_HOST", "Kubernetes"},
+			{"ECS_CONTAINER_METADATA_URI", "AWS ECS"},
+			{"AWS_LAMBDA_FUNCTION_NAME", "AWS Lambda"},
+			{"CONTAINER_APP_NAME", "Azure Container Apps"},
+			{"GAE_ENV", "App Engine"},
+		}
+		for _, p := range prodIndicators {
+			if v := os.Getenv(p.env); v != "" {
+				return fmt.Errorf("auth.dev_mode=true is not allowed in %s (%s=%s)", p.desc, p.env, v)
+			}
+		}
 	}
 	if kService != "" && cloudRunURL == "" {
 		slog.Warn("CLOUD_RUN_URL not set on Cloud Run — Google ID token validation (Strategy 2) will be skipped; tokens will fall through to OAuth2 userinfo (slower)")

--- a/cmd/candela-server/main_test.go
+++ b/cmd/candela-server/main_test.go
@@ -21,8 +21,18 @@ func TestValidateAuthConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set K_SERVICE so validateAuthConfig can detect Cloud Run (#648).
-			t.Setenv("K_SERVICE", tt.kService)
+			// Clear all production indicators so inherited env doesn't leak (#648).
+			for _, env := range []string{
+				"K_SERVICE", "K_REVISION", "KUBERNETES_SERVICE_HOST",
+				"ECS_CONTAINER_METADATA_URI", "AWS_LAMBDA_FUNCTION_NAME",
+				"CONTAINER_APP_NAME", "GAE_ENV",
+			} {
+				t.Setenv(env, "")
+			}
+			// Set K_SERVICE for this specific test case.
+			if tt.kService != "" {
+				t.Setenv("K_SERVICE", tt.kService)
+			}
 			err := validateAuthConfig(tt.devMode, tt.kService, tt.cloudRunURL)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateAuthConfig(devMode=%v, kService=%q, cloudRunURL=%q) error = %v, wantErr %v",

--- a/cmd/candela-server/main_test.go
+++ b/cmd/candela-server/main_test.go
@@ -8,7 +8,7 @@ func TestValidateAuthConfig(t *testing.T) {
 	tests := []struct {
 		name        string
 		devMode     bool
-		kService    string
+		kService    string // set as K_SERVICE env var for the test
 		cloudRunURL string
 		wantErr     bool
 	}{
@@ -21,6 +21,8 @@ func TestValidateAuthConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Set K_SERVICE so validateAuthConfig can detect Cloud Run (#648).
+			t.Setenv("K_SERVICE", tt.kService)
 			err := validateAuthConfig(tt.devMode, tt.kService, tt.cloudRunURL)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateAuthConfig(devMode=%v, kService=%q, cloudRunURL=%q) error = %v, wantErr %v",

--- a/pkg/connecthandlers/catalog_handler.go
+++ b/pkg/connecthandlers/catalog_handler.go
@@ -129,7 +129,7 @@ func (h *CatalogHandler) UpdateModelCatalogEntry(
 	if mask := req.Msg.UpdateMask; mask != nil && len(mask.Paths) > 0 {
 		existing, err := h.store.Get(ctx, entry.Provider, entry.ModelID)
 		if err != nil {
-			if err == catalog.ErrNotFound {
+			if errors.Is(err, catalog.ErrNotFound) {
 				return nil, connect.NewError(connect.CodeNotFound,
 					fmt.Errorf("model %s/%s not found", entry.Provider, entry.ModelID))
 			}
@@ -179,7 +179,7 @@ func (h *CatalogHandler) DeleteModelCatalogEntry(
 	modelID := req.Msg.ModelId
 
 	if err := h.store.Delete(ctx, provider, modelID); err != nil {
-		if err == catalog.ErrNotFound {
+		if errors.Is(err, catalog.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound,
 				fmt.Errorf("model %s/%s not found", provider, modelID))
 		}

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -194,6 +194,9 @@ func (c *Calculator) Calculate(provider, model string, inputTokens, outputTokens
 	if !ok {
 		key := c.key(provider, model)
 		c.unknownMu.Lock()
+		if c.loggedUnknown == nil {
+			c.loggedUnknown = make(map[string]bool)
+		}
 		if !c.loggedUnknown[key] && len(c.loggedUnknown) < maxLoggedUnknown {
 			c.loggedUnknown[key] = true
 			c.unknownMu.Unlock()

--- a/pkg/costcalc/calculator.go
+++ b/pkg/costcalc/calculator.go
@@ -98,8 +98,13 @@ type Calculator struct {
 	aliases        map[string]string              // provider name aliases (e.g. "anthropic-direct" → "anthropic")
 	cacheDiscounts map[string]CacheDiscountConfig // key: canonical provider name
 	globalDiscount float64                        // 0.0–1.0
-	loggedUnknown  sync.Map                       // key: "provider/model" — track logged warnings
+	unknownMu      sync.Mutex                     // guards loggedUnknown
+	loggedUnknown  map[string]bool                // key: "provider/model" — bounded to maxLoggedUnknown (#654)
 }
+
+// maxLoggedUnknown caps the number of unique unknown model keys tracked
+// to prevent unbounded memory growth under enumeration attacks (#654).
+const maxLoggedUnknown = 1000
 
 //go:embed pricing.yaml
 var defaultPricingYAML []byte
@@ -165,6 +170,7 @@ func newBase() *Calculator {
 		fallback:       make(map[string]ModelPricing),
 		aliases:        providerAliases,
 		cacheDiscounts: make(map[string]CacheDiscountConfig),
+		loggedUnknown:  make(map[string]bool),
 	}
 	// Copy default cache discounts.
 	for k, v := range defaultCacheDiscounts {
@@ -187,13 +193,18 @@ func (c *Calculator) Calculate(provider, model string, inputTokens, outputTokens
 	p, ok := c.resolve(provider, model)
 	if !ok {
 		key := c.key(provider, model)
-		if _, alreadyLogged := c.loggedUnknown.LoadOrStore(key, true); !alreadyLogged {
+		c.unknownMu.Lock()
+		if !c.loggedUnknown[key] && len(c.loggedUnknown) < maxLoggedUnknown {
+			c.loggedUnknown[key] = true
+			c.unknownMu.Unlock()
 			slog.Warn("⚠️ missing pricing for cloud model — cost will be $0.00 (inaccurate)",
 				"provider", provider,
 				"model", model,
 				"input_tokens", inputTokens,
 				"output_tokens", outputTokens,
 			)
+		} else {
+			c.unknownMu.Unlock()
 		}
 		return 0 // Unknown model — this is a gap, not a feature
 	}

--- a/pkg/notify/notifier.go
+++ b/pkg/notify/notifier.go
@@ -49,6 +49,8 @@ func (d DeductResult) Ratio() float64 {
 		return 0 // unlimited — no alerts
 	}
 	if d.LimitUSD < 0 {
+		slog.Warn("negative budget limit detected — treating as over budget",
+			"spent_usd", d.SpentUSD, "limit_usd", d.LimitUSD)
 		return 2.0 // data integrity error — treat as over budget
 	}
 	return d.SpentUSD / d.LimitUSD

--- a/pkg/notify/notifier.go
+++ b/pkg/notify/notifier.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -41,9 +42,14 @@ type DeductResult struct {
 }
 
 // Ratio returns the spend-to-limit ratio (0.0–1.0+).
+// Returns 0 when LimitUSD is zero (unlimited / not set).
+// Returns > 1.0 when LimitUSD is negative (data error) to ensure alerts fire (#652).
 func (d DeductResult) Ratio() float64 {
-	if d.LimitUSD <= 0 {
-		return 0
+	if d.LimitUSD == 0 {
+		return 0 // unlimited — no alerts
+	}
+	if d.LimitUSD < 0 {
+		return 2.0 // data integrity error — treat as over budget
 	}
 	return d.SpentUSD / d.LimitUSD
 }
@@ -84,8 +90,17 @@ func (c *BudgetChecker) CheckAndNotify(ctx context.Context, userID, email, perio
 	var alerts []storage.BudgetAlert
 
 	c.mu.Lock()
+	// Evict stale period entries to prevent unbounded growth.
 	if c.currentPeriod != periodKey {
-		c.sent = make(map[string]bool)
+		// Only evict entries from the OLD period — don't wipe all users (#651).
+		old := c.currentPeriod
+		if old != "" {
+			for k := range c.sent {
+				if strings.HasPrefix(k, old+":") {
+					delete(c.sent, k)
+				}
+			}
+		}
 		c.currentPeriod = periodKey
 	}
 
@@ -94,7 +109,8 @@ func (c *BudgetChecker) CheckAndNotify(ctx context.Context, userID, email, perio
 			continue
 		}
 
-		key := fmt.Sprintf("%s:%.2f", userID, threshold)
+		// Include periodKey so users in different periods don't collide.
+		key := fmt.Sprintf("%s:%s:%.2f", periodKey, userID, threshold)
 		if c.sent[key] {
 			continue
 		}

--- a/pkg/proxy/cost_gate.go
+++ b/pkg/proxy/cost_gate.go
@@ -193,13 +193,23 @@ func estimateRequestCost(calc *costcalc.Calculator, provider, model string, reqB
 
 // countBase64Images counts approximate number of base64-encoded images in a
 // request body by looking for common patterns across OpenAI, Anthropic, and
-// Google vision API formats.
+// Google vision API formats. Avoids double-counting when both patterns match (#649).
 func countBase64Images(body []byte) int {
-	count := 0
 	// OpenAI/Gemini: "data:image/..."
-	count += bytes.Count(body, []byte("data:image/"))
+	dataImageCount := bytes.Count(body, []byte("data:image/"))
+
 	// Anthropic: "type": "image" + "source": {"type": "base64", ...}
-	count += bytes.Count(body, []byte(`"type":"base64"`))
-	count += bytes.Count(body, []byte(`"type": "base64"`))
-	return count
+	// Only count these if we didn't already find data:image/ patterns,
+	// since Anthropic base64 images can also contain data:image/ URIs.
+	anthropicCount := bytes.Count(body, []byte(`"type":"base64"`)) +
+		bytes.Count(body, []byte(`"type": "base64"`))
+
+	if dataImageCount > 0 && anthropicCount > 0 {
+		// Both patterns present — use the larger count to avoid double-counting.
+		if anthropicCount > dataImageCount {
+			return anthropicCount
+		}
+		return dataImageCount
+	}
+	return dataImageCount + anthropicCount
 }

--- a/pkg/proxy/cost_gate_test.go
+++ b/pkg/proxy/cost_gate_test.go
@@ -452,7 +452,7 @@ func TestCountBase64Images(t *testing.T) {
 		{"two openai images", `data:image/png;base64,abc data:image/jpeg;base64,def`, 2},
 		{"anthropic base64", `{"type":"base64","media_type":"image/jpeg","data":"abc..."}`, 1},
 		{"anthropic base64 spaced", `{"type": "base64", "media_type": "image/jpeg"}`, 1},
-		{"mixed", `data:image/png;base64,x "type":"base64" data:image/jpeg;base64,y`, 3},
+		{"mixed", `data:image/png;base64,x "type":"base64" data:image/jpeg;base64,y`, 2},
 	}
 
 	for _, tt := range tests {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -258,7 +258,9 @@ type Proxy struct {
 	fallbackResolver *FallbackResolver
 
 	// Optional dependencies for team-mode features.
-	// Protected by setupMu for safe concurrent access (#650).
+	// Protected by setupMu for safe concurrent writes during startup (#650).
+	// Reads are safe without RLock because setters are called before
+	// ListenAndServe — the HTTP server's Start acts as a happens-before barrier.
 	setupMu  sync.RWMutex
 	users    storage.UserStore         // Budget deduction (nil = no budget tracking)
 	budgetCk *notify.BudgetChecker     // Budget threshold notifications (nil = no alerts)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -258,6 +258,8 @@ type Proxy struct {
 	fallbackResolver *FallbackResolver
 
 	// Optional dependencies for team-mode features.
+	// Protected by setupMu for safe concurrent access (#650).
+	setupMu  sync.RWMutex
 	users    storage.UserStore         // Budget deduction (nil = no budget tracking)
 	budgetCk *notify.BudgetChecker     // Budget threshold notifications (nil = no alerts)
 	catalog  catalog.ModelCatalogStore // Access gate lookups (nil = gates skipped)
@@ -477,6 +479,8 @@ func New(cfg Config, submitter SpanSubmitter, calc *costcalc.Calculator) (*Proxy
 // Also initializes the per-user model limit cache (#721) so the proxy
 // can merge Firestore limits with YAML defaults in the pre-flight gate.
 func (p *Proxy) SetUserStore(users storage.UserStore) {
+	p.setupMu.Lock()
+	defer p.setupMu.Unlock()
 	p.users = users
 	if users != nil {
 		p.modelLimits = newModelLimitCache(users, 60*time.Second)
@@ -490,11 +494,15 @@ func (p *Proxy) SetUserStore(users storage.UserStore) {
 
 // SetBudgetChecker sets the optional BudgetChecker for threshold notifications.
 func (p *Proxy) SetBudgetChecker(ck *notify.BudgetChecker) {
+	p.setupMu.Lock()
+	defer p.setupMu.Unlock()
 	p.budgetCk = ck
 }
 
 // SetCatalog sets the optional catalog store for access gate lookups.
 func (p *Proxy) SetCatalog(c catalog.ModelCatalogStore) {
+	p.setupMu.Lock()
+	defer p.setupMu.Unlock()
 	p.catalog = c
 }
 


### PR DESCRIPTION
## Summary

Seven backend bug fixes — all P2.

### 🔴 #652 — DeductResult.Ratio() suppresses alerts for negative limits

`Ratio()` returned 0 when `LimitUSD <= 0`, lumping negative limits (data error) with zero (unlimited). Negative limits now return 2.0 (over budget) to ensure alerts fire.

**File:** `pkg/notify/notifier.go`

### 🔴 #651 — BudgetChecker.sent clears all users on period rollover

When one user's request triggered a period change, `c.sent = make(map[string]bool)` wiped ALL users' notification state, causing duplicate alerts. Now includes `periodKey` in the key and only evicts stale period entries.

**File:** `pkg/notify/notifier.go`

### 🔴 #649 — Double-counting images in Anthropic cost estimate

`countBase64Images` added `data:image/` matches AND `"type":"base64"` matches, double-counting when a single Anthropic image matched both. Now uses `max(dataImage, anthropic)` when both are present.

**File:** `pkg/proxy/cost_gate.go`

### 🔴 #654 — loggedUnknown sync.Map grows unbounded

The `sync.Map` tracking unknown model warnings had no size cap. Under enumeration attacks, it would grow without bound. Replaced with a `map[string]bool` capped at 1000 entries, protected by `sync.Mutex`.

**File:** `pkg/costcalc/calculator.go`

### 🟡 #650 — SetUserStore/SetBudgetChecker/SetCatalog not thread-safe

Optional dependency setters on `Proxy` had no synchronization. Added `setupMu sync.RWMutex` to guard concurrent writes during startup.

**File:** `pkg/proxy/proxy.go`

### 🟡 #653 — catalog_handler uses `==` instead of `errors.Is`

`err == catalog.ErrNotFound` fails when the error is wrapped (e.g. by Firestore), returning 500 instead of 404. Changed to `errors.Is()`.

**File:** `pkg/connecthandlers/catalog_handler.go`

### 🟡 #648 — Dev mode check relies solely on K_SERVICE

`validateAuthConfig` only detected Cloud Run via `K_SERVICE`. Now checks 7 production environment indicators: Cloud Run, Knative, Kubernetes, AWS ECS, AWS Lambda, Azure Container Apps, and App Engine.

**File:** `cmd/candela-server/main.go`

## Testing
- All 5 affected packages pass: notify, proxy, costcalc, connecthandlers, candela-server
- Pre-commit hooks pass (gofmt, go-vet, go-mod-tidy)

Closes #652, closes #651, closes #649, closes #654, closes #650, closes #653, closes #648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented development authentication mode from running in managed production environments.
  - Improved handling of missing catalog entries, including wrapped errors.
  - Corrected base64 image counting to prevent duplicate billing counts.
  - Improved budget alerts for unlimited or invalid limits and across billing periods.
  - Limited repeated warnings for unknown models.

- **Reliability**
  - Improved concurrent configuration updates for more consistent proxy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->