### PR TITLE
fix: 5 infra hardening fixes (#695 #699 #701 #703 #696)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,15 @@ jobs:
       - name: Fix git ownership for Nix flake
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Cache Go modules
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: |
+            /root/go/pkg/mod
+            /root/.cache/go-build
+          key: go-mod-${{ hashFiles('go.sum') }}
+          restore-keys: go-mod-
+
       - name: Start Firestore emulator
         run: |
           nix develop . --command bash -c "
@@ -251,6 +260,15 @@ jobs:
 
       - name: Fix git ownership for Nix flake
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Cache Go modules
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: |
+            /root/go/pkg/mod
+            /root/.cache/go-build
+          key: go-mod-${{ hashFiles('go.sum') }}
+          restore-keys: go-mod-
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -324,7 +342,7 @@ jobs:
 
       - name: Test Windows-relevant packages
         shell: pwsh
-        run: go test -v ./cmd/candela/... ./pkg/runtime/... -count=1
+        run: go test -v -race -timeout 120s ./cmd/candela/... ./pkg/runtime/... -count=1
 
       - name: Build candela.exe (windows/amd64)
         shell: pwsh

--- a/.github/workflows/hurl.yml
+++ b/.github/workflows/hurl.yml
@@ -107,3 +107,10 @@ jobs:
           name: hurl-test-results
           path: test-results/
           retention-days: 7
+
+      - name: Cleanup background processes
+        if: ${{ always() }}
+        run: |
+          # Kill background servers to prevent zombie processes (#696).
+          pkill -f 'upstream.go' || true
+          pkill -f 'candela-server' || true

--- a/deploy/helm/candela-sidecar/templates/_helpers.tpl
+++ b/deploy/helm/candela-sidecar/templates/_helpers.tpl
@@ -50,3 +50,24 @@ Build comma-separated provider names for PROVIDERS env var.
 {{- end }}
 {{- join "," $names }}
 {{- end }}
+
+{{/*
+Sidecar container spec snippet for injection into user pod specs (#703).
+Includes liveness and readiness probes for Kubernetes health management.
+Usage: {{ include "candela-sidecar.container" . | nindent 8 }}
+*/}}
+{{- define "candela-sidecar.container" -}}
+- name: candela-sidecar
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  ports:
+    - containerPort: 8080
+      name: http-proxy
+      protocol: TCP
+  livenessProbe:
+    {{- toYaml .Values.probes.liveness | nindent 4 }}
+  readinessProbe:
+    {{- toYaml .Values.probes.readiness | nindent 4 }}
+  resources:
+    {{- toYaml .Values.resources | nindent 4 }}
+{{- end }}

--- a/deploy/helm/candela-sidecar/values.yaml
+++ b/deploy/helm/candela-sidecar/values.yaml
@@ -119,6 +119,26 @@ resources:
     cpu: 500m
     memory: 256Mi
 
+# Health probes for the sidecar container (#703).
+# The sidecar exposes /healthz (liveness) and /readyz (readiness) on port 8080.
+probes:
+  liveness:
+    httpGet:
+      path: /healthz
+      port: 8080
+    initialDelaySeconds: 5
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readiness:
+    httpGet:
+      path: /readyz
+      port: 8080
+    initialDelaySeconds: 3
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 2
+
 cors:
   origins: "*"
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -44,6 +44,9 @@ pre-commit:
     go-test:
       glob: "*.go"
       run: go test ./... -count=1 -timeout 30s
+    govulncheck:
+      glob: "*.{go,mod,sum}"
+      run: govulncheck ./...
     # ── Rust ──
     cargo-fmt:
       glob: "*.rs"


### PR DESCRIPTION
## Summary

Five CI/CD and infrastructure improvements — all P2.

### #695 — govulncheck in lefthook pre-commit

Catches known Go vulnerabilities before code lands. Triggers on `.go`, `.mod`, `.sum` changes.

**File:** `lefthook.yml`

### #699 — Windows `-race` + `-timeout` flags

Added `-race` and `-timeout 120s` to Windows CI smoke tests. Catches data races on Windows-specific code paths; prevents test hangs from blocking CI.

**File:** `.github/workflows/ci.yml` (line 327)

### #701 — Go module caching in container CI jobs

Added `actions/cache` for `GOMODCACHE` and `GOBUILDCACHE` to both the `go-test` matrix and `build-and-test` jobs. Key: `go-mod-${{ hashFiles('go.sum') }}`. Should significantly reduce CI times on cache hits.

**File:** `.github/workflows/ci.yml` (2 locations)

### #703 — Helm sidecar liveness/readiness probes

Added configurable liveness (`/healthz`) and readiness (`/readyz`) probes to `values.yaml`. Added `candela-sidecar.container` helper template in `_helpers.tpl` for easy injection into user pod specs.

**Files:** `deploy/helm/candela-sidecar/values.yaml`, `deploy/helm/candela-sidecar/templates/_helpers.tpl`

### #696 — Hurl E2E cleanup step

Added `always()` cleanup step that kills background `upstream.go` and `candela-server` processes after tests complete. Prevents zombie processes on the runner.

**File:** `.github/workflows/hurl.yml`

## Testing
- YAML validation passes (check-yaml hook)
- No Go code changes — CI will validate the workflow changes on push

Closes #695, closes #699, closes #701, closes #703, closes #696