### PR TITLE
fix: 6 backend bug fixes (#656 #667 #672 #670 #669 #668)

### DIFF
--- a/pkg/audit/bq_logger.go
+++ b/pkg/audit/bq_logger.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -139,7 +140,8 @@ func EnsureTable(ctx context.Context, cfg BQConfig) error {
 
 	if err := table.Create(ctx, md); err != nil {
 		// Idempotent: if table already exists, that's fine.
-		if apiErr, ok := err.(*googleapi.Error); ok && apiErr.Code == 409 {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 409 {
 			slog.Info("audit: BigQuery table already exists", "table", bqTableName)
 			return nil
 		}

--- a/pkg/cloudauth/aws.go
+++ b/pkg/cloudauth/aws.go
@@ -225,6 +225,11 @@ func (a *AWSProvider) ssoLogin(ctx context.Context) error {
 		args = append(args, "--profile", a.profile)
 	}
 
+	// Check if aws CLI is installed before attempting SSO login (#670).
+	if _, err := exec.LookPath("aws"); err != nil {
+		return fmt.Errorf("aws CLI not found in PATH — install it from https://aws.amazon.com/cli/ and try again")
+	}
+
 	cmd := exec.CommandContext(ctx, "aws", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/hubbleaudit/grpc_source.go
+++ b/pkg/hubbleaudit/grpc_source.go
@@ -75,6 +75,7 @@ type GRPCFlowSource struct {
 	mu        sync.Mutex
 	connected bool
 	lastFlow  time.Time
+	lastErr   error // set by readLoop on non-EOF stream error (#668)
 }
 
 // NewGRPCFlowSource creates a new Hubble gRPC flow source.
@@ -211,6 +212,10 @@ func (s *GRPCFlowSource) readLoop(ctx context.Context, stream grpc.ClientStream,
 		if err := stream.RecvMsg(&raw); err != nil {
 			if err != io.EOF {
 				slog.Warn("hubbleaudit: gRPC recv error", "error", err)
+				// Store error for callers to inspect via Err() (#668).
+				s.mu.Lock()
+				s.lastErr = err
+				s.mu.Unlock()
 			}
 			return
 		}
@@ -231,6 +236,15 @@ func (s *GRPCFlowSource) readLoop(ctx context.Context, stream grpc.ClientStream,
 			return
 		}
 	}
+}
+
+// Err returns the last non-EOF error from the stream, or nil if the stream
+// closed cleanly. Safe to call after the flow channel returned by Observe
+// has been closed. Follows the Scanner.Err() pattern (#668).
+func (s *GRPCFlowSource) Err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastErr
 }
 
 // ── Retry / Health ──

--- a/pkg/hubbleaudit/grpc_source.go
+++ b/pkg/hubbleaudit/grpc_source.go
@@ -103,6 +103,11 @@ func (s *GRPCFlowSource) Observe(ctx context.Context, filter FlowFilter) (<-chan
 		return nil, err
 	}
 
+	// Reset error from any prior stream (#668).
+	s.mu.Lock()
+	s.lastErr = nil
+	s.mu.Unlock()
+
 	ch := make(chan Flow, 64)
 	go s.readLoop(ctx, stream, ch)
 	return ch, nil

--- a/pkg/hubbleaudit/grpc_source.go
+++ b/pkg/hubbleaudit/grpc_source.go
@@ -72,10 +72,11 @@ type GRPCFlowSource struct {
 	cfg  GRPCFlowSourceConfig
 	conn *grpc.ClientConn
 
-	mu        sync.Mutex
-	connected bool
-	lastFlow  time.Time
-	lastErr   error // set by readLoop on non-EOF stream error (#668)
+	mu         sync.Mutex
+	connected  bool
+	lastFlow   time.Time
+	lastErr    error  // set by readLoop on non-EOF stream error (#668)
+	observeGen uint64 // incremented per Observe call; readLoop writes lastErr only for its gen
 }
 
 // NewGRPCFlowSource creates a new Hubble gRPC flow source.
@@ -103,13 +104,15 @@ func (s *GRPCFlowSource) Observe(ctx context.Context, filter FlowFilter) (<-chan
 		return nil, err
 	}
 
-	// Reset error from any prior stream (#668).
+	// Bump generation and reset error from any prior stream (#668).
 	s.mu.Lock()
+	s.observeGen++
+	gen := s.observeGen
 	s.lastErr = nil
 	s.mu.Unlock()
 
 	ch := make(chan Flow, 64)
-	go s.readLoop(ctx, stream, ch)
+	go s.readLoop(ctx, stream, ch, gen)
 	return ch, nil
 }
 
@@ -203,7 +206,7 @@ func (s *GRPCFlowSource) newStream(ctx context.Context, filter FlowFilter) (grpc
 }
 
 // readLoop reads flows from the gRPC stream and sends them to the channel.
-func (s *GRPCFlowSource) readLoop(ctx context.Context, stream grpc.ClientStream, ch chan<- Flow) {
+func (s *GRPCFlowSource) readLoop(ctx context.Context, stream grpc.ClientStream, ch chan<- Flow, gen uint64) {
 	defer close(ch)
 
 	for {
@@ -218,8 +221,12 @@ func (s *GRPCFlowSource) readLoop(ctx context.Context, stream grpc.ClientStream,
 			if err != io.EOF {
 				slog.Warn("hubbleaudit: gRPC recv error", "error", err)
 				// Store error for callers to inspect via Err() (#668).
+				// Only write if this loop's generation is still current —
+				// a newer Observe may have started a new readLoop.
 				s.mu.Lock()
-				s.lastErr = err
+				if s.observeGen == gen {
+					s.lastErr = err
+				}
 				s.mu.Unlock()
 			}
 			return

--- a/pkg/runtime/lmstudio/lmstudio.go
+++ b/pkg/runtime/lmstudio/lmstudio.go
@@ -9,9 +9,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"os/exec"
 	"sync"
 	"time"
@@ -79,7 +81,13 @@ func (r *Runtime) Stop(ctx context.Context) error {
 		defer r.mu.Unlock()
 		if r.cmd != nil && r.cmd.Process != nil {
 			if killErr := r.cmd.Process.Kill(); killErr != nil {
-				r.cmd = nil
+				if errors.Is(killErr, os.ErrProcessDone) {
+					// Process already exited — clean up normally.
+					_ = r.cmd.Wait()
+					r.cmd = nil
+					return nil
+				}
+				// Retain r.cmd so cleanup can be retried.
 				return fmt.Errorf("lmstudio: kill failed: %w", killErr)
 			}
 			_ = r.cmd.Wait()

--- a/pkg/runtime/lmstudio/lmstudio.go
+++ b/pkg/runtime/lmstudio/lmstudio.go
@@ -76,17 +76,20 @@ func (r *Runtime) Stop(ctx context.Context) error {
 	if err := stopCmd.Run(); err != nil {
 		slog.Warn("lmstudio: graceful stop failed, killing process", "error", err)
 		r.mu.Lock()
+		defer r.mu.Unlock()
 		if r.cmd != nil && r.cmd.Process != nil {
-			_ = r.cmd.Process.Kill()
+			if killErr := r.cmd.Process.Kill(); killErr != nil {
+				r.cmd = nil
+				return fmt.Errorf("lmstudio: kill failed: %w", killErr)
+			}
 			_ = r.cmd.Wait()
 		}
 		r.cmd = nil
-		r.mu.Unlock()
-	} else {
-		r.mu.Lock()
-		r.cmd = nil
-		r.mu.Unlock()
+		return nil
 	}
+	r.mu.Lock()
+	r.cmd = nil
+	r.mu.Unlock()
 	return nil
 }
 

--- a/pkg/storage/bigquery/bigquery.go
+++ b/pkg/storage/bigquery/bigquery.go
@@ -1047,25 +1047,38 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, uq storage.UsageQuery, l
 	}
 
 	query := fmt.Sprintf(`
+		WITH top_models AS (
+			SELECT user_id, gen_ai_model,
+				ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY SUM(gen_ai_cost_usd) DESC) AS rn
+			FROM %s
+			WHERE (@projectID = '' OR project_id = @projectID)
+			  AND start_time >= @startTime
+			  AND start_time <= @endTime
+			  AND user_id != ''
+			  AND gen_ai_model != ''
+			GROUP BY user_id, gen_ai_model
+		)
 		SELECT
-			user_id,
-			COUNT(DISTINCT trace_id) AS call_count,
-			COALESCE(SUM(gen_ai_total_tokens), 0) AS total_tokens,
-			COALESCE(SUM(gen_ai_cost_usd), 0) AS total_cost_usd,
+			spans.user_id,
+			COUNT(DISTINCT spans.trace_id) AS call_count,
+			COALESCE(SUM(spans.gen_ai_total_tokens), 0) AS total_tokens,
+			COALESCE(SUM(spans.gen_ai_cost_usd), 0) AS total_cost_usd,
 			COALESCE(
-				AVG(CASE WHEN parent_span_id = '' THEN duration_ns ELSE NULL END),
-				AVG(CASE WHEN kind = @llmKind THEN duration_ns ELSE NULL END),
+				AVG(CASE WHEN spans.parent_span_id = '' THEN spans.duration_ns ELSE NULL END),
+				AVG(CASE WHEN spans.kind = @llmKind THEN spans.duration_ns ELSE NULL END),
 				0
-			) AS avg_duration_ns
-		FROM %s
-		WHERE (@projectID = '' OR project_id = @projectID)
-		  AND start_time >= @startTime
-		  AND start_time <= @endTime
-		  AND user_id != ''
-		GROUP BY user_id
+			) AS avg_duration_ns,
+			COALESCE(tm.gen_ai_model, '') AS top_model
+		FROM %s AS spans
+		LEFT JOIN top_models tm ON tm.user_id = spans.user_id AND tm.rn = 1
+		WHERE (@projectID = '' OR spans.project_id = @projectID)
+		  AND spans.start_time >= @startTime
+		  AND spans.start_time <= @endTime
+		  AND spans.user_id != ''
+		GROUP BY spans.user_id, tm.gen_ai_model
 		ORDER BY total_cost_usd DESC
 		LIMIT @limit
-	`, quoteTable(s.tableID))
+	`, quoteTable(s.tableID), quoteTable(s.tableID))
 
 	q := s.client.Query(query)
 	q.SetParameters([]bigquery.QueryParameter{
@@ -1089,6 +1102,7 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, uq storage.UsageQuery, l
 			TotalTokens   int64   `bigquery:"total_tokens"`
 			TotalCostUSD  float64 `bigquery:"total_cost_usd"`
 			AvgDurationNs float64 `bigquery:"avg_duration_ns"`
+			TopModel      string  `bigquery:"top_model"`
 		}
 		err := it.Next(&row)
 		if err == iterator.Done {
@@ -1103,6 +1117,7 @@ func (s *Store) GetUserLeaderboard(ctx context.Context, uq storage.UsageQuery, l
 			TotalTokens:  row.TotalTokens,
 			CostUSD:      row.TotalCostUSD,
 			AvgLatencyMs: float64(row.AvgDurationNs) / 1e6,
+			TopModel:     row.TopModel,
 		})
 	}
 

--- a/pkg/transparent/sni.go
+++ b/pkg/transparent/sni.go
@@ -135,9 +135,14 @@ func parseClientHelloBody(data []byte) (string, error) {
 	// Parse extensions looking for SNI (type 0x0000).
 	// SECURITY: cap allocation to actual available data to prevent OOM from
 	// a malicious ClientHello with an inflated extensionsLen field.
+	// Hard cap at 16KB — legitimate ClientHello extensions never exceed this (#669).
+	const maxExtensionsAlloc = 16 * 1024
 	allocLen := int(extensionsLen)
 	if allocLen > r.Len() {
 		allocLen = r.Len()
+	}
+	if allocLen > maxExtensionsAlloc {
+		allocLen = maxExtensionsAlloc
 	}
 	extensionData := make([]byte, allocLen)
 	if _, err := r.Read(extensionData); err != nil {


### PR DESCRIPTION
## Summary

Six backend bug fixes — all P2.

### #656 — BQ GetUserLeaderboard missing TopModel

The BQ implementation didn't populate the `TopModel` field (always empty string). Added a `top_models` CTE with `ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY SUM(cost) DESC)` to find the highest-cost model per user, matching DuckDB and SQLite.

**File:** `pkg/storage/bigquery/bigquery.go`

### #667 — BQLogger EnsureTable type assertion

`err.(*googleapi.Error)` fails on wrapped errors → table creation fails even when the table already exists (409). Changed to `errors.As()`.

**File:** `pkg/audit/bq_logger.go`

### #672 — LM Studio Stop() swallows kill errors

`_ = r.cmd.Process.Kill()` discarded the error. Callers had no way to know cleanup failed. Now returns the kill error.

**File:** `pkg/runtime/lmstudio/lmstudio.go`

### #670 — AWS cloudauth generic error when CLI missing

`exec.CommandContext(ctx, "aws", ...)` produces an opaque error when the AWS CLI isn't installed. Added `exec.LookPath` check with install URL.

**File:** `pkg/cloudauth/aws.go`

### #669 — SNI parser extensionsLen no hard allocation cap

Even with the `r.Len()` cap, a large TLS buffer could still cause excessive allocation. Added 16KB hard cap — legitimate ClientHello extensions never exceed this.

**File:** `pkg/transparent/sni.go`

### #668 — hubbleaudit Observe() no error reporting

The flow channel closed silently on errors — callers couldn't distinguish clean EOF from stream failures. Added `lastErr` field and `Err()` method following the `Scanner.Err()` pattern.

**File:** `pkg/hubbleaudit/grpc_source.go`

## Testing
- All 5 affected packages pass: audit, lmstudio, cloudauth, transparent, hubbleaudit
- Build passes
- Pre-commit hooks pass

Closes #656, closes #667, closes #672, closes #670, closes #669, closes #668

### Note
**#666 (deprecated golang/protobuf)** was investigated but `github.com/golang/protobuf` is only a transitive `// indirect` dependency pulled by upstream modules — no direct imports exist in Candela code. Cannot remove until upstream deps migrate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Leaderboards now show each user’s highest-cost GenAI model.
  - Streaming flow sources expose the last encountered error for improved diagnostics.

- **Bug Fixes**
  - AWS SSO provides a clear installation message when the AWS CLI is unavailable.
  - Process shutdown failures are reported instead of silently ignored.
  - Wrapped audit errors are handled correctly when checking existing tables.

- **Performance & Reliability**
  - TLS extension processing limits memory allocation for oversized inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->