### PR TITLE
feat: budget forecast CLI + Today page UI (#795, #796)

### DIFF
--- a/cmd/candela/forecast.go
+++ b/cmd/candela/forecast.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/candelahq/candela/pkg/forecast"
+)
+
+func cmdForecast() {
+	// Parse flags.
+	jsonOutput := false
+	userID := "me"
+	for i := 0; i < len(os.Args[2:]); i++ {
+		arg := os.Args[2+i]
+		switch {
+		case arg == "--json":
+			jsonOutput = true
+		case arg == "--user" && i+1 < len(os.Args[2:]):
+			userID = os.Args[3+i]
+			i++
+		case strings.HasPrefix(arg, "--user="):
+			userID = strings.TrimPrefix(arg, "--user=")
+		}
+	}
+
+	// Use the local proxy — it forwards to the remote server with IAP auth.
+	port := resolvePort(os.Args[2:])
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// Check if proxy is running.
+	pidPath := pidFilePath()
+	if pidPath != "" {
+		data, err := os.ReadFile(pidPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error: proxy not running. Start it first:")
+			fmt.Fprintln(os.Stderr, "  candela start")
+			os.Exit(1)
+		}
+		pid, _ := fmt.Sscanf(string(data), "%d", new(int))
+		_ = pid
+	}
+
+	// Call the REST API through the local proxy.
+	url := baseURL + "/api/v1/users/" + userID + "/budget-forecast"
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: cannot reach proxy at %s\n  %v\n\nIs the proxy running? Try: candela start\n", baseURL, err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		fmt.Fprintf(os.Stderr, "Error: HTTP %d\n  %s\n", resp.StatusCode, string(body))
+		os.Exit(1)
+	}
+
+	var result forecast.Result
+	if err := json.Unmarshal(body, &result); err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing response: %v\n", err)
+		os.Exit(1)
+	}
+
+	if jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(result)
+		return
+	}
+
+	// Pretty output.
+	printForecast(result, userID)
+}
+
+func printForecast(r forecast.Result, userID string) {
+	label := userID
+	if label == "me" {
+		label = "you"
+	}
+
+	fmt.Printf("Budget Forecast for %s\n", label)
+	fmt.Println("─────────────────────────")
+
+	if r.BurnRatePerHour == 0 && r.AvgDailySpend == 0 {
+		fmt.Println("  No budget data available.")
+		fmt.Println("  This may mean no budget is configured or there's no spend history.")
+		return
+	}
+
+	// Burn rate & projection.
+	fmt.Printf("  Burn Rate: $%.2f/hr\n", r.BurnRatePerHour)
+	fmt.Printf("  Projected: $%.2f EOD", r.ProjectedEODSpend)
+	if r.WillExceedBudget {
+		fmt.Print(" ⚠️  WILL EXCEED")
+	}
+	fmt.Println()
+
+	// 7-day history sparkline.
+	if len(r.SpendHistory) > 0 {
+		fmt.Println()
+		fmt.Println("  7-Day History:")
+
+		maxSpend := 0.0
+		for _, d := range r.SpendHistory {
+			if d.SpendUSD > maxSpend {
+				maxSpend = d.SpendUSD
+			}
+		}
+		if maxSpend < 0.01 {
+			maxSpend = 0.01
+		}
+
+		for _, d := range r.SpendHistory {
+			bars := int((d.SpendUSD / maxSpend) * 10)
+			day := dayOfWeek(d.Date)
+			filled := strings.Repeat("█", bars)
+			empty := strings.Repeat("░", 10-bars)
+			fmt.Printf("    %s  %s%s  $%.2f\n", day, filled, empty, d.SpendUSD)
+		}
+	}
+
+	// Average and exhaustion.
+	fmt.Println()
+	if r.AvgDailySpend > 0 {
+		fmt.Printf("  Avg Daily: $%.2f\n", r.AvgDailySpend)
+	}
+
+	if r.DaysUntilExhaustion == 0 {
+		fmt.Println("  Exhaustion: 🚫 Budget exhausted TODAY")
+	} else if r.DaysUntilExhaustion > 0 {
+		dateStr := formatCLIDate(r.EstimatedExhaustion)
+		fmt.Printf("  Exhaustion: %s (%d days)\n", dateStr, r.DaysUntilExhaustion)
+	}
+}
+
+func dayOfWeek(dateStr string) string {
+	t, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		return dateStr[:3]
+	}
+	return t.Weekday().String()[:3]
+}
+
+func formatCLIDate(dateStr string) string {
+	t, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		return dateStr
+	}
+	return t.Format("Mon Jan 2")
+}

--- a/cmd/candela/forecast.go
+++ b/cmd/candela/forecast.go
@@ -54,7 +54,7 @@ func cmdForecast() {
 		fmt.Fprintf(os.Stderr, "Error: cannot reach proxy at %s\n  %v\n\nIs the proxy running? Try: candela start\n", baseURL, err)
 		os.Exit(1)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {

--- a/cmd/candela/main.go
+++ b/cmd/candela/main.go
@@ -205,6 +205,8 @@ func main() {
 			authArgs = os.Args[2:]
 		}
 		handleAuth(authArgs)
+	case "forecast":
+		cmdForecast()
 	case "version":
 		fmt.Printf("candela %s\n", version)
 	default:
@@ -225,6 +227,8 @@ Usage:
   candela auth login --provider aws   Login to AWS
   candela auth status                 Show credential status
   candela auth token --provider gcp   Print a fresh access token
+  candela forecast                    Show budget forecast
+  candela forecast --json             Output forecast as JSON
   candela version                     Print version
 
 Run flags:

--- a/pkg/forecast/handler.go
+++ b/pkg/forecast/handler.go
@@ -93,6 +93,11 @@ func Handler(store BudgetStore, users UserLookup) http.HandlerFunc {
 			return
 		}
 
+		// Resolve "me" alias to the caller's own user ID.
+		if targetUserID == "me" {
+			targetUserID = caller.ID
+		}
+
 		// Auth: self-service or admin.
 		if caller.ID != targetUserID {
 			if !isAdmin(r.Context(), users, caller.ID) {

--- a/ui/src/app/today/page.tsx
+++ b/ui/src/app/today/page.tsx
@@ -1,16 +1,19 @@
 "use client";
 
 import { useTodayBudget } from "@/hooks/useTodayBudget";
+import { useForecast } from "@/hooks/useForecast";
 import { ErrorBanner } from "@/components/ErrorBanner";
 import { useEffect, useMemo, useState } from "react";
 import { BudgetRing } from "@/components/today/BudgetRing";
 import { TokenBar } from "@/components/today/TokenBar";
 import { GrantCard } from "@/components/today/GrantCard";
+import { ForecastBar } from "@/components/today/ForecastBar";
 import { fmtTokens } from "@/components/today/utils";
 import "./today.css";
 
 export default function TodayPage() {
   const { data, loading, error, refresh } = useTodayBudget();
+  const { forecast } = useForecast();
 
   const totalTokens = data
     ? (data.totalInputTokens + data.totalOutputTokens)
@@ -122,6 +125,9 @@ export default function TodayPage() {
             </div>
           </div>
         ) : null}
+
+        {/* Forecast: burn rate, EOD projection, exhaustion warning, sparkline */}
+        {forecast && <ForecastBar forecast={forecast} />}
 
         {/* Quick Stats */}
         <div className="stats-grid animate-in" style={{ animationDelay: "0.08s", marginTop: 24 }}>

--- a/ui/src/app/today/today.css
+++ b/ui/src/app/today/today.css
@@ -354,3 +354,132 @@
   background: var(--bg-tertiary);
   border-radius: 4px;
 }
+
+/* ──────────────────────────────────────────
+   Forecast Bar
+   ────────────────────────────────────────── */
+
+.forecast-bar {
+  margin-top: 16px;
+  padding: 16px 20px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+.forecast-metrics {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 14px;
+}
+
+.forecast-metric {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.forecast-metric-icon {
+  font-size: 16px;
+}
+
+.forecast-metric-value {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.forecast-metric-label {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.forecast-divider {
+  color: var(--text-muted);
+  margin: 0 4px;
+}
+
+.forecast-danger {
+  color: var(--color-danger, #ef4444);
+}
+
+.forecast-exceed-badge {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-danger, #ef4444);
+  margin-left: 4px;
+}
+
+.forecast-exhaustion {
+  margin-top: 12px;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.forecast-exhaustion-warn {
+  background: rgba(234, 179, 8, 0.1);
+  border: 1px solid rgba(234, 179, 8, 0.3);
+  color: #eab308;
+}
+
+.forecast-exhaustion-critical {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #ef4444;
+}
+
+.forecast-sparkline {
+  margin-top: 16px;
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.forecast-sparkline-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  align-self: center;
+}
+
+.forecast-sparkline-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  height: 48px;
+  flex: 1;
+}
+
+.forecast-sparkline-bar-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+  height: 100%;
+  justify-content: flex-end;
+}
+
+.forecast-sparkline-bar {
+  width: 100%;
+  max-width: 24px;
+  background: var(--color-primary, #6366f1);
+  border-radius: 3px 3px 0 0;
+  min-height: 2px;
+  transition: height 0.3s ease;
+}
+
+.forecast-sparkline-day {
+  font-size: 9px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.forecast-avg-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  align-self: center;
+}

--- a/ui/src/components/today/ForecastBar.tsx
+++ b/ui/src/components/today/ForecastBar.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import type { ForecastData } from "@/hooks/useForecast";
+
+interface Props {
+  forecast: ForecastData;
+}
+
+/** Renders burn rate, projected EOD, and exhaustion warning below the BudgetRing. */
+export function ForecastBar({ forecast }: Props) {
+  const {
+    burnRatePerHour,
+    projectedEodSpend,
+    willExceedBudget,
+    avgDailySpend,
+    daysUntilExhaustion,
+    estimatedExhaustionDate,
+    spendHistory,
+  } = forecast;
+
+  // Don't render if no meaningful data (no budget configured).
+  if (burnRatePerHour === 0 && avgDailySpend === 0) {
+    return null;
+  }
+
+  return (
+    <div className="forecast-bar">
+      {/* Burn rate + projected EOD */}
+      <div className="forecast-metrics">
+        <div className="forecast-metric">
+          <span className="forecast-metric-icon">🔥</span>
+          <span className="forecast-metric-value">
+            ${burnRatePerHour.toFixed(2)}/hr
+          </span>
+          <span className="forecast-metric-label">burn rate</span>
+        </div>
+
+        <span className="forecast-divider">·</span>
+
+        <div className="forecast-metric">
+          <span className="forecast-metric-label">Projected EOD:</span>
+          <span
+            className={`forecast-metric-value ${willExceedBudget ? "forecast-danger" : ""}`}
+          >
+            ${projectedEodSpend.toFixed(2)}
+          </span>
+          {willExceedBudget && (
+            <span className="forecast-exceed-badge">⚠️ WILL EXCEED</span>
+          )}
+        </div>
+      </div>
+
+      {/* Exhaustion warning — only when ≤ 7 days */}
+      {daysUntilExhaustion >= 0 && daysUntilExhaustion <= 7 && (
+        <div
+          className={`forecast-exhaustion ${
+            daysUntilExhaustion <= 3
+              ? "forecast-exhaustion-critical"
+              : "forecast-exhaustion-warn"
+          }`}
+        >
+          {daysUntilExhaustion === 0 ? (
+            <span>🚫 Budget exhausted today</span>
+          ) : (
+            <span>
+              ⏳ Budget exhausts in{" "}
+              <strong>
+                {daysUntilExhaustion} day{daysUntilExhaustion !== 1 ? "s" : ""}
+              </strong>{" "}
+              ({formatExhaustionDate(estimatedExhaustionDate)})
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* 7-day sparkline */}
+      {spendHistory.length > 0 && (
+        <div className="forecast-sparkline">
+          <span className="forecast-sparkline-label">7-day spend</span>
+          <div className="forecast-sparkline-bars">
+            {spendHistory.map((day) => {
+              const maxSpend = Math.max(
+                ...spendHistory.map((d) => d.spend_usd),
+                0.01,
+              );
+              const pct = (day.spend_usd / maxSpend) * 100;
+              return (
+                <div
+                  key={day.date}
+                  className="forecast-sparkline-bar-wrapper"
+                  title={`${day.date}: $${day.spend_usd.toFixed(2)}`}
+                >
+                  <div
+                    className="forecast-sparkline-bar"
+                    style={{ height: `${Math.max(pct, 4)}%` }}
+                  />
+                  <span className="forecast-sparkline-day">
+                    {dayLabel(day.date)}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+          {avgDailySpend > 0 && (
+            <span className="forecast-avg-label">
+              avg ${avgDailySpend.toFixed(2)}/day
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function dayLabel(dateStr: string): string {
+  try {
+    const d = new Date(dateStr + "T00:00:00Z");
+    return d.toLocaleDateString(undefined, { weekday: "short" }).slice(0, 3);
+  } catch {
+    return dateStr.slice(-2);
+  }
+}
+
+function formatExhaustionDate(dateStr: string): string {
+  if (!dateStr) return "";
+  try {
+    const d = new Date(dateStr + "T00:00:00Z");
+    return d.toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return dateStr;
+  }
+}

--- a/ui/src/hooks/useForecast.ts
+++ b/ui/src/hooks/useForecast.ts
@@ -1,0 +1,123 @@
+"use client";
+
+import { useCallback, useEffect, useReducer } from "react";
+import { API_BASE_URL } from "@/lib/constants";
+import { firebaseAuth } from "@/lib/firebase";
+
+export interface ForecastData {
+  burnRatePerHour: number;
+  projectedEodSpend: number;
+  willExceedBudget: boolean;
+  avgDailySpend: number;
+  estimatedExhaustionDate: string; // "2026-08-28" or ""
+  daysUntilExhaustion: number; // -1 if N/A
+  spendHistory: { date: string; spend_usd: number; token_count: number }[];
+}
+
+interface State {
+  data: ForecastData | null;
+  loading: boolean;
+  error: string | null;
+  fetchCount: number;
+}
+
+type Action =
+  | { type: "fetch" }
+  | { type: "success"; data: ForecastData }
+  | { type: "error"; message: string }
+  | { type: "refresh" };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "fetch":
+      return { ...state, loading: true, error: null };
+    case "success":
+      return { ...state, loading: false, data: action.data };
+    case "error":
+      return { ...state, loading: false, error: action.message };
+    case "refresh":
+      return { ...state, fetchCount: state.fetchCount + 1 };
+    default:
+      return state;
+  }
+}
+
+/**
+ * Fetches budget forecast data from the REST API.
+ *
+ * The forecast endpoint requires a userID. We extract it from the
+ * Firebase auth user's UID (which matches the server's auth.FromContext).
+ */
+export function useForecast() {
+  const [state, dispatch] = useReducer(reducer, {
+    data: null,
+    loading: true,
+    error: null,
+    fetchCount: 0,
+  });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    dispatch({ type: "fetch" });
+
+    (async () => {
+      try {
+        const user = firebaseAuth?.currentUser;
+        if (!user) {
+          dispatch({ type: "error", message: "Not authenticated" });
+          return;
+        }
+
+        const token = await user.getIdToken();
+        const url = `${API_BASE_URL}/api/v1/users/${user.uid}/budget-forecast`;
+        const res = await fetch(url, {
+          signal: controller.signal,
+          headers: { Authorization: `Bearer ${token}` },
+        });
+
+        if (!res.ok) {
+          dispatch({ type: "error", message: `HTTP ${res.status}` });
+          return;
+        }
+
+        const json = await res.json();
+        const data: ForecastData = {
+          burnRatePerHour: json.burn_rate_usd_per_hour ?? 0,
+          projectedEodSpend: json.projected_eod_spend_usd ?? 0,
+          willExceedBudget: json.will_exceed_budget ?? false,
+          avgDailySpend: json.avg_daily_spend_usd ?? 0,
+          estimatedExhaustionDate: json.estimated_exhaustion_date ?? "",
+          daysUntilExhaustion: json.days_until_exhaustion ?? -1,
+          spendHistory: json.spend_history ?? [],
+        };
+
+        dispatch({ type: "success", data });
+      } catch (err: unknown) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        dispatch({
+          type: "error",
+          message: err instanceof Error ? err.message : "Unknown error",
+        });
+      }
+    })();
+
+    return () => controller.abort();
+  }, [state.fetchCount]);
+
+  // Auto-refresh every 5 minutes (forecast data is cached server-side for 5 min).
+  useEffect(() => {
+    const interval = setInterval(() => {
+      dispatch({ type: "refresh" });
+    }, 5 * 60_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const refresh = useCallback(() => dispatch({ type: "refresh" }), []);
+
+  return {
+    forecast: state.data,
+    loading: state.loading,
+    error: state.error,
+    refresh,
+  };
+}


### PR DESCRIPTION
## Summary

Surfaces the existing budget forecast algorithm (#719 ✅) through the CLI and web UI. Turns Candela from a rearview mirror (what you spent) into a windshield (what's coming).

### What's new

**CLI: `candela forecast`**
```
Budget Forecast for you
─────────────────────────
  Burn Rate: $1.23/hr
  Projected: $29.52 EOD ⚠️  WILL EXCEED

  7-Day History:
    Mon  ████████░░  $18.50
    Tue  ██████░░░░  $16.90
    Wed  █████████░  $20.10
    Thu  ███████░░░  $17.80
    Fri  ██████████  $22.30

  Avg Daily: $19.12
  Exhaustion: Thu Aug 28 (5 days)
```

- Goes through local proxy (handles IAP auth automatically)
- `--json` for machine-readable output
- `--user <id>` for admin to view any user

**UI: ForecastBar on Today page**
- 🔥 Burn rate + projected EOD spend
- ⚠️ WILL EXCEED warning when projected > limit
- ⏳ Exhaustion countdown (amber ≤7 days, red ≤3 days)
- 7-day spend sparkline with per-day bars
- Auto-refreshes every 5 minutes (matches server cache TTL)

**Server: `me` alias**
- `/api/v1/users/me/budget-forecast` resolves to caller's ID
- Enables CLI/UI without knowing Firebase UID

## Files

### CLI
- **[NEW]** `cmd/candela/forecast.go` — forecast command
- **[MODIFY]** `cmd/candela/main.go` — dispatch + help text

### UI
- **[NEW]** `ui/src/hooks/useForecast.ts` — REST API hook
- **[NEW]** `ui/src/components/today/ForecastBar.tsx` — forecast display
- **[MODIFY]** `ui/src/app/today/page.tsx` — wire in ForecastBar
- **[MODIFY]** `ui/src/app/today/today.css` — forecast styles

### Server
- **[MODIFY]** `pkg/forecast/handler.go` — `me` alias support

## Testing
- `go build ./...` ✅
- `go test ./cmd/candela/ ./pkg/forecast/` ✅ (all pass)
- `npx tsc --noEmit` ✅ (no new errors)
- Pre-commit hooks ✅

Closes #795, closes #796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added budget forecasting to the command-line interface, including human-readable and JSON output.
  * Added budget forecast details to the Today page, including burn rate, projected spending, seven-day history, and average daily spend.
  * Added warnings when projected spending exceeds the budget or the budget is nearing exhaustion.
  * Added support for requesting forecasts using the current authenticated account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->