### PR TITLE
fix: session cache background eviction (#671)

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -94,21 +94,34 @@ type UserMsgResolver struct {
 	ttl        time.Duration
 	maxEntries int              // safety cap; 0 means 1000
 	nowFunc    func() time.Time // for testing
+	stop       chan struct{}
+	once       sync.Once
 }
 
 // NewUserMsgResolver creates a resolver with the given in-memory TTL.
-// Entries not accessed within the TTL are evicted lazily on next lookup.
-// The cache is capped at 1000 entries to prevent unbounded growth.
+// Entries not accessed within the TTL are evicted lazily on next lookup
+// and periodically by a background sweep goroutine.
+// The cache is capped at maxEntries (default 1000) to prevent unbounded growth.
+// Call Stop() to terminate the background goroutine on shutdown.
 func NewUserMsgResolver(ttl time.Duration) *UserMsgResolver {
 	if ttl <= 0 {
 		ttl = 30 * time.Minute
 	}
-	return &UserMsgResolver{
+	u := &UserMsgResolver{
 		cache:      make(map[string]*sessionEntry),
 		ttl:        ttl,
 		maxEntries: 1000,
 		nowFunc:    time.Now,
+		stop:       make(chan struct{}),
 	}
+	go u.sweepLoop()
+	return u
+}
+
+// Stop terminates the background eviction goroutine.
+// Safe to call multiple times.
+func (u *UserMsgResolver) Stop() {
+	u.once.Do(func() { close(u.stop) })
 }
 
 func (u *UserMsgResolver) Resolve(info SessionInfo) string {
@@ -183,6 +196,28 @@ func (u *UserMsgResolver) evictLocked(now time.Time) {
 	target := max * 3 / 4
 	for i := 0; i < len(entries) && len(u.cache) > target; i++ {
 		delete(u.cache, entries[i].fp)
+	}
+}
+
+// sweepLoop periodically evicts expired entries in the background.
+// Runs every TTL/2 to ensure expired entries don't linger beyond ~1.5× TTL.
+func (u *UserMsgResolver) sweepLoop() {
+	interval := u.ttl / 2
+	if interval < time.Second {
+		interval = time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-u.stop:
+			return
+		case <-ticker.C:
+			u.mu.Lock()
+			u.evictLocked(u.nowFunc())
+			u.mu.Unlock()
+		}
 	}
 }
 

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -57,6 +57,7 @@ func TestHeaderResolver_CustomName(t *testing.T) {
 
 func TestUserMsgResolver_SameConversationGrows(t *testing.T) {
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 
 	// Turn 1: system + user
 	msgs1 := makeMessages(
@@ -83,6 +84,7 @@ func TestUserMsgResolver_ModelSwitchDifferentSession(t *testing.T) {
 	// After hardening v4, model is part of the fingerprint to prevent
 	// merging unrelated conversations across different models.
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 
 	msgs := makeMessages(
 		msg("system", "You are a helpful assistant."),
@@ -99,6 +101,7 @@ func TestUserMsgResolver_ModelSwitchDifferentSession(t *testing.T) {
 
 func TestUserMsgResolver_DifferentConversations(t *testing.T) {
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 
 	msgs1 := makeMessages(
 		msg("system", "You are a helpful assistant."),
@@ -119,6 +122,7 @@ func TestUserMsgResolver_DifferentConversations(t *testing.T) {
 
 func TestUserMsgResolver_DifferentUsers(t *testing.T) {
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 
 	msgs := makeMessages(
 		msg("system", "You are a helpful assistant."),
@@ -137,6 +141,7 @@ func TestUserMsgResolver_DynamicSystemPrompt(t *testing.T) {
 	// Cline rebuilds messages[0] every turn — fingerprint should still match
 	// because we only hash the first USER message, not the system prompt.
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 
 	msgs1 := makeMessages(
 		msg("system", "You are Cline v1. CWD: /home/alice/project. OS: macOS."),
@@ -160,6 +165,7 @@ func TestUserMsgResolver_DynamicSystemPrompt(t *testing.T) {
 func TestUserMsgResolver_Timeout(t *testing.T) {
 	now := time.Now()
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 	r.nowFunc = func() time.Time { return now }
 
 	msgs := makeMessages(
@@ -179,6 +185,7 @@ func TestUserMsgResolver_Timeout(t *testing.T) {
 
 func TestUserMsgResolver_Compaction(t *testing.T) {
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 
 	// Long conversation: 6 messages
 	msgs1 := makeMessages(
@@ -208,6 +215,7 @@ func TestUserMsgResolver_Compaction(t *testing.T) {
 
 func TestUserMsgResolver_EmptyMessages(t *testing.T) {
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 	got := r.Resolve(SessionInfo{UserID: "alice", Messages: nil})
 	if got != "" {
 		t.Errorf("nil messages should return empty, got %q", got)
@@ -216,6 +224,7 @@ func TestUserMsgResolver_EmptyMessages(t *testing.T) {
 
 func TestUserMsgResolver_NoUserMessage(t *testing.T) {
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 	msgs := makeMessages(msg("system", "You are a helpful assistant."))
 	got := r.Resolve(SessionInfo{UserID: "alice", Messages: msgs})
 	if got != "" {
@@ -283,6 +292,7 @@ func TestChainResolver_FallbackUUID(t *testing.T) {
 
 func TestCacheSize(t *testing.T) {
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 	if r.CacheSize() != 0 {
 		t.Errorf("initial cache size should be 0")
 	}
@@ -297,6 +307,7 @@ func TestCacheSize(t *testing.T) {
 
 func TestUserMsgResolver_MultiModalContent(t *testing.T) {
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 
 	// Multi-modal message: content is an array of objects (e.g., vision API).
 	msgs := json.RawMessage(`[
@@ -321,6 +332,7 @@ func TestUserMsgResolver_MultiModalContent(t *testing.T) {
 
 func TestUserMsgResolver_MultiModalVsString(t *testing.T) {
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 
 	// String content.
 	stringMsgs := makeMessages(
@@ -348,6 +360,7 @@ func TestUserMsgResolver_MultiModalVsString(t *testing.T) {
 
 func TestUserMsgResolver_CacheEviction(t *testing.T) {
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 	r.maxEntries = 5 // small cap for testing
 
 	// Fill cache with 5 unique sessions.
@@ -382,6 +395,7 @@ func TestUserMsgResolver_CacheEviction(t *testing.T) {
 func TestUserMsgResolver_CacheEvictionPrefersTTL(t *testing.T) {
 	now := time.Now()
 	r := NewUserMsgResolver(30 * time.Minute)
+	defer r.Stop()
 	r.maxEntries = 5
 	r.nowFunc = func() time.Time { return now }
 
@@ -409,4 +423,43 @@ func TestUserMsgResolver_CacheEvictionPrefersTTL(t *testing.T) {
 	if r.CacheSize() != 1 {
 		t.Errorf("expired entries should be evicted, cache should be 1, got %d", r.CacheSize())
 	}
+}
+
+func TestUserMsgResolver_BackgroundSweep(t *testing.T) {
+	// Use a short TTL. Sweep interval = max(TTL/2, 1s) = 1s.
+	// So entries expire at 200ms but sweep runs at 1s.
+	r := NewUserMsgResolver(200 * time.Millisecond)
+	defer r.Stop()
+
+	// Populate some entries.
+	r.Resolve(SessionInfo{
+		UserID:   "user1",
+		Model:    "gpt-4",
+		Messages: []byte(`[{"role":"user","content":"hello"}]`),
+	})
+	r.Resolve(SessionInfo{
+		UserID:   "user2",
+		Model:    "gpt-4",
+		Messages: []byte(`[{"role":"user","content":"world"}]`),
+	})
+
+	if r.CacheSize() != 2 {
+		t.Fatalf("expected 2 entries, got %d", r.CacheSize())
+	}
+
+	// Wait for TTL expiry + sweep interval + buffer.
+	// TTL=200ms, sweep=1s, so wait 1.5s total.
+	time.Sleep(1500 * time.Millisecond)
+
+	if got := r.CacheSize(); got != 0 {
+		t.Errorf("background sweep should have evicted all entries, got %d", got)
+	}
+}
+
+func TestUserMsgResolver_StopIdempotent(t *testing.T) {
+	r := NewUserMsgResolver(time.Minute)
+	// Calling Stop multiple times should not panic.
+	r.Stop()
+	r.Stop()
+	r.Stop()
 }


### PR DESCRIPTION
## Problem

The session cache (`UserMsgResolver`) only evicts expired entries lazily — when the same fingerprint is looked up again via `Resolve()`. Entries from one-off conversations that expire but are never revisited sit in memory forever. Under high cardinality (many unique users × unique first messages), memory grows linearly without bound.

## Fix

Add a background sweep goroutine that runs every `TTL/2` (minimum 1 second) and calls `evictLocked()` to remove expired entries proactively. The existing lazy eviction and max-entries cap remain as defense-in-depth.

### Changes

- **`pkg/session/session.go`**:
  - Add `stop chan struct{}` and `once sync.Once` fields
  - `NewUserMsgResolver()` now starts `sweepLoop()` goroutine
  - Add `Stop()` method for clean shutdown (idempotent)
  - Add `sweepLoop()` — ticker-based periodic eviction

- **`pkg/session/session_test.go`**:
  - Add `defer r.Stop()` to all 14 test functions (prevent goroutine leaks)
  - Add `TestUserMsgResolver_BackgroundSweep` — verifies entries evicted without `Resolve()` call
  - Add `TestUserMsgResolver_StopIdempotent` — verifies multiple `Stop()` calls don't panic

## Testing

```
ok  github.com/candelahq/candela/pkg/session  1.682s  (25/25 pass)
```

Closes #671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expired session cache entries are now cleaned up automatically in the background.
  - Added safe resolver shutdown support, including protection against repeated shutdown requests.

- **Bug Fixes**
  - Prevents expired cache data from remaining in memory longer than necessary.

- **Tests**
  - Added coverage for automatic expiration cleanup and repeated shutdown handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->