### PR TITLE
feat: add Gemini 3.8 Flash pricing

### DIFF
--- a/pkg/costcalc/pricing.yaml
+++ b/pkg/costcalc/pricing.yaml
@@ -8,7 +8,13 @@
 
 models:
   # ── Google Gemini ─────────────────────────────────────────
-  # Gemini 3.5 (latest, May 2026)
+  # Gemini 3.8 (latest, Sep 2026)
+  - provider: google
+    model: gemini-3.8-flash
+    input_per_million: 0.75
+    output_per_million: 3.75
+
+  # Gemini 3.5 (May 2026)
   - provider: google
     model: gemini-3.5-flash
     input_per_million: 1.50

--- a/pkg/costcalc/testdata/pricing_snapshot.json
+++ b/pkg/costcalc/testdata/pricing_snapshot.json
@@ -138,6 +138,12 @@
     "output_per_million": 7.5
   },
   {
+    "model": "gemini-3.8-flash",
+    "provider": "google",
+    "input_per_million": 0.75,
+    "output_per_million": 3.75
+  },
+  {
     "model": "imagen-3.0-generate-002",
     "provider": "google",
     "input_per_million": 25,


### PR DESCRIPTION
## Summary

Add Google's new Gemini 3.8 Flash model (released Sep 2, 2026) to the pricing table.

### Pricing
| | Per 1M tokens |
|:---|:---|
| Input | $0.75 |
| Output | $3.75 |

Introductory pricing through Dec 31, 2026.

### Files changed
- `pkg/costcalc/pricing.yaml` — new entry
- `pkg/costcalc/testdata/pricing_snapshot.json` — snapshot updated

### Post-merge: sync Firestore catalog

After deploying the new build, run:
```bash
go run ./cmd/seed-catalog/ --project-id=austin-azra-sandbox-project --merge
```

This adds `gemini-3.8-flash` to the Firestore `model_catalog` collection so it appears in the UI catalog. The `--merge` flag skips existing entries.

### Testing
- `go test ./pkg/costcalc/` ✅ (snapshot updated, all pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pricing support for Google Gemini 3.8 Flash.
  - Gemini 3.8 Flash costs $0.75 per million input tokens and $3.75 per million output tokens.
- **Bug Fixes**
  - Updated pricing validation to include Gemini 3.8 Flash, helping ensure cost calculations and pricing displays use the correct rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->