### PR TITLE
fix(backend): ingest batch limits, firestore sweeper leak, and depguard protobuf rule (#644, #646, #666)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,8 +3,20 @@ run:
   timeout: 5m
   modules-download-mode: readonly
 linters:
+  enable:
+    - depguard
   exclusions:
     paths:
       - scratch
       - ui/node_modules
       - gen
+  settings:
+    depguard:
+      rules:
+        prevent_deprecated_protobuf:
+          list-mode: lax
+          files:
+            - "$all"
+          deny:
+            - pkg: "github.com/golang/protobuf"
+              desc: "use google.golang.org/protobuf instead of deprecated github.com/golang/protobuf"

--- a/gen/go/candela/types/model_catalog.pb.go
+++ b/gen/go/candela/types/model_catalog.pb.go
@@ -71,8 +71,10 @@ type ModelCatalogEntry struct {
 	Region string `protobuf:"bytes,17,opt,name=region,proto3" json:"region,omitempty"`
 	// Access tags required to use this model.
 	// Empty = open to all users (default).
-	// Non-empty = user must have at least one matching tag in their
-	// access_tags field. Examples: ["pro"], ["preview"]
+	// Non-empty = model is restricted; a user must possess at least one matching
+	// tag in their access_tags field to access this model (users with empty
+	// access_tags have default access and can only access models with empty
+	// required_access). Examples: ["pro"], ["preview"].
 	// Admin-managed via UpdateModelCatalogEntry.
 	RequiredAccess []string `protobuf:"bytes,18,rep,name=required_access,json=requiredAccess,proto3" json:"required_access,omitempty"`
 	unknownFields  protoimpl.UnknownFields

--- a/gen/go/candela/types/user.pb.go
+++ b/gen/go/candela/types/user.pb.go
@@ -189,9 +189,9 @@ type User struct {
 	// Access tags controlling which models this user can use.
 	// Freeform strings — admin-defined, no predefined set required.
 	// Examples: ["pro"], ["preview"], ["pro", "preview"]
-	// Empty = unrestricted (backward-compatible default).
-	// A user can access a model if they have ANY tag listed in the
-	// model's required_access field.
+	// Empty = default access (can access all models with empty required_access).
+	// When a model specifies required_access, a user must have at least one
+	// matching tag in access_tags to access it.
 	AccessTags    []string `protobuf:"bytes,10,rep,name=access_tags,json=accessTags,proto3" json:"access_tags,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/proto/otlp v1.10.0
 	go.uber.org/automaxprocs v1.6.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.53.0
 	golang.org/x/oauth2 v0.36.0

--- a/pkg/connecthandlers/ingestion_handler.go
+++ b/pkg/connecthandlers/ingestion_handler.go
@@ -2,6 +2,8 @@ package connecthandlers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	connect "connectrpc.com/connect"
 	v1 "github.com/candelahq/candela/gen/go/candela/v1"
@@ -9,26 +11,70 @@ import (
 	"github.com/candelahq/candela/pkg/storage"
 )
 
+// DefaultMaxIngestBatchSize is the default upper bound on the number of spans
+// that can be ingested in a single IngestSpans call to protect against unbounded
+// memory allocation and pipeline buffer exhaustion (#644).
+const DefaultMaxIngestBatchSize = 10000
+
 // SpanSubmitter is the interface for submitting spans to the processing pipeline.
 // This decouples the handler from the concrete processor implementation.
 type SpanSubmitter interface {
 	SubmitBatch(spans []storage.Span)
 }
 
+// IngestionOption configures an IngestionHandler.
+type IngestionOption func(*IngestionHandler)
+
+// WithMaxBatchSize overrides the maximum allowed spans per IngestSpans request.
+func WithMaxBatchSize(size int) IngestionOption {
+	return func(h *IngestionHandler) {
+		if size > 0 {
+			h.maxBatchSize = size
+		}
+	}
+}
+
 // IngestionHandler implements the IngestionService ConnectRPC/gRPC handler.
 type IngestionHandler struct {
-	submitter SpanSubmitter
+	submitter    SpanSubmitter
+	maxBatchSize int
 }
 
 // NewIngestionHandlerDirect creates a handler that submits spans to an in-process processor.
-func NewIngestionHandlerDirect(submitter SpanSubmitter) *IngestionHandler {
-	return &IngestionHandler{submitter: submitter}
+func NewIngestionHandlerDirect(submitter SpanSubmitter, opts ...IngestionOption) *IngestionHandler {
+	h := &IngestionHandler{
+		submitter:    submitter,
+		maxBatchSize: DefaultMaxIngestBatchSize,
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
 }
 
 func (h *IngestionHandler) IngestSpans(
 	ctx context.Context,
 	req *connect.Request[v1.IngestSpansRequest],
 ) (*connect.Response[v1.IngestSpansResponse], error) {
+	if req.Msg == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("request message cannot be nil"))
+	}
+
+	spanCount := len(req.Msg.Spans)
+	if spanCount > h.maxBatchSize {
+		return nil, connect.NewError(
+			connect.CodeInvalidArgument,
+			fmt.Errorf("batch size %d exceeds maximum allowed batch size %d", spanCount, h.maxBatchSize),
+		)
+	}
+
+	if spanCount == 0 {
+		return connect.NewResponse(&v1.IngestSpansResponse{
+			AcceptedCount: 0,
+			RejectedCount: 0,
+		}), nil
+	}
+
 	// Resolve the caller's identity so we can attribute spans that arrive
 	// without a user_id (e.g. from candela-local).
 	var callerID string
@@ -36,13 +82,13 @@ func (h *IngestionHandler) IngestSpans(
 		callerID = caller.EffectiveID()
 	}
 
-	var spans []storage.Span
-	var errors []string
+	spans := make([]storage.Span, 0, spanCount)
+	var errMsgs []string
 
 	for _, s := range req.Msg.Spans {
 		span, err := protoToSpan(s)
 		if err != nil {
-			errors = append(errors, err.Error())
+			errMsgs = append(errMsgs, err.Error())
 			continue
 		}
 		// Stamp the caller's identity on spans with no user_id.
@@ -60,7 +106,7 @@ func (h *IngestionHandler) IngestSpans(
 
 	return connect.NewResponse(&v1.IngestSpansResponse{
 		AcceptedCount: int32(len(spans)),
-		RejectedCount: int32(len(errors)),
-		Errors:        errors,
+		RejectedCount: int32(len(errMsgs)),
+		Errors:        errMsgs,
 	}), nil
 }

--- a/pkg/connecthandlers/ingestion_handler_test.go
+++ b/pkg/connecthandlers/ingestion_handler_test.go
@@ -2,6 +2,7 @@ package connecthandlers
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -56,5 +57,84 @@ func TestIngestionHandler_IngestSpans(t *testing.T) {
 	}
 	if submitter.spans[0].UserID != "dev@example.com" {
 		t.Errorf("span.UserID = %v, want 'dev@example.com'", submitter.spans[0].UserID)
+	}
+}
+
+func TestIngestionHandler_IngestSpans_MaxBatchSizeExceeded(t *testing.T) {
+	submitter := &mockSpanSubmitter{}
+	// Default limit is 10,000; configure with small limit of 3 for testing
+	handler := NewIngestionHandlerDirect(submitter, WithMaxBatchSize(3))
+
+	spans := make([]*typespb.Span, 4)
+	for i := range spans {
+		spans[i] = &typespb.Span{
+			SpanId:  "span",
+			TraceId: "trace",
+			Name:    "test",
+		}
+	}
+
+	req := connect.NewRequest(&v1.IngestSpansRequest{
+		Spans: spans,
+	})
+
+	_, err := handler.IngestSpans(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for batch exceeding maxBatchSize, got nil")
+	}
+
+	var connectErr *connect.Error
+	if !errors.As(err, &connectErr) {
+		t.Fatalf("expected connect.Error, got %T: %v", err, err)
+	}
+	if connectErr.Code() != connect.CodeInvalidArgument {
+		t.Errorf("got code %v, want %v", connectErr.Code(), connect.CodeInvalidArgument)
+	}
+	if len(submitter.spans) != 0 {
+		t.Errorf("expected 0 spans submitted on rejection, got %d", len(submitter.spans))
+	}
+}
+
+func TestIngestionHandler_IngestSpans_NilMessage(t *testing.T) {
+	submitter := &mockSpanSubmitter{}
+	handler := NewIngestionHandlerDirect(submitter)
+
+	req := &connect.Request[v1.IngestSpansRequest]{} // req.Msg is nil
+
+	_, err := handler.IngestSpans(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for nil message, got nil")
+	}
+
+	var connectErr *connect.Error
+	if !errors.As(err, &connectErr) {
+		t.Fatalf("expected connect.Error, got %T: %v", err, err)
+	}
+	if connectErr.Code() != connect.CodeInvalidArgument {
+		t.Errorf("got code %v, want %v", connectErr.Code(), connect.CodeInvalidArgument)
+	}
+}
+
+func TestIngestionHandler_IngestSpans_EmptyBatch(t *testing.T) {
+	submitter := &mockSpanSubmitter{}
+	handler := NewIngestionHandlerDirect(submitter)
+
+	req := connect.NewRequest(&v1.IngestSpansRequest{
+		Spans: []*typespb.Span{},
+	})
+
+	resp, err := handler.IngestSpans(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error for empty batch: %v", err)
+	}
+
+	if resp.Msg.AcceptedCount != 0 {
+		t.Errorf("AcceptedCount = %d, want 0", resp.Msg.AcceptedCount)
+	}
+	if resp.Msg.RejectedCount != 0 {
+		t.Errorf("RejectedCount = %d, want 0", resp.Msg.RejectedCount)
+	}
+	if len(submitter.spans) != 0 {
+		t.Errorf("expected 0 spans submitted, got %d", len(submitter.spans))
 	}
 }

--- a/pkg/storage/firestoredb/cache_test.go
+++ b/pkg/storage/firestoredb/cache_test.go
@@ -1,8 +1,11 @@
 package firestoredb
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	"go.uber.org/goleak"
 )
 
 func TestRateLimitCache_MissReturnsZeroFalse(t *testing.T) {
@@ -91,4 +94,54 @@ func TestRateLimitCache_OverwriteUpdatesExpiry(t *testing.T) {
 		t.Errorf("overwrite: got limit=%d ok=%v, want limit=10 ok=true", limit, ok)
 	}
 	evictRateLimitCache(key)
+}
+
+func TestRateLimitSweeper_Lifecycle(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Start sweeper with background context
+	StartRateLimitSweeper(context.Background(), 10*time.Millisecond)
+
+	// Stop sweeper and verify clean shutdown
+	StopRateLimitSweeper()
+
+	// Idempotent stop
+	StopRateLimitSweeper()
+	Stop()
+}
+
+func TestRateLimitSweeper_ContextCancellation(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	StartRateLimitSweeper(ctx, 10*time.Millisecond)
+
+	// Cancel context to trigger shutdown
+	cancel()
+
+	// Wait for sweeper to terminate
+	StopRateLimitSweeper()
+}
+
+func TestRateLimitSweeper_PeriodicSweep(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	expiredKey := "auto-sweep-expired@example.com"
+	rateLimitValueCache.mu.Lock()
+	rateLimitValueCache.entries[expiredKey] = rlCacheEntry{
+		limit:     50,
+		expiresAt: time.Now().Add(-10 * time.Millisecond),
+	}
+	rateLimitValueCache.mu.Unlock()
+
+	// Start with short interval
+	StartRateLimitSweeper(context.Background(), 20*time.Millisecond)
+	defer StopRateLimitSweeper()
+
+	// Allow background sweeper to run at least one tick
+	time.Sleep(60 * time.Millisecond)
+
+	if _, ok := getCachedRateLimit(expiredKey); ok {
+		t.Errorf("expected expired key %q to be swept by background goroutine, but it was found", expiredKey)
+	}
 }

--- a/pkg/storage/firestoredb/firestoredb.go
+++ b/pkg/storage/firestoredb/firestoredb.go
@@ -60,17 +60,77 @@ var rateLimitValueCache struct {
 	entries map[string]rlCacheEntry
 }
 
+var (
+	rateLimitSweeperCancel context.CancelFunc
+	rateLimitSweeperDone   chan struct{}
+	rateLimitSweeperMu     sync.Mutex
+)
+
 func init() {
 	rateLimitValueCache.entries = make(map[string]rlCacheEntry)
-	// CRIT-10: sweep expired entries on a background goroutine to prevent
-	// unbounded map growth in environments with high user-ID churn.
+}
+
+// StartRateLimitSweeper starts a background goroutine to periodically sweep
+// expired entries from rateLimitValueCache (#646). If a sweeper is already running,
+// it is stopped before starting a new one.
+// The sweeper stops when ctx is done or when StopRateLimitSweeper / Stop is called.
+func StartRateLimitSweeper(ctx context.Context, interval ...time.Duration) {
+	rateLimitSweeperMu.Lock()
+	defer rateLimitSweeperMu.Unlock()
+
+	if rateLimitSweeperCancel != nil {
+		rateLimitSweeperCancel()
+		if rateLimitSweeperDone != nil {
+			<-rateLimitSweeperDone
+		}
+		rateLimitSweeperCancel = nil
+		rateLimitSweeperDone = nil
+	}
+
+	sweepInterval := rateLimitCacheTTL
+	if len(interval) > 0 && interval[0] > 0 {
+		sweepInterval = interval[0]
+	}
+
+	sweepCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	rateLimitSweeperCancel = cancel
+	rateLimitSweeperDone = done
+
 	go func() {
-		ticker := time.NewTicker(rateLimitCacheTTL)
+		defer close(done)
+		ticker := time.NewTicker(sweepInterval)
 		defer ticker.Stop()
-		for range ticker.C {
-			sweepRateLimitCache()
+		for {
+			select {
+			case <-sweepCtx.Done():
+				return
+			case <-ticker.C:
+				sweepRateLimitCache()
+			}
 		}
 	}()
+}
+
+// StopRateLimitSweeper stops the background rate limit cache sweeper goroutine if running
+// and waits for it to exit (#646).
+func StopRateLimitSweeper() {
+	rateLimitSweeperMu.Lock()
+	defer rateLimitSweeperMu.Unlock()
+
+	if rateLimitSweeperCancel != nil {
+		rateLimitSweeperCancel()
+		if rateLimitSweeperDone != nil {
+			<-rateLimitSweeperDone
+		}
+		rateLimitSweeperCancel = nil
+		rateLimitSweeperDone = nil
+	}
+}
+
+// Stop stops the background sweeper goroutine. Alias for StopRateLimitSweeper (#646).
+func Stop() {
+	StopRateLimitSweeper()
 }
 
 type rlCacheEntry struct {
@@ -125,11 +185,13 @@ func New(ctx context.Context, projectID, databaseID string) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("firestoredb: creating client: %w", err)
 	}
+	StartRateLimitSweeper(ctx)
 	return &Store{client: client, budgetLocation: time.UTC}, nil
 }
 
 // NewWithClient creates a Store with an existing Firestore client (useful for tests).
 func NewWithClient(client *firestore.Client) *Store {
+	StartRateLimitSweeper(context.Background())
 	return &Store{client: client, budgetLocation: time.UTC}
 }
 
@@ -142,9 +204,15 @@ func (s *Store) SetBudgetLocation(loc *time.Location) {
 	s.budgetLocation = loc
 }
 
-// Close releases Firestore resources.
+// Close releases Firestore resources and stops the rate limit cache sweeper (#646).
 func (s *Store) Close() error {
+	StopRateLimitSweeper()
 	return s.client.Close()
+}
+
+// Stop releases Firestore resources and stops background sweepers (#646).
+func (s *Store) Stop() {
+	_ = s.Close()
 }
 
 // Ping verifies that the Firestore backend is reachable by running a

--- a/ui/src/gen/candela/types/model_catalog_pb.ts
+++ b/ui/src/gen/candela/types/model_catalog_pb.ts
@@ -149,8 +149,10 @@ export type ModelCatalogEntry = Message<"candela.types.ModelCatalogEntry"> & {
   /**
    * Access tags required to use this model.
    * Empty = open to all users (default).
-   * Non-empty = user must have at least one matching tag in their
-   * access_tags field. Examples: ["pro"], ["preview"]
+   * Non-empty = model is restricted; a user must possess at least one matching
+   * tag in their access_tags field to access this model (users with empty
+   * access_tags have default access and can only access models with empty
+   * required_access). Examples: ["pro"], ["preview"].
    * Admin-managed via UpdateModelCatalogEntry.
    *
    * @generated from field: repeated string required_access = 18;

--- a/ui/src/gen/candela/types/user_pb.ts
+++ b/ui/src/gen/candela/types/user_pb.ts
@@ -80,9 +80,9 @@ export type User = Message<"candela.types.User"> & {
    * Access tags controlling which models this user can use.
    * Freeform strings — admin-defined, no predefined set required.
    * Examples: ["pro"], ["preview"], ["pro", "preview"]
-   * Empty = unrestricted (backward-compatible default).
-   * A user can access a model if they have ANY tag listed in the
-   * model's required_access field.
+   * Empty = default access (can access all models with empty required_access).
+   * When a model specifies required_access, a user must have at least one
+   * matching tag in access_tags to access it.
    *
    * @generated from field: repeated string access_tags = 10;
    */


### PR DESCRIPTION
## Summary
This PR resolves three backend stability, resource management, and dependency hygiene issues:

1. **IngestSpans Batch Sizing & DoS Guard (#644)**:
   - Enforce a configurable maximum batch size limit (default: 10,000 spans) on `IngestSpans`.
   - Reject requests exceeding the limit with ConnectRPC `CodeInvalidArgument` to prevent memory exhaustion and downstream processor buffer drops.
   - Pre-allocate the span slice to eliminate repeated heap reallocations.
   - Return `CodeInvalidArgument` for nil request message and gracefully handle empty batches.
   - Added unit tests for batch limit rejection, nil message, empty batch, and `WithMaxBatchSize` option.

2. **Firestore Rate Limit Cache Sweeper Goroutine Leak (#646)**:
   - Removed the unmanaged, infinite background goroutine started unconditionally in package `init()`.
   - Added lifecycle control via `StartRateLimitSweeper(ctx, interval...)` and idempotent `StopRateLimitSweeper() / Stop()`.
   - Wired `StopRateLimitSweeper()` into `Store.Close()` and `Store.Stop()`.
   - Added unit tests in `cache_test.go` verifying clean startup/shutdown, context cancellation, periodic sweeping, and verified zero goroutine leaks via `goleak.VerifyNone(t)`.

3. **Protobuf Dependency Hygiene & Linter Enforcement (#666)**:
   - Configured `depguard` in `.golangci.yml` using `version: "2"` configuration under `linters.settings.depguard`.
   - Blocked direct imports of deprecated `github.com/golang/protobuf` in favor of `google.golang.org/protobuf`.
   - Ran `go mod tidy` and verified no direct imports exist in application packages.

Closes #644, Closes #646, Closes #666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for ingestion batch sizes, with a default maximum of 10,000 spans.
  * Added validation for empty and invalid ingestion requests, including clear invalid-argument responses.
  * Added controls for starting, stopping, restarting, and scheduling rate-limit cache cleanup.

* **Bug Fixes**
  * Improved shutdown handling to ensure background cache cleanup stops cleanly when storage closes.

* **Tests**
  * Expanded coverage for ingestion validation, cache cleanup scheduling, cancellation, and lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->