### PR TITLE
fix(audit): make BigQuery buffer configurable

### DIFF
--- a/pkg/audit/bq_logger.go
+++ b/pkg/audit/bq_logger.go
@@ -11,7 +11,10 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
-const bqTableName = "admin_audit_log"
+const (
+	bqTableName         = "admin_audit_log"
+	defaultBQBufferSize = 256
+)
 
 // bqRow is the BigQuery row schema for audit events.
 type bqRow struct {
@@ -38,8 +41,16 @@ type BQLogger struct {
 
 // BQConfig holds BigQuery audit logger configuration.
 type BQConfig struct {
-	ProjectID string
-	Dataset   string
+	ProjectID  string
+	Dataset    string
+	BufferSize int
+}
+
+func bqBufferSize(cfg BQConfig) int {
+	if cfg.BufferSize > 0 {
+		return cfg.BufferSize
+	}
+	return defaultBQBufferSize
 }
 
 // NewBQLogger creates a BigQuery audit logger with an async write loop.
@@ -54,7 +65,7 @@ func NewBQLogger(ctx context.Context, cfg BQConfig) (*BQLogger, error) {
 	l := &BQLogger{
 		client:   client,
 		inserter: table.Inserter(),
-		events:   make(chan bqRow, 256),
+		events:   make(chan bqRow, bqBufferSize(cfg)),
 		done:     make(chan struct{}),
 	}
 	go l.writeLoop()

--- a/pkg/audit/bq_logger_test.go
+++ b/pkg/audit/bq_logger_test.go
@@ -6,6 +6,18 @@ import (
 	"time"
 )
 
+func TestBQBufferSize(t *testing.T) {
+	if got := bqBufferSize(BQConfig{}); got != defaultBQBufferSize {
+		t.Errorf("default buffer size = %d, want %d", got, defaultBQBufferSize)
+	}
+	if got := bqBufferSize(BQConfig{BufferSize: 1024}); got != 1024 {
+		t.Errorf("configured buffer size = %d, want 1024", got)
+	}
+	if got := bqBufferSize(BQConfig{BufferSize: -1}); got != defaultBQBufferSize {
+		t.Errorf("invalid buffer size = %d, want %d", got, defaultBQBufferSize)
+	}
+}
+
 // newTestBQLogger creates a BQLogger with only the events channel initialized
 // (no BigQuery client). This lets us test buffer behavior without cloud deps.
 func newTestBQLogger(bufSize int) *BQLogger {


### PR DESCRIPTION
## Summary

- make the BigQuery audit event buffer configurable through `BQConfig.BufferSize`
- preserve the existing 256-event buffer when the value is zero or negative
- add unit coverage for configured, default, and invalid values

Closes #680

## Verification

- `go test ./pkg/audit` passed
- `git diff --check` passed
- `go test ./...` reached unrelated existing repository/environment failures: DuckDB Windows build constraints and a failing `cmd/candela` test

## Post-Deploy Monitoring & Validation

No additional monitoring is required for this configuration-only change. The existing `audit: BQ event buffer full, dropping event` warning remains the signal for an undersized buffer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable event buffering for BigQuery audit logging.
  * Buffer size can now be set through the audit logger configuration, with a default applied when unspecified or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->